### PR TITLE
[upgrade] Adds header guards to some Greenplum headers

### DIFF
--- a/contrib/pg_upgrade/greenplum/greenplum_cluster_info.h
+++ b/contrib/pg_upgrade/greenplum/greenplum_cluster_info.h
@@ -1,3 +1,5 @@
+#ifndef GREENPLUM_GREENPLUM_CLUSTER_INFO_H
+#define GREENPLUM_GREENPLUM_CLUSTER_INFO_H
 /*
  *	greenplum/greenplum_cluster_info.h
  *
@@ -6,3 +8,5 @@
  */
 
 typedef struct GreenplumClusterInfoData GreenplumClusterInfo;
+
+#endif

--- a/contrib/pg_upgrade/greenplum/greenplum_cluster_info_internal.h
+++ b/contrib/pg_upgrade/greenplum/greenplum_cluster_info_internal.h
@@ -1,3 +1,5 @@
+#ifndef GREENPLUM_GREENPLUM_CLUSTER_INFO_INTERNAL_H
+#define GREENPLUM_GREENPLUM_CLUSTER_INFO_INTERNAL_H
 /*
  *	greenplum/greenplum_cluster_info_internal.h
  *
@@ -15,3 +17,5 @@ int get_gp_dbid(GreenplumClusterInfo *info);
 void set_gp_dbid(GreenplumClusterInfo *info, int gp_dbid);
 
 bool is_gp_dbid_set(GreenplumClusterInfo *info);
+
+#endif


### PR DESCRIPTION
This commit adds header guards to two unguarded headers, which fixes a
loud complaint from my compiler:

```
greenplum/greenplum_cluster_info_internal.h:9:10: note: 'greenplum/greenplum_cluster_info.h' included multiple times, additional include site here
#include "greenplum_cluster_info.h"
         ^
greenplum/greenplum_cluster_info.h:8:41: note: unguarded header; consider using #ifdef guards or #pragma once
```

Also fixed in this patch is the compiler warning about typedef redefinition

```
In file included from greenplum/option_gp.c:4:
In file included from greenplum/greenplum_cluster_info_internal.h:9:
greenplum/greenplum_cluster_info.h:8:41: warning: redefinition of typedef 'GreenplumClusterInfo' is a C11 feature [-Wtypedef-redefinition]
typedef struct GreenplumClusterInfoData GreenplumClusterInfo;
                                        ^
```

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
