### PR TITLE
6X Backport: Fix incorrect superuser time constraint warning logging

### DIFF
--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -2940,6 +2940,8 @@ check_auth_time_constraints_internal(char *rolname, TimestampTz timestamp)
 	HeapTuple		tuple;
 	authPoint 		now;
 	int				status;
+	bool			isRoleSuperuser;
+	bool			found = false;
 
 	timestamptz_to_point(timestamp, &now);
 
@@ -2961,10 +2963,7 @@ check_auth_time_constraints_internal(char *rolname, TimestampTz timestamp)
 		return STATUS_OK;
 	}
 
-	if (((Form_pg_authid) GETSTRUCT(roleTup))->rolsuper)
-		ereport(WARNING,
-				(errmsg("time constraints added on superuser role")));
-
+	isRoleSuperuser = ((Form_pg_authid) GETSTRUCT(roleTup))->rolsuper;
 	roleId = HeapTupleGetOid(roleTup);
 
 	ReleaseSysCache(roleTup);
@@ -2997,6 +2996,9 @@ check_auth_time_constraints_internal(char *rolname, TimestampTz timestamp)
 		bool			isnull;
 		authInterval	given;
 
+		/* Record that we found constraints regardless if they apply now */
+		found = true;
+
 		constraint_tuple = (Form_pg_auth_time_constraint) GETSTRUCT(tuple);
 		Assert(constraint_tuple->authid == roleId);
 
@@ -3026,6 +3028,11 @@ check_auth_time_constraints_internal(char *rolname, TimestampTz timestamp)
 	/* Clean up. */
 	systable_endscan(scan);
 	heap_close(reltimeconstr, AccessShareLock);
+
+	/* Time constraints shouldn't be added to superuser roles */
+	if (found && isRoleSuperuser)
+		ereport(WARNING,
+				(errmsg("time constraints added on superuser role")));
 
 	/* Re-enable immediate response to SIGTERM/SIGINT/timeout interrupts */
 	ImmediateInterruptOK = true;

--- a/src/test/regress/output/auth_constraint.source
+++ b/src/test/regress/output/auth_constraint.source
@@ -964,7 +964,6 @@ create role abc deny day 1;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 alter role abc superuser;
 SELECT check_auth_time_constraints('abc', '2011-08-29 12:00:00');
-WARNING:  time constraints added on superuser role
  check_auth_time_constraints 
 -----------------------------
  t


### PR DESCRIPTION
The check for role time constraints had a bug in the superuser check such that it would raise a WARNING every time a superuser role was checked regardless of if it had constraints added against it. This was causing log-spamming of erroneous entries.

Fix by only raising a WARNING in case there were any constraints added.

Backported from master commit 25a7630ef5b20602f27477e7fb4fa044b in #9397