### PR TITLE
Retire guc gp_session_role

### DIFF
--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -116,7 +116,7 @@ cleanDemo(){
 
     (export MASTER_DATA_DIRECTORY=$QDDIR/${SEG_PREFIX}-1;
      source ${GPHOME}/greenplum_path.sh;
-     gpstop -a)
+     gpstop -ai)
 
     ##
     ## Remove the files and directories created; allow test harnesses

--- a/gpAux/gpdemo/probe_config.sh
+++ b/gpAux/gpdemo/probe_config.sh
@@ -71,7 +71,7 @@ for ((i=PORT_MIN; i<PORT_MAX+1; i++)); do
             echo "----------------------------------------"
             echo "Table: gp_$table"
             echo "----------------------------------------"
-            PGOPTIONS="-c gp_session_role=utility" $GPPATH/psql --pset pager=off -p ${PORTS[$i]} -d template1 -c  "select * from gp_"$table
+            PGOPTIONS="-c gp_role=utility" $GPPATH/psql --pset pager=off -p ${PORTS[$i]} -d template1 -c  "select * from gp_"$table
             RETVAL=$?
             if [ $RETVAL -ne 0 ]; then
                 echo "$0 failed."
@@ -84,7 +84,7 @@ for ((i=PORT_MIN; i<PORT_MAX+1; i++)); do
             echo "----------------------------------------"
             echo "Table: gp_$table"
             echo "----------------------------------------"
-            PGOPTIONS="-c gp_session_role=utility" $GPPATH/psql --pset pager=off -p ${PORTS[$i]} -d template1 -c \
+            PGOPTIONS="-c gp_role=utility" $GPPATH/psql --pset pager=off -p ${PORTS[$i]} -d template1 -c \
                 "select * from gp_"$table
             RETVAL=$?
             if [ $RETVAL -ne 0 ]; then

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -315,7 +315,7 @@ def connect(user=None, password=None, host=None, port=None,
     # unset search path due to CVE-2018-1058
     options = '-c search_path='
     if utilityMode:
-        options += ' -c gp_session_role=utility'
+        options += ' -c gp_role=utility'
 
     if not user: user = GV.opt['-U']
     if not password: password = GV.opt['-P']
@@ -3189,7 +3189,7 @@ def checkSegmentRepair(maybeRemove, catmod_guc, seg):
     file.write('COMMIT;\n')
     file.close()
 
-    run_psql_script = '''{maybe}env PGOPTIONS="-c gp_session_role=utility {guc}" psql -X -a -h {hostname} -p {port} -f {fname} "{dbname}" > {fname}.out'''.format(
+    run_psql_script = '''{maybe}env PGOPTIONS="-c gp_role=utility {guc}" psql -X -a -h {hostname} -p {port} -f {fname} "{dbname}" > {fname}.out'''.format(
         maybe=maybeRemove, guc=catmod_guc,
         hostname=c['hostname'],
         port=c['port'],

--- a/gpMgmt/bin/gpcheckcat_modules/repair.py
+++ b/gpMgmt/bin/gpcheckcat_modules/repair.py
@@ -126,7 +126,7 @@ class Repair:
         psql_cmd = ""
 
         if segment['content'] != -1:
-            psql_cmd += 'PGOPTIONS=\'-c gp_session_role=utility\' '
+            psql_cmd += 'PGOPTIONS=\'-c gp_role=utility\' '
 
         psql_cmd += 'psql -X -v ON_ERROR_STOP=1 -a -h {hostname} -p {port} '.format(hostname=segment['hostname'], port=segment['port'])
 

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1321,11 +1321,11 @@ UPDATE_GPCONFIG () {
 		U_ROLE=$8
 
 		U_DB=$DEFAULTDB
-		CHK_COUNT=`env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -d "$U_DB" -X -A -t -c "SELECT count(*) FROM $GP_CONFIG_TBL WHERE content=${U_CONTENT} AND preferred_role='${U_ROLE}';" 2>/dev/null` >> $LOG_FILE 2>&1
+		CHK_COUNT=`env PGOPTIONS="-c gp_role=utility" $PSQL -p $MASTER_PORT -d "$U_DB" -X -A -t -c "SELECT count(*) FROM $GP_CONFIG_TBL WHERE content=${U_CONTENT} AND preferred_role='${U_ROLE}';" 2>/dev/null` >> $LOG_FILE 2>&1
 		ERROR_CHK $? "obtain psql count Master $GP_CONFIG_TBL" 2
 		if [ $CHK_COUNT -eq 0 ]; then
 				LOG_MSG "[INFO]:-Adding $U_CONTENT on $U_HOSTNAME, path $U_DIR to Master gp_segment_configuration"
-				env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -d "$U_DB" -c "SELECT pg_catalog.gp_add_segment(${U_DBID}::int2, ${U_CONTENT}::int2, '${U_ROLE}', '${U_ROLE}', 's', 'u', ${U_PORT}, '${U_HOSTNAME}', '${U_ADDRESS}', '${U_DIR}');" >> $LOG_FILE 2>&1
+				env PGOPTIONS="-c gp_role=utility" $PSQL -p $MASTER_PORT -d "$U_DB" -c "SELECT pg_catalog.gp_add_segment(${U_DBID}::int2, ${U_CONTENT}::int2, '${U_ROLE}', '${U_ROLE}', 's', 'u', ${U_PORT}, '${U_HOSTNAME}', '${U_ADDRESS}', '${U_DIR}');" >> $LOG_FILE 2>&1
 				ERROR_CHK $? "add $U_CONTENT on $U_HOSTNAME in dir $U_DIR to Master gp_segment_configuration" 2
 		else
 				LOG_MSG "[INFO]:-Content $U_CONTENT already exists in gp_segment_configuration system table"
@@ -1439,7 +1439,7 @@ REGISTER_MIRRORS () {
 		for I in "${QE_MIRROR_ARRAY[@]}"
 		do
 			SET_VAR $I
-			dbid=`env PGOPTIONS="-c gp_session_role=utility" $PSQL -p $MASTER_PORT -d "${DEFAULTDB}" -X -A -t -c "select pg_catalog.gp_add_segment_mirror(${GP_CONTENT}::int2, '${GP_HOSTNAME}', '${GP_HOSTADDRESS}', ${GP_PORT}, '${GP_DIR}');" 2>/dev/null` >> $LOG_FILE 2>&1
+			dbid=`env PGOPTIONS="-c gp_role=utility" $PSQL -p $MASTER_PORT -d "${DEFAULTDB}" -X -A -t -c "select pg_catalog.gp_add_segment_mirror(${GP_CONTENT}::int2, '${GP_HOSTNAME}', '${GP_HOSTADDRESS}', ${GP_PORT}, '${GP_DIR}');" 2>/dev/null` >> $LOG_FILE 2>&1
 			ERROR_CHK $? "failed to register mirror for contentid=${GP_CONTENT}" 2
 			MIRRORS_UPDATED_DBID=(${MIRRORS_UPDATED_DBID[@]} ${GP_HOSTADDRESS}~${GP_PORT}~${GP_DIR}~${dbid}~${GP_CONTENT})
 		done

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -144,20 +144,16 @@ class PgCtlBackendOptions(CmdArgs):
 
     >>> str(PgCtlBackendOptions(5432, 1, 2))
     '-p 5432 --silent-mode=true'
-    >>> str(PgCtlBackendOptions(5432, 1, 2).set_master(True))
-    '-p 5432 --silent-mode=true -i'
-    >>> str(PgCtlBackendOptions(5432, 1, 2).set_master(False))
-    '-p 5432 --silent-mode=true -i -E'
-    >>> str(PgCtlBackendOptions(5432, 1, 2).set_segment(1))
-    '-p 5432 --silent-mode=true -i'
+    >>> str(PgCtlBackendOptions(5432, 1, 2).set_master())
+    '-p 5432 --silent-mode=true -i -c gp_role=dispatch'
+    >>> str(PgCtlBackendOptions(5432, 1, 2).set_execute())
+    '-p 5432 --silent-mode=true -i -c gp_role=execute'
     >>> str(PgCtlBackendOptions(5432, 1, 2).set_special('upgrade'))
     '-p 5432 --silent-mode=true -U'
     >>> str(PgCtlBackendOptions(5432, 1, 2).set_special('maintenance'))
     '-p 5432 --silent-mode=true -m'
-    >>> str(PgCtlBackendOptions(5432, 1, 2).set_utility(True))
+    >>> str(PgCtlBackendOptions(5432, 1, 2).set_utility())
     '-p 5432 --silent-mode=true -c gp_role=utility'
-    >>> str(PgCtlBackendOptions(5432, 1, 2).set_utility(False))
-    '-p 5432 --silent-mode=true'
     >>> str(PgCtlBackendOptions(5432, 1, 2).set_restricted(True,1))
     '-p 5432 --silent-mode=true -c superuser_reserved_connections=1'
     >>>
@@ -176,11 +172,11 @@ class PgCtlBackendOptions(CmdArgs):
     # master/segment-specific options
     #
 
-    def set_master(self, is_utility_mode):
+    def set_master(self):
         """
         @param is_utility_mode: start with is_utility_mode?
         """
-        if not is_utility_mode: self.append("-E")
+        self.append("-c gp_role=dispatch")
         return self
 
     #
@@ -195,11 +191,18 @@ class PgCtlBackendOptions(CmdArgs):
         if opt: self.append(opt)
         return self
 
-    def set_utility(self, utility):
+    def set_utility(self):
         """
         @param utility: true if starting in utility mode
         """
-        if utility: self.append("-c gp_role=utility")
+        self.append("-c gp_role=utility")
+        return self
+
+    def set_execute(self):
+        """
+        @param utility: true if starting in utility mode
+        """
+        self.append("-c gp_role=execute")
         return self
 
     def set_restricted(self, restricted, max_connections):
@@ -293,13 +296,16 @@ class MasterStart(Command):
 
         # build backend options
         b = PgCtlBackendOptions(port)
-        b.set_master(is_utility_mode=utilityMode)
-        b.set_utility(utilityMode)
+        if utilityMode:
+            b.set_utility()
+        else:
+            b.set_master()
         b.set_special(specialMode)
         b.set_restricted(restrictedMode, max_connections)
 
         # build pg_ctl command
         c = PgCtlStartArgs(dataDir, b, era, wrapper, wrapper_args, wait, timeout)
+        logger.info("MasterStart pg_ctl cmd is %s", c);
         self.cmdStr = str(c)
 
         Command.__init__(self, name, self.cmdStr, ctxt, remoteHost)
@@ -348,11 +354,15 @@ class SegmentStart(Command):
 
         # build backend options
         b = PgCtlBackendOptions(port)
-        b.set_utility(utilityMode)
+        if utilityMode:
+            b.set_utility()
+        else:
+            b.set_execute()
         b.set_special(specialMode)
 
         # build pg_ctl command
         c = PgCtlStartArgs(datadir, b, era, wrapper, wrapper_args, pg_ctl_wait, timeout)
+        logger.info("SegmentStart pg_ctl cmd is %s", c);
         self.cmdStr = str(c) + ' 2>&1'
 
         Command.__init__(self, name, self.cmdStr, ctxt, remoteHost)
@@ -427,7 +437,7 @@ class SegmentRewind(Command):
         # Build the pg_rewind command. Do not run pg_rewind if recovery.conf
         # file exists in target data directory because the target instance can
         # be started up normally as a mirror for WAL replication catch up.
-        rewind_cmd = '[ -f %s/recovery.conf ] || PGOPTIONS="-c gp_session_role=utility" $GPHOME/bin/pg_rewind --write-recovery-conf --slot="internal_wal_replication_slot" --source-server="%s" --target-pgdata=%s' % (target_datadir, source_server, target_datadir)
+        rewind_cmd = '[ -f %s/recovery.conf ] || PGOPTIONS="-c gp_role=utility" $GPHOME/bin/pg_rewind --write-recovery-conf --slot="internal_wal_replication_slot" --source-server="%s" --target-pgdata=%s' % (target_datadir, source_server, target_datadir)
 
         if verbose:
             rewind_cmd = rewind_cmd + ' --progress'

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -192,16 +192,10 @@ class PgCtlBackendOptions(CmdArgs):
         return self
 
     def set_utility(self):
-        """
-        @param utility: true if starting in utility mode
-        """
         self.append("-c gp_role=utility")
         return self
 
     def set_execute(self):
-        """
-        @param utility: true if starting in utility mode
-        """
         self.append("-c gp_role=execute")
         return self
 

--- a/gpMgmt/bin/gppylib/db/dbconn.py
+++ b/gpMgmt/bin/gppylib/db/dbconn.py
@@ -158,7 +158,7 @@ def connect(dburl, utility=False, verbose=False,
             encoding=None, allowSystemTableMods=False, logConn=True, unsetSearchPath=True):
 
     if utility:
-        options = '-c gp_session_role=utility'
+        options = '-c gp_role=utility'
     else:
         options = ''
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_repair.py
@@ -68,10 +68,10 @@ class RepairTestCase(GpTestCase):
                     "cd $(dirname $0)\n",
                     "\n",
                     "echo \"some desc\"\n",
-                    "PGOPTIONS='-c gp_session_role=utility' psql -X -v ON_ERROR_STOP=1 -a -h somehost -p 25432 -c \"delete_sql\" \"somedb\" >> somedb_extra_timestamp.out 2>&1\n",
+                    "PGOPTIONS='-c gp_role=utility' psql -X -v ON_ERROR_STOP=1 -a -h somehost -p 25432 -c \"delete_sql\" \"somedb\" >> somedb_extra_timestamp.out 2>&1\n",
                     "\n",
                     "echo \"some desc\"\n",
-                    "PGOPTIONS='-c gp_session_role=utility' psql -X -v ON_ERROR_STOP=1 -a -h somehost -p 25433 -c \"delete_sql\" \"somedb\" >> somedb_extra_timestamp.out 2>&1\n",
+                    "PGOPTIONS='-c gp_role=utility' psql -X -v ON_ERROR_STOP=1 -a -h somehost -p 25433 -c \"delete_sql\" \"somedb\" >> somedb_extra_timestamp.out 2>&1\n",
                     "\n",
                     "echo \"some desc\"\n",
                     "psql -X -v ON_ERROR_STOP=1 -a -h somehost -p 15432 -c \"delete_sql\" \"somedb\" >> somedb_extra_timestamp.out 2>&1\n"]
@@ -96,13 +96,13 @@ class RepairTestCase(GpTestCase):
             "cd $(dirname $0)\n",
             "\n",
             "echo \"some desc\"\n",
-            "PGOPTIONS='-c gp_session_role=utility' psql -X -v ON_ERROR_STOP=1 -a -h somehost -p 25432 -f \"0.somehost.25432.somedb.timestamp.sql\" \"somedb\" >> somedb_orphan_toast_tables_timestamp.out 2>&1\n",
+            "PGOPTIONS='-c gp_role=utility' psql -X -v ON_ERROR_STOP=1 -a -h somehost -p 25432 -f \"0.somehost.25432.somedb.timestamp.sql\" \"somedb\" >> somedb_orphan_toast_tables_timestamp.out 2>&1\n",
             "\n",
             "echo \"some desc\"\n",
-            "PGOPTIONS='-c gp_session_role=utility' psql -X -v ON_ERROR_STOP=1 -a -h somehost -p 25433 -f \"1.somehost.25433.somedb.timestamp.sql\" \"somedb\" >> somedb_orphan_toast_tables_timestamp.out 2>&1\n",
+            "PGOPTIONS='-c gp_role=utility' psql -X -v ON_ERROR_STOP=1 -a -h somehost -p 25433 -f \"1.somehost.25433.somedb.timestamp.sql\" \"somedb\" >> somedb_orphan_toast_tables_timestamp.out 2>&1\n",
             "\n",
             "echo \"some desc\"\n",
-            "PGOPTIONS='-c gp_session_role=utility' psql -X -v ON_ERROR_STOP=1 -a -h somehost -p 25434 -f \"2.somehost.25434.somedb.timestamp.sql\" \"somedb\" >> somedb_orphan_toast_tables_timestamp.out 2>&1\n"]
+            "PGOPTIONS='-c gp_role=utility' psql -X -v ON_ERROR_STOP=1 -a -h somehost -p 25434 -f \"2.somehost.25434.somedb.timestamp.sql\" \"somedb\" >> somedb_orphan_toast_tables_timestamp.out 2>&1\n"]
 
         self.verify_repair_dir_contents("runsql_timestamp.sh", bash_contents)
 

--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -18,7 +18,7 @@ gpsd_version = '%prog 1.0'
 sysnslist = "('pg_toast', 'pg_bitmapindex', 'pg_temp_1', 'pg_catalog', 'information_schema')"
 orca = False
 # unset search path due to CVE-2018-1058
-pgoptions = '-c gp_session_role=utility -c search_path='
+pgoptions = '-c gp_role=utility -c search_path='
 
 
 def ResultIter(cursor, arraysize=1000):

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -252,7 +252,7 @@ CREATE_QES_MIRROR () {
 START_QE() {
 	LOG_MSG "[INFO][$INST_COUNT]:-Starting Functioning instance on segment ${GP_HOSTADDRESS}"
 	PG_CTL_WAIT=$1
-	$TRUSTED_SHELL ${GP_HOSTADDRESS} "$EXPORT_LIB_PATH;export PGPORT=${GP_PORT}; $PG_CTL $PG_CTL_WAIT -l $GP_DIR/pg_log/startup.log -D $GP_DIR -o \"-i -p ${GP_PORT}\" start" >> $LOG_FILE 2>&1
+	$TRUSTED_SHELL ${GP_HOSTADDRESS} "$EXPORT_LIB_PATH;export PGPORT=${GP_PORT}; $PG_CTL $PG_CTL_WAIT -l $GP_DIR/pg_log/startup.log -D $GP_DIR -o \"-p ${GP_PORT} -c gp_role=execute\" start" >> $LOG_FILE 2>&1
 	RETVAL=$?
 	if [ $RETVAL -ne 0 ]; then
 		BACKOUT_COMMAND "$TRUSTED_SHELL $GP_HOSTADDRESS \"${EXPORT_LIB_PATH};export PGPORT=${GP_PORT}; $PG_CTL -w -D $GP_DIR -o \"-i -p ${GP_PORT}\" -m immediate  stop\""

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -69,7 +69,7 @@ PATH_PREFIX = '/tmp/'
 PGDUMP_FILE = 'pg_dump_out.sql'
 sysnslist = "('pg_toast', 'pg_bitmapindex', 'pg_catalog', 'information_schema', 'gp_toolkit')"
 # unset search path due to CVE-2018-1058
-pgoptions = '-c gp_session_role=utility -c search_path='
+pgoptions = '-c gp_role=utility -c search_path='
 
 class MRQuery(object):
     def __init__(self):

--- a/gpMgmt/doc/gpstart_help
+++ b/gpMgmt/doc/gpstart_help
@@ -71,7 +71,7 @@ OPTIONS
   for maintenance tasks. This mode only allows connections to the master 
   in utility mode. For example:
 
-  PGOPTIONS='-c gp_session_role=utility' psql
+  PGOPTIONS='-c gp_role=utility' psql
 
   Note that starting the system in master-only mode is only advisable
   under supervision of Greenplum support.  Improper use of this option
@@ -140,7 +140,7 @@ Start the Greenplum master instance only and connect in utility mode:
 
 gpstart -m
 
-PGOPTIONS='-c gp_session_role=utility' psql
+PGOPTIONS='-c gp_role=utility' psql
 
 
 Display the online help for the gpstart utility:

--- a/gpMgmt/test/behave/mgmt_utils/steps/cross_subnet.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/cross_subnet.py
@@ -124,7 +124,7 @@ def impl(context, segment):
         #     https://www.postgresql.org/docs/9.4/protocol-replication.html
         subprocess.check_call([
             'ssh', '-n', mirror_hostname,
-            'PGOPTIONS="-c gp_session_role=utility"',
+            'PGOPTIONS="-c gp_role=utility"',
             '{gphome}/bin/psql -h {host} -p {port} "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"'.format(
                 gphome=os.environ['GPHOME'],
                 host=primary.address, # use the "internal" routing address

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1605,7 +1605,7 @@ def impl(context, table, dbname, segid):
     source_file = os.path.join(os.environ.get('GPHOME'), 'greenplum_path.sh')
     # Yes, the below line is ugly.  It looks much uglier when done with separate strings, given the multiple levels of escaping required.
     remote_cmd = """
-ssh %s "source %s; export PGUSER=%s; export PGPORT=%s; export PGOPTIONS=\\\"-c gp_session_role=utility\\\"; psql -d %s -c \\\"SET allow_system_table_mods=true; DELETE FROM pg_attribute where attrelid=\'%s\'::regclass::oid;\\\""
+ssh %s "source %s; export PGUSER=%s; export PGPORT=%s; export PGOPTIONS=\\\"-c gp_role=utility\\\"; psql -d %s -c \\\"SET allow_system_table_mods=true; DELETE FROM pg_attribute where attrelid=\'%s\'::regclass::oid;\\\""
 """ % (host, source_file, user, port, dbname, table)
     run_command(context, remote_cmd.strip())
 
@@ -1615,7 +1615,7 @@ ssh %s "source %s; export PGUSER=%s; export PGPORT=%s; export PGOPTIONS=\\\"-c g
 @given('The user runs sql "{query}" in "{dbname}" on first primary segment')
 def impl(context, query, dbname):
     host, port = get_primary_segment_host_port()
-    psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_session_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
+    psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
     dbname, host, port, query)
     Command(name='Running Remote command: %s' % psql_cmd, cmdStr=psql_cmd).run(validateAfter=True)
 
@@ -1629,7 +1629,7 @@ def impl(context, query, dbname):
         host = seg.getSegmentHostName()
         if seg.isSegmentPrimary() or seg.isSegmentMaster():
             port = seg.getSegmentPort()
-            psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_session_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
+            psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
             dbname, host, port, query)
             Command(name='Running Remote command: %s' % psql_cmd, cmdStr=psql_cmd).run(validateAfter=True)
 
@@ -1646,7 +1646,7 @@ def impl(context, file, dbname):
         host = seg.getSegmentHostName()
         if seg.isSegmentPrimary() or seg.isSegmentMaster():
             port = seg.getSegmentPort()
-            psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_session_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
+            psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
             dbname, host, port, query)
             Command(name='Running Remote command: %s' % psql_cmd, cmdStr=psql_cmd).run(validateAfter=True)
 
@@ -1654,7 +1654,7 @@ def impl(context, file, dbname):
 @when('The user runs sql "{query}" in "{dbname}" on specified segment {host}:{port} in utility mode')
 @given('The user runs sql "{query}" in "{dbname}" on specified segment {host}:{port} in utility mode')
 def impl(context, query, dbname, host, port):
-    psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_session_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
+    psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
     dbname, host, port, query)
     cmd = Command(name='Running Remote command: %s' % psql_cmd, cmdStr=psql_cmd)
     cmd.run(validateAfter=True)
@@ -1665,7 +1665,7 @@ def impl(context, query, dbname, host, port):
 @given('table {table_name} exists in "{dbname}" on specified segment {host}:{port}')
 def impl(context, table_name, dbname, host, port):
     query = "SELECT COUNT(*) FROM pg_class WHERE relname = '%s'" % table_name
-    psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_session_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
+    psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
     dbname, host, port, query)
     cmd = Command(name='Running Remote command: %s' % psql_cmd, cmdStr=psql_cmd)
     cmd.run(validateAfter=True)

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -71,7 +71,7 @@ def impl(context, seg):
 
 @then('the saved primary segment reports the same value for sql "{sql_cmd}" db "{dbname}" as was saved')
 def impl(context, sql_cmd, dbname):
-    psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_session_role=utility\' psql -t -h %s -p %s -c \"%s\"; " % (
+    psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_role=utility\' psql -t -h %s -p %s -c \"%s\"; " % (
         dbname, context.remote_pair_primary_host, context.remote_pair_primary_port, sql_cmd)
     cmd = Command(name='Running Remote command: %s' % psql_cmd, cmdStr = psql_cmd)
     cmd.run(validateAfter=True)
@@ -103,7 +103,7 @@ def runCommandOnRemoteSegment(context, cid, sql_cmd):
     port, host = context.stdout_message.split("|")
     port = port.strip()
     host = host.strip()
-    psql_cmd = "PGDATABASE=\'template1\' PGOPTIONS=\'-c gp_session_role=utility\' psql -h %s -p %s -c \"%s\"; " % (host, port, sql_cmd)
+    psql_cmd = "PGDATABASE=\'template1\' PGOPTIONS=\'-c gp_role=utility\' psql -h %s -p %s -c \"%s\"; " % (host, port, sql_cmd)
     Command(name='Running Remote command: %s' % psql_cmd, cmdStr = psql_cmd).run(validateAfter=True)
 
 @then('gprecoverseg should print "{output}" to stdout for each mirror')

--- a/gpcontrib/gp_inject_fault/gp_inject_fault.c
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault.c
@@ -22,7 +22,8 @@ void _PG_init(void);
 static void
 fts_with_panic_warning(FaultInjectorEntry_s faultEntry)
 {
-	if (Gp_role == GP_ROLE_DISPATCH && !FtsIsActive()) return;
+	if (Gp_role == GP_ROLE_DISPATCH && !FtsIsActive())
+		return;
 
 	if (faultEntry.faultInjectorType == FaultInjectorTypePanic)
 		ereport(WARNING, (

--- a/gpcontrib/gp_internal_tools/README
+++ b/gpcontrib/gp_internal_tools/README
@@ -171,7 +171,7 @@ The "gp_ao_co_diagnostics" shared library contains nine functions.
 
   3. Connect to the segment you wish to evaluate.
 
-       PGOPTIONS=' -c gp_session_role=utility ' psql
+       PGOPTIONS=' -c gp_role=utility ' psql
 
 
   4. Get the Oid of the table you are interested in.

--- a/gpcontrib/gp_replica_check/gp_replica_check.py
+++ b/gpcontrib/gp_replica_check/gp_replica_check.py
@@ -59,7 +59,7 @@ Mirror Data Directory Location: %s' % (self.getName(), self.host, self.port, sel
                                           self.ploc, self.mloc)
 
     def run(self):
-        cmd = '''PGOPTIONS='-c gp_session_role=utility' psql -h %s -p %s -c "select * from gp_replica_check('%s', '%s', '%s')" %s''' % (self.host, self.port,
+        cmd = '''PGOPTIONS='-c gp_role=utility' psql -h %s -p %s -c "select * from gp_replica_check('%s', '%s', '%s')" %s''' % (self.host, self.port,
                                                                                                                                         self.ploc, self.mloc,
                                                                                                                                         self.relation_types,
                                                                                                                                         pipes.quote(self.datname))

--- a/gpdb-doc/dita/admin_guide/managing/startstop.xml
+++ b/gpdb-doc/dita/admin_guide/managing/startstop.xml
@@ -101,7 +101,7 @@
           <cmd>Connect to the master in maintenance mode to do catalog maintenance. For
             example:</cmd>
           <stepxmp>
-            <codeblock id="kg155401">$ PGOPTIONS='-c gp_session_role=utility' psql postgres</codeblock>
+            <codeblock id="kg155401">$ PGOPTIONS='-c gp_role=utility' psql postgres</codeblock>
           </stepxmp>
         </step>
         <step>

--- a/gpdb-doc/dita/utility_guide/ref/gpstart.xml
+++ b/gpdb-doc/dita/utility_guide/ref/gpstart.xml
@@ -92,7 +92,7 @@ Continue only if you are certain that the standby is not acting as the master.</
                         maintenance tasks. This mode only allows connections to the master in
                         utility mode. For example:</pd>
                     <pd>
-                        <codeblock>PGOPTIONS='-c gp_session_role=utility' psql</codeblock>
+                        <codeblock>PGOPTIONS='-c gp_role=utility' psql</codeblock>
                     </pd>
                     <pd>The consistency of the heap checksum setting on master and segment instances
                         is not checked.</pd>
@@ -155,7 +155,7 @@ Continue only if you are certain that the standby is not acting as the master.</
                 connections):</p>
             <codeblock>gpstart -R</codeblock>
             <p>Start the Greenplum master instance only and connect in utility mode:</p>
-            <codeblock>gpstart -m PGOPTIONS='-c gp_session_role=utility' psql</codeblock>
+            <codeblock>gpstart -m PGOPTIONS='-c gp_role=utility' psql</codeblock>
         </section>
         <section id="section6">
             <title>See Also</title>

--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -618,11 +618,7 @@ redoDistributedForgetCommitRecord(TMGXACT_LOG *gxact_log)
 bool
 DtxRecoveryStartRule(Datum main_arg)
 {
-	/* only start dtx recovery in dispatch mode */
-	if (IsUnderMasterDispatchMode())
-		return true;
-
-	return false;
+	return (Gp_role == GP_ROLE_DISPATCH);
 }
 
 /*

--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -54,7 +54,7 @@ FtsShmemSize(void)
 {
 	RequestNamedLWLockTranche("ftsControlLock", 1);
 
-	return MAXALIGN(sizeof(FtsControlBlock) + sizeof(*shmFtsProbePID));
+	return MAXALIGN(sizeof(FtsControlBlock));
 }
 
 void
@@ -70,6 +70,8 @@ FtsShmemInit(void)
 	/* Initialize locks and shared memory area */
 	ftsControlLock = shared->ControlLock;
 	ftsProbeInfo = &shared->fts_probe_info;
+	shmFtsProbePID = &shared->fts_probe_pid;
+	*shmFtsProbePID = 0;
 
 	if (!IsUnderPostmaster)
 	{
@@ -78,9 +80,6 @@ FtsShmemInit(void)
 
 		shared->fts_probe_info.status_version = 0;
 	}
-
-	shmFtsProbePID = (volatile pid_t*) ShmemAlloc(sizeof(*shmFtsProbePID));
-	*shmFtsProbePID = 0;
 }
 
 void

--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -44,7 +44,7 @@
 volatile FtsProbeInfo *ftsProbeInfo = NULL;	/* Probe process updates this structure */
 static LWLockId ftsControlLock;
 
-extern volatile bool *pm_launch_walreceiver;
+extern volatile pid_t *shmFtsProbePID;
 
 /*
  * get fts share memory size
@@ -54,13 +54,7 @@ FtsShmemSize(void)
 {
 	RequestNamedLWLockTranche("ftsControlLock", 1);
 
-	/*
-	 * this shared memory block doesn't even need to *exist* on the QEs!
-	 */
-	if ((Gp_role != GP_ROLE_DISPATCH) && (Gp_role != GP_ROLE_UTILITY))
-		return 0;
-
-	return MAXALIGN(sizeof(FtsControlBlock));
+	return MAXALIGN(sizeof(FtsControlBlock) + sizeof(*shmFtsProbePID));
 }
 
 void
@@ -69,14 +63,13 @@ FtsShmemInit(void)
 	bool		found;
 	FtsControlBlock *shared;
 
-	shared = (FtsControlBlock *) ShmemInitStruct("Fault Tolerance manager", FtsShmemSize(), &found);
+	shared = (FtsControlBlock *) ShmemInitStruct("Fault Tolerance manager", sizeof(FtsControlBlock), &found);
 	if (!shared)
 		elog(FATAL, "FTS: could not initialize fault tolerance manager share memory");
 
 	/* Initialize locks and shared memory area */
 	ftsControlLock = shared->ControlLock;
 	ftsProbeInfo = &shared->fts_probe_info;
-	pm_launch_walreceiver = &shared->pm_launch_walreceiver;
 
 	if (!IsUnderPostmaster)
 	{
@@ -84,8 +77,10 @@ FtsShmemInit(void)
 		ftsControlLock = shared->ControlLock;
 
 		shared->fts_probe_info.status_version = 0;
-		shared->pm_launch_walreceiver = false;
 	}
+
+	shmFtsProbePID = (volatile pid_t*) ShmemAlloc(sizeof(*shmFtsProbePID));
+	*shmFtsProbePID = 0;
 }
 
 void

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -325,13 +325,8 @@ rel_partition_key_attrs(Oid relid)
 	HeapTuple	tuple;
 	List	   *pkeys = NIL;
 
-	/*
-	 * Table pg_partition is only populated on the entry database, however, we
-	 * disable calls from outside dispatch to foil use of utility mode.  (Full
-	 * UCS may may this test obsolete.)
-	 */
-	if (Gp_session_role != GP_ROLE_DISPATCH)
-		elog(ERROR, "mode not dispatch");
+	if (!IS_QUERY_DISPATCHER())
+		elog(ERROR, "pg_partition is only accessible on entry database");
 
 	rel = heap_open(PartitionRelationId, AccessShareLock);
 

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -985,11 +985,7 @@ rollbackDtxTransaction(void)
 int
 tmShmemSize(void)
 {
-	if ((Gp_role != GP_ROLE_DISPATCH) && (Gp_role != GP_ROLE_UTILITY))
-		return 0;
-
-	return
-		MAXALIGN(TMCONTROLBLOCK_BYTES(max_tm_gxacts));
+	return MAXALIGN(TMCONTROLBLOCK_BYTES(max_tm_gxacts));
 }
 
 
@@ -1010,9 +1006,6 @@ tmShmemInit(void)
 	 * to the number of prepared.
 	 */
 	max_tm_gxacts = max_prepared_xacts;
-
-	if ((Gp_role != GP_ROLE_DISPATCH) && (Gp_role != GP_ROLE_UTILITY))
-		return;
 
 	shared = (TmControlBlock *) ShmemInitStruct("Transaction manager", tmShmemSize(), &found);
 	if (!shared)

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1060,7 +1060,6 @@ cdb_setup(void)
 {
 	elog(DEBUG1, "Initializing Greenplum components...");
 
-	/* If gp_role is UTILITY, skip this call. */
 	if (Gp_role != GP_ROLE_UTILITY)
 	{
 		ensureInterconnectAddress();

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -150,7 +150,9 @@ cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 	/*
 	 * For entry DB connection, we make sure both "hostaddr" and "host" are
 	 * empty string. Or else, it will fall back to environment variables and
-	 * won't use domain socket in function connectDBStart.
+	 * won't use domain socket in function connectDBStart. Also we set the
+	 * connection type for entrydb connection so that QE could change Gp_role
+	 * from DISPATCH to EXECUTE.
 	 *
 	 * For other QE connections, we set "hostaddr". "host" is not used.
 	 */

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -445,9 +445,6 @@ cdbgang_parse_gpqeid_params(struct Port *port pg_attribute_unused(),
 	char	   *cp;
 	char	   *np = gpqeid;
 
-	/* The presence of an gpqeid string means this backend is a qExec. */
-	SetConfigOption("gp_session_role", "execute", PGC_POSTMASTER, PGC_S_OVERRIDE);
-
 	/* gp_session_id */
 	if (gpqeid_next_param(&cp, &np))
 		SetConfigOption("gp_session_id", cp, PGC_POSTMASTER, PGC_S_OVERRIDE);

--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -277,7 +277,7 @@ InstrShmemSize(void)
 	Size		number_slots;
 
 	/* If start in utility mode, disallow Instrumentation on Shmem */
-	if (Gp_session_role == GP_ROLE_UTILITY)
+	if (Gp_role == GP_ROLE_UTILITY)
 		return size;
 
 	/* If GUCs not enabled, bypass Instrumentation on Shmem */
@@ -369,7 +369,7 @@ static bool
 shouldPickInstrInShmem(NodeTag tag)
 {
 	/* For utility mode, don't alloc in shmem */
-	if (Gp_session_role == GP_ROLE_UTILITY)
+	if (Gp_role == GP_ROLE_UTILITY)
 		return false;
 
 	if (!gp_enable_query_metrics || NULL == InstrumentGlobal)

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -54,7 +54,7 @@ bool am_ftshandler = false;
 /*
  * STATIC VARIABLES
  */
-static volatile pid_t *shmFtsProbePID;
+volatile pid_t *shmFtsProbePID = NULL;
 static bool skip_fts_probe = false;
 
 static volatile bool probe_requested = false;
@@ -90,16 +90,6 @@ sigIntHandler(SIGNAL_ARGS)
 		SetLatch(MyLatch);
 }
 
-void
-FtsProbeShmemInit(void)
-{
-	if (IsUnderPostmaster)
-		return;
-
-	shmFtsProbePID = (volatile pid_t*)ShmemAlloc(sizeof(*shmFtsProbePID));
-	*shmFtsProbePID = 0;
-}
-
 pid_t
 FtsProbePID(void)
 {
@@ -109,11 +99,7 @@ FtsProbePID(void)
 bool
 FtsProbeStartRule(Datum main_arg)
 {
-	/* we only start fts probe on master when -E is specified */
-	if (IsUnderMasterDispatchMode())
-		return true;
-
-	return false;
+	return (Gp_role == GP_ROLE_DISPATCH);
 }
 
 /*

--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -266,7 +266,7 @@ SysLoggerMain(int argc, char *argv[])
 
 	am_syslogger = true;
 
-	if (IsUnderMasterDispatchMode())
+	if (Gp_role == GP_ROLE_DISPATCH)
 		init_ps_display("master logger process", "", "", "");
 	else
 		init_ps_display("logger process", "", "", "");
@@ -1331,7 +1331,7 @@ fillinErrorDataFromSegvChunk(GpErrorData *errorData, PipeProtoChunk *chunk)
 	Assert(signalName != NULL);
 	snprintf(errorData->error_message, ERROR_MESSAGE_MAX_SIZE,
 			 "Unexpected internal error: %s received signal %s",
-			 IsUnderMasterDispatchMode() ? "Master process" : "Segment process",
+			 Gp_role == GP_ROLE_DISPATCH ? "Master process" : "Segment process",
 			 signalName);
 	
 	errorData->error_detail = NULL;

--- a/src/backend/replication/walreceiverfuncs.c
+++ b/src/backend/replication/walreceiverfuncs.c
@@ -33,6 +33,8 @@
 
 WalRcvData *WalRcv = NULL;
 
+extern volatile bool *pm_launch_walreceiver;
+
 /*
  * How long to wait for walreceiver to start up after requesting
  * postmaster to launch it. In seconds.
@@ -46,6 +48,7 @@ WalRcvShmemSize(void)
 	Size		size = 0;
 
 	size = add_size(size, sizeof(WalRcvData));
+	size = add_size(size, sizeof(*pm_launch_walreceiver));
 
 	return size;
 }
@@ -58,6 +61,7 @@ WalRcvShmemInit(void)
 
 	WalRcv = (WalRcvData *)
 		ShmemInitStruct("Wal Receiver Ctl", WalRcvShmemSize(), &found);
+	pm_launch_walreceiver = (bool *) (WalRcv + 1);
 
 	if (!found)
 	{
@@ -66,6 +70,8 @@ WalRcvShmemInit(void)
 		WalRcv->walRcvState = WALRCV_STOPPED;
 		SpinLockInit(&WalRcv->mutex);
 		InitSharedLatch(&WalRcv->latch);
+
+		*pm_launch_walreceiver = false;
 	}
 }
 

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -149,7 +149,8 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 		else if (IsResGroupEnabled())
 			size = add_size(size, ResGroupShmemSize());
 		size = add_size(size, SharedSnapshotShmemSize());
-		size = add_size(size, FtsShmemSize());
+		if (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_UTILITY)
+			size = add_size(size, FtsShmemSize());
 
 		size = add_size(size, ProcGlobalShmemSize());
 		size = add_size(size, XLOGShmemSize());
@@ -268,8 +269,9 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 	CommitTsShmemInit();
 	SUBTRANSShmemInit();
 	MultiXactShmemInit();
-    FtsShmemInit();
-    tmShmemInit();
+	if (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_UTILITY)
+		FtsShmemInit();
+	tmShmemInit();
 	InitBufferPool();
 
 	/*
@@ -352,8 +354,6 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 		InstrShmemInit();
 
 	GpExpandVersionShmemInit();
-
-	FtsProbeShmemInit();
 
 #ifdef EXEC_BACKEND
 

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -270,10 +270,8 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 	SUBTRANSShmemInit();
 	MultiXactShmemInit();
 	if (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_UTILITY)
-	{
 		FtsShmemInit();
-		tmShmemInit();
-	}
+	tmShmemInit();
 	InitBufferPool();
 
 	/*

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -270,8 +270,10 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 	SUBTRANSShmemInit();
 	MultiXactShmemInit();
 	if (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_UTILITY)
+	{
 		FtsShmemInit();
-	tmShmemInit();
+		tmShmemInit();
+	}
 	InitBufferPool();
 
 	/*

--- a/src/backend/storage/ipc/shmem.c
+++ b/src/backend/storage/ipc/shmem.c
@@ -195,7 +195,7 @@ ShmemAlloc(Size size)
 	void	   *newSpace;
 
 	/*
-	 * Beter to return NULL for this else caller could still use memory that
+	 * Better to return NULL for this else caller could still use memory that
 	 * does not belong to it.
 	 */
 	if (size == 0)

--- a/src/backend/storage/ipc/shmem.c
+++ b/src/backend/storage/ipc/shmem.c
@@ -195,6 +195,13 @@ ShmemAlloc(Size size)
 	void	   *newSpace;
 
 	/*
+	 * Beter to return NULL for this else caller could still use memory that
+	 * does not belong to it.
+	 */
+	if (size == 0)
+		return NULL;
+
+	/*
 	 * Ensure all space is adequately aligned.  We used to only MAXALIGN this
 	 * space but experience has proved that on modern systems that is not good
 	 * enough.  Many parts of the system are very sensitive to critical data

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -848,7 +848,7 @@ LockAcquireExtended(const LOCKTAG *locktag,
 	
 	if (lockmethodid == DEFAULT_LOCKMETHOD && locktag->locktag_type != LOCKTAG_TRANSACTION)
 	{
-		if (Gp_role == GP_ROLE_EXECUTE && !Gp_is_writer && gp_session_id >= 0)
+		if (IS_QUERY_EXECUTOR_BACKEND() && !Gp_is_writer)
 		{	
 			if (lockHolderProcPtr == MyProc)
 			{
@@ -1135,7 +1135,7 @@ LockAcquireExtended(const LOCKTAG *locktag,
 			return LOCKACQUIRE_NOT_AVAIL;
 		}
 
-		if (Gp_role == GP_ROLE_EXECUTE && gp_session_id >= 0)
+		if (IS_QUERY_EXECUTOR_BACKEND())
 		{
 			if (!Gp_is_writer)
 				elog(LOG,"Reader gang member waiting on a lock [%u,%u] %s",

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -848,9 +848,9 @@ LockAcquireExtended(const LOCKTAG *locktag,
 	
 	if (lockmethodid == DEFAULT_LOCKMETHOD && locktag->locktag_type != LOCKTAG_TRANSACTION)
 	{
-		if (Gp_role == GP_ROLE_EXECUTE && !Gp_is_writer)
+		if (Gp_role == GP_ROLE_EXECUTE && !Gp_is_writer && gp_session_id >= 0)
 		{	
-			if (lockHolderProcPtr == NULL || lockHolderProcPtr == MyProc)
+			if (lockHolderProcPtr == MyProc)
 			{
 				/* Find the guy who should manage our locks */
 				PGPROC * proc = FindProcByGpSessionId(gp_session_id);
@@ -1135,7 +1135,7 @@ LockAcquireExtended(const LOCKTAG *locktag,
 			return LOCKACQUIRE_NOT_AVAIL;
 		}
 
-		if (Gp_role == GP_ROLE_EXECUTE)
+		if (Gp_role == GP_ROLE_EXECUTE && gp_session_id >= 0)
 		{
 			if (!Gp_is_writer)
 				elog(LOG,"Reader gang member waiting on a lock [%u,%u] %s",

--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -94,7 +94,7 @@ bool
 GlobalDeadLockDetectorStartRule(Datum main_arg)
 {
 	/* we only start gdd on master when -E is specified */
-	if (IsUnderMasterDispatchMode() &&
+	if (Gp_role == GP_ROLE_DISPATCH &&
 		gp_enable_global_deadlock_detector)
 		return true;
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -6264,7 +6264,7 @@ set_config_option(const char *name, const char *value,
 			{
 				ereport(elevel,
 						(errcode(ERRCODE_CANT_CHANGE_RUNTIME_PARAM),
-						 errmsg("parameter \"%s\" cannot be set after connection start",
+						 errmsg("parameter \"%s\" cannot be set after connection starts",
 								name)));
 				return 0;
 			}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4213,25 +4213,14 @@ struct config_string ConfigureNamesString_gp[] =
 	},
 
 	{
-		{"gp_session_role", PGC_BACKEND, GP_WORKER_IDENTITY,
-			gettext_noop("Reports the default role for the session."),
-			gettext_noop("Valid values are DISPATCH, EXECUTE, and UTILITY."),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
-		},
-		&gp_session_role_string,
-		"dispatch",
-		check_gp_session_role, assign_gp_session_role, show_gp_session_role
-	},
-
-	{
-		{"gp_role", PGC_SUSET, CLIENT_CONN_OTHER,
+		{"gp_role", PGC_BACKEND, GP_WORKER_IDENTITY,
 			gettext_noop("Sets the role for the session."),
 			gettext_noop("Valid values are DISPATCH, EXECUTE, and UTILITY."),
 			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
 		},
 		&gp_role_string,
-		"dispatch",
-		NULL, assign_gp_role, show_gp_role
+		"undefined",
+		check_gp_role, assign_gp_role, show_gp_role
 	},
 
 	{

--- a/src/backend/utils/misc/ps_status.c
+++ b/src/backend/utils/misc/ps_status.c
@@ -367,7 +367,7 @@ set_ps_display(const char *activity, bool force)
 		cp += snprintf(cp, ep - cp, "con%d ", gp_session_id);
 
 	/* Which segment is accessed by this qExec? */
-	if (Gp_role == GP_ROLE_EXECUTE &&
+	if (Gp_role == GP_ROLE_EXECUTE && gp_session_id >= 0 &&
 		GpIdentity.segindex >= -1 && ep - cp > 0)
 		cp += snprintf(cp, ep - cp, "seg%d ", GpIdentity.segindex);
 

--- a/src/backend/utils/misc/ps_status.c
+++ b/src/backend/utils/misc/ps_status.c
@@ -364,11 +364,13 @@ set_ps_display(const char *activity, bool force)
 
 	/* Add client session's global id. */
 	if (gp_session_id > 0 && ep - cp > 0)
+	{
 		cp += snprintf(cp, ep - cp, "con%d ", gp_session_id);
 
-	/* Which segment is accessed by this qExec? */
-	if (IS_QUERY_EXECUTOR_BACKEND() && GpIdentity.segindex >= -1 && ep - cp > 0)
-		cp += snprintf(cp, ep - cp, "seg%d ", GpIdentity.segindex);
+		/* Which segment is accessed by this qExec? */
+		if (Gp_role == GP_ROLE_EXECUTE && GpIdentity.segindex >= -1)
+			cp += snprintf(cp, ep - cp, "seg%d ", GpIdentity.segindex);
+	}
 
 	/* Add count of commands received from client session. */
 	if (gp_command_count > 0 && ep - cp > 0)

--- a/src/backend/utils/misc/ps_status.c
+++ b/src/backend/utils/misc/ps_status.c
@@ -367,8 +367,7 @@ set_ps_display(const char *activity, bool force)
 		cp += snprintf(cp, ep - cp, "con%d ", gp_session_id);
 
 	/* Which segment is accessed by this qExec? */
-	if (Gp_role == GP_ROLE_EXECUTE && gp_session_id >= 0 &&
-		GpIdentity.segindex >= -1 && ep - cp > 0)
+	if (IS_QUERY_EXECUTOR_BACKEND() && GpIdentity.segindex >= -1 && ep - cp > 0)
 		cp += snprintf(cp, ep - cp, "seg%d ", GpIdentity.segindex);
 
 	/* Add count of commands received from client session. */

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -197,7 +197,7 @@ static char *authwarning = NULL;
  * (no quoting to worry about).
  */
 static const char *boot_options = "-F";
-static const char *backend_options = "--single -F -O -j -c gp_session_role=utility -c search_path=pg_catalog -c exit_on_error=true";
+static const char *backend_options = "--single -F -O -j -c gp_role=utility -c search_path=pg_catalog -c exit_on_error=true";
 
 static const char *const subdirs[] = {
 	"global",

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -562,7 +562,7 @@ test_postmaster_connection(pgpid_t pm_pid, bool do_checkpoint)
 	PGPing		ret = PQPING_NO_RESPONSE;
 	char		connstr[MAXPGPATH * 2 + 256];
 	int			i;
-	static const char *backend_options = "'-c gp_session_role=utility'";
+	static const char *backend_options = "'-c gp_role=utility'";
 
 	/* if requested wait time is zero, return "still starting up" code */
 	if (wait_seconds <= 0)

--- a/src/bin/pg_dump/pg_backup_db.c
+++ b/src/bin/pg_dump/pg_backup_db.c
@@ -305,7 +305,7 @@ ConnectDatabase(Archive *AHX,
 		if (binary_upgrade)
 		{
 			keywords[6] = "options";
-			values[6] = "-c gp_session_role=utility";
+			values[6] = "-c gp_role=utility";
 			keywords[7] = NULL;
 			values[7] = NULL;
 		}

--- a/src/bin/pg_rewind/sql/config_test.sh
+++ b/src/bin/pg_rewind/sql/config_test.sh
@@ -83,7 +83,7 @@ PORT_STANDBY=`expr $PORT_MASTER + 1`
 MASTER_DBID=2
 STANDBY_DBID=5
 
-PGOPTIONS_UTILITY='-c gp_session_role=utility'
+PGOPTIONS_UTILITY='-c gp_role=utility'
 MASTER_PSQL="psql -a --no-psqlrc -p $PORT_MASTER"
 STANDBY_PSQL="psql -a --no-psqlrc -p $PORT_STANDBY"
 STANDBY_PSQL_TUPLES_ONLY="psql -t --no-psqlrc -p $PORT_STANDBY"

--- a/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -11,7 +11,7 @@
 #include "pg_upgrade.h"
 
 
-#define PG_OPTIONS_UTILITY_MODE " PGOPTIONS='-c gp_session_role=utility' "
+#define PG_OPTIONS_UTILITY_MODE " PGOPTIONS='-c gp_role=utility' "
 
 
 /*

--- a/src/bin/pg_upgrade/server.c
+++ b/src/bin/pg_upgrade/server.c
@@ -82,7 +82,7 @@ get_db_conn(ClusterInfo *cluster, const char *db_name)
 	}
 
 	appendPQExpBuffer(&conn_opts, " options=");
-	appendConnStrVal(&conn_opts, "-c gp_session_role=utility");
+	appendConnStrVal(&conn_opts, "-c gp_role=utility");
 
 	conn = PQconnectdb(conn_opts.data);
 	termPQExpBuffer(&conn_opts);

--- a/src/bin/pg_upgrade/test_gpdb.sh
+++ b/src/bin/pg_upgrade/test_gpdb.sh
@@ -147,7 +147,7 @@ check_vacuum_worked()
 
 	# Query for the xmin ages.
 	local xmin_ages=$( \
-		PGOPTIONS='-c gp_session_role=utility' \
+		PGOPTIONS='-c gp_role=utility' \
 		"${NEW_BINDIR}/psql" -c 'SELECT age(xmin) FROM pg_catalog.gp_segment_configuration GROUP BY age(xmin);' \
 			 -p 18432 -t -A template1 \
 	)
@@ -255,7 +255,7 @@ diff_and_exit() {
 	if (( $smoketest )) ; then
 		# After a smoke test, we only have the master available to query.
 		args='-m'
-		pgopts='-c gp_session_role=utility'
+		pgopts='-c gp_role=utility'
 	fi
 
 	# Start the new cluster, dump it and stop it again when done. We need to bump

--- a/src/bin/scripts/t/090_reindexdb.pl
+++ b/src/bin/scripts/t/090_reindexdb.pl
@@ -13,7 +13,7 @@ my $node = get_new_node('main');
 $node->init;
 $node->start;
 
-$ENV{PGOPTIONS} = '-c gp_session_role=utility --client-min-messages=WARNING';
+$ENV{PGOPTIONS} = '-c gp_role=utility --client-min-messages=WARNING';
 
 $node->issues_sql_like(
 	[ 'reindexdb', 'postgres' ],

--- a/src/bin/scripts/t/091_reindexdb_all.pl
+++ b/src/bin/scripts/t/091_reindexdb_all.pl
@@ -8,7 +8,7 @@ my $node = get_new_node('main');
 $node->init;
 $node->start;
 
-$ENV{PGOPTIONS} = '-c gp_session_role=utility --client-min-messages=WARNING';
+$ENV{PGOPTIONS} = '-c gp_role=utility --client-min-messages=WARNING';
 
 $node->issues_sql_like(
 	[ 'reindexdb', '-a' ],

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -45,7 +45,6 @@ typedef struct FtsControlBlock
 {
 	LWLockId		ControlLock;
 	FtsProbeInfo	fts_probe_info;
-	volatile bool	pm_launch_walreceiver;
 }	FtsControlBlock;
 
 extern volatile FtsProbeInfo *ftsProbeInfo;

--- a/src/include/cdb/cdbfts.h
+++ b/src/include/cdb/cdbfts.h
@@ -45,6 +45,7 @@ typedef struct FtsControlBlock
 {
 	LWLockId		ControlLock;
 	FtsProbeInfo	fts_probe_info;
+	pid_t			fts_probe_pid;
 }	FtsControlBlock;
 
 extern volatile FtsProbeInfo *ftsProbeInfo;

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -724,7 +724,7 @@ extern int get_dbid_string_length(void);
 #define UNINITIALIZED_GP_IDENTITY_VALUE (-10000)
 #define IS_QUERY_DISPATCHER() (GpIdentity.segindex == MASTER_CONTENT_ID)
 
-#define IS_QUERY_EXECUTOR_BACKEND() (Gp_role == GP_ROLE_EXECUTE && gp_session_id >= 0)
+#define IS_QUERY_EXECUTOR_BACKEND() (Gp_role == GP_ROLE_EXECUTE && gp_session_id > 0)
 
 /* Stores the listener port that this process uses to listen for incoming
  * Interconnect connections from other Motion nodes.

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -724,6 +724,8 @@ extern int get_dbid_string_length(void);
 #define UNINITIALIZED_GP_IDENTITY_VALUE (-10000)
 #define IS_QUERY_DISPATCHER() (GpIdentity.segindex == MASTER_CONTENT_ID)
 
+#define IS_QUERY_EXECUTOR_BACKEND() (Gp_role == GP_ROLE_EXECUTE && gp_session_id >= 0)
+
 /* Stores the listener port that this process uses to listen for incoming
  * Interconnect connections from other Motion nodes.
  */

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -32,10 +32,10 @@
 #define PRIO_MAX 20
 #endif
 /*
- * Parameters gp_session_role and gp_role
+ * Parameters gp_role
  *
- * The run-time parameters (GUC variables) gp_session_role and
- * gp_role report and provide control over the role assumed by a
+ * The run-time parameters (GUC variables) gp_role
+ * reports and provides control over the role assumed by a
  * postgres process.
  *
  * Valid  roles are the following:
@@ -44,81 +44,26 @@
  *	execute		The process acts as a parallel SQL executor.
  *	utility		The process acts as a simple SQL engine.
  *
- * Both parameters are initialized to the same value at connection
- * time and are local to the backend process resulting from the
- * connection.	The default is dispatch which is the normal setting
- * for a user of Greenplum connecting to a node of  the Greenplum cluster.
- * Neither parameter appears in the configuration file.
+ * For postmaster, the parameter is initialized by '-c' (required).
  *
- * gp_session_role
+ * For normal connections to cluster, you can connect to QD directly,
+ * but can not connect to QE directly unless specifying the utility role.
  *
- * - does not affect the operation of the backend, and
- * - does not change during the lifetime of PostgreSQL session.
- *
- * gp_role
- *
- * - determines the operating role of the backend, and
- * - may be changed by a superuser via the SET command.
- *
- * The connection time value of gp_session_role used by a
- * libpq-based client application can be specified using the
- * environment variable PGOPTIONS.	For example, this is how to
- * invoke psql on database test as a utility:
- *
- *	PGOPTIONS='-c gp_session_role=utility' psql test
- *
+ * For utility role connection to either QD or QE, PGOPTIONS could be used.
  * Alternatively, libpq-based applications can be modified to set
  * the value directly via an argument to one of the libpq functions
  * PQconnectdb, PQsetdbLogin or PQconnectStart.
  *
- * Don't try to set gp_role this way.  At the time options are
- * processed it is unknown whether the user is a superuser, so
- * the attempt will be rejected.
- *
- * ----------
- *
- * Greenplum Developers can access the values of these parameters via the
- * global variables Gp_session_role and Gp_role of type
- * GpRoleValue. For example
- *
- *	#include "cdb/cdbvars.h"
- *
- *	switch ( Gp_role  )
- *	{
- *		case GP_ROLE_DISPATCH:
- *			... Act like a query dispatcher ...
- *			break;
- *		case GP_ROLE_EXECUTE:
- *			... Act like a query executor ...
- *			break;
- *		case GP_ROLE_UTILITY:
- *			... Act like an unmodified PostgreSQL backend. ...
- *			break;
- *		default:
- *			... Won't happen ..
- *			break;
- *	}
- *
- * You can also modify Gp_role (even if the session doesn't have
- * superuser privileges) by setting it to one of the three valid
- * values, however this must be well documented to avoid
- * disagreements between modules.  Don't modify the value  of
- * Gp_session_role.
- *
+ * For single backend connection, utility role is enforced in code.
  */
 
 typedef enum
 {
-	GP_ROLE_UTILITY = 0,		/* Operating as a simple database engine */
+	GP_ROLE_UNDEFINED = 0,		/* Should never see this role in use */
+	GP_ROLE_UTILITY,			/* Operating as a simple database engine */
 	GP_ROLE_DISPATCH,			/* Operating as the parallel query dispatcher */
 	GP_ROLE_EXECUTE,			/* Operating as a parallel query executor */
-	GP_ROLE_UNDEFINED			/* Should never see this role in use */
 } GpRoleValue;
-
-
-extern GpRoleValue Gp_session_role;	/* GUC var - server startup mode.  */
-extern char *gp_session_role_string;	/* Use by guc.c as staging area for
-										 * value. */
 
 extern GpRoleValue Gp_role;	/* GUC var - server operating mode.  */
 extern char *gp_role_string;	/* Use by guc.c as staging area for value. */

--- a/src/include/postmaster/fts.h
+++ b/src/include/postmaster/fts.h
@@ -147,7 +147,6 @@ extern void probeWalRepUpdateConfig(int16 dbid, int16 segindex, char role,
 
 extern bool FtsProbeStartRule(Datum main_arg);
 extern void FtsProbeMain (Datum main_arg);
-extern void FtsProbeShmemInit(void);
 extern pid_t FtsProbePID(void);
 
 #endif   /* FTS_H */

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -74,7 +74,6 @@ extern void ShmemBackendArrayAllocation(void);
 
 extern void load_auxiliary_libraries(void);
 extern bool amAuxiliaryBgWorker(void);
-extern bool IsUnderMasterDispatchMode(void);
 
 /*
  * Note: MAX_BACKENDS is limited to 2^18-1 because that's the width reserved

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -803,9 +803,6 @@ extern bool check_wal_buffers(int *newval, void **extra, GucSource source);
 extern void assign_xlog_sync_method(int new_sync_method, void *extra);
 
 /* in cdb/cdbvars.c */
-extern bool check_gp_session_role(char **newval, void **extra, GucSource source);
-extern void assign_gp_session_role(const char *newval, void *extra);
-extern const char *show_gp_session_role(void);
 extern bool check_gp_role(char **newval, void **extra, GucSource source);
 extern void assign_gp_role(const char *newval, void *extra);
 extern const char *show_gp_role(void);

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -244,7 +244,6 @@
 		"gp_server_version",
 		"gp_server_version_num",
 		"gp_session_id",
-		"gp_session_role",
 		"gp_set_proc_affinity",
 		"gp_sort_flags",
 		"gp_sort_max_distinct",

--- a/src/test/gpdb_pitr/test_gpdb_pitr.sh
+++ b/src/test/gpdb_pitr/test_gpdb_pitr.sh
@@ -144,7 +144,7 @@ done
 # Reconfigure the segment configuration on the replica master so that
 # the other replicas are recognized as primary segments.
 echo "Configuring replica master's gp_segment_configuration..."
-PGOPTIONS="-c gp_session_role=utility" psql postgres -c "
+PGOPTIONS="-c gp_role=utility" psql postgres -c "
 SET allow_system_table_mods=true;
 DELETE FROM gp_segment_configuration WHERE preferred_role='m';
 UPDATE gp_segment_configuration SET dbid=${REPLICA_MASTER_DBID}, datadir='${REPLICA_MASTER}' WHERE content = -1;

--- a/src/test/isolation2/expected/resgroup/resgroup_parallel_queries.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_parallel_queries.out
@@ -523,17 +523,17 @@ create resource group rg_test_g8 with (concurrency= 1, cpu_rate_limit=1, memory_
 CREATE
 create role rg_test_r8 login resource group rg_test_g8;
 CREATE
-51:select dblink_connect('dblink_rg_test51', 'dbname=isolation2resgrouptest user=rg_test_r8 options=''-c gp_session_role=utility''');
+51:select dblink_connect('dblink_rg_test51', 'dbname=isolation2resgrouptest user=rg_test_r8 options=''-c gp_role=utility''');
  dblink_connect 
 ----------------
  OK             
 (1 row)
-52:select dblink_connect('dblink_rg_test52', 'dbname=isolation2resgrouptest user=rg_test_r8 options=''-c gp_session_role=utility''');
+52:select dblink_connect('dblink_rg_test52', 'dbname=isolation2resgrouptest user=rg_test_r8 options=''-c gp_role=utility''');
  dblink_connect 
 ----------------
  OK             
 (1 row)
-53:select dblink_connect('dblink_rg_test53', 'dbname=isolation2resgrouptest user=rg_test_r8 options=''-c gp_session_role=utility''');
+53:select dblink_connect('dblink_rg_test53', 'dbname=isolation2resgrouptest user=rg_test_r8 options=''-c gp_role=utility''');
  dblink_connect 
 ----------------
  OK             

--- a/src/test/isolation2/helpers/server_helpers.sql
+++ b/src/test/isolation2/helpers/server_helpers.sql
@@ -57,6 +57,7 @@ returns text as $$
     import subprocess
     cmd = 'pg_ctl -l postmaster.log -D %s ' % datadir
     opts = '-p %d' % (port)
+    opts = opts + ' -c gp_role=execute'
     cmd = cmd + '-o "%s" start' % opts
     return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
 $$ language plpythonu;

--- a/src/test/isolation2/sql/resgroup/resgroup_parallel_queries.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_parallel_queries.sql
@@ -258,9 +258,9 @@ select dblink_disconnect('dblink_rg_test');
 --
 create resource group rg_test_g8 with (concurrency= 1, cpu_rate_limit=1, memory_limit=1);
 create role rg_test_r8 login resource group rg_test_g8;
-51:select dblink_connect('dblink_rg_test51', 'dbname=isolation2resgrouptest user=rg_test_r8 options=''-c gp_session_role=utility''');
-52:select dblink_connect('dblink_rg_test52', 'dbname=isolation2resgrouptest user=rg_test_r8 options=''-c gp_session_role=utility''');
-53:select dblink_connect('dblink_rg_test53', 'dbname=isolation2resgrouptest user=rg_test_r8 options=''-c gp_session_role=utility''');
+51:select dblink_connect('dblink_rg_test51', 'dbname=isolation2resgrouptest user=rg_test_r8 options=''-c gp_role=utility''');
+52:select dblink_connect('dblink_rg_test52', 'dbname=isolation2resgrouptest user=rg_test_r8 options=''-c gp_role=utility''');
+53:select dblink_connect('dblink_rg_test53', 'dbname=isolation2resgrouptest user=rg_test_r8 options=''-c gp_role=utility''');
 
 51>:select exec_commands_n('dblink_rg_test51', 'select 1', 'begin', 'end', 100, '', '', true);
 51<:

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -151,7 +151,7 @@ class SQLIsolationExecutor(object):
                 self.con = self.connectdb(given_dbname=self.dbname,
                                           given_host=hostname,
                                           given_port=port,
-                                          given_opt="-c gp_session_role=utility")
+                                          given_opt="-c gp_role=utility")
             elif self.mode == "standby":
                 # Connect to standby even when it's role is recorded
                 # as mirror.  This is useful for scenarios where a
@@ -196,7 +196,7 @@ class SQLIsolationExecutor(object):
             """
             query = ("SELECT hostname, port FROM gp_segment_configuration WHERE"
                      " content = %s AND role = '%s'") % (contentid, role)
-            con = self.connectdb(self.dbname, given_opt="-c gp_session_role=utility")
+            con = self.connectdb(self.dbname, given_opt="-c gp_role=utility")
             r = con.query(query).getresult()
             con.close()
             if len(r) == 0:

--- a/src/test/perl/PostgresNode.pm
+++ b/src/test/perl/PostgresNode.pm
@@ -663,7 +663,7 @@ sub start
 
 	$self->_update_pid(1);
 
-	$ENV{PGOPTIONS}      = '-c gp_session_role=utility';
+	$ENV{PGOPTIONS}      = '-c gp_role=utility';
 }
 
 =pod
@@ -1082,7 +1082,7 @@ sub psql
 	my $timeout           = undef;
 	my $timeout_exception = 'psql timed out';
 
-	local $ENV{PGOPTIONS} = '-c gp_session_role=utility';
+	local $ENV{PGOPTIONS} = '-c gp_role=utility';
 
 	my @psql_params =
 	  ('psql', '-XAtq', '-d', $self->connstr($dbname), '-f', '-');

--- a/src/test/regress/dld.pl
+++ b/src/test/regress/dld.pl
@@ -246,7 +246,7 @@ if (1)
 #        print Data::Dumper->Dump([$vv]), "\n";
         
 
-        my $psql_seg = "PGOPTIONS=\'-c gp_session_role=utility\' psql -h $rowh->{hostname} -p $rowh->{port} template1 -c $sel_str";
+        my $psql_seg = "PGOPTIONS=\'-c gp_role=utility\' psql -h $rowh->{hostname} -p $rowh->{port} template1 -c $sel_str";
 
         print $psql_seg,"\n"
             if ($glob_verbose);
@@ -302,7 +302,7 @@ if (1)
 #        print Data::Dumper->Dump([$vv]), "\n";
         
 
-            my $psql_seg = "PGOPTIONS=\'-c gp_session_role=utility\' psql -h $rowh->{hostname}  -p $rowh->{port} template1 -c $sel_str";
+            my $psql_seg = "PGOPTIONS=\'-c gp_role=utility\' psql -h $rowh->{hostname}  -p $rowh->{port} template1 -c $sel_str";
 
             my $lk1 = `$psql_seg`;
 

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -692,7 +692,7 @@ COPY (SELECT * FROM segment_reject_limit_from) TO '/tmp/segment_reject_limit<SEG
 
 -- 'COPY (SELECT ...) TO' on utility mode
 CREATE EXTERNAL WEB TABLE copy_cmd_utility(a text, b int)
-  EXECUTE E'PGOPTIONS="-c gp_session_role=utility" \\
+  EXECUTE E'PGOPTIONS="-c gp_role=utility" \\
     psql -p $GP_MASTER_PORT $GP_DATABASE $GP_USER -c \\
       "COPY (SELECT * FROM pg_class) TO \'/dev/null\'"'
   ON MASTER FORMAT 'text' (DELIMITER ' ');

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -728,7 +728,7 @@ LINE 1: COPY segment_reject_limit_from to PROGRAM STDOUT;
 COPY (SELECT * FROM segment_reject_limit_from) TO '/tmp/segment_reject_limit<SEGID>.csv' ON SEGMENT;
 -- 'COPY (SELECT ...) TO' on utility mode
 CREATE EXTERNAL WEB TABLE copy_cmd_utility(a text, b int)
-  EXECUTE E'PGOPTIONS="-c gp_session_role=utility" \\
+  EXECUTE E'PGOPTIONS="-c gp_role=utility" \\
     psql -p $GP_MASTER_PORT $GP_DATABASE $GP_USER -c \\
       "COPY (SELECT * FROM pg_class) TO \'/dev/null\'"'
   ON MASTER FORMAT 'text' (DELIMITER ' ');

--- a/src/test/regress/pg_regress_main.c
+++ b/src/test/regress/pg_regress_main.c
@@ -127,7 +127,7 @@ psql_start_test(const char *testname,
 					   "%s \"%s%spsql\" -X -a -q -d \"%s\" > \"%s\" 2>&1 <<EOF\n"
 					   "$(cat \"%s\" \"%s\")\n"
 					   "EOF",
-					   use_utility_mode ? "env PGOPTIONS='-c gp_session_role=utility'" : "",
+					   use_utility_mode ? "env PGOPTIONS='-c gp_role=utility'" : "",
 					   bindir ? bindir : "",
 					   bindir ? "/" : "",
 					   dblist->str,

--- a/src/test/ssl/t/001_ssltests.pl
+++ b/src/test/ssl/t/001_ssltests.pl
@@ -35,7 +35,7 @@ sub run_test_psql
 	my $connstr   = $_[0];
 	my $logstring = $_[1];
 
-	local $ENV{PGOPTIONS} = '-c gp_session_role=utility';
+	local $ENV{PGOPTIONS} = '-c gp_role=utility';
 
 	my $cmd = [
 		'psql', '-X', '-A', '-t', '-c', "SELECT 'connected with $connstr'",


### PR DESCRIPTION
Use guc gp_role only now and replace the functionatlity of guc gp_session_role with it
also. Previously we have both gucs. The difference of the two gucs are (copied
from code comment):

 * gp_session_role
 *
 * - does not affect the operation of the backend, and
 * - does not change during the lifetime of PostgreSQL session.
 *
 * gp_role
 *
 * - determines the operating role of the backend, and
 * - may be changed by a superuser via the SET command.

This is not friendly for coding. For example, You could find Gp_role and
Gp_session_role are set as GP_ROLE_DISPATCH on Postmaster & many aux processes
on all nodes (even QE nodes) in a cluster, so you can see that to differ from
QD postmaster and QE postmaster, current gpdb uses an additional -E option in
postmaster arguments. These makes developers confusing when writing role branch
related code given we have three related variables.  Also some related code is
even buggy now (e.g. 'set gp_role' even FATAL quits).

With this patch we just have gp_role now. Some changes which might be
intersting in the patch are:

1. For postmster, we should specify '-c gp_role=' (e.g. via pg_ctl argument) to
   determine the role else we assume the utility role.

2. For stand-alone backend, utility role is enforced (no need to specify by
   users).

3. Could still connect QE/QD nodes using utility mode with PGOPTIONS, etc as
   before.

4. Remove the '-E' gpdb hacking and align the '-E' usage with upstream.

5. Move pm_launch_walreceiver out of the fts related shmem given the later is
   not used on QE.