### PR TITLE
Fix compiler warnings.

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -462,7 +462,7 @@ cdbpath_create_motion_path(PlannerInfo *root,
 	/* apply final path target */
         newSubqueryScanPath = (SubqueryScanPath *)apply_projection_to_path(root,
                                                                            subqueryScanPath->path.parent,
-                                                                           newSubqueryScanPath,
+                                                                           (Path *) newSubqueryScanPath,
                                                                            subqueryScanPath->path.pathtarget);
 
         return (Path *) newSubqueryScanPath;


### PR DESCRIPTION
Commit ce81ca79aae introduces a compiler warning.
This commit removes the warning.

===================

It just removes a warning. No test cases needed.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
