### PR TITLE
Apply additional time control for 2pc prepared commit/abort retry.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -152,7 +152,7 @@ bool		Debug_datumstream_write_use_small_initial_buffers = false;
 bool		gp_create_table_random_default_distribution = true;
 bool		gp_allow_non_uniform_partitioning_ddl = true;
 bool		gp_enable_exchange_default_partition = false;
-int			dtx_phase2_retry_count = 0;
+int			dtx_phase2_retry_second = 0;
 
 bool		log_dispatch_stats = false;
 
@@ -3981,15 +3981,16 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"dtx_phase2_retry_count", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Maximum number of retries during two phase commit after which master PANICs."),
+		{"dtx_phase2_retry_second", PGC_SUSET, GP_ARRAY_TUNING,
+			gettext_noop("Maximum number of timeout during two phase commit after which master PANICs."),
 			NULL,
-			GUC_SUPERUSER_ONLY |  GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY |  GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_UNIT_S
 		},
-		&dtx_phase2_retry_count,
-		10, 0, INT_MAX,
+		&dtx_phase2_retry_second,
+		60, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
+
 
 	{
 		/* Can't be set in postgresql.conf */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -317,7 +317,7 @@ extern bool Debug_resource_group;
 extern bool gp_create_table_random_default_distribution;
 extern bool gp_allow_non_uniform_partitioning_ddl;
 extern bool gp_enable_exchange_default_partition;
-extern int  dtx_phase2_retry_count;
+extern int  dtx_phase2_retry_second;
 
 /* WAL replication debug gucs */
 extern bool debug_walrepl_snd;

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -5,7 +5,6 @@
 		"DateStyle",
 		"default_tablespace",
 		"dml_ignore_target_partition_check",
-		"dtx_phase2_retry_count",
 		"execute_pruned_plan",
 		"explain_memory_verbosity",
 		"force_parallel_mode",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -105,6 +105,7 @@
 		"default_transaction_isolation",
 		"default_transaction_read_only",
 		"default_with_oids",
+		"dtx_phase2_retry_second",
 		"dynamic_library_path",
 		"dynamic_shared_memory_type",
 		"effective_cache_size",

--- a/src/test/heap_checksum/expected/heap_checksum_corruption.out
+++ b/src/test/heap_checksum/expected/heap_checksum_corruption.out
@@ -299,7 +299,6 @@ WARNING:  consider disabling FTS probes while injecting a panic.
 (4 rows)
 
 set client_min_messages='ERROR';
-set dtx_phase2_retry_count=10;
 create table trigger_recovery_on_primaries(c int);
 reset client_min_messages;
 -- reconnect to the database after restart

--- a/src/test/heap_checksum/sql/heap_checksum_corruption.sql
+++ b/src/test/heap_checksum/sql/heap_checksum_corruption.sql
@@ -175,7 +175,6 @@ select count(*) from mark_buffer_dirty_hint;
 -- trigger recovery on primaries with multiple retries and ignore warning/notice messages
 select gp_inject_fault_infinite('finish_prepared_after_record_commit_prepared', 'panic', dbid) from gp_segment_configuration where role = 'p';
 set client_min_messages='ERROR';
-set dtx_phase2_retry_count=10;
 create table trigger_recovery_on_primaries(c int);
 reset client_min_messages;
 -- reconnect to the database after restart

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -18,6 +18,16 @@
 include: helpers/server_helpers.sql;
 CREATE
 
+-- Make the test faster and also make some queries fail as expected after
+-- 2pc retry PANIC (do not finish earlier before PANIC happens).
+alter system set dtx_phase2_retry_second to 5;
+ALTER
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+
 -- This function is used to loop until master shutsdown, to make sure
 -- next command executed is only after restart and doesn't go through
 -- while PANIC is still being processed by master, as master continues
@@ -188,10 +198,10 @@ INSERT 10
 -- To help speedy recovery
 11: CHECKPOINT;
 CHECKPOINT
--- Set to maximum number of 2PC retries to avoid any failures. Alter
+-- Increase 2PC retry timeout to avoid any failures. Alter
 -- system is required to set the GUC and can't be set on session level
 -- as session reset happens for every abort retry.
-11: alter system set dtx_phase2_retry_count to 1500;
+11: alter system set dtx_phase2_retry_second to 600;
 ALTER
 11: select pg_reload_conf();
  pg_reload_conf 
@@ -250,9 +260,17 @@ DETAIL:
 -----------------
  Success:        
 (1 row)
-13: alter system reset dtx_phase2_retry_count;
+13: alter system reset dtx_phase2_retry_second;
 ALTER
 13: select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+
+14: alter system reset dtx_phase2_retry_second;
+ALTER
+14: select pg_reload_conf();
  pg_reload_conf 
 ----------------
  t              

--- a/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
@@ -22,8 +22,6 @@
 --
 -- end_matchsubs
 
-1:set dtx_phase2_retry_count=10;
-SET
 !\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
 -- start_ignore
 -- end_ignore

--- a/src/test/isolation2/sql/segwalrep/twophase_tolerance_with_mirror_promotion.sql
+++ b/src/test/isolation2/sql/segwalrep/twophase_tolerance_with_mirror_promotion.sql
@@ -22,7 +22,6 @@
 --
 -- end_matchsubs
 
-1:set dtx_phase2_retry_count=10;
 !\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
 -- Allow extra time for mirror promotion to complete recovery to avoid
 -- gprecoverseg BEGIN failures due to gang creation failure as some primaries

--- a/src/test/regress/expected/dtm_retry.out
+++ b/src/test/regress/expected/dtm_retry.out
@@ -5,7 +5,6 @@
 -- Check if retry logic handles errors correctly.  The retry logic had
 -- a bug where error state wasn't cleaned up correctly during retries,
 -- leading to PANIC due to ERRORDATA_STACK_SIZE exeeded.
-set dtx_phase2_retry_count = 11;
 -- Set a fault on one of the QEs such that an error is raised exactly
 -- 10 times at the beginning of 2nd phase of 2PC.
 -- ERRORDATA_STACK_SIZE is defined as 10.  By erroring out 10 times,

--- a/src/test/regress/sql/dtm_retry.sql
+++ b/src/test/regress/sql/dtm_retry.sql
@@ -5,7 +5,6 @@
 -- Check if retry logic handles errors correctly.  The retry logic had
 -- a bug where error state wasn't cleaned up correctly during retries,
 -- leading to PANIC due to ERRORDATA_STACK_SIZE exeeded.
-set dtx_phase2_retry_count = 11;
 -- Set a fault on one of the QEs such that an error is raised exactly
 -- 10 times at the beginning of 2nd phase of 2PC.
 -- ERRORDATA_STACK_SIZE is defined as 10.  By erroring out 10 times,


### PR DESCRIPTION
2pc prepared commit/abort retry failure is an annoying issue since it causes
PANIC in production.  We've seen some users' complaints about reducing such
cases when the cluster is in healthy state or during recovery (e.g. via
gprecoverseg). There are many reasons that 2pc retry could not complete, e.g.
primary is recovering (for this create gang could tolerate and retry), or
could not create connections to segments (e.g. too many connections?), etc
Ideally 2pc retry dispatch/execute code should be run as first-class citizen
but it seems to be hard to inspect all cases, so this patch simply adds a guc
dtx_phase2_retry_second to set retry time limit.

we have had a guc dtx_phase2_retry_count (default 10) - that's the limit of 2pc
retry times, also we do sleep 100ms in each try but this is not enough sometime
(e.g. how if dispatch fails soon even fts shows the segments are all ok) so we
could enforce the retry time limit also. With this we stop retry when both
control is exhausted.