### PR TITLE
Fix inconsistent snapshot during concurrent update

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -444,6 +444,7 @@ DistributedLog_GetDistributedXid(
 	ptr += entryno;
 	*distribTimeStamp = ptr->distribTimeStamp;
 	*distribXid = ptr->distribXid;
+	LWLockRelease(DistributedLogControlLock);
 }
 
 /*

--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -424,6 +424,29 @@ DistributedLog_SetCommittedTree(TransactionId xid, int nxids, TransactionId *xid
 }
 
 /*
+ * Get the corresponding distributed xid and timestamp of a local xid.
+ */
+void
+DistributedLog_GetDistributedXid(
+	TransactionId 						localXid,
+	DistributedTransactionTimeStamp		*distribTimeStamp,
+	DistributedTransactionId 			*distribXid)
+{
+	int			page = TransactionIdToPage(localXid);
+	int			entryno = TransactionIdToEntry(localXid);
+	int			slotno;
+	DistributedLogEntry *ptr;
+
+	Assert(!IS_QUERY_DISPATCHER());
+
+	slotno = SimpleLruReadPage_ReadOnly(DistributedLogCtl, page, localXid);
+	ptr = (DistributedLogEntry *) DistributedLogCtl->shared->page_buffer[slotno];
+	ptr += entryno;
+	*distribTimeStamp = ptr->distribTimeStamp;
+	*distribXid = ptr->distribXid;
+}
+
+/*
  * Determine if a distributed transaction committed in the distributed log.
  */
 bool

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -647,6 +647,11 @@ XactLockTableWait(TransactionId xid, Relation rel, ItemPointer ctid,
 	ErrorContextCallback callback;
 	bool		first = true;
 
+	/*
+	 * Concurrent update and delete will wait on segment when GDD is enabled,
+	 * need to report the waited transactions to QD to make sure the they have
+	 * the same transaction order on the master.
+	 */
 	if (gp_enable_global_deadlock_detector && Gp_role == GP_ROLE_EXECUTE)
 	{
 		MemoryContext oldContext;

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -24,7 +24,9 @@
 #include "miscadmin.h"
 #include "storage/lmgr.h"
 #include "storage/procarray.h"
+#include "storage/proc.h"
 #include "utils/inval.h"
+#include "utils/memutils.h"
 
 #include "access/heapam.h"
 #include "catalog/namespace.h"
@@ -645,6 +647,19 @@ XactLockTableWait(TransactionId xid, Relation rel, ItemPointer ctid,
 	ErrorContextCallback callback;
 	bool		first = true;
 
+	if (gp_enable_global_deadlock_detector && Gp_role == GP_ROLE_EXECUTE)
+	{
+		MemoryContext oldContext;
+		DistributedTransactionId gxid = LocalXidGetDistributedXid(xid);
+
+		if (gxid != InvalidDistributedTransactionId)
+		{
+			oldContext = MemoryContextSwitchTo(TopTransactionContext);
+			MyTmGxactLocal->waitGxids = lappend_int(MyTmGxactLocal->waitGxids, gxid);
+			MemoryContextSwitchTo(oldContext);
+		}
+	}
+
 	/*
 	 * If an operation is specified, set up our verbose error context
 	 * callback.
@@ -701,6 +716,45 @@ XactLockTableWait(TransactionId xid, Relation rel, ItemPointer ctid,
 
 	if (oper != XLTW_None)
 		error_context_stack = callback.previous;
+}
+
+/*
+ *		GxactLockTableInsert
+ *
+ * CDB: a copy of XactLockTableInsert
+ * Insert a lock showing that the given distributed transaction ID is running
+ */
+void
+GxactLockTableInsert(DistributedTransactionId gxid)
+{
+	LOCKTAG		tag;
+
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+
+	SET_LOCKTAG_DISTRIB_TRANSACTION(tag, gxid);
+
+	(void) LockAcquire(&tag, ExclusiveLock, false, false);
+}
+
+/*
+ *		GxactLockTableWait
+ *
+ * CDB: a copy of XactLockTableWait, no need to take care of sub-transaction.
+ * Wait for the specified distributed transaction to commit or abort.
+ */
+void
+GxactLockTableWait(DistributedTransactionId gxid)
+{
+	LOCKTAG		tag;
+
+	Assert(gxid != InvalidDistributedTransactionId);
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+
+	SET_LOCKTAG_DISTRIB_TRANSACTION(tag, gxid);
+
+	(void) LockAcquire(&tag, ShareLock, false, false);
+
+	LockRelease(&tag, ShareLock, false);
 }
 
 /*
@@ -1104,6 +1158,11 @@ DescribeLockTag(StringInfo buf, const LOCKTAG *tag)
 		case LOCKTAG_TRANSACTION:
 			appendStringInfo(buf,
 							 _("transaction %u"),
+							 tag->locktag_field1);
+			break;
+		case LOCKTAG_DISTRIB_TRANSACTION:
+			appendStringInfo(buf,
+							 _("distributed transaction %u"),
 							 tag->locktag_field1);
 			break;
 		case LOCKTAG_VIRTUALTRANSACTION:

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -659,7 +659,12 @@ XactLockTableWait(TransactionId xid, Relation rel, ItemPointer ctid,
 
 		if (gxid != InvalidDistributedTransactionId)
 		{
-			oldContext = MemoryContextSwitchTo(TopTransactionContext);
+			/*
+			 * allocate waitGxids in TopMemoryContext since it's used in
+			 * 'commit prepared' and the TopTransactionContext has been delete
+			 * after 'prepare'
+			 */
+			oldContext = MemoryContextSwitchTo(TopMemoryContext);
 			MyTmGxactLocal->waitGxids = lappend_int(MyTmGxactLocal->waitGxids, gxid);
 			MemoryContextSwitchTo(oldContext);
 		}

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -38,6 +38,7 @@ const char *const LockTagTypeNames[] = {
 	"speculative token",
 	"object",
 	"resource queue",
+	"distributed xid",
 	"userlock",
 	"advisory"
 };
@@ -394,6 +395,18 @@ pg_lock_status(PG_FUNCTION_ARGS)
 				nulls[9] = true;
 				break;
 			case LOCKTAG_TRANSACTION:
+				values[6] =
+					TransactionIdGetDatum(instance->locktag.locktag_field1);
+				nulls[1] = true;
+				nulls[2] = true;
+				nulls[3] = true;
+				nulls[4] = true;
+				nulls[5] = true;
+				nulls[7] = true;
+				nulls[8] = true;
+				nulls[9] = true;
+				break;
+			case LOCKTAG_DISTRIB_TRANSACTION:
 				values[6] =
 					TransactionIdGetDatum(instance->locktag.locktag_field1);
 				nulls[1] = true;

--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -82,5 +82,9 @@ extern void DistributedLog_InitOldestXmin(void);
 extern void DistributedLog_redo(XLogReaderState *record);
 extern void DistributedLog_desc(StringInfo buf, XLogReaderState *record);
 extern const char *DistributedLog_identify(uint8 info);
+extern void DistributedLog_GetDistributedXid(
+				TransactionId 						localXid,
+				DistributedTransactionTimeStamp		*distribTimeStamp,
+				DistributedTransactionId 			*distribXid);
 
 #endif							/* DISTRIBUTEDLOG_H */

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -233,6 +233,7 @@ typedef struct TMGXACTLOCAL
 
 	Bitmapset					*dtxSegmentsMap;
 	List						*dtxSegments;
+	List						*waitGxids;
 }	TMGXACTLOCAL;
 
 typedef struct TMGXACTSTATUS

--- a/src/include/storage/lmgr.h
+++ b/src/include/storage/lmgr.h
@@ -119,4 +119,6 @@ extern bool LockTagIsTemp(const LOCKTAG *tag);
 
 extern bool CondUpgradeRelLock(Oid relid, bool noWait);
 
+extern void GxactLockTableInsert(DistributedTransactionId xid);
+extern void GxactLockTableWait(DistributedTransactionId xid);
 #endif   /* LMGR_H */

--- a/src/include/storage/lock.h
+++ b/src/include/storage/lock.h
@@ -179,6 +179,7 @@ typedef enum LockTagType
 	 * Also, we use DB OID = 0 for shared objects such as tablespaces.
 	 */
 	LOCKTAG_RESOURCE_QUEUE,		/* ID info for resource queue is QUEUE ID */
+	LOCKTAG_DISTRIB_TRANSACTION,/* CDB: distributed transaction (for waiting for distributed xact done) */
 	LOCKTAG_USERLOCK,			/* reserved for old contrib/userlock code */
 	LOCKTAG_ADVISORY			/* advisory user locks */
 } LockTagType;
@@ -248,6 +249,14 @@ typedef struct LOCKTAG
 	 (locktag).locktag_field3 = 0, \
 	 (locktag).locktag_field4 = 0, \
 	 (locktag).locktag_type = LOCKTAG_TRANSACTION, \
+	 (locktag).locktag_lockmethodid = DEFAULT_LOCKMETHOD)
+
+#define SET_LOCKTAG_DISTRIB_TRANSACTION(locktag,gxid) \
+	((locktag).locktag_field1 = (gxid), \
+	 (locktag).locktag_field2 = 0, \
+	 (locktag).locktag_field3 = 0, \
+	 (locktag).locktag_field4 = 0, \
+	 (locktag).locktag_type = LOCKTAG_DISTRIB_TRANSACTION, \
 	 (locktag).locktag_lockmethodid = DEFAULT_LOCKMETHOD)
 
 #define SET_LOCKTAG_VIRTUALTRANSACTION(locktag,vxid) \

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -106,5 +106,6 @@ extern void ProcArraySetReplicationSlotXmin(TransactionId xmin,
 
 extern void ProcArrayGetReplicationSlotXmin(TransactionId *xmin,
 								TransactionId *catalog_xmin);
+extern DistributedTransactionId LocalXidGetDistributedXid(TransactionId xid);
 
 #endif   /* PROCARRAY_H */

--- a/src/interfaces/libpq/fe-exec.c
+++ b/src/interfaces/libpq/fe-exec.c
@@ -183,6 +183,8 @@ PQmakeEmptyPGresult(PGconn *conn, ExecStatusType status)
 	result->numCompleted = 0;
 	result->naotupcounts = 0;
 	result->aotupcounts = NULL;
+	result->nWaits = 0;
+	result->waitGxids = NULL;
 
 	if (conn)
 	{
@@ -739,6 +741,9 @@ PQclear(PGresult *res)
 		free(res->aotupcounts);
 	res->naotupcounts = 0;
 
+	if (res->waitGxids)
+		free(res->waitGxids);
+	res->nWaits = 0;
 	/* Free the PGresult structure itself */
 	free(res);
 }

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -248,6 +248,8 @@ struct pg_result
 	/* GPDB: number of processed tuples for each AO partition */
 	int			naotupcounts;   /* number of aotupcounts, the count in it is an int64 */
 	PQaoRelTupCount *aotupcounts;
+	int		nWaits;
+	int		*waitGxids;
 };
 
 /* PGAsyncStatusType defines the state of the query-execution state machine */

--- a/src/test/isolation2/expected/concurrent_update.out
+++ b/src/test/isolation2/expected/concurrent_update.out
@@ -22,6 +22,54 @@ UPDATE 1
 ---+----+--------------------------------------------------------------------------------------
  1 | 21 | test                                                                                 
 (1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+
+DROP TABLE t_concurrent_update;
+DROP
+
+
+-- Test the concurrent update transaction order on the segment is reflected on master
+CREATE TABLE t_concurrent_update(a int, b int);
+CREATE
+INSERT INTO t_concurrent_update VALUES(1,1);
+INSERT 1
+
+1: BEGIN;
+BEGIN
+1: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+UPDATE 1
+2: BEGIN;
+BEGIN
+-- transaction 2 will wait transaction 1 on the segment
+2&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;  <waiting ...>
+-- transaction 1 suspend before commit, but it will wake up transaction 2 on segment
+1: select gp_inject_fault('before_xact_end_procarray', 'suspend', '', '', '', 1, 1, 0, 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: END;  <waiting ...>
+-- transaction 2 should wait transaction 1 commit on master
+2&: END;  <waiting ...>
+select gp_inject_fault('before_xact_end_procarray', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- the query should not get the incorrect distributed snapshot: transaction 1 in-progress
+-- and transaction 2 finished
+SELECT * FROM t_concurrent_update;
+ a | b 
+---+---
+ 1 | 1 
+(1 row)
+1<:  <... completed>
+END
+2<:  <... completed>
+UPDATE 1
+1q: ... <quitting>
+2q: ... <quitting>
 
 DROP TABLE t_concurrent_update;
 DROP

--- a/src/test/isolation2/expected/concurrent_update.out
+++ b/src/test/isolation2/expected/concurrent_update.out
@@ -30,46 +30,138 @@ DROP
 
 
 -- Test the concurrent update transaction order on the segment is reflected on master
-CREATE TABLE t_concurrent_update(a int, b int);
+-- enable gdd
+--start_ignore
+! gpconfig -c gp_enable_global_deadlock_detector -v on;
+20200305:08:04:41:016395 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-c gp_enable_global_deadlock_detector -v on'
+
+! gpstop -rai;
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Gathering information and validating the environment...
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5622.g0cc5452d2bc build dev'
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb5/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb5/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Stopping master standby host 09c5497cf854 mode=immediate
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Successfully shutdown standby process on 09c5497cf854
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-0.00% of jobs completed
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-100.00% of jobs completed
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-0.00% of jobs completed
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-100.00% of jobs completed
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-----------------------------------------------------
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-----------------------------------------------------
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Cleaning up leftover shared memory
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Restarting System...
+
+--end_ignore
+
+1: SHOW gp_enable_global_deadlock_detector;
+ gp_enable_global_deadlock_detector 
+------------------------------------
+ on                                 
+(1 row)
+1: CREATE TABLE t_concurrent_update(a int, b int);
 CREATE
-INSERT INTO t_concurrent_update VALUES(1,1);
+1: INSERT INTO t_concurrent_update VALUES(1,1);
 INSERT 1
 
-1: BEGIN;
-BEGIN
-1: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
-UPDATE 1
 2: BEGIN;
 BEGIN
--- transaction 2 will wait transaction 1 on the segment
-2&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;  <waiting ...>
--- transaction 1 suspend before commit, but it will wake up transaction 2 on segment
-1: select gp_inject_fault('before_xact_end_procarray', 'suspend', '', '', '', 1, 1, 0, 1);
+2: SET optimizer=off;
+SET
+2: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+UPDATE 1
+3: BEGIN;
+BEGIN
+3: SET optimizer=off;
+SET
+-- transaction 3 will wait transaction 1 on the segment
+3&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;  <waiting ...>
+
+-- transaction 2 suspend before commit, but it will wake up transaction 3 on segment
+2: select gp_inject_fault('before_xact_end_procarray', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-1&: END;  <waiting ...>
--- transaction 2 should wait transaction 1 commit on master
 2&: END;  <waiting ...>
-select gp_inject_fault('before_xact_end_procarray', 'reset', 1);
+1: select gp_wait_until_triggered_fault('before_xact_end_procarray', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- transaction 3 should wait transaction 2 commit on master
+3<:  <... completed>
+UPDATE 1
+3&: END;  <waiting ...>
+1: select gp_inject_fault('before_xact_end_procarray', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
 -- the query should not get the incorrect distributed snapshot: transaction 1 in-progress
 -- and transaction 2 finished
-SELECT * FROM t_concurrent_update;
+1: SELECT * FROM t_concurrent_update;
  a | b 
 ---+---
  1 | 1 
 (1 row)
-1<:  <... completed>
-END
 2<:  <... completed>
-UPDATE 1
-1q: ... <quitting>
+END
+3<:  <... completed>
+END
 2q: ... <quitting>
+3q: ... <quitting>
 
-DROP TABLE t_concurrent_update;
+1: SELECT * FROM t_concurrent_update;
+ a | b  
+---+----
+ 1 | 21 
+(1 row)
+1: DROP TABLE t_concurrent_update;
 DROP
+
+--start_ignore
+! gpconfig -r gp_enable_global_deadlock_detector;
+20200305:08:04:46:016977 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-r gp_enable_global_deadlock_detector'
+
+! gpstop -rai;
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Gathering information and validating the environment...
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5622.g0cc5452d2bc build dev'
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb5/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb5/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Stopping master standby host 09c5497cf854 mode=immediate
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Successfully shutdown standby process on 09c5497cf854
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-0.00% of jobs completed
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-100.00% of jobs completed
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-0.00% of jobs completed
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-100.00% of jobs completed
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-----------------------------------------------------
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-----------------------------------------------------
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Cleaning up leftover shared memory
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Restarting System...
+
+--end_ignore
+1q: ... <quitting>

--- a/src/test/isolation2/sql/concurrent_update.sql
+++ b/src/test/isolation2/sql/concurrent_update.sql
@@ -17,26 +17,45 @@ DROP TABLE t_concurrent_update;
 
 
 -- Test the concurrent update transaction order on the segment is reflected on master
-CREATE TABLE t_concurrent_update(a int, b int);
-INSERT INTO t_concurrent_update VALUES(1,1);
+-- enable gdd
+--start_ignore
+! gpconfig -c gp_enable_global_deadlock_detector -v on;
+! gpstop -rai;
+--end_ignore
 
-1: BEGIN;
-1: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+1: SHOW gp_enable_global_deadlock_detector;
+1: CREATE TABLE t_concurrent_update(a int, b int);
+1: INSERT INTO t_concurrent_update VALUES(1,1);
+
 2: BEGIN;
--- transaction 2 will wait transaction 1 on the segment
-2&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
--- transaction 1 suspend before commit, but it will wake up transaction 2 on segment
-1: select gp_inject_fault('before_xact_end_procarray', 'suspend', '', '', '', 1, 1, 0, 1);
-1&: END;
--- transaction 2 should wait transaction 1 commit on master
+2: SET optimizer=off;
+2: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+3: BEGIN;
+3: SET optimizer=off;
+-- transaction 3 will wait transaction 1 on the segment
+3&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+
+-- transaction 2 suspend before commit, but it will wake up transaction 3 on segment
+2: select gp_inject_fault('before_xact_end_procarray', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
 2&: END;
-select gp_inject_fault('before_xact_end_procarray', 'reset', 1);
+1: select gp_wait_until_triggered_fault('before_xact_end_procarray', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+-- transaction 3 should wait transaction 2 commit on master
+3<:
+3&: END;
+1: select gp_inject_fault('before_xact_end_procarray', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
 -- the query should not get the incorrect distributed snapshot: transaction 1 in-progress
 -- and transaction 2 finished
-SELECT * FROM t_concurrent_update;
-1<:
+1: SELECT * FROM t_concurrent_update;
 2<:
-1q:
+3<:
 2q:
+3q:
 
-DROP TABLE t_concurrent_update;
+1: SELECT * FROM t_concurrent_update;
+1: DROP TABLE t_concurrent_update;
+
+--start_ignore
+! gpconfig -r gp_enable_global_deadlock_detector;
+! gpstop -rai;
+--end_ignore 
+1q:

--- a/src/test/isolation2/sql/concurrent_update.sql
+++ b/src/test/isolation2/sql/concurrent_update.sql
@@ -10,5 +10,33 @@ INSERT INTO t_concurrent_update VALUES(1,1,'test');
 1: END;
 2<:
 1: SELECT * FROM t_concurrent_update;
+1q:
+2q:
+
+DROP TABLE t_concurrent_update;
+
+
+-- Test the concurrent update transaction order on the segment is reflected on master
+CREATE TABLE t_concurrent_update(a int, b int);
+INSERT INTO t_concurrent_update VALUES(1,1);
+
+1: BEGIN;
+1: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+2: BEGIN;
+-- transaction 2 will wait transaction 1 on the segment
+2&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+-- transaction 1 suspend before commit, but it will wake up transaction 2 on segment
+1: select gp_inject_fault('before_xact_end_procarray', 'suspend', '', '', '', 1, 1, 0, 1);
+1&: END;
+-- transaction 2 should wait transaction 1 commit on master
+2&: END;
+select gp_inject_fault('before_xact_end_procarray', 'reset', 1);
+-- the query should not get the incorrect distributed snapshot: transaction 1 in-progress
+-- and transaction 2 finished
+SELECT * FROM t_concurrent_update;
+1<:
+2<:
+1q:
+2q:
 
 DROP TABLE t_concurrent_update;


### PR DESCRIPTION
After enabling the global deadlock detector, we can support concurrent updates.
When updating one tuple at the same time, the conflict and wait are moved from
QD to QE. We need to make sure the implicated transaction order on the segments
is also considered on the master when taking the distributed snapshots.

This is reported: https://github.com/greenplum-db/gpdb/issues/9407

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
