### PR TITLE
docs - update supported platform table for pxf v5.10.1

### DIFF
--- a/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
@@ -14,8 +14,7 @@ PXF bundles all of the Hadoop JAR files on which it depends, and supports the fo
 |-------------|----------------|---------------------|-------------|
 | 5.10 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
 | 5.9 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
-| 5.8.2 | 2.x | 1.x | 1.3.2 |
-| 5.8.1 | 2.x | 1.x | 1.3.2 |
+| 5.8 | 2.x | 1.x | 1.3.2 |
 
 ## <a id="arch"></a> Architectural Overview
 

--- a/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
@@ -12,6 +12,7 @@ PXF bundles all of the Hadoop JAR files on which it depends, and supports the fo
 
 | PXF Version | Hadoop Version | Hive Server Version | HBase Server Version |
 |-------------|----------------|---------------------|-------------|
+| 5.10.1 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
 | 5.10.0 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
 | 5.9.1 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
 | 5.9.0 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |

--- a/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
@@ -12,10 +12,8 @@ PXF bundles all of the Hadoop JAR files on which it depends, and supports the fo
 
 | PXF Version | Hadoop Version | Hive Server Version | HBase Server Version |
 |-------------|----------------|---------------------|-------------|
-| 5.10.1 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
-| 5.10.0 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
-| 5.9.1 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
-| 5.9.0 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
+| 5.10 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
+| 5.9 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
 | 5.8.2 | 2.x | 1.x | 1.3.2 |
 | 5.8.1 | 2.x | 1.x | 1.3.2 |
 


### PR DESCRIPTION
add an entry for pxf v5.10.1 to the table.

notes:  
- this info will move to the pxf release notes when pxf is released via its own tile or filegroup
- we could combine some of the table rows by using 5.8.x, 5.9.x, ....  but i wanted this table to contain a distinct row for every pxf release since greenplum 6.0 was released.  (i could be persuaded otherwise.)
