### PR TITLE
Fix EXPLAIN JSON/XML/YAML format for Sequence nodes.

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2208,6 +2208,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 		IsA(plan, ModifyTable) ||
 		IsA(plan, Append) ||
 		IsA(plan, MergeAppend) ||
+		IsA(plan, Sequence) ||
 		IsA(plan, BitmapAnd) ||
 		IsA(plan, BitmapOr) ||
 		IsA(plan, SubqueryScan) ||

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -492,8 +492,58 @@ QUERY PLAN
   </Query>
 </explain>
 (1 row)
+-- Test for an old bug in printing Sequence nodes in JSON/XML format
+-- (https://github.com/greenplum-db/gpdb/issues/9410)
+CREATE TABLE jsonexplaintest (i int4) PARTITION BY RANGE (i) (START(1) END(3) EVERY(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "jsonexplaintest_1_prt_1" for table "jsonexplaintest"
+NOTICE:  CREATE TABLE will create partition "jsonexplaintest_1_prt_2" for table "jsonexplaintest"
+EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Gather Motion",
+      "Senders": 1,
+      "Receivers": 1,
+      "Slice": 1,
+      "Segments": 1,
+      "Gang Type": "primary reader",
+      "Parallel Aware": false,
+      "Plans": [
+        {
+          "Node Type": "Append",
+          "Parent Relationship": "Outer",
+          "Slice": 1,
+          "Segments": 1,
+          "Gang Type": "primary reader",
+          "Parallel Aware": false,
+          "Plans": [
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Member",
+              "Slice": 1,
+              "Segments": 1,
+              "Gang Type": "primary reader",
+              "Parallel Aware": false,
+              "Relation Name": "jsonexplaintest_1_prt_2",
+              "Alias": "jsonexplaintest_1_prt_2",
+              "Filter": "(i = 2)"
+            }
+          ]
+        }
+      ]
+    },
+    "Settings": {
+      "Optimizer": "Postgres query optimizer"
+    }
+  }
+]
+(1 row)
 -- explain_processing_on
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;
+DROP TABLE jsonexplaintest;

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -454,8 +454,70 @@ QUERY PLAN
   </Query>
 </explain>
 (1 row)
+-- Test for an old bug in printing Sequence nodes in JSON/XML format
+-- (https://github.com/greenplum-db/gpdb/issues/9410)
+CREATE TABLE jsonexplaintest (i int4) PARTITION BY RANGE (i) (START(1) END(3) EVERY(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "jsonexplaintest_1_prt_1" for table "jsonexplaintest"
+NOTICE:  CREATE TABLE will create partition "jsonexplaintest_1_prt_2" for table "jsonexplaintest"
+EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Gather Motion",
+      "Senders": 1,
+      "Receivers": 1,
+      "Slice": 1,
+      "Segments": 1,
+      "Gang Type": "primary reader",
+      "Parallel Aware": false,
+      "Plans": [
+        {
+          "Node Type": "Sequence",
+          "Parent Relationship": "Outer",
+          "Slice": 1,
+          "Segments": 1,
+          "Gang Type": "primary reader",
+          "Parallel Aware": false,
+          "Plans": [
+            {
+              "Node Type": "Partition Selector",
+              "Parent Relationship": "Member",
+              "Slice": 1,
+              "Segments": 1,
+              "Gang Type": "primary reader",
+              "Parallel Aware": false,
+              "Relation": "jsonexplaintest",
+              "Dynamic Scan Id": 1,
+              "Partitions selected": "1 (out of 2)"
+            },
+            {
+              "Node Type": "Dynamic Seq Scan",
+              "Parent Relationship": "Member",
+              "Slice": 1,
+              "Segments": 1,
+              "Gang Type": "primary reader",
+              "Parallel Aware": false,
+              "Relation Name": "jsonexplaintest",
+              "Alias": "jsonexplaintest",
+              "Dynamic Scan Id": 1,
+              "Filter": "(i = 2)"
+            }
+          ]
+        }
+      ]
+    },
+    "Settings": {
+      "Optimizer": "Pivotal Optimizer (GPORCA) version 3.88.0"
+    }
+  }
+]
+(1 row)
 -- explain_processing_on
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;
+DROP TABLE jsonexplaintest;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -94,9 +94,16 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
 EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);
 
 EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);
+
+-- Test for an old bug in printing Sequence nodes in JSON/XML format
+-- (https://github.com/greenplum-db/gpdb/issues/9410)
+CREATE TABLE jsonexplaintest (i int4) PARTITION BY RANGE (i) (START(1) END(3) EVERY(1));
+EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
+
 -- explain_processing_on
 
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;
+DROP TABLE jsonexplaintest;


### PR DESCRIPTION
We failed to print the start/end markers of the list of child nodes of
Sequence.

Fixes github issue https://github.com/greenplum-db/gpdb/issues/9410.
