### PR TITLE
Fix EXPLAIN JSON/XML/YAML format for Sequence nodes. (6X_STABLE)

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2253,6 +2253,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 		IsA(plan, ModifyTable) ||
 		IsA(plan, Append) ||
 		IsA(plan, MergeAppend) ||
+		IsA(plan, Sequence) ||
 		IsA(plan, BitmapAnd) ||
 		IsA(plan, BitmapOr) ||
 		IsA(plan, SubqueryScan) ||

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -462,6 +462,52 @@ QUERY PLAN
   </Query>
 </explain>
 (1 row)
+-- Test for an old bug in printing Sequence nodes in JSON/XML format
+-- (https://github.com/greenplum-db/gpdb/issues/9410)
+CREATE TABLE jsonexplaintest (i int4) PARTITION BY RANGE (i) (START(1) END(3) EVERY(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "jsonexplaintest_1_prt_1" for table "jsonexplaintest"
+NOTICE:  CREATE TABLE will create partition "jsonexplaintest_1_prt_2" for table "jsonexplaintest"
+EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Gather Motion",
+      "Senders": 1,
+      "Receivers": 1,
+      "Slice": 1,
+      "Segments": 1,
+      "Gang Type": "primary reader",
+      "Plans": [
+        {
+          "Node Type": "Append",
+          "Parent Relationship": "Outer",
+          "Slice": 1,
+          "Segments": 1,
+          "Gang Type": "primary reader",
+          "Plans": [
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Member",
+              "Slice": 1,
+              "Segments": 1,
+              "Gang Type": "primary reader",
+              "Relation Name": "jsonexplaintest_1_prt_2",
+              "Alias": "jsonexplaintest_1_prt_2",
+              "Filter": "(i = 2)"
+            }
+          ]
+        }
+      ]
+    },
+    "Settings": {
+      "Optimizer": "Postgres query optimizer"
+    }
+  }
+]
+(1 row)
 -- explain_processing_on
 -- Test for github issue #9359
 --
@@ -680,3 +726,4 @@ commit;
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;
+DROP TABLE jsonexplaintest;

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -434,6 +434,63 @@ QUERY PLAN
   </Query>
 </explain>
 (1 row)
+-- Test for an old bug in printing Sequence nodes in JSON/XML format
+-- (https://github.com/greenplum-db/gpdb/issues/9410)
+CREATE TABLE jsonexplaintest (i int4) PARTITION BY RANGE (i) (START(1) END(3) EVERY(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "jsonexplaintest_1_prt_1" for table "jsonexplaintest"
+NOTICE:  CREATE TABLE will create partition "jsonexplaintest_1_prt_2" for table "jsonexplaintest"
+EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Gather Motion",
+      "Senders": 1,
+      "Receivers": 1,
+      "Slice": 1,
+      "Segments": 1,
+      "Gang Type": "primary reader",
+      "Plans": [
+        {
+          "Node Type": "Sequence",
+          "Parent Relationship": "Outer",
+          "Slice": 1,
+          "Segments": 1,
+          "Gang Type": "primary reader",
+          "Plans": [
+            {
+              "Node Type": "Partition Selector",
+              "Parent Relationship": "Member",
+              "Slice": 1,
+              "Segments": 1,
+              "Gang Type": "primary reader",
+              "Relation": "jsonexplaintest",
+              "Dynamic Scan Id": 1,
+              "Partitions selected": "1 (out of 2)"
+            },
+            {
+              "Node Type": "Dynamic Seq Scan",
+              "Parent Relationship": "Member",
+              "Slice": 1,
+              "Segments": 1,
+              "Gang Type": "primary reader",
+              "Relation Name": "jsonexplaintest",
+              "Alias": "jsonexplaintest",
+              "Dynamic Scan Id": 1,
+              "Filter": "(i = 2)"
+            }
+          ]
+        }
+      ]
+    },
+    "Settings": {
+      "Optimizer": "Pivotal Optimizer (GPORCA) version 3.88.0"
+    }
+  }
+]
+(1 row)
 -- explain_processing_on
 -- Test for github issue #9359
 --
@@ -670,3 +727,4 @@ commit;
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;
+DROP TABLE jsonexplaintest;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -94,6 +94,12 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
 EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);
 
 EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);
+
+-- Test for an old bug in printing Sequence nodes in JSON/XML format
+-- (https://github.com/greenplum-db/gpdb/issues/9410)
+CREATE TABLE jsonexplaintest (i int4) PARTITION BY RANGE (i) (START(1) END(3) EVERY(1));
+EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
+
 -- explain_processing_on
 
 
@@ -125,3 +131,4 @@ commit;
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;
+DROP TABLE jsonexplaintest;


### PR DESCRIPTION
Straightforward backport of https://github.com/greenplum-db/gpdb/pull/9423. Opened a PR to get a pipeline run through it before pushing.