### PR TITLE
Copy GrantStmt for dispatch

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -608,16 +608,19 @@ ExecuteGrantStmt(GrantStmt *stmt)
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
+		GrantStmt *tmpStmt = copyObject(stmt);
+
 		/*
 		 * GPDB: It is possible that objectNamesToOids has expanded references to
 		 * partitioned relations. It is needed to recostruct the GrantStmt objects
 		 * to include those references. We do it uncoditionally of partitioned
 		 * references now for Object Targets.
 		 */
-		if (stmt->targtype == ACL_TARGET_OBJECT &&
-				stmt->objtype == ACL_OBJECT_RELATION)
+		if (tmpStmt->targtype == ACL_TARGET_OBJECT &&
+			tmpStmt->objtype == ACL_OBJECT_RELATION)
 		{
 			List *n = NIL;
+
 			foreach(cell, istmt.objects)
 			{
 				Oid rid = lfirst_oid(cell);
@@ -629,10 +632,10 @@ ExecuteGrantStmt(GrantStmt *stmt)
 				n = lappend(n, rv);
 			}
 
-			stmt->objects = n;
+			tmpStmt->objects = n;
 		}
 
-		CdbDispatchUtilityStatement((Node *) stmt,
+		CdbDispatchUtilityStatement((Node *) tmpStmt,
 									DF_CANCEL_ON_ERROR|
 									DF_WITH_SNAPSHOT|
 									DF_NEED_TWO_PHASE,

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -4281,6 +4281,38 @@ and datname = current_database();
  pg_class | part_acl_test_1_prt_p2 | pg_authid  | part_acl_u1
 (6 rows)
 
+-- Validate, using GrantStmt from cached plan in function works
+-- fine. Using partition table is added spice to this validation as
+-- for partition tables need to perform parent to all child partition
+-- lookup on QD before dispatching the command to segments. There used
+-- to bug where functions cached plan was scribbled during this
+-- process.
+CREATE TABLE grant_test (f1 int) PARTITION BY RANGE (f1) (START (2018) END (2020) EVERY (1), DEFAULT PARTITION extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "grant_test_1_prt_extra" for table "grant_test"
+NOTICE:  CREATE TABLE will create partition "grant_test_1_prt_2" for table "grant_test"
+NOTICE:  CREATE TABLE will create partition "grant_test_1_prt_3" for table "grant_test"
+CREATE FUNCTION grant_table_in_function() RETURNS void AS
+$$
+BEGIN
+    GRANT ALL ON TABLE grant_test TO part_acl_u1;
+END;
+$$ VOLATILE LANGUAGE plpgsql;
+SELECT grant_table_in_function();
+ grant_table_in_function 
+-------------------------
+ 
+(1 row)
+
+-- calling it second time in same session should use cached plan for
+-- GrantStmt
+SELECT grant_table_in_function();
+ grant_table_in_function 
+-------------------------
+ 
+(1 row)
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition cascade;


### PR DESCRIPTION
Since segments don't have partition information, need to dispatch
names of all the tables for GRANT to segments. Doing so scribbles on
the existing stmt. This is problematic when the stmt is stored in
planned cache. We shouldn't scribble on plan cache stmt, hence make
copy and then only modify it.

The current code quite sub-optimal. As on QD, parent to child oid lookup
happens. Then oid to name lookup happens for these tables for dispatching.
Then on QE, again name to OID lookup happens. `ExecuteGrantStmt()` 
creates `InternalGrant` stmt but it's not Node type and hence can't be use for 
`CdbDispatchUtilityStatement()`.

This all can go away, once segments have partition information.

Fixes https://github.com/greenplum-db/gpdb/issues/9428.

Co-authored-by: Taylor Vesely <tvesely@pivotal.io>

Note: Instead of copy, we tried to allocate the newer object in previous objects memory context using `MemoryContextSwitchTo(GetMemoryChunkContext(stmt->objects));`. But the problem with that approach is the list keeps growing for partition table on every call to function, as first call will expand it from just parent name to parent and all child tables. This will keep happening on every call. Also, caching child table names seems incorrect / bad idea as well.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
