### PR TITLE
Fix instr_in_shmem_terminate test failure

### DIFF
--- a/src/test/isolation2/expected/instr_in_shmem_terminate.out
+++ b/src/test/isolation2/expected/instr_in_shmem_terminate.out
@@ -229,7 +229,7 @@ SELECT count(*) FROM pg_sleep(1);
 -------
  1     
 (1 row)
-SELECT count(DISTINCT pid) FROM gp_instrument_shmem_detail WHERE ssid <> (SELECT setting FROM pg_settings WHERE name = 'gp_session_id')::int AND segid < 0 AND nid >= 5;
+SELECT count(DISTINCT pid) FROM gp_instrument_shmem_detail WHERE ssid <> (SELECT setting FROM pg_settings WHERE name = 'gp_session_id')::int AND segid < 0 AND nid >= 4;
  count 
 -------
  2     

--- a/src/test/isolation2/sql/instr_in_shmem_terminate.sql
+++ b/src/test/isolation2/sql/instr_in_shmem_terminate.sql
@@ -165,7 +165,7 @@ SELECT count(*) FROM (SELECT 1 FROM gp_instrument_shmem_detail GROUP BY ssid, cc
 SELECT count(*) FROM pg_sleep(1);
 SELECT count(DISTINCT pid) FROM gp_instrument_shmem_detail
 WHERE ssid <> (SELECT setting FROM pg_settings WHERE name = 'gp_session_id')::int
- AND segid < 0 AND nid >= 5;
+ AND segid < 0 AND nid >= 4;
 -- validate no different tmid across segments
 SELECT count(*) FROM (SELECT DISTINCT tmid FROM gp_instrument_shmem_detail) t;
 -- cancel the query


### PR DESCRIPTION
Because plannode id start from 0 instead of 1 now,
the expected max nid in instr_in_shmem_terminate test
changed from 5 to 4.