### PR TITLE
Require --with-libxml for enabling gpcloud

### DIFF
--- a/configure
+++ b/configure
@@ -8247,6 +8247,14 @@ if test "$with_libcurl" = "no" && test "$enable_pxf" = "yes"; then
   as_fn_error $? "libcurl is required by PXF" "$LINENO" 5
 fi
 
+if test "$with_libcurl" = "no" && test "$enable_gpcloud" = "yes"; then
+  as_fn_error $? "libcurl is required by gpcloud" "$LINENO" 5
+fi
+
+if test "$with_libxml" = "no" && test "$enable_gpcloud" = "yes"; then
+  as_fn_error $? "libxml is required by gpcloud" "$LINENO" 5
+fi
+
 #
 # libapr. Used for gpfdist and gpperfmon
 #

--- a/configure.in
+++ b/configure.in
@@ -1124,6 +1124,14 @@ if test "$with_libcurl" = "no" && test "$enable_pxf" = "yes"; then
   AC_MSG_ERROR([libcurl is required by PXF])
 fi
 
+if test "$with_libcurl" = "no" && test "$enable_gpcloud" = "yes"; then
+  AC_MSG_ERROR([libcurl is required by gpcloud])
+fi
+
+if test "$with_libxml" = "no" && test "$enable_gpcloud" = "yes"; then
+  AC_MSG_ERROR([libxml is required by gpcloud])
+fi
+
 #
 # libapr. Used for gpfdist and gpperfmon
 #


### PR DESCRIPTION
GPCloud requires libxml, but the dependency wasn't coded in autoconf
which would lead to a tree that didn't compile on systems without
libxml installed.

Fixes: https://github.com/greenplum-db/gpdb/issues/8560
Reported-by: Bradford D. Boyle <bboyle@pivotal.io>
Reviewed-by: Ashwin Agrawal <aagrawal@pivotal.io>
(cherry picked from commit 9534208dc808484f2cec58280b3e506d78c7172c)
