### PR TITLE
ci: depends on more-itertools<8.1

### DIFF
--- a/concourse/scripts/combine_cli_coverage.bash
+++ b/concourse/scripts/combine_cli_coverage.bash
@@ -27,8 +27,7 @@ read -r COMMIT_SHA < gpdb_src/.git/HEAD
 source ./gpdb_src/concourse/scripts/common.bash
 time install_gpdb
 
-pip install -r ./gpdb_src/gpMgmt/requirements-dev.txt
-pip install gsutil
+pip install -r ./gpdb_src/gpMgmt/requirements-dev.txt gsutil
 
 # Save the JSON_KEY to a file, for later use by gsutil.
 keyfile=secret-key.json

--- a/concourse/scripts/gsutil_sync
+++ b/concourse/scripts/gsutil_sync
@@ -43,7 +43,7 @@ gs_service_key_file = $(pwd)/$keyfile
 EOF
 export BOTO_CONFIG=$(pwd)/boto.cfg
 
-pip install gsutil
+pip install -r ./gpdb_src/gpMgmt/requirements-dev.txt gsutil
 
 # Trim a trailing slash from the source directory if it has one
 SOURCE_DIRECTORY="${1%/}"

--- a/gpMgmt/requirements-dev.txt
+++ b/gpMgmt/requirements-dev.txt
@@ -1,2 +1,3 @@
 behave~=1.2.6
 coverage~=4.5
+more-itertools<8.1


### PR DESCRIPTION
The current version of more-itertools is 8.1.0 and will cause below
error:

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-UK2VKZ/more-itertools/setup.py", line 5, in <module>
        from more_itertools import __version__
      File "more_itertools/__init__.py", line 1, in <module>
        from .more import *  # noqa
      File "more_itertools/more.py", line 480
        yield from iterable
                 ^
    SyntaxError: invalid syntax

It used to work well with more-itertools 8.0.2, so we need to specify
that we need a version < 8.1

Also make sure that we call pip install with the proper dependence
requirements.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
