### PR TITLE
Dispatched once in one vacuum (#9304)

### DIFF
--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4404,6 +4404,7 @@ _outVacuumStmt(StringInfo str, const VacuumStmt *node)
 	WRITE_NODE_FIELD(expanded_relids);
 	WRITE_NODE_FIELD(appendonly_compaction_segno);
 	WRITE_NODE_FIELD(appendonly_compaction_insert_segno);
+	WRITE_BOOL_FIELD(appendonly_relation_empty);
 	WRITE_ENUM_FIELD(appendonly_phase, AOVacuumPhase);
 }
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2819,6 +2819,7 @@ _readVacuumStmt(void)
 	READ_NODE_FIELD(expanded_relids);
 	READ_NODE_FIELD(appendonly_compaction_segno);
 	READ_NODE_FIELD(appendonly_compaction_insert_segno);
+	READ_BOOL_FIELD(appendonly_relation_empty);
 	READ_ENUM_FIELD(appendonly_phase, AOVacuumPhase);
 
 	READ_DONE();

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -335,3 +335,26 @@ WARNING:  skipping "s_serial" --- cannot vacuum non-tables, external tables, for
 DROP SEQUENCE s_serial;
 VACUUM gp_toolkit.__gp_log_master_ext;
 WARNING:  skipping "__gp_log_master_ext" --- cannot vacuum non-tables, external tables, foreign tables or special system tables
+-- Vacuum related access control tests (Issue: https://github.com/greenplum-db/gpdb/issues/9001)
+-- Given a non-super-user role
+CREATE ROLE non_super_user_vacuum;
+-- And a heap table with auxiliary relations under the pg_toast namespace.
+CREATE TABLE vac_acl_heap(i int, j text);
+-- And an AO table with auxiliary relations under the pg_aoseg namespace.
+CREATE TABLE vac_acl_ao(i int, j text) with (appendonly=true);
+-- And an AOCS table with auxiliary relations under the pg_aocsseg namespace.
+CREATE TABLE vac_acl_aocs(i int, j text) with (appendonly=true, orientation=column);
+-- And all the tables belong to the non-super-user role.
+ALTER TABLE vac_acl_heap OWNER TO non_super_user_vacuum;
+ALTER TABLE vac_acl_ao OWNER TO non_super_user_vacuum;
+ALTER TABLE vac_acl_aocs OWNER TO non_super_user_vacuum;
+-- We can vacuum each table as the non-super-user
+SET ROLE TO non_super_user_vacuum;
+VACUUM vac_acl_heap;
+VACUUM vac_acl_ao;
+VACUUM vac_acl_aocs;
+\c
+DROP TABLE vac_acl_heap;
+DROP TABLE vac_acl_ao;
+DROP TABLE vac_acl_aocs;
+DROP ROLE non_super_user_vacuum;


### PR DESCRIPTION
During the rewriting of vacuum during the 9.0 merge, in commit:
greenplum-db/gpdb-postgres-merge@e26231c the vacuum
workflow was changed to dispatch once per auxiliary table along
with the dispatch for the main table. Before, a vacuum would
dispatch only once and all of the auxiliary tables would be
vacuumed in the same dispatch.

Our heap and ao tables have auxiliary tables. The primary table and
each auxiliary table are dispatched separately. One vacuum will have
too many dispatches, which will cause performance problems.

In postgres, we only verify the permition on the main table. But if
we dispatch auxiliary tables separately, the segment will verify
the permition on auxiliary tables. This will cause failure in
permission verification.

We refactored the code so that each vacuum is dispatched only once.

this commit cherry-pick from 6f625509570944ba7b6bfab635493e9233d66e0f

Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
