### PR TITLE
WIP: (for review) fix concurrent split update

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2885,6 +2885,7 @@ table_delete(ResultRelInfo *resultRelInfo, EState *estate, bool isUpdate,
 							 cid,
 							 crosscheck_snapshot,
 							 wait,
+							 isUpdate,
 							 hufd);
 	}
 	else if (RelationIsAoRows(resultRelationDesc))

--- a/src/backend/utils/time/tqual.c
+++ b/src/backend/utils/time/tqual.c
@@ -1158,9 +1158,14 @@ HeapTupleSatisfiesMVCC(Relation relation, HeapTuple htup, Snapshot snapshot,
 		}
 		else
 		{
+			bool distributedSnapshotIgnore = false;
+
+			if (!HeapTupleHeaderSplitUpdateIsSet(tuple))
+				distributedSnapshotIgnore = ((tuple->t_infomask2 & HEAP_XMIN_DISTRIBUTED_SNAPSHOT_IGNORE) != 0);
+
 			snapshotCheckResult =
 				XidInMVCCSnapshot(HeapTupleHeaderGetRawXmin(tuple), snapshot,
-								  ((tuple->t_infomask2 & HEAP_XMIN_DISTRIBUTED_SNAPSHOT_IGNORE) != 0),
+								  distributedSnapshotIgnore,
 								  &setDistributedSnapshotIgnore);
 			if (setDistributedSnapshotIgnore)
 			{
@@ -1186,9 +1191,14 @@ HeapTupleSatisfiesMVCC(Relation relation, HeapTuple htup, Snapshot snapshot,
 		/* xmin is committed, but maybe not according to our snapshot */
 		if (!HeapTupleHeaderXminFrozen(tuple))
 		{
+			bool distributedSnapshotIgnore = false;
+
+			if (!HeapTupleHeaderSplitUpdateIsSet(tuple))
+				distributedSnapshotIgnore = ((tuple->t_infomask2 & HEAP_XMIN_DISTRIBUTED_SNAPSHOT_IGNORE) != 0);
+
 			snapshotCheckResult =
 				XidInMVCCSnapshot(HeapTupleHeaderGetRawXmin(tuple), snapshot,
-								  ((tuple->t_infomask2 & HEAP_XMIN_DISTRIBUTED_SNAPSHOT_IGNORE) != 0),
+								  distributedSnapshotIgnore,
 								  &setDistributedSnapshotIgnore);
 			if (setDistributedSnapshotIgnore)
 			{
@@ -1228,9 +1238,14 @@ HeapTupleSatisfiesMVCC(Relation relation, HeapTuple htup, Snapshot snapshot,
 				return false;	/* deleted before scan started */
 		}
 
+		bool distributedSnapshotIgnore = false;
+
+		if (!HeapTupleHeaderSplitUpdateIsSet(tuple))
+			distributedSnapshotIgnore = ((tuple->t_infomask2 & HEAP_XMAX_DISTRIBUTED_SNAPSHOT_IGNORE) != 0);
+
 		snapshotCheckResult = XidInMVCCSnapshot(xmax, snapshot,
-									   ((tuple->t_infomask2 & HEAP_XMAX_DISTRIBUTED_SNAPSHOT_IGNORE) != 0),
-									   &setDistributedSnapshotIgnore);
+												distributedSnapshotIgnore,
+												&setDistributedSnapshotIgnore);
 		if (setDistributedSnapshotIgnore)
 		{
 			tuple->t_infomask2 |= HEAP_XMAX_DISTRIBUTED_SNAPSHOT_IGNORE;
@@ -1254,9 +1269,14 @@ HeapTupleSatisfiesMVCC(Relation relation, HeapTuple htup, Snapshot snapshot,
 				return false;	/* deleted before scan started */
 		}
 
+		bool distributedSnapshotIgnore = false;
+
+		if (!HeapTupleHeaderSplitUpdateIsSet(tuple))
+			distributedSnapshotIgnore = ((tuple->t_infomask2 & HEAP_XMAX_DISTRIBUTED_SNAPSHOT_IGNORE) != 0);
+
 		snapshotCheckResult = XidInMVCCSnapshot(HeapTupleHeaderGetRawXmax(tuple), snapshot,
-									   ((tuple->t_infomask2 & HEAP_XMAX_DISTRIBUTED_SNAPSHOT_IGNORE) != 0),
-									   &setDistributedSnapshotIgnore);
+												distributedSnapshotIgnore,
+												&setDistributedSnapshotIgnore);
 		if (setDistributedSnapshotIgnore)
 		{
 			tuple->t_infomask2 |= HEAP_XMAX_DISTRIBUTED_SNAPSHOT_IGNORE;
@@ -1280,9 +1300,14 @@ HeapTupleSatisfiesMVCC(Relation relation, HeapTuple htup, Snapshot snapshot,
 	else
 	{
 		/* xmax is committed, but maybe not according to our snapshot */
+		bool distributedSnapshotIgnore = false;
+
+		if (!HeapTupleHeaderSplitUpdateIsSet(tuple))
+			distributedSnapshotIgnore = ((tuple->t_infomask2 & HEAP_XMAX_DISTRIBUTED_SNAPSHOT_IGNORE) != 0);
+
 		snapshotCheckResult =
 			XidInMVCCSnapshot(HeapTupleHeaderGetRawXmax(tuple), snapshot,
-							  ((tuple->t_infomask2 & HEAP_XMAX_DISTRIBUTED_SNAPSHOT_IGNORE) != 0),
+							  distributedSnapshotIgnore,
 							  &setDistributedSnapshotIgnore);
 		if (setDistributedSnapshotIgnore)
 		{

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -165,7 +165,7 @@ extern Oid heap_insert(Relation relation, HeapTuple tup, CommandId cid,
 extern void heap_multi_insert(Relation relation, HeapTuple *tuples, int ntuples,
 				  CommandId cid, int options, BulkInsertState bistate, TransactionId xid);
 extern HTSU_Result heap_delete(Relation relation, ItemPointer tid,
-			CommandId cid, Snapshot crosscheck, bool wait,
+							   CommandId cid, Snapshot crosscheck, bool wait, bool is_splitupdate,
 			HeapUpdateFailureData *hufd);
 extern void heap_finish_speculative(Relation relation, HeapTuple tuple);
 extern void heap_abort_speculative(Relation relation, HeapTuple tuple);

--- a/src/include/access/htup_details.h
+++ b/src/include/access/htup_details.h
@@ -277,6 +277,15 @@ struct HeapTupleHeaderData
 #define HEAP2_XACT_MASK			0xE000	/* visibility-related bits */
 
 /*
+ * The two bits HEAP_XMIN_DISTRIBUTED_SNAPSHOT_IGNORE and
+ * HEAP_XMAX_DISTRIBUTED_SNAPSHOT_IGNORE is introduced by Greenplum.
+ * They have their own usage. Here we combine them to use the two
+ * bits as a flag for the tuple is deleted by a splitupdate if they are
+ * both set.
+ */
+#define HEAP_IS_SPLIT_UPDATE (HEAP_XMIN_DISTRIBUTED_SNAPSHOT_IGNORE|HEAP_XMAX_DISTRIBUTED_SNAPSHOT_IGNORE)
+
+/*
  * HEAP_TUPLE_HAS_MATCH is a temporary flag used during hash joins.  It is
  * only used in tuples that are in the hash table, and those don't need
  * any visibility information, so we can overlay it on a visibility flag
@@ -355,6 +364,12 @@ struct HeapTupleHeaderData
 ( \
 	AssertMacro(!HeapTupleHeaderXminInvalid(tup)), \
 	((tup)->t_infomask |= HEAP_XMIN_FROZEN) \
+)
+
+#define HeapTupleHeaderSplitUpdateIsSet(tup) \
+( \
+ (((tup)->t_infomask2) & HEAP_XMIN_DISTRIBUTED_SNAPSHOT_IGNORE) && \
+ (((tup)->t_infomask2) & HEAP_XMAX_DISTRIBUTED_SNAPSHOT_IGNORE)	   \
 )
 
 /*

--- a/src/test/isolation2/expected/gdd/concurrent_splitupdate_with_norm_upddel.out
+++ b/src/test/isolation2/expected/gdd/concurrent_splitupdate_with_norm_upddel.out
@@ -1,0 +1,26 @@
+create table t_concurrent_splitupdate_with_norm_upddel (a int, b int) distributed by (a);
+CREATE
+
+insert into t_concurrent_splitupdate_with_norm_upddel values (1, 1);
+INSERT 1
+
+1: begin;
+BEGIN
+1: update t_concurrent_splitupdate_with_norm_upddel set a = 2 where b = 1;
+UPDATE 1
+
+2: begin;
+BEGIN
+2&: delete from t_concurrent_splitupdate_with_norm_upddel;  <waiting ...>
+
+1: end;
+END
+2<:  <... completed>
+ERROR:  the tuple is deleted by a split update, concurrently update or delete with splitupdate is not allowed in Greenplum. (heapam.c:3569)  (seg1 127.0.1.1:7003 pid=73840) (heapam.c:3569)
+
+1q: ... <quitting>
+2:abort;
+ABORT
+2q: ... <quitting>
+
+

--- a/src/test/isolation2/sql/gdd/concurrent_splitupdate_with_norm_upddel.sql
+++ b/src/test/isolation2/sql/gdd/concurrent_splitupdate_with_norm_upddel.sql
@@ -1,0 +1,18 @@
+create table t_concurrent_splitupdate_with_norm_upddel (a int, b int) distributed by (a);
+
+insert into t_concurrent_splitupdate_with_norm_upddel values (1, 1);
+
+1: begin;
+1: update t_concurrent_splitupdate_with_norm_upddel set a = 2 where b = 1;
+
+2: begin;
+2&: delete from t_concurrent_splitupdate_with_norm_upddel;
+
+1: end;
+2<:
+
+1q:
+2:abort;
+2q:
+
+


### PR DESCRIPTION
Try to fix the issue: https://github.com/greenplum-db/gpdb/issues/8919

Related gpdb-dev mailing list thread is here: https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/Yg5ypzj-fqg

Greenplum use a technique called split update to handle update on distkeys.
The top modify table plannode will decide to do ExecDelete or ExecInsert based on the
action field in the tuple(this field is generated by split plannode).

The ExecDelete and the corresponding ExecInsert may happend in different segment, so this is
a huge difference from Postgres's heap_update. (You can easily get the new tuple if it is heap_update),
but for split update, it is not easy to get the new tuple.

The following is the RCA of the github issue 8919
```
Let's go through this:
transaction1: it is a split update, it delete the tuple (let's name it tupleA) in seg0, 
and insert a new tuple (let's name it tupleB ) in seg1
transaction2: it is a delete the whole table, it will hang, yes,
when it delete the tuple in seg0(which deleted by transaction1).
And it will continue if tx1 commited.
But, tupleB cannot be seen by transaction2 if the isolation level is read-committed.
```

The PR introduces a new idea to fix this. When we invoke ExecDelete, we already if this is a splitupdate,
it so, we can encode this information into the tuple's infomask field. So that, if others wait for the XID
on the tuple, and find out it is modified by a committed split-update transaction, then the transaction
aborts itself to make things consistent.

In infomask2, postgres left two bits not used. But these two bits have been used by Greenplum.

`HEAP_XMIN_DISTRIBUTED_SNAPSHOT_IGNORE `and `HEAP_XMAX_DISTRIBUTED_SNAPSHOT_IGNORE`.

After some thoughts, I decide to combine these two fields to represent the tuple is deleted by a splitupdate.

It is hacky.

A test case is attached to show the fix's result.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
