### PR TITLE
Remove dead code to handle CHECK constraints on external tables.

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -158,16 +158,9 @@ external_beginscan(Relation relation, uint32 scancounter,
 	scan->fs_noop = false;
 	scan->fs_file = NULL;
 	scan->fs_formatter = NULL;
-	scan->fs_constraintExprs = NULL;
-	if (relation->rd_att->constr != NULL && relation->rd_att->constr->num_check > 0)
-	{
-		scan->fs_hasConstraints = true;
-	}
-	else
-	{
-		scan->fs_hasConstraints = false;
-	}
 
+	/* There should be no CHECK constraints on external tables. */
+	Assert(relation->rd_att->constr == NULL || relation->rd_att->constr->num_check == 0);
 
 	/*
 	 * get the external URI assigned to us.

--- a/src/include/access/relscan.h
+++ b/src/include/access/relscan.h
@@ -161,10 +161,6 @@ typedef struct FileScanDescData
 	FmgrInfo   *fs_custom_formatter_func; /* function to convert to custom format */
 	List	   *fs_custom_formatter_params; /* list of defelems that hold user's format parameters */
 	FormatterData *fs_formatter;
-
-	/* external partition */
-	bool		fs_hasConstraints;
-	List		**fs_constraintExprs;	
 }	FileScanDescData;
 
 typedef FileScanDescData *FileScanDesc;


### PR DESCRIPTION
As far as I can see, it is not possible to create CHECK constraints on
external tables. The CREATE TABLE syntax doesn't allow it, and ALTER TABLE
nor ALTER EXTERNAL TABLE doesn't allow it either. Remove the dead code to
handle them in the executor.
