### PR TITLE
A little cosmetic refactoring on aggregation.

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -2507,16 +2507,12 @@ ExecInitAgg(Agg *node, EState *estate, int eflags)
 		phasedata->sortnode = sortnode;
 
 		/* Compute group_ids */
+		phasedata->group_id = palloc0(numGroupingSets * sizeof(int));
+
+		for (int setno = 1; setno < num_sets; setno++)
 		{
-			int			setno;
-
-			phasedata->group_id = palloc0(numGroupingSets * sizeof(int));
-
-			for (setno = 1; setno < num_sets; setno++)
-			{
-				if (bms_equal(phasedata->grouped_cols[setno], phasedata->grouped_cols[setno - 1]))
-					phasedata->group_id[setno] = phasedata->group_id[setno - 1] + 1;
-			}
+			if (bms_equal(phasedata->grouped_cols[setno], phasedata->grouped_cols[setno - 1]))
+				phasedata->group_id[setno] = phasedata->group_id[setno - 1] + 1;
 		}
 	}
 

--- a/src/test/regress/expected/olap_plans.out
+++ b/src/test/regress/expected/olap_plans.out
@@ -7,7 +7,7 @@ insert into olap_test select g / 5000, g / 1000, g / 500, g from generate_series
 analyze olap_test;
 create table olap_test_single(a int4, b int4, c int4, d int4) distributed by (a);
 insert into olap_test_single select g / 5000, g / 1000, g / 500, g from generate_series(1, 10000) g;
-analyze olap_test;
+analyze olap_test_single;
 -- If the GROUP BY is a superset of the table's distribution keys, the
 -- aggregation can be independently in segments, and just gather the
 -- results. (1-phase agg)

--- a/src/test/regress/expected/olap_plans_optimizer.out
+++ b/src/test/regress/expected/olap_plans_optimizer.out
@@ -7,7 +7,7 @@ insert into olap_test select g / 5000, g / 1000, g / 500, g from generate_series
 analyze olap_test;
 create table olap_test_single(a int4, b int4, c int4, d int4) distributed by (a);
 insert into olap_test_single select g / 5000, g / 1000, g / 500, g from generate_series(1, 10000) g;
-analyze olap_test;
+analyze olap_test_single;
 -- If the GROUP BY is a superset of the table's distribution keys, the
 -- aggregation can be independently in segments, and just gather the
 -- results. (1-phase agg)

--- a/src/test/regress/sql/olap_plans.sql
+++ b/src/test/regress/sql/olap_plans.sql
@@ -7,7 +7,7 @@ analyze olap_test;
 
 create table olap_test_single(a int4, b int4, c int4, d int4) distributed by (a);
 insert into olap_test_single select g / 5000, g / 1000, g / 500, g from generate_series(1, 10000) g;
-analyze olap_test;
+analyze olap_test_single;
 
 -- If the GROUP BY is a superset of the table's distribution keys, the
 -- aggregation can be independently in segments, and just gather the


### PR DESCRIPTION
This patch performs a little cosmetic refactoring on how group_ids are
computed. Also in test case `olap_plans`, I believe we meant to execute
`analyze olap_test_single` as in this patch.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
