### PR TITLE
No need to do oid synchronization for truncate.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1679,9 +1679,6 @@ ExecuteTruncate(TruncateStmt *stmt)
 	/*
 	 * OK, truncate each table.
 	 */
-	if (Gp_role == GP_ROLE_DISPATCH)
-		cdb_sync_oid_to_segments();
-
 	mySubid = GetCurrentSubTransactionId();
 
 	foreach(cell, rels)
@@ -1768,11 +1765,12 @@ ExecuteTruncate(TruncateStmt *stmt)
 	{
 		ListCell	*lc;
 
+		Assert(GetAssignedOidsForDispatch() == NIL);
 		CdbDispatchUtilityStatement((Node *) stmt,
 									DF_CANCEL_ON_ERROR |
 									DF_WITH_SNAPSHOT |
 									DF_NEED_TWO_PHASE,
-									GetAssignedOidsForDispatch(),
+									NIL,
 									NULL);
 
 		/* MPP-6929: metadata tracking */


### PR DESCRIPTION
We may introduce new relfilenodes (but no new oids) during truncate. Upstream
still uses oid code for relfilenode allocation, but gpdb has decouple oid and
relfilenode allocation in commit 1fd11387d2b9f250c14f0ccb893c0956b1bf1487, thus
we do not need worry about oid synchronization for truncate.