### PR TITLE
6X: Fix gpperfmon tmid inconsistent across master and segments

### DIFF
--- a/src/backend/utils/gpmon/gpmon.c
+++ b/src/backend/utils/gpmon/gpmon.c
@@ -159,7 +159,12 @@ void gpmon_record_update(int32 tmid, int32 ssid, int32 ccnt,
 
 void gpmon_gettmid(int32* tmid)
 {
-	*tmid = (int32)getDtxStartTime();
+	if (QEDtxContextInfo.distributedSnapshot.distribTransactionTimeStamp > 0)
+		/* On QE */
+		*tmid = (int32)QEDtxContextInfo.distributedSnapshot.distribTransactionTimeStamp;
+	else
+		/* On QD */
+		*tmid = (int32)getDtxStartTime();
 } 
 
 

--- a/src/test/isolation2/expected/instr_in_shmem_terminate.out
+++ b/src/test/isolation2/expected/instr_in_shmem_terminate.out
@@ -117,12 +117,23 @@ SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, cc
 3&:SET OPTIMIZER TO off;EXPLAIN ANALYZE INSERT INTO QUERY_METRICS.a SELECT *, pg_sleep(1) FROM generate_series(1,10);  <waiting ...>
 
 -- validate plan nodes exist in instrument solts
+SELECT count(*) FROM pg_sleep(1);
+ count 
+-------
+ 1     
+(1 row)
 SELECT ro, CASE WHEN max(nid) > 2 THEN 'ok' ELSE 'wrong' END isok FROM ( SELECT CASE WHEN segid >= 0 THEN 's' ELSE 'm' END ro, nid FROM gp_instrument_shmem_detail WHERE ssid <> (SELECT setting FROM pg_settings WHERE name = 'gp_session_id')::int AND nid > 0 ) dt GROUP BY (ro) ORDER BY ro;
  ro | isok 
 ----+------
  m  | ok   
  s  | ok   
 (2 rows)
+-- validate no different tmid across segments
+SELECT count(*) FROM (SELECT DISTINCT tmid FROM gp_instrument_shmem_detail) t;
+ count 
+-------
+ 1     
+(1 row)
 -- cancel the query
 SELECT pg_cancel_backend(pid, 'test DML') FROM pg_stat_activity WHERE query LIKE 'SET OPTIMIZER TO off;EXPLAIN ANALYZE INSERT INTO QUERY_METRICS.a SELECT%' ORDER BY pid LIMIT 1;
  pg_cancel_backend 
@@ -163,12 +174,23 @@ SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, cc
 4&:SET OPTIMIZER TO off;SELECT a, b, array_dims(array_agg(x)) FROM QUERY_METRICS.mergeappend_test r GROUP BY a, b UNION ALL SELECT NULL, NULL, array_dims(array_agg(x)) FROM QUERY_METRICS.mergeappend_test r, pg_sleep(10) ORDER BY 1,2;  <waiting ...>
 
 -- validate plan nodes exist in instrument solts
+SELECT count(*) FROM pg_sleep(1);
+ count 
+-------
+ 1     
+(1 row)
 SELECT ro, CASE WHEN max(nid) > 5 THEN 'ok' ELSE 'wrong' END isok FROM ( SELECT CASE WHEN segid >= 0 THEN 's' ELSE 'm' END ro, nid FROM gp_instrument_shmem_detail WHERE ssid <> (SELECT setting FROM pg_settings WHERE name = 'gp_session_id')::int AND nid > 0 ) dt GROUP BY (ro) ORDER BY ro;
  ro | isok 
 ----+------
  m  | ok   
  s  | ok   
 (2 rows)
+-- validate no different tmid across segments
+SELECT count(*) FROM (SELECT DISTINCT tmid FROM gp_instrument_shmem_detail) t;
+ count 
+-------
+ 1     
+(1 row)
 -- cancel the query
 SELECT pg_cancel_backend(pid, 'test MergeAppend') FROM pg_stat_activity WHERE query LIKE 'SET OPTIMIZER TO off;SELECT a, b, array_dims(array_agg(x)) FROM QUERY_METRICS.mergeappend_test%' ORDER BY pid LIMIT 1;
  pg_cancel_backend 
@@ -180,6 +202,55 @@ SELECT pg_cancel_backend(pid, 'test MergeAppend') FROM pg_stat_activity WHERE qu
 4<:  <... completed>
 ERROR:  canceling statement due to user request: "test MergeAppend"
 4q: ... <quitting>
+-- end_ignore
+
+-- query backend to ensure no PANIC on postmaster and wait cleanup done
+SELECT count(*) FROM foo, pg_sleep(2);
+ count 
+-------
+ 10    
+(1 row)
+
+-- test 5: entrydb
+-- Expected result is 1 row, means only current query in instrument slots,
+-- If more than one row returned, means previous test has leaked slots.
+SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, ccnt) t;
+ count 
+-------
+ 1     
+(1 row)
+
+-- this query will be cancelled by 'test pg_cancel_backend'
+5&:SET OPTIMIZER TO off;EXPLAIN ANALYZE INSERT INTO QUERY_METRICS.a(id) SELECT oid FROM pg_class, pg_sleep(10);  <waiting ...>
+
+-- validate QD and entrydb have instrumentations on each backend process
+SELECT count(*) FROM pg_sleep(1);
+ count 
+-------
+ 1     
+(1 row)
+SELECT count(DISTINCT pid) FROM gp_instrument_shmem_detail WHERE ssid <> (SELECT setting FROM pg_settings WHERE name = 'gp_session_id')::int AND segid < 0 AND nid >= 5;
+ count 
+-------
+ 2     
+(1 row)
+-- validate no different tmid across segments
+SELECT count(*) FROM (SELECT DISTINCT tmid FROM gp_instrument_shmem_detail) t;
+ count 
+-------
+ 1     
+(1 row)
+-- cancel the query
+SELECT pg_cancel_backend(pid, 'test entrydb') FROM pg_stat_activity WHERE query LIKE 'SET OPTIMIZER TO off;EXPLAIN ANALYZE INSERT INTO QUERY_METRICS.a(id) SELECT%' ORDER BY pid LIMIT 1;
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+
+-- start_ignore
+5<:  <... completed>
+ERROR:  canceling statement due to user request: "test entrydb"
+5q: ... <quitting>
 -- end_ignore
 
 -- query backend to ensure no PANIC on postmaster and wait cleanup done


### PR DESCRIPTION
The tmid should be of the same value among the cluster.
It increases only on gpdb cluster full restart.
Tmid, gp_session_id, and gp_command_count are put together to
uniquely identify a single query execution, monitoring agents
such as gpperfmon relies on this uniqueness.

In 34c1d3eee9871adeb914f680850bfe02d12678a7 introduced a different
way for gpmon_gettmid(), it brings in a problem that on master
and segments the tmid may be different.
This commit fixes the problem.

Reviewed-by: Ning Yu <nyu@pivotal.io>
