### PR TITLE
docs - update DISCARD command. DISCARD ALL not supported

### DIFF
--- a/gpdb-doc/dita/ref_guide/feature_summary.xml
+++ b/gpdb-doc/dita/ref_guide/feature_summary.xml
@@ -615,7 +615,10 @@ NEXT 10 ROWS ONLY; </codeblock><p>Greenplum
             <row>
               <entry colname="col1"><codeph>DISCARD</codeph></entry>
               <entry colname="col2">YES</entry>
-              <entry colname="col3"/>
+              <entry colname="col3">
+                <p><b>Limitation:</b>
+                  <codeph>DISCARD ALL</codeph> is not supported.</p>
+              </entry>
             </row>
             <row>
               <entry colname="col1"><codeph>DO</codeph></entry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DISCARD.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DISCARD.xml
@@ -1,29 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="dn20941">DISCARD</title><body><p id="sql_command_desc">Discards the session state.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">DISCARD { ALL | PLANS | TEMPORARY | TEMP }</codeblock></section><section id="section3">
+<topic id="topic1">
+  <title id="dn20941">DISCARD</title>
+  <body>
+    <p id="sql_command_desc">Discards the session state.</p>
+    <section id="section2">
+      <title>Synopsis</title>
+      <codeblock id="sql_command_synopsis">DISCARD { ALL | PLANS | TEMPORARY | TEMP }</codeblock>
+    </section>
+    <section id="section3">
       <title>Description</title>
-  <p><codeph>DISCARD</codeph> releases internal resources associated with a database session. This command is useful for partially or fully
-    resetting the session's state. There are several subcommands to
-    release different types of resources; the <codeph>DISCARD ALL</codeph>
-      variant subsumes all the others, and also resets additional state.
-  </p>
-</section><section id="section4"><title>Parameters</title><parml><plentry><pt>PLANS</pt><pd>Releases all cached query plans, forcing re-planning to occur
-  the next time the associated prepared statement is used.</pd></plentry><plentry><pt>SEQUENCES</pt><pd>Discards all cached sequence-related state, including any preallocated sequence values that have
-            not yet been returned by <codeph>nextval()</codeph>. (See <codeph>CREATE
-              SEQUENCE</codeph> for a description of preallocated sequence values.) </pd></plentry>
+      <p><codeph>DISCARD</codeph> releases internal resources associated with a database session.
+        This command is useful for partially or fully resetting the session's state. There are
+        several subcommands to release different types of resources; the <codeph>DISCARD
+          ALL</codeph> variant subsumes all the others, and also resets additional state. </p>
+    </section>
+    <section id="section4">
+      <title>Parameters</title>
+      <parml>
+        <plentry>
+          <pt>PLANS</pt>
+          <pd>Releases all cached query plans, forcing re-planning to occur the next time the
+            associated prepared statement is used.</pd>
+        </plentry>
+        <plentry>
+          <pt>SEQUENCES</pt>
+          <pd>Discards all cached sequence-related state, including any preallocated sequence values
+            that have not yet been returned by <codeph>nextval()</codeph>. (See <codeph>CREATE
+              SEQUENCE</codeph> for a description of preallocated sequence values.) </pd>
+        </plentry>
         <plentry>
           <pt>TEMPORARY/TEMP</pt>
           <pd>Drops all temporary tables created in the current session.</pd>
-        </plentry><plentry><pt>ALL</pt><pd>Releases all temporary resources associated with the current session and resets the session to
-            its initial state. Currently, this has the same effect as executing the following
-            sequence of statements:
+        </plentry>
+        <plentry>
+          <pt>ALL</pt>
+          <pd>Releases all temporary resources associated with the current session and resets the
+            session to its initial state.
+            <note>Greenplum Database does not support <codeph>DISCARD ALL</codeph> and returns a
+              notice message if you attempt to run the command.</note></pd>
+          <pd>As an alternative, you can the run following commands to release temporary session
+            resources:
             <codeblock>SET SESSION AUTHORIZATION DEFAULT;
 RESET ALL;
 DEALLOCATE ALL;
 CLOSE ALL;
-UNLISTEN *;
 SELECT pg_advisory_unlock_all();
 DISCARD PLANS;
 DISCARD SEQUENCES;
-DISCARD TEMP;</codeblock></pd></plentry></parml></section><section id="section5"><title>Notes</title><p><codeph>DISCARD ALL</codeph> cannot be executed inside a transaction block.</p></section><section id="section6"><title>Compatibility</title><p><codeph>DISCARD</codeph>  is a Greenplum Database extension.</p></section></body></topic>
+DISCARD TEMP;</codeblock></pd>
+        </plentry>
+      </parml>
+    </section>
+    <section id="section6">
+      <title>Compatibility</title>
+      <p><codeph>DISCARD</codeph> is a Greenplum Database extension.</p>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/DISCARD.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/DISCARD.xml
@@ -13,8 +13,8 @@
       <title>Description</title>
       <p><codeph>DISCARD</codeph> releases internal resources associated with a database session.
         This command is useful for partially or fully resetting the session's state. There are
-        several subcommands to release different types of resources; the <codeph>DISCARD
-          ALL</codeph> variant subsumes all the others, and also resets additional state. </p>
+        several subcommands to release different types of resources. <codeph>DISCARD ALL</codeph> is
+        not supported by Greenplum Database. </p>
     </section>
     <section id="section4">
       <title>Parameters</title>

--- a/gpdb-doc/dita/utility_guide/ref/pgbouncer-ini.xml
+++ b/gpdb-doc/dita/utility_guide/ref/pgbouncer-ini.xml
@@ -455,7 +455,8 @@ db = ...
                   <codeph>server_reset_query</codeph> should be empty, as clients should not use any
                 session features. If clients do use session features, they will be broken because
                 transaction pooling does not guarantee that the next query will run on the same
-                connection.</p><p>Default: <codeph>DISCARD ALL;</codeph></p></pd>
+                connection.</p><p>Default: <codeph>DISCARD ALL;</codeph> (Not supported by Greenplum
+                Database.)</p></pd>
           </plentry>
           <plentry>
             <pt>server_reset_query_always</pt>

--- a/gpdb-doc/dita/utility_guide/ref/pgbouncer-ini.xml
+++ b/gpdb-doc/dita/utility_guide/ref/pgbouncer-ini.xml
@@ -444,20 +444,26 @@ db = ...
             <pt>server_reset_query</pt>
             <pd>Query sent to server on connection release, before making it available to other
               clients. At that moment no transaction is in progress so it should not include
-                <codeph>ABORT</codeph> or <codeph>ROLLBACK</codeph>.<p>The query should clean any changes made to a database session so that the next client gets a connection in a well-defined state. Default is <codeph>DISCARD ALL</codeph> which cleans everything, but that leaves the next client no pre-cached state.</p> <p>When
-                transaction pooling is used, the <codeph>server_reset_query</codeph> should be
-                empty, as clients should not use any session features. If clients do use session
-                features, they will be broken because transaction pooling does not guarantee
-                that the next query will run on the same connection.</p><p>Default:
-                  <codeph>DISCARD ALL;</codeph></p></pd>
+                <codeph>ABORT</codeph> or <codeph>ROLLBACK</codeph>.<p>The query should clean any
+                changes made to a database session so that the next client gets a connection in a
+                well-defined state. Default is <codeph>DISCARD ALL</codeph> which cleans everything,
+                but that leaves the next client no pre-cached state.
+                <note>Greenplum Database does not support <codeph>DISCARD ALL</codeph>.
+                </note></p><p>You can use other commands to clean up the session state. For example,
+                  <codeph>DEALLOCATE ALL</codeph> drops prepared statements, and <codeph>DISCARD
+                  TEMP</codeph> drops temporary tables. </p><p>When transaction pooling is used, the
+                  <codeph>server_reset_query</codeph> should be empty, as clients should not use any
+                session features. If clients do use session features, they will be broken because
+                transaction pooling does not guarantee that the next query will run on the same
+                connection.</p><p>Default: <codeph>DISCARD ALL;</codeph></p></pd>
           </plentry>
           <plentry>
             <pt>server_reset_query_always</pt>
             <pd>
               <p>Whether <codeph>server_reset_query</codeph> should be run in all pooling modes.
-                When this setting is off (default), the <codeph>server_reset_query</codeph> will
-                be run only in pools that are in sessions pooling mode. Connections in
-                transaction pooling mode should not have any need for reset query.</p>
+                When this setting is off (default), the <codeph>server_reset_query</codeph> will be
+                run only in pools that are in sessions pooling mode. Connections in transaction
+                pooling mode should not have any need for reset query.</p>
               <p>Default: 0</p>
             </pd>
           </plentry>


### PR DESCRIPTION
-Update DISCARD command
-Update pgbouncer.ini file parameter: server_reset_query default is DISCARD ALL

This will be backported to 6X_STABLE and 5X_STABLE

dev PR https://github.com/greenplum-db/gpdb/pull/9387