### PR TITLE
group by + limit query statement stuck due to packet loss of udpifc

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -5446,7 +5446,7 @@ SendChunkUDPIFC(ChunkTransportState *transportStates,
 	{
 		int			timeout = (doCheckExpiration ? 0 : computeTimeout(conn, retry));
 
-		if (QueryFinishPending)
+		if (transportStates->sliceId == transportStates->sliceTable->slices->length-1 && QueryFinishPending)
 		{
 			conn->stillActive = false;
 			return false;
@@ -5598,7 +5598,7 @@ SendEosUDPIFC(ChunkTransportState *transportStates,
 				retry = 0;
 				ic_control_info.lastPacketSendTime = 0;
 
-				if (QueryFinishPending)
+				if (transportStates->sliceId == transportStates->sliceTable->slices->length-1 && QueryFinishPending)
 				{
 					conn->stillActive = false;
 					continue;


### PR DESCRIPTION
### In the case of udpifc packet loss, if the group by statement is added with limit, it will get stuck
Here is the process of problem recurrence：

1. create table for test
create table mytbl(id int, name text, age int, salary int);

2. create simulation data
insert into mytbl SELECT generate_series, chr(int4(random()*26)+65) || chr(int4(random()*26)+65) || chr(int4(random()*26)+65) || chr(int4(random()*26)+65) || chr(int4(random()*26)+65) || chr(int4(random()*26)+65), (random()*(6^2))::integer, (random()*(10^4))::integer from generate_series(1,10000000);

3. Simulate packet loss and delay at one of the nodes
tc qdisc add dev eth0 root netem delay 100ms loss 10%

4. The following statement will be stuck when gp_interconnect_type is udpifc
select count(*) from mytbl group by name limit 1;

Analyze problems from source code:

- Because the statement involves redistribute motion,One of slice2 received all the EOS packages of slice1 and sends EOS packets to the master.

- When the master receives an EOS package sent by slice2, and calls function PortalDrop->PortalCleanup->ExectorEnd->standard_ExecutorEnd->mppExecutorFinishup->cdbdisp_checkDispatchResult->cdbdisp_checkDispatchResult_async->checkDispatchResult->signalQEs->cdbconn_signalQE->PQrequestFinish->internal_cancel sends FINISH_REQUEST_CODE messages to all Slices.

- Slice1 receives a FINISH_REQUEST_CODE message, calls function processCancelRequest->SendProcSignal(,PROCSIG_QUERY_FINISH,), and then the variable QueryFinishPending is set to true in function procsignal_sigusr1_handler->QueryFinishHandler. 

- In the SendEosUDPIFC function, if the packet is lost after sending the EOS packet, judge whether QueryFinishPending is true before pollAcks, if it is true, set conn->stillActive to false and continue. Therefore, the loss EOS packet will not be re sent to the rest of Slice2. 

- As a result, some Slice2 has been waiting. Finally, the query statement has been stuck.


My solution:
In the SendEosUDPIFC function, after sending the EOS package, judge whether the current slice is the top slice and QueryFinishPending is true before pollAcks. If yes, then conn->stillActive is set to false and continue.

```C
...
if (conn->stillActive)
{
    retry = 0;
    ic_control_info.lastPacketSendTime = 0;

    if (transportStates->sliceId == transportStates->sliceTable->slices->length-1 && 
					QueryFinishPending)
    {
        conn->stillActive = false;
        continue;
    }
...
```

Do you have a good solution?

