### PR TITLE
Forgot to remove WARNING from expected output.

### DIFF
--- a/src/test/regress/output/auth_constraint.source
+++ b/src/test/regress/output/auth_constraint.source
@@ -964,7 +964,6 @@ create role abc deny day 1;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 alter role abc superuser;
 SELECT check_auth_time_constraints('abc', '2011-08-29 12:00:00');
-WARNING:  time constraints added on superuser role
  check_auth_time_constraints 
 -----------------------------
  t


### PR DESCRIPTION
Commit 25a7630e silenced printing a lot of spurious "time constraints
added on superuser rule" warnings from the log. But there was also one
such warning memorized in the expected output, which was overlooked by
that commit. Remove the warning.

The warning was memorized in the expected output in the 9.0 merge
(commit 5ec5c30a), but it should never have been printed. Making a role
superuser with "ALTER ROLE <role> SUPERUSER" drops all
pg_auth_time_constraint entries for the role, so this
check_auth_time_constraints() call shouldn't print such a warning.
