### PR TITLE
fix DTX RollbackAndReleaseCurrentSubTransaction dispatch failed #9357

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -959,6 +959,7 @@ advance_combine_function(AggState *aggstate,
 {
 	MemoryContext oldContext;
 	Datum		newVal;
+	MemoryManagerContainer *mem_manager = &(aggstate->mem_manager);
 
 	if (pertrans->transfn.fn_strict)
 	{
@@ -1023,8 +1024,11 @@ advance_combine_function(AggState *aggstate,
 							   pertrans->transtypeByVal,
 							   pertrans->transtypeLen);
 		}
-		if (!pergroupstate->transValueIsNull)
-			pfree(DatumGetPointer(pergroupstate->transValue));
+		if (!pergroupstate->transValueIsNull && mem_manager->free)
+		{
+			(*(mem_manager->free))(mem_manager->manager,DatumGetPointer(pergroupstate->transValue));
+		}
+			//pfree(DatumGetPointer(pergroupstate->transValue));
 	}
 
 	pergroupstate->transValue = newVal;


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
madlib test srcipt  pmml_glm_ig.sql_in
- [ ] Document changes
nodeAgg.c
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
reason
pergroupstate->transValueIsNull is allocated by mem_manager->alloc. In advance_combine_function pergroupstate->transValueIsNullis freed by pfree will cause segment default error