### PR TITLE
6x: Avoid potential deadlock on QD

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -1204,19 +1204,13 @@ CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
 	 */
 	if (lockmode == RowExclusiveLock)
 	{
-		rel = try_heap_open(relid, NoLock, noWait);
-		if (!rel)
-			return NULL;
-
 		if (Gp_role == GP_ROLE_DISPATCH &&
-			(!gp_enable_global_deadlock_detector ||
-			 RelationIsAppendOptimized(rel)))
+			CondUpgradeRelLock(relid, noWait))
 		{
 			lockmode = ExclusiveLock;
 			if (lockUpgraded != NULL)
 				*lockUpgraded = true;
 		}
-		relation_close(rel, NoLock);
     }
 
 	rel = try_heap_open(relid, lockmode, noWait);

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -25,6 +25,7 @@
 #include "storage/lmgr.h"
 #include "storage/procarray.h"
 #include "utils/inval.h"
+#include "utils/guc.h"
 
 #include "access/heapam.h"
 #include "catalog/namespace.h"
@@ -1072,12 +1073,15 @@ LockTagIsTemp(const LOCKTAG *tag)
  * we have to keep upgrading locks for AO table.
  */
 bool
-CondUpgradeRelLock(Oid relid)
+CondUpgradeRelLock(Oid relid, bool noWait)
 {
 	Relation rel;
 	bool upgrade = false;
 
-	rel = try_relation_open(relid, NoLock, true);
+	if (!gp_enable_global_deadlock_detector)
+		return true;
+
+	rel = try_relation_open(relid, NoLock, noWait);
 
 	if (!rel)
 		elog(ERROR, "Relation open failed!");

--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -1553,7 +1553,7 @@ AcquireExecutorLocks(List *stmt_list, bool acquire)
 				if (rte->relid >= FirstNormalObjectId &&
 					(plannedstmt->commandType == CMD_UPDATE ||
 					 plannedstmt->commandType == CMD_DELETE) &&
-					CondUpgradeRelLock(rte->relid))
+					CondUpgradeRelLock(rte->relid, false))
 					lockmode = ExclusiveLock;
 				else
 					lockmode = RowExclusiveLock;
@@ -1643,7 +1643,7 @@ ScanQueryForLocks(Query *parsetree, bool acquire)
 					if (rte->relid >= FirstNormalObjectId &&
 						(parsetree->commandType == CMD_UPDATE ||
 						 parsetree->commandType == CMD_DELETE) &&
-						CondUpgradeRelLock(rte->relid))
+						CondUpgradeRelLock(rte->relid, false))
 						lockmode = ExclusiveLock;
 					else
 						lockmode = RowExclusiveLock;

--- a/src/include/storage/lmgr.h
+++ b/src/include/storage/lmgr.h
@@ -107,6 +107,6 @@ extern void DescribeLockTag(StringInfo buf, const LOCKTAG *tag);
 /* Knowledge about which locktags describe temp objects */
 extern bool LockTagIsTemp(const LOCKTAG *tag);
 
-extern bool CondUpgradeRelLock(Oid relid);
+extern bool CondUpgradeRelLock(Oid relid, bool noWait);
 
 #endif   /* LMGR_H */

--- a/src/test/regress/expected/prepare_lockmode.out
+++ b/src/test/regress/expected/prepare_lockmode.out
@@ -1,0 +1,38 @@
+-- start_ignore
+drop table if exists t_prepare_lockmode;
+NOTICE:  table "t_prepare_lockmode" does not exist, skipping
+-- end_ignore
+create table t_prepare_lockmode(c1 int, c2 int) distributed by (c1);
+prepare myupdate as update t_prepare_lockmode set c2 = $1;
+show gp_enable_global_deadlock_detector;
+ gp_enable_global_deadlock_detector 
+------------------------------------
+ off
+(1 row)
+
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/9446
+-- Previously, when executing prepare statement, the lock mode is
+-- determined by the function CondUpgradeRelLock. However, it did not
+-- consider the GUC gp_enable_global_deadlock_detector's value. When
+-- gp_enable_global_deadlock_detector is set off, previously, we would
+-- hold RowExclusiveLock for the cached plan and then in the function
+-- InitPlan we try to hold ExclusiveLock. The lock mode upgrade will
+-- lead to deadlock on QD.
+-- Now things get correct. If gp_enable_global_deadlock_detector is set
+-- off, then no RowExclusiveLock will be held on the table.
+-- The following test query the lock mode of RowExclusiveLock, this should
+-- give empty results.
+begin;
+execute myupdate(1);
+select mode, granted
+from pg_locks
+where
+  gp_segment_id = -1 and
+  locktype = 'relation' and
+  mode = 'RowExclusiveLock' and
+  relation::regclass::text = 't_prepare_lockmode';
+ mode | granted 
+------+---------
+(0 rows)
+
+abort;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -37,7 +37,7 @@ test: gp_tablespace
 test: temp_tablespaces
 test: default_tablespace
 
-test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy_encoding gp_create_table gp_create_view window_views create_table_like_gp matview_ao
+test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy_encoding gp_create_table gp_create_view window_views create_table_like_gp matview_ao prepare_lockmode
 # below test(s) inject faults so each of them need to be in a separate group
 test: gpcopy
 

--- a/src/test/regress/sql/prepare_lockmode.sql
+++ b/src/test/regress/sql/prepare_lockmode.sql
@@ -1,0 +1,31 @@
+-- start_ignore
+drop table if exists t_prepare_lockmode;
+-- end_ignore
+
+create table t_prepare_lockmode(c1 int, c2 int) distributed by (c1);
+prepare myupdate as update t_prepare_lockmode set c2 = $1;
+
+show gp_enable_global_deadlock_detector;
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/9446
+-- Previously, when executing prepare statement, the lock mode is
+-- determined by the function CondUpgradeRelLock. However, it did not
+-- consider the GUC gp_enable_global_deadlock_detector's value. When
+-- gp_enable_global_deadlock_detector is set off, previously, we would
+-- hold RowExclusiveLock for the cached plan and then in the function
+-- InitPlan we try to hold ExclusiveLock. The lock mode upgrade will
+-- lead to deadlock on QD.
+-- Now things get correct. If gp_enable_global_deadlock_detector is set
+-- off, then no RowExclusiveLock will be held on the table.
+-- The following test query the lock mode of RowExclusiveLock, this should
+-- give empty results.
+
+begin;
+execute myupdate(1);
+select mode, granted
+from pg_locks
+where
+  gp_segment_id = -1 and
+  locktype = 'relation' and
+  mode = 'RowExclusiveLock' and
+  relation::regclass::text = 't_prepare_lockmode';
+abort;


### PR DESCRIPTION
For prepared statements of update|delete the lock mode
is determined by the function `CondUpgradeRelLock`, it
forgot taking the GUC `gp_enable_global_deadlock_detector`
into consideration. So before this commit, QD will first
hold RowExclusiveLock and then hold ExclusiveLock on the
table if `gp_enable_global_deadlock_detector` is set off,
which might lead to local deadlock in QD.

This commit fixes github issue 9446.

=======================================

This pr makes code in 6x more similar to master.

It fixes the issue: https://github.com/greenplum-db/gpdb/issues/9446

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
