### PR TITLE
Fix another crash in JSON/YAML-format EXPLAIN, due to missing Flow.

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -2509,6 +2509,13 @@ create_bitmap_subplan(PlannerInfo *root, Path *bitmapqual,
 		plan->plan_rows =
 			clamp_row_est(ipath->indexselectivity * ipath->path.parent->tuples);
 		plan->plan_width = 0;	/* meaningless */
+
+		/* decorate the node with a Flow node, for EXPLAIN. */
+		plan->flow = cdbpathtoplan_create_flow(root,
+											   ipath->path.locus,
+											   ipath->path.parent->relids,
+											   plan);
+
 		*qual = get_actual_clauses(ipath->indexclauses);
 		*indexqual = get_actual_clauses(ipath->indexquals);
 		foreach(l, ipath->indexinfo->indpred)

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -627,6 +627,55 @@ QUERY PLAN
   }
 ]
 (1 row)
+-- Test for similar bug of missing flow with bitmap index scan.
+-- (github issue #9404).
+CREATE INDEX ss_f1 on SUBSELECT_TBL(f1);
+begin;
+set local enable_seqscan=off;
+set local enable_indexscan=off;
+set local enable_bitmapscan=on;
+explain (format json, costs off) select * from subselect_tbl where f1 < 10;
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Gather Motion",
+      "Senders": 3,
+      "Receivers": 1,
+      "Slice": 1,
+      "Segments": 3,
+      "Gang Type": "primary reader",
+      "Plans": [
+        {
+          "Node Type": "Bitmap Heap Scan",
+          "Parent Relationship": "Outer",
+          "Slice": 1,
+          "Segments": 3,
+          "Gang Type": "primary reader",
+          "Relation Name": "subselect_tbl",
+          "Alias": "subselect_tbl",
+          "Recheck Cond": "(f1 < 10)",
+          "Plans": [
+            {
+              "Node Type": "Bitmap Index Scan",
+              "Parent Relationship": "Outer",
+              "Slice": 1,
+              "Segments": 3,
+              "Gang Type": "primary reader",
+              "Index Name": "ss_f1",
+              "Index Cond": "(f1 < 10)"
+            }
+          ]
+        }
+      ]
+    },
+    "Settings": {
+      "Optimizer": "Postgres query optimizer"
+    }
+  }
+]
+(1 row)
+commit;
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -626,6 +626,46 @@ QUERY PLAN
   }
 ]
 (1 row)
+-- Test for similar bug of missing flow with bitmap index scan.
+-- (github issue #9404).
+CREATE INDEX ss_f1 on SUBSELECT_TBL(f1);
+begin;
+set local enable_seqscan=off;
+set local enable_indexscan=off;
+set local enable_bitmapscan=on;
+explain (format json, costs off) select * from subselect_tbl where f1 < 10;
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Gather Motion",
+      "Senders": 3,
+      "Receivers": 1,
+      "Slice": 1,
+      "Segments": 3,
+      "Gang Type": "primary reader",
+      "Plans": [
+        {
+          "Node Type": "Index Scan",
+          "Parent Relationship": "Outer",
+          "Slice": 1,
+          "Segments": 3,
+          "Gang Type": "primary reader",
+          "Scan Direction": "Forward",
+          "Index Name": "ss_f1",
+          "Relation Name": "subselect_tbl",
+          "Alias": "subselect_tbl",
+          "Index Cond": "(f1 < 10)"
+        }
+      ]
+    },
+    "Settings": {
+      "Optimizer": "Pivotal Optimizer (GPORCA) version 3.87.0"
+    }
+  }
+]
+(1 row)
+commit;
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -111,6 +111,16 @@ explain (format json) SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELEC
   WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE
     f2 IN (SELECT f1 FROM SUBSELECT_TBL));
 
+-- Test for similar bug of missing flow with bitmap index scan.
+-- (github issue #9404).
+CREATE INDEX ss_f1 on SUBSELECT_TBL(f1);
+begin;
+set local enable_seqscan=off;
+set local enable_indexscan=off;
+set local enable_bitmapscan=on;
+explain (format json, costs off) select * from subselect_tbl where f1 < 10;
+commit;
+
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;


### PR DESCRIPTION
This is similar to commit 51257848, but this time it was a Bitmap Index
Scan node that was missing the Flow information. Fix by populating the
Flow for Bitmap Index Scans.

This class of bugs seem to happen pretty often, so make the explain code
more defensives so that it does not crash if this happens again. In both
of these bugs, the Flow information is only needed so that we can print
the # of segments in the EXPLAIN output. That's not critical, so in
production, it seems better to print possible incorrect information than
crash. Keep the Assert, though, so that we still catch these in
development.

Fixes github issue https://github.com/greenplum-db/gpdb/issues/9404.
