### PR TITLE
Fix possible build and install errors

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -28,7 +28,7 @@ installprograms: installdirs
 	done
 	# Symlink gpcheckcat from bin to bin/lib to maintain backward compatibility
 	if [ ! -L $(DESTDIR)$(bindir)/lib/gpcheckcat  ]; then \
-		$(LN_S) ../gpcheckcat $(DESTDIR)$(bindir)/lib/gpcheckcat; \
+		cd $(DESTDIR)$(bindir)/lib/ && $(LN_S) ../gpcheckcat gpcheckcat; \
 	fi
 	$(INSTALL_DATA) gpload.bat '$(DESTDIR)$(bindir)/gpload.bat'
 

--- a/gpMgmt/bin/stream/Makefile
+++ b/gpMgmt/bin/stream/Makefile
@@ -20,7 +20,7 @@ install: stream installdirs
 	$(INSTALL_PROGRAM) stream$(X) '$(DESTDIR)$(bindir)/lib/stream$(X)'
 	# Symlink bin/lib/stream to bin/stream to maintain backward compatibility
 	if [ ! -f $(DESTDIR)$(bindir)/stream/stream$(X) ] && [ ! -L $(DESTDIR)$(bindir)/stream/stream$(X) ]; then \
-		$(LN_S) ../lib/stream$(X) $(DESTDIR)$(bindir)/stream/stream$(X); \
+		cd $(DESTDIR)$(bindir)/stream/ && $(LN_S) ../lib/stream$(X) stream$(X); \
 	fi
 
 uninstall:

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -260,7 +260,7 @@ install-bin: postgres $(POSTGRES_IMP) installdirs
 	$(INSTALL_PROGRAM) postgres$(X) '$(DESTDIR)$(bindir)/postgres$(X)'
 ifneq ($(PORTNAME), win32)
 	@rm -f $(DESTDIR)$(bindir)/postmaster$(X)
-	ln -s postgres$(X) $(DESTDIR)$(bindir)/postmaster$(X)
+	$(LN_S) postgres$(X) $(DESTDIR)$(bindir)/postmaster$(X)
 else
 	$(INSTALL_PROGRAM) postgres$(X) '$(DESTDIR)$(bindir)/postmaster$(X)'
 endif

--- a/src/bin/pg_upgrade/Makefile
+++ b/src/bin/pg_upgrade/Makefile
@@ -44,7 +44,7 @@ clean distclean maintainer-clean:
 		   hostfile regression.diffs aomd_filehandler.c
 
 greenplum/aomd_filehandler.c: $(top_srcdir)/src/backend/access/appendonly/aomd_filehandler.c
-	rm -f $@ && $(LN_S) ../$< $@
+	rm -f $@ && cd greenplum && $(LN_S) ../$< aomd_filehandler.c
 
 check: test_gpdb.sh all
 	bash $< -C -r -s -o $(top_builddir)/gpAux/gpdemo/datadirs/ -b $(DESTDIR)$(bindir)


### PR DESCRIPTION
In most cases, the variable LN_S is 'ln -s', however, the LN_S can
be changed to 'cp -pR' if the configure finds the file system does
not support symbolic links. It would be incompatible when linking
a subdir path to a relative path.

cd to subdir first before linking a file.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
