### PR TITLE
Fix potential global deadlock for upsert.

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1697,3 +1697,26 @@ getgpsegmentCount(void)
 
 	return numsegments;
 }
+
+/*
+ * IsOnConflictUpdate
+ * Return true if a plannedstmt is an upsert: insert ... on conflict do update
+ */
+bool
+IsOnConflictUpdate(PlannedStmt *ps)
+{
+	Plan      *plan;
+
+	if (ps == NULL || ps->commandType != CMD_INSERT)
+		return false;
+
+	plan = ps->planTree;
+
+	if (plan && IsA(plan, Motion))
+		plan = outerPlan(plan);
+
+	if (plan == NULL || !IsA(plan, ModifyTable))
+		return false;
+
+	return ((ModifyTable *)plan)->onConflictAction == ONCONFLICT_UPDATE;
+}

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1645,6 +1645,9 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 		int			numResultRelations = list_length(resultRelations);
 		ResultRelInfo *resultRelInfos;
 		ResultRelInfo *resultRelInfo;
+		bool        is_conflict_update;
+
+		is_conflict_update = IsOnConflictUpdate(plannedstmt);
 
 		/*
 		 * MPP-2879: The QEs don't pass their MPPEXEC statements through
@@ -1679,7 +1682,8 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 			Relation	resultRelation;
 
 			resultRelationOid = getrelid(resultRelationIndex, rangeTable);
-			if (operation == CMD_UPDATE || operation == CMD_DELETE)
+			if (operation == CMD_UPDATE || operation == CMD_DELETE ||
+				(operation == CMD_INSERT && is_conflict_update)) /* conflictUpdate should be treated as update */
 			{
 				/*
 				 * On QD, the lock on the table has already been taken during parsing, so if it's a child

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -19,6 +19,7 @@
 
 #include "catalog/gp_segment_config.h"
 #include "nodes/pg_list.h"
+#include "nodes/plannodes.h"
 
 struct SegmentDatabaseDescriptor;
 
@@ -208,6 +209,8 @@ extern int numsegmentsFromQD;
  * Returns the number of segments
  */
 extern int getgpsegmentCount(void);
+
+extern bool IsOnConflictUpdate(PlannedStmt *ps);
 
 #define ELOG_DISPATCHER_DEBUG(...) do { \
        if (gp_log_gang >= GPVARS_VERBOSITY_DEBUG) elog(LOG, __VA_ARGS__); \

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -158,6 +158,7 @@ struct ParseState
 	bool		p_hasSubLinks;
 	bool		p_hasModifyingCTE;
 	bool		p_is_insert;
+	bool        p_is_on_conflict_update;
 	bool        p_canOptSelectLockingClause; /* Whether can do some optimization on select with locking clause */
 	LockingClause *p_lockclause_from_parent;
 	bool		p_locked_from_parent;

--- a/src/test/isolation2/expected/gdd/dist-deadlock-upsert.out
+++ b/src/test/isolation2/expected/gdd/dist-deadlock-upsert.out
@@ -1,0 +1,46 @@
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/9449
+-- insert into t values (x, x) on conflict (a, b) do update set b = yyy.
+-- this kind of statement may lock tuples in segment and may lead to
+-- global deadlock when GDD is enabled.
+
+DROP TABLE IF EXISTS t_upsert;
+DROP
+CREATE TABLE t_upsert (id int, val int) distributed by (id);
+CREATE
+CREATE UNIQUE INDEX uidx_t_upsert on t_upsert(id, val);
+CREATE
+INSERT INTO t_upsert (id, val) SELECT i, i FROM generate_series(1, 100) i;
+INSERT 100
+
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+RESET
+20: RESET optimizer;
+RESET
+
+10: BEGIN;
+BEGIN
+20: BEGIN;
+BEGIN
+
+10: INSERT INTO t_upsert VALUES (segid(0,1), segid(0,1)) on conflict (id, val) do update set val = 999;
+INSERT 1
+
+20: INSERT INTO t_upsert VALUES (segid(1,1), segid(1,1)) on conflict (id, val) do update set val = 888;
+INSERT 1
+
+-- seg 0: con20 ==> con10, xid lock
+20&: INSERT INTO t_upsert VALUES (segid(0,1), segid(0,1)) on conflict (id, val) do update set val = 666;  <waiting ...>
+
+-- seg 1: con10 ~~> con20, tuple lock
+10&: INSERT INTO t_upsert VALUES (segid(1,1), segid(1,1)) on conflict (id, val) do update set val = 777;  <waiting ...>
+
+-- con20 will be cancelled by gdd
+20<:  <... completed>
+ERROR:  canceling statement due to user request: "cancelled by global deadlock detector"
+20q: ... <quitting>
+
+-- no more deadlock
+10<:  <... completed>
+INSERT 1
+10q: ... <quitting>

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -26,6 +26,17 @@ CREATE
 create table t_lockmods_rep(c int) distributed replicated;
 CREATE
 
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/9449
+-- upsert may lock tuples on segment, so we should upgrade lock level
+-- on QD if GDD is disabled.
+create table t_lockmods_upsert(a int, b int) distributed by (a);
+CREATE
+create unique index uidx_t_lockmodes_upsert on t_lockmods_upsert(a, b);
+CREATE
+-- add analyze to avoid auto vacuum when executing first insert
+analyze t_lockmods_upsert;
+ANALYZE
+
 -- 1.1.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
 BEGIN
@@ -285,7 +296,20 @@ INSERT 5
 1: abort;
 ABORT
 
--- 1.1.4 use cached plan should be consistent with no cached plan
+-- 1.1.4 upsert should hold ExclusiveLock on result relations
+1: begin;
+BEGIN
+1: insert into t_lockmods_upsert values (1, 1) on conflict(a, b) do update set b = 99;
+INSERT 1
+2: select * from show_locks_lockmodes;
+ locktype | mode          | granted | relation          
+----------+---------------+---------+-------------------
+ relation | ExclusiveLock | t       | t_lockmods_upsert 
+(1 row)
+1: abort;
+ABORT
+
+-- 1.1.5 use cached plan should be consistent with no cached plan
 1: prepare select_for_update as select * from t_lockmods for update;
 PREPARE
 1: prepare select_for_nokeyupdate as select * from t_lockmods for no key update;
@@ -299,6 +323,8 @@ PREPARE
 1: prepare delete_tlockmods as delete from t_lockmods;
 PREPARE
 1: prepare insert_tlockmods as insert into t_lockmods select * from generate_series(1, 5);
+PREPARE
+1: prepare upsert_tlockmods as insert into t_lockmods_upsert values (1, 1) on conflict(a, b) do update set b = 99;
 PREPARE
 
 1: begin;
@@ -410,6 +436,19 @@ EXECUTE 5
 ----------+------------------+---------+------------
  relation | RowExclusiveLock | t       | t_lockmods 
 (1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: execute upsert_tlockmods;
+EXECUTE 1
+2: select * from show_locks_lockmodes;
+ locktype | mode            | granted | relation          
+----------+-----------------+---------+-------------------
+ relation | AccessShareLock | t       | t_lockmods_upsert 
+ relation | ExclusiveLock   | t       | t_lockmods_upsert 
+(2 rows)
 1: abort;
 ABORT
 
@@ -907,7 +946,7 @@ BEGIN
  4 
  5 
 (5 rows)
-1: select * from show_locks_lockmodes;
+2: select * from show_locks_lockmodes;
  locktype | mode            | granted | relation   
 ----------+-----------------+---------+------------
  relation | AccessShareLock | t       | t_lockmods 
@@ -1238,7 +1277,20 @@ INSERT 5
 1: abort;
 ABORT
 
--- 2.1.4 use cached plan should be consistent with no cached plan
+-- 2.1.4 upsert should hold RowExclusiveLock on result relations
+1: begin;
+BEGIN
+1: insert into t_lockmods_upsert values (1, 1) on conflict(a, b) do update set b = 99;
+INSERT 1
+2: select * from show_locks_lockmodes;
+ locktype | mode             | granted | relation          
+----------+------------------+---------+-------------------
+ relation | RowExclusiveLock | t       | t_lockmods_upsert 
+(1 row)
+1: abort;
+ABORT
+
+-- 2.1.5 use cached plan should be consistent with no cached plan
 1: prepare select_for_update as select * from t_lockmods for update;
 PREPARE
 1: prepare select_for_nokeyupdate as select * from t_lockmods for no key update;
@@ -1252,6 +1304,8 @@ PREPARE
 1: prepare delete_tlockmods as delete from t_lockmods;
 PREPARE
 1: prepare insert_tlockmods as insert into t_lockmods select * from generate_series(1, 5);
+PREPARE
+1: prepare upsert_tlockmods as insert into t_lockmods_upsert values (1, 1) on conflict(a, b) do update set b = 99;
 PREPARE
 
 1: begin;
@@ -1363,6 +1417,19 @@ EXECUTE 5
 ----------+------------------+---------+------------
  relation | RowExclusiveLock | t       | t_lockmods 
 (1 row)
+1: abort;
+ABORT
+
+1: begin;
+BEGIN
+1: execute upsert_tlockmods;
+EXECUTE 1
+2: select * from show_locks_lockmodes;
+ locktype | mode             | granted | relation          
+----------+------------------+---------+-------------------
+ relation | AccessShareLock  | t       | t_lockmods_upsert 
+ relation | RowExclusiveLock | t       | t_lockmods_upsert 
+(2 rows)
 1: abort;
 ABORT
 
@@ -1857,7 +1924,7 @@ BEGIN
 -- GPDB_96_MERGE_FIXME: this test had indeterministic row order differences,
 -- because of the "LockRows loses sort order" issue.
 --1: select * from t_lockmods order by c for update;
-1: select * from show_locks_lockmodes;
+2: select * from show_locks_lockmodes;
  locktype | mode            | granted | relation   
 ----------+-----------------+---------+------------
  relation | AccessShareLock | t       | t_lockmods 

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -25,7 +25,7 @@ test: packcore
 
 # Tests on global deadlock detector
 test: gdd/prepare
-test: gdd/dist-deadlock-01 gdd/dist-deadlock-04 gdd/dist-deadlock-05 gdd/dist-deadlock-06 gdd/dist-deadlock-07 gdd/dist-deadlock-102 gdd/dist-deadlock-103 gdd/dist-deadlock-104 gdd/dist-deadlock-106 gdd/non-lock-105
+test: gdd/dist-deadlock-01 gdd/dist-deadlock-04 gdd/dist-deadlock-05 gdd/dist-deadlock-06 gdd/dist-deadlock-07 gdd/dist-deadlock-102 gdd/dist-deadlock-103 gdd/dist-deadlock-104 gdd/dist-deadlock-106 gdd/dist-deadlock-upsert gdd/non-lock-105
 # until we can improve below flaky case please keep it disabled
 ignore: gdd/non-lock-107
 # keep this in a separate group

--- a/src/test/isolation2/sql/gdd/dist-deadlock-upsert.sql
+++ b/src/test/isolation2/sql/gdd/dist-deadlock-upsert.sql
@@ -1,0 +1,34 @@
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/9449
+-- insert into t values (x, x) on conflict (a, b) do update set b = yyy.
+-- this kind of statement may lock tuples in segment and may lead to
+-- global deadlock when GDD is enabled.
+
+DROP TABLE IF EXISTS t_upsert;
+CREATE TABLE t_upsert (id int, val int) distributed by (id);
+CREATE UNIQUE INDEX uidx_t_upsert on t_upsert(id, val);
+INSERT INTO t_upsert (id, val) SELECT i, i FROM generate_series(1, 100) i;
+
+-- gang creation order is important, reset any guc to force the creation
+10: RESET optimizer;
+20: RESET optimizer;
+
+10: BEGIN;
+20: BEGIN;
+
+10: INSERT INTO t_upsert VALUES (segid(0,1), segid(0,1)) on conflict (id, val) do update set val = 999;
+
+20: INSERT INTO t_upsert VALUES (segid(1,1), segid(1,1)) on conflict (id, val) do update set val = 888;
+
+-- seg 0: con20 ==> con10, xid lock
+20&: INSERT INTO t_upsert VALUES (segid(0,1), segid(0,1)) on conflict (id, val) do update set val = 666;
+
+-- seg 1: con10 ~~> con20, tuple lock
+10&: INSERT INTO t_upsert VALUES (segid(1,1), segid(1,1)) on conflict (id, val) do update set val = 777;
+
+-- con20 will be cancelled by gdd
+20<:
+20q:
+
+-- no more deadlock
+10<:
+10q:

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -22,6 +22,14 @@ create table t_lockmods1 (c int) distributed randomly;
 
 create table t_lockmods_rep(c int) distributed replicated;
 
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/9449
+-- upsert may lock tuples on segment, so we should upgrade lock level
+-- on QD if GDD is disabled.
+create table t_lockmods_upsert(a int, b int) distributed by (a);
+create unique index uidx_t_lockmodes_upsert on t_lockmods_upsert(a, b);
+-- add analyze to avoid auto vacuum when executing first insert
+analyze t_lockmods_upsert;
+
 -- 1.1.1 select for (update|share|key share|no key update) should hold ExclusiveLock on range tables
 1: begin;
 1: explain select * from t_lockmods for update;
@@ -88,7 +96,13 @@ create table t_lockmods_rep(c int) distributed replicated;
 2: select * from show_locks_lockmodes;
 1: abort;
 
--- 1.1.4 use cached plan should be consistent with no cached plan
+-- 1.1.4 upsert should hold ExclusiveLock on result relations
+1: begin;
+1: insert into t_lockmods_upsert values (1, 1) on conflict(a, b) do update set b = 99;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+-- 1.1.5 use cached plan should be consistent with no cached plan
 1: prepare select_for_update as select * from t_lockmods for update;
 1: prepare select_for_nokeyupdate as select * from t_lockmods for no key update;
 1: prepare select_for_share as select * from t_lockmods for share;
@@ -96,6 +110,7 @@ create table t_lockmods_rep(c int) distributed replicated;
 1: prepare update_tlockmods as update t_lockmods set c = c + 0;
 1: prepare delete_tlockmods as delete from t_lockmods;
 1: prepare insert_tlockmods as insert into t_lockmods select * from generate_series(1, 5);
+1: prepare upsert_tlockmods as insert into t_lockmods_upsert values (1, 1) on conflict(a, b) do update set b = 99;
 
 1: begin;
 1: execute select_for_update;
@@ -129,6 +144,11 @@ create table t_lockmods_rep(c int) distributed replicated;
 
 1: begin;
 1: execute insert_tlockmods;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: execute upsert_tlockmods;
 2: select * from show_locks_lockmodes;
 1: abort;
 
@@ -266,7 +286,7 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 1: begin;
 1: explain select * from t_lockmods order by c for update;
 1: select * from t_lockmods order by c for update;
-1: select * from show_locks_lockmodes;
+2: select * from show_locks_lockmodes;
 1: abort;
 
 1q:
@@ -353,7 +373,13 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 2: select * from show_locks_lockmodes;
 1: abort;
 
--- 2.1.4 use cached plan should be consistent with no cached plan
+-- 2.1.4 upsert should hold RowExclusiveLock on result relations
+1: begin;
+1: insert into t_lockmods_upsert values (1, 1) on conflict(a, b) do update set b = 99;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+-- 2.1.5 use cached plan should be consistent with no cached plan
 1: prepare select_for_update as select * from t_lockmods for update;
 1: prepare select_for_nokeyupdate as select * from t_lockmods for no key update;
 1: prepare select_for_share as select * from t_lockmods for share;
@@ -361,6 +387,7 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 1: prepare update_tlockmods as update t_lockmods set c = c + 0;
 1: prepare delete_tlockmods as delete from t_lockmods;
 1: prepare insert_tlockmods as insert into t_lockmods select * from generate_series(1, 5);
+1: prepare upsert_tlockmods as insert into t_lockmods_upsert values (1, 1) on conflict(a, b) do update set b = 99;
 
 1: begin;
 1: execute select_for_update;
@@ -394,6 +421,11 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 
 1: begin;
 1: execute insert_tlockmods;
+2: select * from show_locks_lockmodes;
+1: abort;
+
+1: begin;
+1: execute upsert_tlockmods;
 2: select * from show_locks_lockmodes;
 1: abort;
 
@@ -539,7 +571,7 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 -- GPDB_96_MERGE_FIXME: this test had indeterministic row order differences,
 -- because of the "LockRows loses sort order" issue.
 --1: select * from t_lockmods order by c for update;
-1: select * from show_locks_lockmodes;
+2: select * from show_locks_lockmodes;
 1: abort;
 
 1q:


### PR DESCRIPTION
Statement `insert on conflict do update` may invoke ExecUpdate
on segments, so it should be treated as update statement for the
lock mode issue.

Fixes github issue https://github.com/greenplum-db/gpdb/issues/9449

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
