### PR TITLE
[5X backport] Reduce chances of master PANIC due to failure of phase 2 of 2PC.

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -54,6 +54,7 @@ extern struct Port *MyProcPort;
 
 #define DTM_DEBUG3 (Debug_print_full_dtm ? LOG : DEBUG3)
 #define DTM_DEBUG5 (Debug_print_full_dtm ? LOG : DEBUG5)
+#define DTX_PHASE2_SLEEP_TIME_BETWEEN_RETRIES_MSECS 100
 
 /*
  * Directory where Utility Mode DTM REDO file reside within PGDATA
@@ -810,6 +811,13 @@ doNotifyingCommitPrepared(void)
 
 	while (!succeeded && dtx_phase2_retry_count > retry++)
 	{
+		/*
+		 * sleep for brief duration before retry, to increase chances of
+		 * success if first try failed due to segment panic/restart. Otherwise
+		 * all the retries complete in less than a sec, defeating the purpose
+		 * of the retry.
+		 */
+		pg_usleep(DTX_PHASE2_SLEEP_TIME_BETWEEN_RETRIES_MSECS * 1000);
 		elog(WARNING, "the distributed transaction 'Commit Prepared' broadcast "
 			 "failed to one or more segments for gid = %s.  Retrying ... try %d",
 			 currentGxact->gid, retry);
@@ -874,7 +882,17 @@ retryAbortPrepared(void)
 		 * segment instances.  And, we will abort the transactions in the
 		 * segments. What's left are possibily prepared transactions.
 		 */
-		elog(NOTICE, "Releasing segworker groups to retry broadcast.");
+		if (retry > 1)
+		{
+			elog(NOTICE, "Releasing segworker groups to retry broadcast.");
+			/*
+			 * sleep for brief duration before retry, to increase chances of
+			 * success if first try failed due to segment panic/restart. Otherwise
+			 * all the retries complete in less than a sec, defeating the purpose
+			 * of the retry.
+			 */
+			pg_usleep(DTX_PHASE2_SLEEP_TIME_BETWEEN_RETRIES_MSECS * 1000);
+		}
 		DisconnectAndDestroyAllGangs(true);
 
 		/*

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1043,8 +1043,8 @@ doNotifyingAbort(void)
 			setCurrentGxactState( DTX_STATE_RETRY_ABORT_PREPARED );
 			setDistributedTransactionContext(DTX_CONTEXT_QD_RETRY_PHASE_2);
 			releaseTmLock();
+			retryAbortPrepared();
 		}
-		retryAbortPrepared();
 	}
 
 	SIMPLE_FAULT_INJECTOR(DtmBroadcastAbortPrepared);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4820,7 +4820,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_SUPERUSER_ONLY |  GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},
 		&dtx_phase2_retry_count,
-		2, 0, 15, NULL, NULL
+		10, 0, INT_MAX, NULL, NULL
 	},
 
 	{

--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -47,7 +47,6 @@ INSERT INTO distxact1_1 VALUES (7);
 INSERT INTO distxact1_1 VALUES (8);
 SET debug_abort_after_distributed_prepared = true;
 COMMIT;
-NOTICE:  Releasing segworker groups to retry broadcast.
 ERROR:  Raise an error as directed by Debug_abort_after_distributed_prepared
 RESET debug_abort_after_distributed_prepared;
 SELECT * FROM distxact1_1;
@@ -72,7 +71,6 @@ SET debug_dtm_action = "fail_begin_command";
 SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "prepare";
 COMMIT;
-NOTICE:  Releasing segworker groups to retry broadcast.
 ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid = 1259106572-0000015083. (cdbtm.c:633)
 RESET debug_dtm_action;
 RESET debug_dtm_action_target;
@@ -136,7 +134,6 @@ SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "abort_prepared";
 COMMIT;
 WARNING:  the distributed transaction 'Abort Prepared' broadcast failed to one or more segments for gid = 1477546849-0000000078.  Retrying ... try 1
-NOTICE:  Releasing segworker groups to retry broadcast.
 ERROR:  Raise an error as directed by Debug_abort_after_distributed_prepared
 SELECT * FROM distxact1_4;
  a 
@@ -800,7 +797,6 @@ select count(*) = 5 as passed from subt_reindex_co;
 \c postgres
 SET debug_abort_after_distributed_prepared = true;
 reindex table pg_class;
-NOTICE:  Releasing segworker groups to retry broadcast.
 ERROR:  Raise an error as directed by Debug_abort_after_distributed_prepared
 RESET debug_abort_after_distributed_prepared;
 \c regression

--- a/src/test/regress/expected/dtm_retry.out
+++ b/src/test/regress/expected/dtm_retry.out
@@ -108,7 +108,6 @@ NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
-NOTICE:  Releasing segworker groups to retry broadcast.
 ERROR:  The distributed transaction 'Prepare' broadcast failed to one or more segments for gid DUMMY
 -- Verify that the table wasn't truncated due to prevous transaction
 -- being aborted.
@@ -168,7 +167,6 @@ truncate table dtm_retry_table;
 -- abort_prepared message succeeds.
 end;
 WARNING:  the distributed transaction 'Abort Prepared' broadcast failed to one or more segments for gid DUMMY
-NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.


### PR DESCRIPTION
This commit increases retry count and adds small delay between retries
for 2PC.

Commit-Prepared or Abort-Prepared (phase 2) of 2PC perform retries if
first attempt fails to complete the transaction. Default only 2
retries were performed and also were with zero delay. Once retries are
exhausted master PANIC's and has to continue retrying. Most of the
times the phase 2 fails on first attempt if segment is undergoing
recovery or failover happens on mirror. In such instances, just 2
retries are attempted in msecs and seems to defeat the purpose of the
retries.

Hence, modifying default number to retries to 10. Also, adding 100msec
delay between each retry to provide resonable opportunity to succeed
on retries. This should help avoid master PANICs for not able to
complete phase 2. I gave lot of thought but couldn't think of any
downsides from incresing the number of retries.

Also, maximum number allowed to be configured was only 15, which seems
too restrictive. Mainly for the tests where sometime to avoid
flakiness and avoiding master panics having higher number of retries
is helpful. So, changing the guc `dtx_phase2_retry_count` maximum
allowed to INT_MAX. Don't practically expect it to be set to any value
higher than some thousands. But think we don't have to be so
restrictive for the maximum.

Cherry-picked from f66054cd16cf1f1af2e7cf1c2e34aba66b9681aa