### PR TITLE
Add sanity check for on conflict update to avoid wrong data distribut…

### DIFF
--- a/src/test/regress/expected/insert_conflict.out
+++ b/src/test/regress/expected/insert_conflict.out
@@ -265,6 +265,7 @@ insert into insertconflicttest values (2, 'Orange') on conflict (key, key, key) 
 insert into insertconflicttest
 values (1, 'Apple'), (2, 'Orange')
 on conflict (key) do update set (fruit, key) = (excluded.fruit, excluded.key);
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
 -- Give good diagnostic message when EXCLUDED.* spuriously referenced from
 -- RETURNING:
 insert into insertconflicttest values (1, 'Apple') on conflict (key) do update set fruit = excluded.fruit RETURNING excluded.fruit;

--- a/src/test/regress/expected/update.out
+++ b/src/test/regress/expected/update.out
@@ -164,29 +164,17 @@ INSERT INTO upsert_test VALUES(1, 'Boo');
 WITH aaa AS (SELECT 1 AS a, 'Foo' AS b) INSERT INTO upsert_test
   VALUES (1, 'Bar') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b, a FROM aaa) RETURNING *;
- a |  b  
----+-----
- 1 | Foo
-(1 row)
-
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
 -- correlated sub-select:
 INSERT INTO upsert_test VALUES (1, 'Baz') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b || ', Correlated', a from upsert_test i WHERE i.a = upsert_test.a)
   RETURNING *;
- a |        b        
----+-----------------
- 1 | Foo, Correlated
-(1 row)
-
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
 -- correlated sub-select (EXCLUDED.* alias):
 INSERT INTO upsert_test VALUES (1, 'Bat') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING *;
- a |             b             
----+---------------------------
- 1 | Foo, Correlated, Excluded
-(1 row)
-
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
 DROP TABLE update_test;
 DROP TABLE upsert_test;
 --

--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -560,6 +560,26 @@ SELECT * from update_gp_foo;
      12 | 1 |      1 | 12
 (1 row)
 
+-- Test insert on conflict do update
+-- Insert on conflict do update is an insert statement but might
+-- invoke ExecUpdate on segments, but updating distkeys of a table
+-- may lead to wrong data distribution. We will check this before
+-- planning, if a `insert on conflict do update` statement set the
+-- dist keys of the table, it will raise an error.
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/9444
+create table t_insert_on_conflict_update_distkey(a int, b int) distributed by (a);
+create unique index uidx_t_insert_on_conflict_update_distkey on t_insert_on_conflict_update_distkey(a, b);
+-- the following statement should error out because the on conflict update want to
+-- modify the tuple's distkey which might lead to wrong data distribution
+insert into t_insert_on_conflict_update_distkey values (1, 1) on conflict(a, b) do update set a = 1;
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+drop index uidx_t_insert_on_conflict_update_distkey;
+drop table t_insert_on_conflict_update_distkey;
+-- randomly distributed table cannot add unique constrain, so next we test replicated table
+create table t_insert_on_conflict_update_distkey(a int, b int) distributed replicated;
+create unique index uidx_t_insert_on_conflict_update_distkey on t_insert_on_conflict_update_distkey(a, b);
+-- the following statement should succeed because replicated table does not contain distkey
+insert into t_insert_on_conflict_update_distkey values (1, 1) on conflict(a, b) do update set a = 1;
 -- start_ignore
 drop table r;
 drop table s;

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -563,6 +563,26 @@ SELECT * from update_gp_foo;
      12 | 1 |      1 | 12
 (1 row)
 
+-- Test insert on conflict do update
+-- Insert on conflict do update is an insert statement but might
+-- invoke ExecUpdate on segments, but updating distkeys of a table
+-- may lead to wrong data distribution. We will check this before
+-- planning, if a `insert on conflict do update` statement set the
+-- dist keys of the table, it will raise an error.
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/9444
+create table t_insert_on_conflict_update_distkey(a int, b int) distributed by (a);
+create unique index uidx_t_insert_on_conflict_update_distkey on t_insert_on_conflict_update_distkey(a, b);
+-- the following statement should error out because the on conflict update want to
+-- modify the tuple's distkey which might lead to wrong data distribution
+insert into t_insert_on_conflict_update_distkey values (1, 1) on conflict(a, b) do update set a = 1;
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+drop index uidx_t_insert_on_conflict_update_distkey;
+drop table t_insert_on_conflict_update_distkey;
+-- randomly distributed table cannot add unique constrain, so next we test replicated table
+create table t_insert_on_conflict_update_distkey(a int, b int) distributed replicated;
+create unique index uidx_t_insert_on_conflict_update_distkey on t_insert_on_conflict_update_distkey(a, b);
+-- the following statement should succeed because replicated table does not contain distkey
+insert into t_insert_on_conflict_update_distkey values (1, 1) on conflict(a, b) do update set a = 1;
 -- start_ignore
 drop table r;
 drop table s;

--- a/src/test/regress/expected/update_optimizer.out
+++ b/src/test/regress/expected/update_optimizer.out
@@ -166,29 +166,17 @@ INSERT INTO upsert_test VALUES(1, 'Boo');
 WITH aaa AS (SELECT 1 AS a, 'Foo' AS b) INSERT INTO upsert_test
   VALUES (1, 'Bar') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b, a FROM aaa) RETURNING *;
- a |  b  
----+-----
- 1 | Foo
-(1 row)
-
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
 -- correlated sub-select:
 INSERT INTO upsert_test VALUES (1, 'Baz') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b || ', Correlated', a from upsert_test i WHERE i.a = upsert_test.a)
   RETURNING *;
- a |        b        
----+-----------------
- 1 | Foo, Correlated
-(1 row)
-
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
 -- correlated sub-select (EXCLUDED.* alias):
 INSERT INTO upsert_test VALUES (1, 'Bat') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING *;
- a |             b             
----+---------------------------
- 1 | Foo, Correlated, Excluded
-(1 row)
-
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
 DROP TABLE update_test;
 DROP TABLE upsert_test;
 --

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -1966,9 +1966,7 @@ upsert_cte AS (
 INSERT INTO z VALUES(2, 'Red') ON CONFLICT (k) DO
 UPDATE SET (k, v) = (SELECT k, v FROM upsert_cte WHERE upsert_cte.k = z.k)
 RETURNING k, v;
-ERROR:  writable CTE queries cannot be themselves writable
-DETAIL:  Greenplum Database currently only support CTEs with one writable clause, called in a non-writable context.
-HINT:  Rewrite the query to only include one writable clause.
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
 DROP TABLE z;
 -- check that run to completion happens in proper ordering
 TRUNCATE TABLE y;


### PR DESCRIPTION
…ion.

Statement `Insert on conflict do update` will invoke update on segments.
If the on conflict update modifies the distkeys of the table, this would
lead to wrong data distribution.

This commit avoid this issue by raising error when transformInsertStmt,
if it finds that the on conflict update will touch the distribution keys of
the table.

Fixes github issue: https://github.com/greenplum-db/gpdb/issues/9444

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
