### PR TITLE
Bugfix: rows might be split into wrong partitions

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17702,7 +17702,7 @@ split_rows(Relation intoa, Relation intob, Relation temprel)
 	ExprState *bchk = NULL;
 
 	/*
-	 * Set up for reconstructMatchingTupleSlot.  In split operation,
+	 * Set up for reconstructPartitionTupleSlot.  In split operation,
 	 * slot/tupdesc should look same between A and B, but here we don't
 	 * assume so just in case, to be safe.
 	 */
@@ -17807,19 +17807,31 @@ split_rows(Relation intoa, Relation intob, Relation temprel)
 				break;
 		}
 
-		/* prepare for ExecQual */
-		econtext->ecxt_scantuple = slotT;
+		/*
+		 * Map attributes from origin to target. We should consider dropped
+		 * columns in the origin.
+		 * 
+		 * ExecQual should use targetSlot rather than slotT in case possible 
+		 * partition key mapping.
+		 */
+		AssertImply(!PointerIsValid(achk), PointerIsValid(bchk));
+		targetSlot = reconstructPartitionTupleSlot(slotT, achk ? rria : rrib);
+		econtext->ecxt_scantuple = targetSlot;
 
 		/* determine if we are inserting into a or b */
 		if (achk)
 		{
 			targetIsA = ExecQual((List *)achk, econtext, false);
+
+			if (!targetIsA)
+				targetSlot = reconstructPartitionTupleSlot(slotT, rrib);
 		}
 		else
 		{
-			Assert(PointerIsValid(bchk));
-
 			targetIsA = !ExecQual((List *)bchk, econtext, false);
+
+			if (targetIsA)
+				targetSlot = reconstructPartitionTupleSlot(slotT, rria);
 		}
 
 		/* load variables for the specific target */
@@ -17837,12 +17849,6 @@ split_rows(Relation intoa, Relation intob, Relation temprel)
 			targetAOCSDescPtr = &aocsinsertdesc_b;
 			targetRelInfo = rrib;
 		}
-
-		/*
-		 * Map attributes from origin to target.  We should consider dropped
-		 * columns in the origin.
-		 */
-		targetSlot = reconstructPartitionTupleSlot(slotT, targetRelInfo);
 
 		/* insert into the target table */
 		if (RelationIsHeap(targetRelation))

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -2838,3 +2838,59 @@ reset session authorization;
 DROP TABLE part_expr_test_range;
 DROP TABLE part_expr_test_list;
 DROP ROLE part_expr_role;
+--
+-- Test handling of dropped columns in SPLIT PARTITION. (PR #9386)
+--
+DROP TABLE IF EXISTS users_test;
+NOTICE:  table "users_test" does not exist, skipping
+CREATE TABLE users_test
+(
+  id          INT,
+  dd          TEXT,
+  user_name   VARCHAR(40),
+  user_email  VARCHAR(60),
+  born_time   TIMESTAMP,
+  create_time TIMESTAMP
+)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (create_time)
+(
+  PARTITION p2019 START ('2019-01-01'::TIMESTAMP) END ('2020-01-01'::TIMESTAMP),
+  DEFAULT PARTITION extra
+);
+NOTICE:  CREATE TABLE will create partition "users_test_1_prt_extra" for table "users_test"
+NOTICE:  CREATE TABLE will create partition "users_test_1_prt_p2019" for table "users_test"
+-- Drop useless column dd for some reason
+ALTER TABLE users_test DROP COLUMN dd;
+-- Assume we forgot/failed to split out new partitions beforehand
+INSERT INTO users_test VALUES(1, 'A', 'A@abc.com', '1970-01-01', '2019-01-01 12:00:00');
+INSERT INTO users_test VALUES(2, 'B', 'B@abc.com', '1980-01-01', '2020-01-01 12:00:00');
+INSERT INTO users_test VALUES(3, 'C', 'C@abc.com', '1990-01-01', '2021-01-01 12:00:00');
+-- New partition arrives late
+ALTER TABLE users_test SPLIT DEFAULT PARTITION START ('2020-01-01'::TIMESTAMP) END ('2021-01-01'::TIMESTAMP)
+ INTO (PARTITION p2020, DEFAULT PARTITION);
+NOTICE:  exchanged partition "extra" of relation "users_test" with relation "pg_temp_114588"
+NOTICE:  dropped partition "extra" for relation "users_test"
+NOTICE:  CREATE TABLE will create partition "users_test_1_prt_p2020" for table "users_test"
+NOTICE:  CREATE TABLE will create partition "users_test_1_prt_extra" for table "users_test"
+-- Expect A
+SELECT user_name FROM users_test_1_prt_p2019;
+ user_name 
+-----------
+ A
+(1 row)
+
+-- Expect B
+SELECT user_name FROM users_test_1_prt_p2020;
+ user_name 
+-----------
+ B
+(1 row)
+
+-- Expect C
+SELECT user_name FROM users_test_1_prt_extra;
+ user_name 
+-----------
+ C
+(1 row)
+


### PR DESCRIPTION
This Bug has existed for a long time, since GP opened sources.

split_rows() scans tuples from T and route them to new parts (A, B) based
on A's or B's constraints. If T has one or more dropped columns before its
partition key, T's partition key would have a different attribute number
from its new parts. In this case, the constraints choose a wrong column
which can cause bad behaviors.

To fix it, each tuple iteration should reconstruct the partition tuple
slot and assign it to econtext before ExecQual calls. The reconstruction
process can happen once or twice because we assume A, B might have two
different tupdescs.

One bad behavior, rows are split into wrong partitions. Reproduce:

```sql
DROP TABLE IF EXISTS users_test;

CREATE TABLE users_test
(
  id INT,
  dd TEXT,
  user_name   VARCHAR(40),
  user_email  VARCHAR(60),
  born_time   TIMESTAMP,
  create_time TIMESTAMP
)
DISTRIBUTED BY (id)
PARTITION BY RANGE(create_time)
(
  PARTITION p2019 START ('2019-01-01'::TIMESTAMP) END ('2020-01-01'::TIMESTAMP),
  DEFAULT PARTITION extra
);

/* Drop useless column dd for some reason */
ALTER TABLE users_test DROP COLUMN dd;

/* Forgot/Failed to split out new partitions beforehand */
INSERT INTO users_test VALUES(1, 'A', 'A@abc.com', '1970-01-01', '2020-01-01 12:00:00');
INSERT INTO users_test VALUES(2, 'B', 'B@abc.com', '1980-01-01', '2020-01-02 18:00:00');
INSERT INTO users_test VALUES(3, 'C', 'C@abc.com', '1990-01-01', '2020-01-03 08:00:00');

/* New partition arrives late */
ALTER TABLE users_test SPLIT DEFAULT PARTITION START ('2020-01-01'::TIMESTAMP) END ('2021-01-01'::TIMESTAMP)
 INTO (PARTITION p2020, DEFAULT PARTITION);

/*
 * - How many new users already in 2020?
 * - Wow, no one.
 */
SELECT count(1) FROM users_test_1_prt_p2020;
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
