### PR TITLE
Fix format change in resgroup test case

### DIFF
--- a/src/test/isolation2/input/resgroup/resgroup_memory_runaway.source
+++ b/src/test/isolation2/input/resgroup/resgroup_memory_runaway.source
@@ -12,12 +12,6 @@ CREATE OR REPLACE FUNCTION hold_memory_by_percent(float) RETURNS int AS $$
 	SELECT * FROM resGroupPalloc($1)
 $$ LANGUAGE sql;
 
-CREATE OR REPLACE VIEW rg_mem_status AS
-	SELECT groupname, memory_limit, memory_shared_quota
-	FROM gp_toolkit.gp_resgroup_config
-	WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test'
-	ORDER BY groupid;
-
 CREATE OR REPLACE VIEW memory_result AS SELECT rsgname, memory_usage from gp_toolkit.gp_resgroup_status;
 
 -- start_ignore

--- a/src/test/isolation2/output/resgroup/resgroup_memory_runaway.source
+++ b/src/test/isolation2/output/resgroup/resgroup_memory_runaway.source
@@ -13,9 +13,6 @@ CREATE
 CREATE OR REPLACE FUNCTION hold_memory_by_percent(float) RETURNS int AS $$ SELECT * FROM resGroupPalloc($1) $$ LANGUAGE sql;
 CREATE
 
-CREATE OR REPLACE VIEW rg_mem_status AS SELECT groupname, memory_limit, memory_shared_quota FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg1_memory_test' OR groupname='rg2_memory_test' ORDER BY groupid;
-CREATE
-
 CREATE OR REPLACE VIEW memory_result AS SELECT rsgname, memory_usage from gp_toolkit.gp_resgroup_status;
 CREATE
 
@@ -79,41 +76,41 @@ CREATE
 1: SET ROLE TO role1_memory_test;
 SET
 1: SELECT hold_memory_by_percent(1.0);
- hold_memory_by_percent 
-------------------------
- 0                      
+hold_memory_by_percent
+----------------------
+0                     
 (1 row)
 1: SELECT hold_memory_by_percent(0.3);
- hold_memory_by_percent 
-------------------------
- 0                      
+hold_memory_by_percent
+----------------------
+0                     
 (1 row)
 1: SELECT hold_memory_by_percent(0.3);
-ERROR:  Canceling query because of high VMEM usage. current group id is 806868, group memory usage 218 MB, group shared memory quota is 0 MB, slot memory quota is 68 MB, global freechunks memory is 124 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)
+ERROR:  Canceling query because of high VMEM usage. current group id is 122887, group memory usage 218 MB, group shared memory quota is 0 MB, slot memory quota is 68 MB, global freechunks memory is 124 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
 
 --	1b) on QEs
 2: SELECT pg_sleep(1);
- pg_sleep 
-----------
-          
+pg_sleep
+--------
+        
 (1 row)
 2: SET ROLE TO role1_memory_test;
 SET
 2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
- count 
--------
- 0     
+count
+-----
+0    
 (1 row)
 2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
- count 
--------
- 0     
+count
+-----
+0    
 (1 row)
 2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
-ERROR:  Canceling query because of high VMEM usage. current group id is 806868, group memory usage 218 MB, group shared memory quota is 0 MB, slot memory quota is 68 MB, global freechunks memory is 124 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)  (seg0 slice1 10.146.0.4:7002 pid=10883) (runaway_cleaner.c:197)
-CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+ERROR:  Canceling query because of high VMEM usage. current group id is 122887, group memory usage 218 MB, group shared memory quota is 0 MB, slot memory quota is 68 MB, global freechunks memory is 124 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)  (seg0 slice1 10.146.0.4:25432 pid=6214) (cdbdisp.c:252)
+DETAIL:  SQL function "hold_memory_by_percent" statement 1
 2q: ... <quitting>
 
 0: DROP ROLE role1_memory_test;
@@ -138,51 +135,51 @@ CREATE
 1: SET ROLE TO role1_memory_test;
 SET
 1: SELECT hold_memory_by_percent(1.0);
- hold_memory_by_percent 
-------------------------
- 0                      
+hold_memory_by_percent
+----------------------
+0                     
 (1 row)
 1: SELECT hold_memory_by_percent(0.3);
- hold_memory_by_percent 
-------------------------
- 0                      
+hold_memory_by_percent
+----------------------
+0                     
 (1 row)
 1: SELECT hold_memory_by_percent(0.3);
- hold_memory_by_percent 
-------------------------
- 0                      
+hold_memory_by_percent
+----------------------
+0                     
 (1 row)
 1: SELECT hold_memory_by_percent(0.3);
-ERROR:  Canceling query because of high VMEM usage. current group id is 806877, group memory usage 259 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 117 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)
+ERROR:  Canceling query because of high VMEM usage. current group id is 122896, group memory usage 259 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 117 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
 
 --	1b) on QEs
 2: SELECT pg_sleep(1);
- pg_sleep 
-----------
-          
+pg_sleep
+--------
+        
 (1 row)
 2: SET ROLE TO role1_memory_test;
 SET
 2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
- count 
--------
- 0     
+count
+-----
+0    
 (1 row)
 2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
- count 
--------
- 0     
+count
+-----
+0    
 (1 row)
 2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
- count 
--------
- 0     
+count
+-----
+0    
 (1 row)
 2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.3)=0;
-ERROR:  Canceling query because of high VMEM usage. current group id is 806877, group memory usage 259 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 117 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)  (seg0 slice1 10.146.0.4:7002 pid=10918) (runaway_cleaner.c:197)
-CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+ERROR:  Canceling query because of high VMEM usage. current group id is 122896, group memory usage 259 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 117 MB, global safe memory threshold is 137 MB (runaway_cleaner.c:197)  (seg0 slice1 10.146.0.4:25432 pid=6263) (cdbdisp.c:252)
+DETAIL:  SQL function "hold_memory_by_percent" statement 1
 2q: ... <quitting>
 
 0: DROP ROLE role1_memory_test;
@@ -211,41 +208,41 @@ CREATE
 1: SET ROLE TO role1_memory_test;
 SET
 1: SELECT hold_memory_by_percent(1.0);
- hold_memory_by_percent 
-------------------------
- 0                      
+hold_memory_by_percent
+----------------------
+0                     
 (1 row)
 1: SELECT hold_memory_by_percent(0.15);
- hold_memory_by_percent 
-------------------------
- 0                      
+hold_memory_by_percent
+----------------------
+0                     
 (1 row)
 1: SELECT hold_memory_by_percent(0.15);
-ERROR:  Canceling query because of high VMEM usage. current group id is 806886, group memory usage 178 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 62 MB, global safe memory threshold is 69 MB (runaway_cleaner.c:197)
+ERROR:  Canceling query because of high VMEM usage. current group id is 122905, group memory usage 178 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 62 MB, global safe memory threshold is 69 MB (runaway_cleaner.c:197)
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
 
 --	1b) on QEs
 2: SELECT pg_sleep(1);
- pg_sleep 
-----------
-          
+pg_sleep
+--------
+        
 (1 row)
 2: SET ROLE TO role1_memory_test;
 SET
 2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(1.0)=0;
- count 
--------
- 0     
+count
+-----
+0    
 (1 row)
 2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.15)=0;
- count 
--------
- 0     
+count
+-----
+0    
 (1 row)
 2: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.15)=0;
-ERROR:  Canceling query because of high VMEM usage. current group id is 806886, group memory usage 178 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 62 MB, global safe memory threshold is 69 MB (runaway_cleaner.c:197)  (seg0 slice1 10.146.0.4:7002 pid=10952) (runaway_cleaner.c:197)
-CONTEXT:  SQL function "hold_memory_by_percent" statement 1
+ERROR:  Canceling query because of high VMEM usage. current group id is 122905, group memory usage 178 MB, group shared memory quota is 68 MB, slot memory quota is 34 MB, global freechunks memory is 62 MB, global safe memory threshold is 69 MB (runaway_cleaner.c:197)  (seg0 slice1 10.146.0.4:25432 pid=6295) (cdbdisp.c:252)
+DETAIL:  SQL function "hold_memory_by_percent" statement 1
 2q: ... <quitting>
 
 0: DROP ROLE role1_memory_test;


### PR DESCRIPTION
This is used to fix resgroup test cases failure due to format change in 5X. 
No test cases needed.
