### PR TITLE
Fix node out/read routines for Partition and PartitionRule structs.

### DIFF
--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -709,44 +709,6 @@ _outPartitionBoundSpec(StringInfo str, PartitionBoundSpec *node)
 }
 
 static void
-_outPartition(StringInfo str, Partition *node)
-{
-	WRITE_NODE_TYPE("PARTITION");
-
-	WRITE_OID_FIELD(partid);
-	WRITE_OID_FIELD(parrelid);
-	WRITE_CHAR_FIELD(parkind);
-	WRITE_INT_FIELD(parlevel);
-	WRITE_BOOL_FIELD(paristemplate);
-	WRITE_BINARY_FIELD(parnatts, sizeof(int16));
-	WRITE_INT_ARRAY(paratts, node->parnatts, int16);
-	WRITE_OID_ARRAY(parclass, node->parnatts);
-}
-
-static void
-_outPartitionRule(StringInfo str, PartitionRule *node)
-{
-	WRITE_NODE_TYPE("PARTITIONRULE");
-
-	WRITE_OID_FIELD(parruleid);
-	WRITE_OID_FIELD(paroid);
-	WRITE_OID_FIELD(parchildrelid);
-	WRITE_OID_FIELD(parparentoid);
-	WRITE_BOOL_FIELD(parisdefault);
-	WRITE_STRING_FIELD(parname);
-	WRITE_NODE_FIELD(parrangestart);
-	WRITE_BOOL_FIELD(parrangestartincl);
-	WRITE_NODE_FIELD(parrangeend);
-	WRITE_BOOL_FIELD(parrangeendincl);
-	WRITE_NODE_FIELD(parrangeevery);
-	WRITE_NODE_FIELD(parlistvalues);
-	WRITE_BINARY_FIELD(parruleord, sizeof(int16));
-	WRITE_NODE_FIELD(parreloptions);
-	WRITE_OID_FIELD(partemplatespaceId);
-	WRITE_NODE_FIELD(children);
-}
-
-static void
 _outAlterPartitionCmd(StringInfo str, AlterPartitionCmd *node)
 {
 	WRITE_NODE_TYPE("ALTERPARTITIONCMD");

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3551,12 +3551,9 @@ _outExpandStmtSpec(StringInfo str, const ExpandStmtSpec *node)
 }
 
 
-#ifndef COMPILING_BINARY_FUNCS
 static void
 _outPartition(StringInfo str, const Partition *node)
 {
-	int i;
-
 	WRITE_NODE_TYPE("PARTITION");
 
 	WRITE_OID_FIELD(partid);
@@ -3565,17 +3562,20 @@ _outPartition(StringInfo str, const Partition *node)
 	WRITE_INT_FIELD(parlevel);
 	WRITE_BOOL_FIELD(paristemplate);
 	WRITE_INT_FIELD(parnatts);
+#ifndef COMPILING_BINARY_FUNCS
 	appendStringInfoLiteral(str, " :paratts");
-	for (i = 0; i < node->parnatts; i++)
+	for (int i = 0; i < node->parnatts; i++)
 		appendStringInfo(str, " %i", node->paratts[i]);
 
 	appendStringInfoLiteral(str, " :parclass");
-	for (i = 0; i < node->parnatts; i++)
+	for (int i = 0; i < node->parnatts; i++)
 		appendStringInfo(str, " %d", node->parclass[i]);
-}
+#else
+	WRITE_INT_ARRAY(paratts, node->parnatts, int16);
+	WRITE_OID_ARRAY(parclass, node->parnatts);
 #endif /* COMPILING_BINARY_FUNCS */
+}
 
-#ifndef COMPILING_BINARY_FUNCS
 static void
 _outPartitionRule(StringInfo str, const PartitionRule *node)
 {
@@ -3585,6 +3585,7 @@ _outPartitionRule(StringInfo str, const PartitionRule *node)
 	WRITE_OID_FIELD(paroid);
 	WRITE_OID_FIELD(parchildrelid);
 	WRITE_OID_FIELD(parparentoid);
+	WRITE_BOOL_FIELD(parisdefault);
 	WRITE_STRING_FIELD(parname);
 	WRITE_NODE_FIELD(parrangestart);
 	WRITE_BOOL_FIELD(parrangestartincl);
@@ -3597,7 +3598,6 @@ _outPartitionRule(StringInfo str, const PartitionRule *node)
 	WRITE_OID_FIELD(partemplatespaceId);
 	WRITE_NODE_FIELD(children);
 }
-#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outPartitionNode(StringInfo str, const PartitionNode *node)

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1295,48 +1295,6 @@ _readExpandStmtSpec(void)
 	READ_DONE();
 }
 
-static Partition *
-_readPartition(void)
-{
-	READ_LOCALS(Partition);
-
-	READ_OID_FIELD(partid);
-	READ_OID_FIELD(parrelid);
-	READ_CHAR_FIELD(parkind);
-	READ_INT_FIELD(parlevel);
-	READ_BOOL_FIELD(paristemplate);
-	READ_BINARY_FIELD(parnatts, sizeof(int16));
-	READ_ATTRNUMBER_ARRAY(paratts, local_node->parnatts);
-	READ_OID_ARRAY(parclass, local_node->parnatts);
-
-	READ_DONE();
-}
-
-static PartitionRule *
-_readPartitionRule(void)
-{
-	READ_LOCALS(PartitionRule);
-
-	READ_OID_FIELD(parruleid);
-	READ_OID_FIELD(paroid);
-	READ_OID_FIELD(parchildrelid);
-	READ_OID_FIELD(parparentoid);
-	READ_BOOL_FIELD(parisdefault);
-	READ_STRING_FIELD(parname);
-	READ_NODE_FIELD(parrangestart);
-	READ_BOOL_FIELD(parrangestartincl);
-	READ_NODE_FIELD(parrangeend);
-	READ_BOOL_FIELD(parrangeendincl);
-	READ_NODE_FIELD(parrangeevery);
-	READ_NODE_FIELD(parlistvalues);
-	READ_BINARY_FIELD(parruleord, sizeof(int16));
-	READ_NODE_FIELD(parreloptions);
-	READ_OID_FIELD(partemplatespaceId);
-	READ_NODE_FIELD(children);
-
-	READ_DONE();
-}
-
 static CreateExternalStmt *
 _readCreateExternalStmt(void)
 {

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -3373,7 +3373,6 @@ _readCreateStmt(void)
 }
 #endif /* COMPILING_BINARY_FUNCS */
 
-#ifndef COMPILING_BINARY_FUNCS
 static Partition *
 _readPartition(void)
 {
@@ -3390,9 +3389,7 @@ _readPartition(void)
 
 	READ_DONE();
 }
-#endif /* COMPILING_BINARY_FUNCS */
 
-#ifndef COMPILING_BINARY_FUNCS
 static PartitionRule *
 _readPartitionRule(void)
 {
@@ -3402,6 +3399,7 @@ _readPartitionRule(void)
 	READ_OID_FIELD(paroid);
 	READ_OID_FIELD(parchildrelid);
 	READ_OID_FIELD(parparentoid);
+	READ_BOOL_FIELD(parisdefault);
 	READ_STRING_FIELD(parname);
 	READ_NODE_FIELD(parrangestart);
 	READ_BOOL_FIELD(parrangestartincl);
@@ -3416,7 +3414,6 @@ _readPartitionRule(void)
 
 	READ_DONE();
 }
-#endif /* COMPILING_BINARY_FUNCS */
 
 static PartitionNode *
 _readPartitionNode(void)


### PR DESCRIPTION
The functions for PartitionRule in outfuncs.c and readfuncs.c were missing
the 'parisdefault' field. That was harmless, because those functions are
in fact unused; we never materialize PartitionRule structs to disk.

To fix, add the field, and to reduce the chance of similar bugs in the
future and to reduce the amount of duplication, remove binary versions of
these functions from outfast.c/readfast.c.

Also remove the binary versions of _readPartition() and _outPartition()
while we're at it. No fields were missing from those, but less duplicated
code is good.

Discussion: https://github.com/greenplum-db/gpdb/issues/9390
