### PR TITLE
Fix node out/read routines for Partition-related structs. (6X_STABLE)

### DIFF
--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -773,44 +773,6 @@ _outPartitionBoundSpec(StringInfo str, PartitionBoundSpec *node)
 }
 
 static void
-_outPartition(StringInfo str, Partition *node)
-{
-	WRITE_NODE_TYPE("PARTITION");
-
-	WRITE_OID_FIELD(partid);
-	WRITE_OID_FIELD(parrelid);
-	WRITE_CHAR_FIELD(parkind);
-	WRITE_INT_FIELD(parlevel);
-	WRITE_BOOL_FIELD(paristemplate);
-	WRITE_BINARY_FIELD(parnatts, sizeof(int16));
-	WRITE_INT_ARRAY(paratts, node->parnatts, int16);
-	WRITE_OID_ARRAY(parclass, node->parnatts);
-}
-
-static void
-_outPartitionRule(StringInfo str, PartitionRule *node)
-{
-	WRITE_NODE_TYPE("PARTITIONRULE");
-
-	WRITE_OID_FIELD(parruleid);
-	WRITE_OID_FIELD(paroid);
-	WRITE_OID_FIELD(parchildrelid);
-	WRITE_OID_FIELD(parparentoid);
-	WRITE_BOOL_FIELD(parisdefault);
-	WRITE_STRING_FIELD(parname);
-	WRITE_NODE_FIELD(parrangestart);
-	WRITE_BOOL_FIELD(parrangestartincl);
-	WRITE_NODE_FIELD(parrangeend);
-	WRITE_BOOL_FIELD(parrangeendincl);
-	WRITE_NODE_FIELD(parrangeevery);
-	WRITE_NODE_FIELD(parlistvalues);
-	WRITE_BINARY_FIELD(parruleord, sizeof(int16));
-	WRITE_NODE_FIELD(parreloptions);
-	WRITE_OID_FIELD(partemplatespaceId);
-	WRITE_NODE_FIELD(children);
-}
-
-static void
 _outAlterPartitionCmd(StringInfo str, AlterPartitionCmd *node)
 {
 	WRITE_NODE_TYPE("ALTERPARTITIONCMD");

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3107,13 +3107,9 @@ _outExpandStmtSpec(StringInfo str, const ExpandStmtSpec *node)
 	WRITE_OID_FIELD(backendId);
 }
 
-
-#ifndef COMPILING_BINARY_FUNCS
 static void
 _outPartition(StringInfo str, const Partition *node)
 {
-	int i;
-
 	WRITE_NODE_TYPE("PARTITION");
 
 	WRITE_OID_FIELD(partid);
@@ -3122,17 +3118,20 @@ _outPartition(StringInfo str, const Partition *node)
 	WRITE_INT_FIELD(parlevel);
 	WRITE_BOOL_FIELD(paristemplate);
 	WRITE_INT_FIELD(parnatts);
+#ifndef COMPILING_BINARY_FUNCS
 	appendStringInfoLiteral(str, " :paratts");
-	for (i = 0; i < node->parnatts; i++)
+	for (int i = 0; i < node->parnatts; i++)
 		appendStringInfo(str, " %i", node->paratts[i]);
 
 	appendStringInfoLiteral(str, " :parclass");
-	for (i = 0; i < node->parnatts; i++)
+	for (int i = 0; i < node->parnatts; i++)
 		appendStringInfo(str, " %d", node->parclass[i]);
-}
+#else
+	WRITE_INT_ARRAY(paratts, node->parnatts, int16);
+	WRITE_OID_ARRAY(parclass, node->parnatts);
 #endif /* COMPILING_BINARY_FUNCS */
+}
 
-#ifndef COMPILING_BINARY_FUNCS
 static void
 _outPartitionRule(StringInfo str, const PartitionRule *node)
 {
@@ -3142,6 +3141,7 @@ _outPartitionRule(StringInfo str, const PartitionRule *node)
 	WRITE_OID_FIELD(paroid);
 	WRITE_OID_FIELD(parchildrelid);
 	WRITE_OID_FIELD(parparentoid);
+	WRITE_BOOL_FIELD(parisdefault);
 	WRITE_STRING_FIELD(parname);
 	WRITE_NODE_FIELD(parrangestart);
 	WRITE_BOOL_FIELD(parrangestartincl);
@@ -3154,7 +3154,6 @@ _outPartitionRule(StringInfo str, const PartitionRule *node)
 	WRITE_OID_FIELD(partemplatespaceId);
 	WRITE_NODE_FIELD(children);
 }
-#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outPartitionNode(StringInfo str, const PartitionNode *node)

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1233,60 +1233,6 @@ _readExpandStmtSpec(void)
 	READ_DONE();
 }
 
-static Partition *
-_readPartition(void)
-{
-	READ_LOCALS(Partition);
-
-	READ_OID_FIELD(partid);
-	READ_OID_FIELD(parrelid);
-	READ_CHAR_FIELD(parkind);
-	READ_INT_FIELD(parlevel);
-	READ_BOOL_FIELD(paristemplate);
-	READ_BINARY_FIELD(parnatts, sizeof(int16));
-	READ_INT_ARRAY(paratts, local_node->parnatts, int16);
-	READ_OID_ARRAY(parclass, local_node->parnatts);
-
-	READ_DONE();
-}
-
-static PartitionRule *
-_readPartitionRule(void)
-{
-	READ_LOCALS(PartitionRule);
-
-	READ_OID_FIELD(parruleid);
-	READ_OID_FIELD(paroid);
-	READ_OID_FIELD(parchildrelid);
-	READ_OID_FIELD(parparentoid);
-	READ_BOOL_FIELD(parisdefault);
-	READ_STRING_FIELD(parname);
-	READ_NODE_FIELD(parrangestart);
-	READ_BOOL_FIELD(parrangestartincl);
-	READ_NODE_FIELD(parrangeend);
-	READ_BOOL_FIELD(parrangeendincl);
-	READ_NODE_FIELD(parrangeevery);
-	READ_NODE_FIELD(parlistvalues);
-	READ_BINARY_FIELD(parruleord, sizeof(int16));
-	READ_NODE_FIELD(parreloptions);
-	READ_OID_FIELD(partemplatespaceId);
-	READ_NODE_FIELD(children);
-
-	READ_DONE();
-}
-
-static PartitionNode *
-_readPartitionNode(void)
-{
-	READ_LOCALS(PartitionNode);
-
-	READ_NODE_FIELD(part);
-	READ_NODE_FIELD(default_part);
-	READ_NODE_FIELD(rules);
-
-	READ_DONE();
-}
-
 static CreateExternalStmt *
 _readCreateExternalStmt(void)
 {

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -179,11 +179,11 @@ inline static char extended_char(char* token, size_t length)
 /* Read an integer array (anything written as ":fldname %d %d ...") */
 #define READ_INT_ARRAY(fldname, count, Type) \
 	token = pg_strtok(&length);		/* skip :fldname */ \
-	if ( local_node->count > 0 ) \
+	if ( count > 0 ) \
 	{ \
 		int i; \
-		local_node->fldname = (Type *)palloc(local_node->count * sizeof(Type)); \
-		for(i=0; i<local_node->count; i++) \
+		local_node->fldname = (Type *)palloc(count * sizeof(Type)); \
+		for(i=0; i<count; i++) \
 		{ \
 			token = pg_strtok(&length);		/* get field value */ \
 			local_node->fldname[i] = (Type) atoi(token); \
@@ -258,11 +258,11 @@ inline static char extended_char(char* token, size_t length)
 /* Read an Oid array (written as ":fldname %u %u ...") */
 #define READ_OID_ARRAY(fldname, count) \
 	token = pg_strtok(&length);		/* skip :fldname */ \
-	if ( local_node->count > 0 ) \
+	if ( count > 0 ) \
 	{ \
 		int i; \
-		local_node->fldname = (Oid *)palloc(local_node->count * sizeof(Oid)); \
-		for(i=0; i<local_node->count; i++) \
+		local_node->fldname = (Oid *)palloc(count * sizeof(Oid)); \
+		for(i=0; i<count; i++) \
 		{ \
 			token = pg_strtok(&length);		/* get field value */ \
 			local_node->fldname[i] = atooid(token); \
@@ -2348,8 +2348,8 @@ _readPartition(void)
 	READ_INT_FIELD(parlevel);
 	READ_BOOL_FIELD(paristemplate);
 	READ_INT_FIELD(parnatts);
-	READ_INT_ARRAY(paratts, parnatts, int16);
-	READ_OID_ARRAY(parclass, parnatts);
+	READ_INT_ARRAY(paratts, local_node->parnatts, int16);
+	READ_OID_ARRAY(parclass, local_node->parnatts);
 
 	READ_DONE();
 }

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2336,7 +2336,6 @@ _readCreateStmt(void)
 }
 #endif /* COMPILING_BINARY_FUNCS */
 
-#ifndef COMPILING_BINARY_FUNCS
 static Partition *
 _readPartition(void)
 {
@@ -2353,9 +2352,7 @@ _readPartition(void)
 
 	READ_DONE();
 }
-#endif /* COMPILING_BINARY_FUNCS */
 
-#ifndef COMPILING_BINARY_FUNCS
 static PartitionRule *
 _readPartitionRule(void)
 {
@@ -2365,6 +2362,7 @@ _readPartitionRule(void)
 	READ_OID_FIELD(paroid);
 	READ_OID_FIELD(parchildrelid);
 	READ_OID_FIELD(parparentoid);
+	READ_BOOL_FIELD(parisdefault);
 	READ_STRING_FIELD(parname);
 	READ_NODE_FIELD(parrangestart);
 	READ_BOOL_FIELD(parrangestartincl);
@@ -2379,20 +2377,18 @@ _readPartitionRule(void)
 
 	READ_DONE();
 }
-#endif /* COMPILING_BINARY_FUNCS */
 
-#ifndef COMPILING_BINARY_FUNCS
 static PartitionNode *
 _readPartitionNode(void)
 {
 	READ_LOCALS(PartitionNode);
 
 	READ_NODE_FIELD(part);
+	READ_NODE_FIELD(default_part);
 	READ_NODE_FIELD(rules);
 
 	READ_DONE();
 }
-#endif /* COMPILING_BINARY_FUNCS */
 
 static PgPartRule *
 _readPgPartRule(void)


### PR DESCRIPTION
The functions for PartitionRule in outfuncs.c and readfuncs.c were missing
the 'parisdefault' field, and readfuncs.c function for PartitionNode was
missing the 'default_part' field. Those omissions were harmless, because
those functions are in fact unused; we never materialize PartitionRule
or PartitionNode structs to disk. But let's be tidy.

To fix, add the missing fields to the out/readfuncs.c functions, and to
reduce the chance of similar bugs in the future and to reduce the amount
of duplication, remove binary versions of these functions from
outfast.c/readfast.c.

Also remove the binary versions of _readPartition() and _outPartition()
while we're at it. No fields were missing from those, but less duplicated
code is good.

The string and binary versions for Partition and PartitionRule were not
exactly the same. The binary version wrote out the 'parruleord' and
'parnatts' fields as 16-bit integers, whereas the string version used a
32-bit integer. But that's OK, we're free to change the binary functions
in minor versions, and had in fact already made one such change since
the last minor version (6.3.0), in commit 22b72301. Using a 16-bit int
is in principle more compact, but these are not that space-critical that
it would matter.

Discussion: https://github.com/greenplum-db/gpdb/issues/9390
