### PR TITLE
Backport 5X: Support resource group runaway in global shared memory.

### DIFF
--- a/src/backend/utils/mmgr/redzone_handler.c
+++ b/src/backend/utils/mmgr/redzone_handler.c
@@ -22,6 +22,7 @@
 #include "port/atomics.h"
 #include "utils/vmem_tracker.h"
 #include "utils/session_state.h"
+#include "utils/resgroup.h"
 #include "utils/resource_manager.h"
 
 /* External dependencies within the runaway cleanup framework */
@@ -133,7 +134,10 @@ RedZoneHandler_IsVmemRedZone()
 
 	if (vmemTrackerInited)
 	{
-		return *segmentVmemChunks > redZoneChunks;
+		if (IsResGroupEnabled())
+			return IsGroupInRedZone();
+		else
+			return *segmentVmemChunks > redZoneChunks;
 	}
 
 	return false;
@@ -152,6 +156,7 @@ RedZoneHandler_FlagTopConsumer()
 
 	Assert(NULL != MySessionState);
 
+	Oid resGroupId = InvalidOid;
 	uint32 expected = 0;
 	bool success = pg_atomic_compare_exchange_u32((pg_atomic_uint32 *) isRunawayDetector, &expected, 1);
 
@@ -182,9 +187,53 @@ RedZoneHandler_FlagTopConsumer()
 
 	SessionState *curSessionState = AllSessionStateEntries->usedList;
 
+	/*
+	 * Find the group which used the most of global memory in resgroup mode.
+	 * Since there exists concurrent DDLs to drop resource group and it is
+	 * not safe to acquire resgroup lock in redzone. We access ResGroupData
+	 * in a lock free way, and using SessionStateLock to ensure the groups with
+	 * sessions will not be dropped.
+	 */
+	if (IsResGroupEnabled())
+	{
+		int32	maxGlobalShareMem = 0;
+		Oid		sessionGroupId = InvalidOid;
+		int32	sessionGroupGSMem;
+
+		while (curSessionState != NULL)
+		{
+			Assert(INVALID_SESSION_ID != curSessionState->sessionId);
+
+			sessionGroupGSMem = SessionGetResGroupGlobalShareMemUsage(curSessionState);
+
+			if (sessionGroupGSMem > maxGlobalShareMem)
+			{
+				maxGlobalShareMem = sessionGroupGSMem;
+				sessionGroupId = SessionGetResGroupId(curSessionState);
+
+				Assert(InvalidOid != sessionGroupId);
+				resGroupId = sessionGroupId;
+			}
+
+			curSessionState = curSessionState->next;
+		}
+	}
+
+	curSessionState = AllSessionStateEntries->usedList;
+
 	while (curSessionState != NULL)
 	{
 		Assert(INVALID_SESSION_ID != curSessionState->sessionId);
+
+		/* 
+		 * in resgroup mode, we should only flag top consumer in group which uses
+		 * the most of the global shared memory
+		 */
+		if (IsResGroupEnabled() && SessionGetResGroupId(curSessionState) != resGroupId)
+		{
+			curSessionState = curSessionState->next;	
+			continue;
+		}
 
 		int32 curVmem = curSessionState->sessionVmem;
 
@@ -295,17 +344,6 @@ RedZoneHandler_FlagTopConsumer()
 void
 RedZoneHandler_DetectRunawaySession()
 {
-	/*
-	 * Runaway system pick one session who consumed the most memories and
-	 * notify it to clean up once red-zone is hit, meanwhile, memories are
-	 * isolated between groups in resource group which means one query in
-	 * a resource group may cancel queries within another resource group.
-	 *
-	 * To avoid this, we do not do runaway detection when resource group
-	 * is enabled.
-	 */
-	if (IsResGroupEnabled())
-		return;
 
 	/*
 	 * InterruptHoldoffCount > 0 indicates we are in a sensitive code path that doesn't

--- a/src/backend/utils/mmgr/runaway_cleaner.c
+++ b/src/backend/utils/mmgr/runaway_cleaner.c
@@ -24,6 +24,8 @@
 #include "miscadmin.h"
 #include "port/atomics.h"
 #include "utils/faultinjector.h"
+#include "utils/resgroup.h"
+#include "utils/resource_manager.h"
 #include "utils/session_state.h"
 #include "utils/vmem_tracker.h"
 
@@ -184,7 +186,18 @@ RunawayCleaner_StartCleanup()
 		{
 			SIMPLE_FAULT_INJECTOR(RunawayCleanup);
 
-			ereport(ERROR, (errmsg("Canceling query because of high VMEM usage. Used: %dMB, available %dMB, red zone: %dMB",
+			if (IsResGroupEnabled())
+			{
+				StringInfoData    str;
+				initStringInfo(&str);
+			
+				LWLockAcquire(ResGroupLock, LW_SHARED);
+				ResGroupGetMemoryRunawayInfo(&str);
+				LWLockRelease(ResGroupLock);
+				ereport(ERROR, (errmsg("Canceling query because of high VMEM usage. %s", str.data)));
+			}
+			else
+				ereport(ERROR, (errmsg("Canceling query because of high VMEM usage. Used: %dMB, available %dMB, red zone: %dMB",
 					VmemTracker_ConvertVmemChunksToMB(MySessionState->sessionVmem), VmemTracker_GetAvailableVmemMB(),
 					RedZoneHandler_GetRedZoneLimitMB()), errprintstack(true)));
 		}

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -150,6 +150,7 @@ struct ResGroupProcData
 struct ResGroupSlotData
 {
 	Oid				groupId;
+	ResGroupData	*group;		/* pointer to the group */
 
 	ResGroupCaps	caps;
 
@@ -234,6 +235,12 @@ struct ResGroupControl
 	volatile int32	freeChunks;		/* memory chunks not allocated to any group,
 									will be used for the query which group share
 									memory is not enough*/
+	/* 
+	 * Safe memory threshold:
+	 * if remained global shared memory is less than this threshold,
+	 * then the resource group memory usage is in red zone.
+	 */
+	pg_atomic_uint32 safeChunksThreshold;
 
 	int32			chunkSizeInBits;
 
@@ -476,6 +483,7 @@ ResGroupControlInit(void)
     pResGroupControl->nGroups = MaxResourceGroups;
 	pResGroupControl->totalChunks = 0;
 	pResGroupControl->freeChunks = 0;
+	pg_atomic_init_u32(&pResGroupControl->safeChunksThreshold, 0);
 	pResGroupControl->chunkSizeInBits = BITS_IN_MB;
 
 	for (i = 0; i < MaxResourceGroups; i++)
@@ -567,6 +575,8 @@ InitResGroups(void)
 	/* These initialization must be done before createGroup() */
 	decideTotalChunks(&pResGroupControl->totalChunks, &pResGroupControl->chunkSizeInBits);
 	pResGroupControl->freeChunks = pResGroupControl->totalChunks;
+	pg_atomic_write_u32(&pResGroupControl->safeChunksThreshold,
+						pResGroupControl->totalChunks * (100 - runaway_detector_activation_percent) / 100);
 	if (pResGroupControl->totalChunks == 0)
 		ereport(PANIC,
 				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
@@ -687,7 +697,7 @@ InitResGroups(void)
 
 		ResGroupOps_SetCpuSet(DEFAULT_CPUSET_GROUP_ID, cpuset);
 	}
-	
+
 	pResGroupControl->loaded = true;
 	LOG_RESGROUP_DEBUG(LOG, "initialized %d resource groups", numGroups);
 
@@ -1457,6 +1467,7 @@ selfAttachResGroup(ResGroupData *group, ResGroupSlotData *slot)
 {
 	selfSetGroup(group);
 	selfSetSlot(slot);
+
 	groupIncMemUsage(group, slot, self->memUsage);
 	pg_atomic_add_fetch_u32((pg_atomic_uint32*) &slot->nProcs, 1);
 }
@@ -1483,6 +1494,7 @@ initSlot(ResGroupSlotData *slot, ResGroupData *group, int32 slotMemQuota)
 	Assert(!slotIsInUse(slot));
 	Assert(group->groupId != InvalidOid);
 
+	slot->group = group;
 	slot->groupId = group->groupId;
 	slot->caps = group->caps;
 	slot->memQuota = slotMemQuota;
@@ -1516,6 +1528,7 @@ slotpoolInit(void)
 	{
 		slot = &pResGroupControl->slots[i];
 
+		slot->group = NULL;
 		slot->groupId = InvalidOid;
 		slot->memQuota = -1;
 		slot->memUsage = 0;
@@ -1556,6 +1569,7 @@ slotpoolFreeSlot(ResGroupSlotData *slot)
 	Assert(slotIsInUse(slot));
 	Assert(slot->nProcs == 0);
 
+	slot->group = NULL;
 	slot->groupId = InvalidOid;
 	slot->memQuota = -1;
 	slot->memUsage = 0;
@@ -1931,6 +1945,12 @@ mempoolReserve(Oid groupId, int32 chunks)
 			break;
 	}
 
+	/* also update the safeChunksThreshold which is used in runaway detector */
+	if (reserved != 0)
+	{
+		pg_atomic_sub_fetch_u32(&pResGroupControl->safeChunksThreshold,
+								reserved * (100 - runaway_detector_activation_percent) / 100);
+	}
 	LOG_RESGROUP_DEBUG(LOG, "allocate %u out of %u chunks to group %d",
 					   reserved, oldFreeChunks, groupId);
 
@@ -1953,6 +1973,10 @@ mempoolRelease(Oid groupId, int32 chunks)
 	newFreeChunks = pg_atomic_add_fetch_u32((pg_atomic_uint32 *)
 											&pResGroupControl->freeChunks,
 											chunks);
+
+	/* also update the safeChunksThreshold which is used in runaway detector */
+	pg_atomic_add_fetch_u32(&pResGroupControl->safeChunksThreshold,
+							chunks * (100 - runaway_detector_activation_percent) / 100);
 
 	LOG_RESGROUP_DEBUG(LOG, "free %u to pool(%u) chunks from group %d",
 					   chunks, newFreeChunks - chunks, groupId);
@@ -2548,6 +2572,7 @@ AssignResGroupOnMaster(void)
 		pgstat_report_resgroup(0, bypassedGroup->groupId);
 
 		/* Initialize the fake slot */
+		bypassedSlot.group = groupInfo.group;
 		bypassedSlot.groupId = groupInfo.groupId;
 		bypassedSlot.memQuota = 0;
 		bypassedSlot.memUsage = 0;
@@ -2621,6 +2646,7 @@ UnassignResGroup(void)
 		groupDecMemUsage(bypassedGroup, &bypassedSlot, self->memUsage);
 
 		/* Reset the fake slot */
+		bypassedSlot.group = NULL;
 		bypassedSlot.groupId = InvalidOid;
 		bypassedGroup = NULL;
 
@@ -4239,4 +4265,121 @@ EnsureCpusetIsAvailable(int elevel)
 	}
 
 	return true;
+}
+
+/*
+ * Check whether current resource group's memory usage is in RedZone.
+ */
+bool
+IsGroupInRedZone(void)
+{
+	uint32				remainGlobalSharedMem;
+	uint32				safeChunksThreshold;
+	ResGroupSlotData	*slot = self->slot;
+	ResGroupData		*group = self->group;
+
+	/*
+	 * IsGroupInRedZone is called frequently, we should put the
+	 * condition which returns with higher probability in front.
+	 * 
+	 * safe: global shared memory is not in redzone
+	 */
+	remainGlobalSharedMem = (uint32) pg_atomic_read_u32(&pResGroupControl->freeChunks);
+	safeChunksThreshold = (uint32) pg_atomic_read_u32(&pResGroupControl->safeChunksThreshold);
+	if (remainGlobalSharedMem >= safeChunksThreshold)
+		return false;
+
+	AssertImply(slot != NULL, group != NULL);
+	if (!slot)
+		return false;
+
+	/* safe: slot memory is not used up */
+	if (slot->memQuota > slot->memUsage)
+		return false;
+
+	/* safe: group shared memory is not in redzone */
+	if (group->memSharedGranted > group->memSharedUsage)
+		return false;
+
+	/* memory usage in this group is in RedZone */
+	return true;
+}
+
+
+
+/*
+ * Dump memory information for current resource group.
+ * This is the output of resource group runaway.
+ */
+void
+ResGroupGetMemoryRunawayInfo(StringInfo str)
+{
+	ResGroupSlotData	*slot = self->slot;
+	ResGroupData		*group = self->group;
+	uint32				remainGlobalSharedMem = 0;
+	uint32				safeChunksThreshold = 0;
+
+	if (group)
+	{
+		Assert(selfIsAssigned());
+
+		remainGlobalSharedMem = (uint32) pg_atomic_read_u32(&pResGroupControl->freeChunks);
+		safeChunksThreshold = (uint32) pg_atomic_read_u32(&pResGroupControl->safeChunksThreshold);
+
+		appendStringInfo(str,
+						 "current group id is %u, "
+						 "group memory usage %d MB, "
+						 "group shared memory quota is %d MB, "
+						 "slot memory quota is %d MB, "
+						 "global freechunks memory is %u MB, "
+						 "global safe memory threshold is %u MB",
+						 group->groupId,
+						 VmemTracker_ConvertVmemChunksToMB(group->memUsage),
+						 VmemTracker_ConvertVmemChunksToMB(group->memSharedGranted),
+						 VmemTracker_ConvertVmemChunksToMB(slot->memQuota),
+						 VmemTracker_ConvertVmemChunksToMB(remainGlobalSharedMem),
+						 VmemTracker_ConvertVmemChunksToMB(safeChunksThreshold));
+	}
+	else
+	{
+		Assert(!selfIsAssigned());
+
+		appendStringInfo(str,
+						 "Resource group memory information: "
+						 "memory usage in current proc is %d MB",
+						 VmemTracker_ConvertVmemChunksToMB(self->memUsage));
+	}
+}
+
+/*
+ * Return group id for a session
+ */
+Oid
+SessionGetResGroupId(SessionState *session)
+{
+	ResGroupSlotData	*sessionSlot = (ResGroupSlotData *)session->resGroupSlot;
+	if (sessionSlot)
+		return sessionSlot->groupId;
+	else
+		return InvalidOid;
+}
+
+/*
+ * Return group global share memory for a session
+ */
+int32
+SessionGetResGroupGlobalShareMemUsage(SessionState *session)
+{
+	ResGroupSlotData	*sessionSlot = (ResGroupSlotData *)session->resGroupSlot;
+	if (sessionSlot)
+	{
+		/* lock not needed here, we just need esimated result */
+		ResGroupData	*group = sessionSlot->group;
+		return group->memSharedUsage - group->memSharedGranted;
+	}
+	else
+	{
+		/* session doesnot have group slot */
+		return 0;
+	}
 }

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -18,6 +18,7 @@
 
 #include "cdb/memquota.h"
 #include "catalog/pg_resgroup.h"
+#include "utils/session_state.h"
 
 /*
  * The max number of resource groups.
@@ -211,6 +212,10 @@ extern void CpusetDifference(char *cpuset1, const char *cpuset2, int len);
 extern bool CpusetIsEmpty(const char *cpuset);
 extern void SetCpusetEmpty(char *cpuset, int cpusetSize);
 extern bool EnsureCpusetIsAvailable(int elevel);
+extern bool IsGroupInRedZone(void);
+extern void ResGroupGetMemoryRunawayInfo(StringInfo str);
+extern Oid SessionGetResGroupId(SessionState *session);
+extern int32 SessionGetResGroupGlobalShareMemUsage(SessionState *session);
 
 #define LOG_RESGROUP_DEBUG(...) \
 	do {if (Debug_resource_group) elog(__VA_ARGS__); } while(false);

--- a/src/test/isolation2/init_file_resgroup
+++ b/src/test/isolation2/init_file_resgroup
@@ -1,5 +1,6 @@
 -- start_matchignore
 m/^CONTEXT:  SQL function ".+" statement \d+$/
+m/^ERROR:  Canceling query because of high VMEM .+/
 -- end_matchignore
 
 -- start_matchsubs

--- a/src/test/isolation2/input/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/enable_resgroup.source
@@ -47,6 +47,7 @@ $$;
 ! gpconfig -c gp_resource_manager -v group;
 ! gpconfig -c gp_resource_group_cpu_limit -v 0.9;
 ! gpconfig -c max_connections -v 250 -m 25;
+! gpconfig -c runaway_detector_activation_percent -v 100;
 ! gpstop -rai;
 -- end_ignore
 

--- a/src/test/isolation2/input/resgroup/resgroup_memory_runaway.source
+++ b/src/test/isolation2/input/resgroup/resgroup_memory_runaway.source
@@ -1,0 +1,139 @@
+-- start_ignore
+DROP ROLE IF EXISTS role1_memory_test;
+DROP RESOURCE GROUP rg1_memory_test;
+DROP RESOURCE GROUP rg2_memory_test;
+-- end_ignore
+
+CREATE OR REPLACE FUNCTION resGroupPalloc(float) RETURNS int AS
+'@abs_builddir@/../regress/regress@DLSUFFIX@', 'resGroupPalloc'
+LANGUAGE C READS SQL DATA;
+
+CREATE OR REPLACE FUNCTION hold_memory_by_percent(float) RETURNS int AS $$
+	SELECT * FROM resGroupPalloc($1)
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE VIEW rg_mem_status AS
+	SELECT groupname, memory_limit, memory_shared_quota
+	FROM gp_toolkit.gp_resgroup_config
+	WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test'
+	ORDER BY groupid;
+
+CREATE OR REPLACE VIEW memory_result AS SELECT rsgname, memory_usage from gp_toolkit.gp_resgroup_status;
+
+-- start_ignore
+! gpconfig -c runaway_detector_activation_percent -v 50;
+! gpstop -ari;
+-- end_ignore
+
+-- after the restart we need a new connection to run the queries
+--	1) single allocation
+--	Group Share Quota = 0
+--	Global Share Quota > 0
+--	Slot Quota > 0
+--	-----------------------
+
+--	we assume system total chunks is 100%
+--	rg1's expected: 100% * 20% => 20%
+--	rg1's slot quota: 20% / 2 * 2 => 20%
+--	rg1's single slot quota: 20% / 2 => 10%
+--	rg1's shared quota: 20% - 20% => %0
+--	system free chunks: 100% - 10% - 30% - 20% => 40%
+--  global area safe threshold: 40% / 2 = 20%
+1: CREATE RESOURCE GROUP rg1_memory_test
+    WITH (concurrency=2, cpu_rate_limit=10,
+          memory_limit=20, memory_shared_quota=0);
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+1: SELECT hold_memory_by_percent(1.0);
+1: SELECT hold_memory_by_percent(0.3);
+1: SELECT hold_memory_by_percent(0.3);
+1q:
+
+--	1b) on QEs
+2: SELECT pg_sleep(1);
+2: SET ROLE TO role1_memory_test;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+2q:
+
+0: DROP ROLE role1_memory_test;
+0: DROP RESOURCE GROUP rg1_memory_test;
+0q:
+
+
+--	we assume system total chunks is 100%
+--	rg1's expected: 100% * 20% => 20%
+--	rg1's slot quota: 20% / 2  => 10%
+--	rg1's single slot quota: 10% / 2 => 5%
+--	rg1's shared quota: %20 - %10 => %10
+--	system free chunks: 100% - 10% - 30% - 20% => 40%
+--  safe threshold: 40% / 2 = 20%
+1: CREATE RESOURCE GROUP rg1_memory_test
+    WITH (concurrency=2, cpu_rate_limit=10,
+          memory_limit=20, memory_shared_quota=50);
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+1: SELECT hold_memory_by_percent(1.0);
+1: SELECT hold_memory_by_percent(0.3);
+1: SELECT hold_memory_by_percent(0.3);
+1: SELECT hold_memory_by_percent(0.3);
+1q:
+
+--	1b) on QEs
+2: SELECT pg_sleep(1);
+2: SET ROLE TO role1_memory_test;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+2q:
+
+0: DROP ROLE role1_memory_test;
+0: DROP RESOURCE GROUP rg1_memory_test;
+0q:
+
+
+
+--	we assume system total chunks is 100%
+--	rg1's expected: 100% * 20% => 20%
+--	rg1's slot quota: 20% / 2  => 10%
+--	rg1's single slot quota: 10% / 2 => 5%
+--	rg1's shared quota: %20 - %10 => %10
+--	rg2's expected: 100% * 20% => 20%
+--	system free chunks: 100% - 10% - 30% - 20% - 20%=> 20%
+--  safe threshold: 20% / 2 = 10%
+1: CREATE RESOURCE GROUP rg1_memory_test
+    WITH (concurrency=2, cpu_rate_limit=10,
+          memory_limit=20, memory_shared_quota=50);
+1: CREATE RESOURCE GROUP rg2_memory_test
+    WITH (concurrency=2, cpu_rate_limit=10,
+          memory_limit=20, memory_shared_quota=0);
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+1: SELECT hold_memory_by_percent(1.0);
+1: SELECT hold_memory_by_percent(0.15);
+1: SELECT hold_memory_by_percent(0.15);
+1q:
+
+--	1b) on QEs
+2: SELECT pg_sleep(1);
+2: SET ROLE TO role1_memory_test;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.15)=0;
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.15)=0;
+2q:
+
+0: DROP ROLE role1_memory_test;
+0: DROP RESOURCE GROUP rg1_memory_test;
+0: DROP RESOURCE GROUP rg2_memory_test;
+0q:
+
+
+-- start_ignore
+! gpconfig -c runaway_detector_activation_percent -v 100;
+! gpstop -ari;
+-- end_ignore

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -17,6 +17,7 @@ test: resgroup/resgroup_bypass_memory_limit
 test: resgroup/resgroup_alter_concurrency
 test: resgroup/resgroup_memory_statistic
 test: resgroup/resgroup_memory_limit
+test: resgroup/resgroup_memory_runaway
 test: resgroup/resgroup_alter_memory
 test: resgroup/resgroup_cpu_rate_limit
 test: resgroup/resgroup_alter_memory_spill_ratio

--- a/src/test/isolation2/output/resgroup/resgroup_memory_runaway.source
+++ b/src/test/isolation2/output/resgroup/resgroup_memory_runaway.source
@@ -1,0 +1,259 @@
+-- start_ignore
+DROP ROLE IF EXISTS role1_memory_test;
+DROP
+DROP RESOURCE GROUP rg1_memory_test;
+ERROR:  resource group "rg1_memory_test" does not exist
+DROP RESOURCE GROUP rg2_memory_test;
+ERROR:  resource group "rg2_memory_test" does not exist
+-- end_ignore
+
+CREATE OR REPLACE FUNCTION resGroupPalloc(float) RETURNS int AS '@abs_builddir@/../regress/regress@DLSUFFIX@', 'resGroupPalloc' LANGUAGE C READS SQL DATA;
+CREATE
+
+CREATE OR REPLACE FUNCTION hold_memory_by_percent(float) RETURNS int AS $$ SELECT * FROM resGroupPalloc($1) $$ LANGUAGE sql;
+CREATE
+
+CREATE OR REPLACE VIEW rg_mem_status AS SELECT groupname, memory_limit, memory_shared_quota FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test' ORDER BY groupid;
+CREATE
+
+CREATE OR REPLACE VIEW memory_result AS SELECT rsgname, memory_usage from gp_toolkit.gp_resgroup_status;
+CREATE
+
+-- start_ignore
+! gpconfig -c runaway_detector_activation_percent -v 50;
+20191213:05:03:47:014263 gpconfig:hubert-gp-centos:huanzhang-[INFO]:-completed successfully with parameters '-c runaway_detector_activation_percent -v 50'
+
+! gpstop -ari;
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Starting gpstop with args: -ari
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Gathering information and validating the environment...
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Obtaining Greenplum Master catalog information
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Obtaining Segment details from master...
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5211.gf5c0dd1 build dev'
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Master segment instance directory=/home/huanzhang/workspace/gpdb7/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Attempting forceful termination of any leftover master process
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Terminating processes for segment /home/huanzhang/workspace/gpdb7/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Stopping master standby host hubert-gp-centos mode=immediate
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Successfully shutdown standby process on hubert-gp-centos
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20191213:05:03:48:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-0.00% of jobs completed
+20191213:05:03:49:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-100.00% of jobs completed
+20191213:05:03:49:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20191213:05:03:49:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-0.00% of jobs completed
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-100.00% of jobs completed
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-----------------------------------------------------
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-   Segments stopped successfully      = 6
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-   Segments with errors during stop   = 0
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-----------------------------------------------------
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Database successfully shutdown with no errors reported
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Cleaning up leftover gpmmon process
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-No leftover gpmmon process found
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Cleaning up leftover gpsmon processes
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Cleaning up leftover shared memory
+20191213:05:03:50:014419 gpstop:hubert-gp-centos:huanzhang-[INFO]:-Restarting System...
+
+-- end_ignore
+
+-- after the restart we need a new connection to run the queries
+--	1) single allocation
+--	Group Share Quota = 0
+--	Global Share Quota > 0
+--	Slot Quota > 0
+--	-----------------------
+
+--	we assume system total chunks is 100%
+--	rg1's expected: 100% * 20% => 20%
+--	rg1's slot quota: 20% / 2 * 2 => 20%
+--	rg1's single slot quota: 20% / 2 => 10%
+--	rg1's shared quota: 20% - 20% => %0
+--	system free chunks: 100% - 10% - 30% - 20% => 40%
+--  global area safe threshold: 40% / 2 = 20%
+1: CREATE RESOURCE GROUP rg1_memory_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=20, memory_shared_quota=0);
+CREATE
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+CREATE
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+SET
+1: SELECT hold_memory_by_percent(1.0);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.3);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.3);
+ERROR:  Canceling query because of high VMEM usage. current group id is 806868, group memory usage 218 MB, group shared memory quota is 0 MB, slot memory quota is 68 MB, global freechunks memory is 124 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)
+CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+1q: ... <quitting>
+
+--	1b) on QEs
+2: SELECT pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+2: SET ROLE TO role1_memory_test;
+SET
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+ERROR:  Canceling query because of high VMEM usage. current group id is 806868, group memory usage 218 MB, group shared memory quota is 0 MB, slot memory quota is 68 MB, global freechunks memory is 124 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)  (seg0 slice1 10.146.0.4:7002 pid=10883) (runaway_cleaner.c:197)
+CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+2q: ... <quitting>
+
+0: DROP ROLE role1_memory_test;
+DROP
+0: DROP RESOURCE GROUP rg1_memory_test;
+DROP
+0q: ... <quitting>
+
+
+--	we assume system total chunks is 100%
+--	rg1's expected: 100% * 20% => 20%
+--	rg1's slot quota: 20% / 2  => 10%
+--	rg1's single slot quota: 10% / 2 => 5%
+--	rg1's shared quota: %20 - %10 => %10
+--	system free chunks: 100% - 10% - 30% - 20% => 40%
+--  safe threshold: 40% / 2 = 20%
+1: CREATE RESOURCE GROUP rg1_memory_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=20, memory_shared_quota=50);
+CREATE
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+CREATE
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+SET
+1: SELECT hold_memory_by_percent(1.0);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.3);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.3);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.3);
+ERROR:  Canceling query because of high VMEM usage. current group id is 806877, group memory usage 259 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 117 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)
+CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+1q: ... <quitting>
+
+--	1b) on QEs
+2: SELECT pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+2: SET ROLE TO role1_memory_test;
+SET
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
+ERROR:  Canceling query because of high VMEM usage. current group id is 806877, group memory usage 259 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 117 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)  (seg0 slice1 10.146.0.4:7002 pid=10918) (runaway_cleaner.c:197)
+CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+2q: ... <quitting>
+
+0: DROP ROLE role1_memory_test;
+DROP
+0: DROP RESOURCE GROUP rg1_memory_test;
+DROP
+0q: ... <quitting>
+
+
+
+--	we assume system total chunks is 100%
+--	rg1's expected: 100% * 20% => 20%
+--	rg1's slot quota: 20% / 2  => 10%
+--	rg1's single slot quota: 10% / 2 => 5%
+--	rg1's shared quota: %20 - %10 => %10
+--	rg2's expected: 100% * 20% => 20%
+--	system free chunks: 100% - 10% - 30% - 20% - 20%=> 20%
+--  safe threshold: 20% / 2 = 10%
+1: CREATE RESOURCE GROUP rg1_memory_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=20, memory_shared_quota=50);
+CREATE
+1: CREATE RESOURCE GROUP rg2_memory_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=20, memory_shared_quota=0);
+CREATE
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+CREATE
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+SET
+1: SELECT hold_memory_by_percent(1.0);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.15);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.15);
+ERROR:  Canceling query because of high VMEM usage. current group id is 806886, group memory usage 178 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 62 MB, global safe memory threshold is 69 MB (runaway_cleaner.c:197)
+CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+1q: ... <quitting>
+
+--	1b) on QEs
+2: SELECT pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+2: SET ROLE TO role1_memory_test;
+SET
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.15)=0;
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.15)=0;
+ERROR:  Canceling query because of high VMEM usage. current group id is 806886, group memory usage 178 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 62 MB, global safe memory threshold is 69 MB (runaway_cleaner.c:197)  (seg0 slice1 10.146.0.4:7002 pid=10952) (runaway_cleaner.c:197)
+CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+2q: ... <quitting>
+
+0: DROP ROLE role1_memory_test;
+DROP
+0: DROP RESOURCE GROUP rg1_memory_test;
+DROP
+0: DROP RESOURCE GROUP rg2_memory_test;
+DROP
+0q: ... <quitting>
+
+


### PR DESCRIPTION
In resource queue, gpdb has runaway mechanism which kills the top memory
consumer query when the memory usage of the segment is in red zone.
We support similar mechanism in resource group mode as well.
Resource group has three level memory management:
1. slot level.
2. group shared level.
3. global shared level.
Query will fetch memory from lower level firstly, if lower level is used
up, then go to uppper level.
We set runaway on global shared level, which means if a query in a resource
group used up all the level1 and level2 memory and begin to consume level3
memory. If global shared memory usage reaches a red zone(e.g. 80% usage),
then we select a top consumer query to kill.

Note that if global shared memory is not set, runaway will not take effect.

Reviewed-by: Ning Yu <nyu@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
