### PR TITLE
Revert unnessarry and/or confusing 2pc while dispatching set commands

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -265,7 +265,6 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 {
 	CdbDispatcherState *ds;
 	DispatchCommandQueryParms *pQueryParms;
-	Gang *primaryGang;
 	char	   *queryText;
 	int		queryTextLength;
 	ListCell   *le;
@@ -281,7 +280,7 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 
 	queryText = buildGpQueryString(pQueryParms, &queryTextLength);
 
-	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, cdbcomponent_getCdbComponentsList());
+	AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, cdbcomponent_getCdbComponentsList());
 
 	/* put all idle segment to a gang so QD can send SET command to them */
 	AllocateGang(ds, GANGTYPE_PRIMARY_READER, formIdleSegmentIdList());
@@ -295,8 +294,6 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 
 		cdbdisp_dispatchToGang(ds, rg, -1);
 	}
-	addToGxactTwophaseSegments(primaryGang);
-
 	/*
 	 * No need for two-phase commit, so no need to call
 	 * addToGxactTwophaseSegments.


### PR DESCRIPTION
Greenplum commit `b43629be3d` is optimising away the need for creating gangs
and/or have a two phase commit in some cases. Along with it, it introduced a call to
addToGxactTwophaseSegments() while dispatching a Set Command. To be fair, the
call will most probably not have altered the state. However a pre-existing comment, 
introduced by greenplum commit `9db306813428` was being explicit about the 
need to have a two phase commit in this case.

Undo the confusion.
