### PR TITLE
Update Ivy version for resolving gphdfs dependencies

### DIFF
--- a/gpAux/extensions/gphdfs/Makefile
+++ b/gpAux/extensions/gphdfs/Makefile
@@ -25,6 +25,7 @@ all: $(JAR_FILES) unittest $(JAVADOC_TARS)
 
 dist/hadoop-gnet-1.2.0.0.jar:
 	$(ANT) clean
+	$(ANT) download-ivy
 	ANT_OPTS=$(ANT_OPTS) $(ANT) dist -Dgphdgnet.version=hadoop-gnet-1.2.0.0 \
                 -Dgpgnet.src=1.2 -Dgpgnet.configuration=hadoop2
 	cp dist/hadoop-gnet-1.2.0.0.jar dist/hdp-gnet-1.2.0.0.jar

--- a/gpAux/extensions/gphdfs/build.xml
+++ b/gpAux/extensions/gphdfs/build.xml
@@ -21,7 +21,7 @@
   <loadproperties srcfile="${basedir}/ivy/libraries.properties" />
   <property name="build.ivy.lib.dir" value="${build.dir}/lib" />
   <property name="ivy.artifact.retrieve.pattern" value="[artifact]-[revision](-[classifier]).[ext]" />
-  <property name="ivy.install.version" value="2.2.0" />
+  <property name="ivy.install.version" value="2.5.0" />
   <condition property="ivy.home" value="${env.IVY_HOME}">
     <isset property="env.IVY_HOME" />
   </condition>
@@ -90,7 +90,7 @@
 
   <target name="download-ivy" unless="offline">
     <mkdir dir="${ivy.jar.dir}" />
-    <get src="http://repo2.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
+    <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
          dest="${ivy.jar.file}" usetimestamp="true" />
   </target>
 

--- a/gpAux/extensions/gphdfs/ivy/libraries.properties
+++ b/gpAux/extensions/gphdfs/ivy/libraries.properties
@@ -2,4 +2,4 @@
 apacheant.version=1.7.1
 ant-task.version=2.0.10
 checkstyle.version=5.0
-ivy.version=2.2.0
+ivy.version=2.5.0

--- a/gpAux/extensions/gphdfs/ivysettings.xml
+++ b/gpAux/extensions/gphdfs/ivysettings.xml
@@ -6,21 +6,11 @@
 
   <!-- ====================================================================== -->
 
-  <resolvers>
-    <url name="shared" m2compatible="true">
-      <ivy      pattern="https://mvnrepository.com/artifact/releases/[organisation]/[module]/[revision]/ivys/ivy-[revision].xml" />
-      <artifact pattern="https://mvnrepository.com/artifact/[organisation]/[module]/[revision]/[module]-[revision]." />
-    </url>
-    <filesystem name="local">
-      <ivy      pattern="/opt/ivy/modules/[organisation]/[module]/ivy-[revision].xml" />
-      <artifact pattern="/opt/ivy/modules/[organisation]/[module]/[type]s/[module]-[revision].[ext]" />
-    </filesystem>
-  </resolvers>
-
   <include url="${ivy.default.settings.dir}/ivysettings-public.xml"/>
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml"/>
+  <include url="${ivy.default.settings.dir}/ivysettings-local.xml"/>
   <include url="${ivy.default.settings.dir}/ivysettings-main-chain.xml"/>
   <include url="${ivy.default.settings.dir}/ivysettings-default-chain.xml"/>
-
   <!-- ====================================================================== -->
 
   <triggers>


### PR DESCRIPTION
From [0]:

> Effective January 15, 2020, The Central Repository no longer supports
> insecure communication over plain HTTP and requires that all requests to
> the repository are encrypted over HTTPS.

This commit updates the source URL for downloading Ivy and also updates
the version of Ivy from 2.2.0 to 2.5.0. Without upgrading the version of
Ivy, dependencies were searched for with HTTP; with the new version
HTTPS is used.

[0]: https://support.sonatype.com/hc/en-us/articles/360041287334-Central-501-HTTPS-Required