### PR TITLE
Make the postgres_fdw extension work

### DIFF
--- a/contrib/file_fdw/output/file_fdw.source
+++ b/contrib/file_fdw/output/file_fdw.source
@@ -276,9 +276,9 @@ SELECT tableoid::regclass, * FROM ONLY agg;
 
 -- updates aren't supported
 UPDATE agg SET a = 1;
-ERROR:  incompatible loci in target inheritance set
+ERROR:  ModifyTable mixes distributed and entry-only tables
 DELETE FROM agg WHERE a = 100;
-ERROR:  incompatible loci in target inheritance set
+ERROR:  ModifyTable mixes distributed and entry-only tables
 -- but this should be allowed
 SELECT tableoid::regclass, * FROM agg FOR UPDATE;
  tableoid |  a  |    b    

--- a/contrib/postgres_fdw/connection.c
+++ b/contrib/postgres_fdw/connection.c
@@ -729,17 +729,12 @@ pgfdw_xact_callback(XactEvent event, void *arg)
 				case XACT_EVENT_PRE_PREPARE:
 
 					/*
-					 * We disallow remote transactions that modified anything,
-					 * since it's not very reasonable to hold them open until
-					 * the prepared transaction is committed.  For the moment,
-					 * throw error unconditionally; later we might allow
-					 * read-only cases.  Note that the error will cause us to
-					 * come right back here with event == XACT_EVENT_ABORT, so
-					 * we'll clean up the connection state at that point.
+					 * FDW update is not the same as Greenplum segments update,
+					 * doesn't need the two-phase commit.
+					 *
+					 * Besides that, Greenplum prepares on many cases including
+					 * DTX distributing for MPP usages, just break here.
 					 */
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							 errmsg("cannot prepare a transaction that modified remote tables")));
 					break;
 				case XACT_EVENT_PARALLEL_COMMIT:
 				case XACT_EVENT_COMMIT:

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -225,6 +225,10 @@ cdbconn_doConnectStart(SegmentDatabaseDescriptor *segdbDesc,
 	}
 	nkeywords++;
 
+	keywords[nkeywords] = GPCONN_TYPE;
+	values[nkeywords] = GPCONN_TYPE_INTERNAL;
+	nkeywords++;
+
 	keywords[nkeywords] = NULL;
 	values[nkeywords] = NULL;
 

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -2153,6 +2153,9 @@ _outNode(StringInfo str, void *obj)
 			case T_RowIdExpr:
 				_outRowIdExpr(str, obj);
 				break;
+			case T_RestrictInfo:
+				_outRestrictInfo(str, obj);
+				break;
 
 			default:
 				elog(ERROR, "could not serialize unrecognized node type: %d",

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2875,6 +2875,7 @@ _outParamPathInfo(StringInfo str, const ParamPathInfo *node)
 	WRITE_FLOAT_FIELD(ppi_rows, "%.0f");
 	WRITE_NODE_FIELD(ppi_clauses);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outRestrictInfo(StringInfo str, const RestrictInfo *node)
@@ -2907,6 +2908,7 @@ _outRestrictInfo(StringInfo str, const RestrictInfo *node)
 	WRITE_OID_FIELD(hashjoinoperator);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outPlaceHolderVar(StringInfo str, const PlaceHolderVar *node)
 {

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2569,6 +2569,9 @@ readNodeBinary(void)
 				return_value = _readLockStmt();
 				break;
 
+			case T_RestrictInfo:
+				return_value = _readRestrictInfo();
+				break;
 			case T_ExtensibleNode:
 				return_value = _readExtensibleNode();
 				break;

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -3333,6 +3333,38 @@ _readAlternativeSubPlan(void)
 	READ_DONE();
 }
 
+static RestrictInfo *
+_readRestrictInfo(void)
+{
+	READ_LOCALS(RestrictInfo);
+
+	/* NB: this isn't a complete set of fields */
+	READ_NODE_FIELD(clause);
+	READ_BOOL_FIELD(is_pushed_down);
+	READ_BOOL_FIELD(outerjoin_delayed);
+	READ_BOOL_FIELD(can_join);
+	READ_BOOL_FIELD(pseudoconstant);
+	READ_BOOL_FIELD(contain_outer_query_references);
+	READ_BITMAPSET_FIELD(clause_relids);
+	READ_BITMAPSET_FIELD(required_relids);
+	READ_BITMAPSET_FIELD(outer_relids);
+	READ_BITMAPSET_FIELD(nullable_relids);
+	READ_BITMAPSET_FIELD(left_relids);
+	READ_BITMAPSET_FIELD(right_relids);
+	READ_NODE_FIELD(orclause);
+
+	READ_FLOAT_FIELD(norm_selec);
+	READ_FLOAT_FIELD(outer_selec);
+	READ_NODE_FIELD(mergeopfamilies);
+
+	READ_NODE_FIELD(left_em);
+	READ_NODE_FIELD(right_em);
+	READ_BOOL_FIELD(outer_is_left);
+	READ_OID_FIELD(hashjoinoperator);
+
+	READ_DONE();
+}
+
 #ifndef COMPILING_BINARY_FUNCS
 /*
  * _readExtensibleNode
@@ -4257,6 +4289,8 @@ parseNodeString(void)
 		return_value = _readSubPlan();
 	else if (MATCH("ALTERNATIVESUBPLAN", 18))
 		return_value = _readAlternativeSubPlan();
+	else if (MATCH("RESTRICTINFO", 12))
+		return_value = _readRestrictInfo();
 	else if (MATCH("EXTENSIBLENODE", 14))
 		return_value = _readExtensibleNode();
 

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -2442,7 +2442,9 @@ create_modifytable_plan(PlannerInfo *root, ModifyTablePath *best_path)
 			else
 			{
 				if (policy->ptype != policyType)
-					elog(ERROR, "ModifyTable mixes distributed and entry-only tables");
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("ModifyTable mixes distributed and entry-only tables")));
 			}
 
 			if (policyType != POLICYTYPE_ENTRY)

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1645,7 +1645,7 @@ inheritance_planner(PlannerInfo *root)
 				 */
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("incompatible loci in target inheritance set")));
+						 errmsg("ModifyTable mixes distributed and entry-only tables")));
 			}
 		}
 

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -234,6 +234,9 @@ pathnode_walk_kids(Path            *path,
 		case T_Append:
 			v = pathnode_walk_list(((AppendPath *)path)->subpaths, walker, context);
 			break;
+		case T_MergeAppend:
+			v = pathnode_walk_list(((MergeAppendPath *)path)->subpaths, walker, context);
+			break;
 		case T_Material:
 			v = pathnode_walk_node(((MaterialPath *)path)->subpath, walker, context);
 			break;

--- a/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
+++ b/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
@@ -20,6 +20,7 @@
 #include <sys/time.h>
 
 #include "libpq-fe.h"
+#include "libpq/pqcomm.h"
 #include "pqexpbuffer.h"
 #include "access/xlog.h"
 #include "miscadmin.h"
@@ -101,8 +102,8 @@ libpqwalreceiver_PG_init(void)
 static void
 libpqrcv_connect(char *conninfo)
 {
-	const char *keys[5];
-	const char *vals[5];
+	const char *keys[6];
+	const char *vals[6];
 
 	/*
 	 * We use the expand_dbname parameter to process the connection string (or
@@ -119,8 +120,10 @@ libpqrcv_connect(char *conninfo)
 	vals[2] = "replication";
 	keys[3] = "fallback_application_name";
 	vals[3] = "walreceiver";
-	keys[4] = NULL;
-	vals[4] = NULL;
+	keys[4] = GPCONN_TYPE;
+	vals[4] = GPCONN_TYPE_INTERNAL;
+	keys[5] = NULL;
+	vals[5] = NULL;
 
 	streamConn = PQconnectdbParams(keys, vals, /* expand_dbname = */ true);
 	if (PQstatus(streamConn) != CONNECTION_OK)

--- a/src/include/libpq/pqcomm.h
+++ b/src/include/libpq/pqcomm.h
@@ -223,5 +223,6 @@ typedef struct CancelRequestPacket
 #define GPCONN_TYPE "gpconntype"
 #define GPCONN_TYPE_FTS "fts"
 #define GPCONN_TYPE_FAULT "fault"
+#define GPCONN_TYPE_INTERNAL "internal"
 
 #endif   /* PQCOMM_H */

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -2357,7 +2357,12 @@ build_startup_packet(const PGconn *conn, char *packet,
 		ADD_STARTUP_OPTION("database", conn->dbName);
 	if (conn->replication && conn->replication[0])
 		ADD_STARTUP_OPTION("replication", conn->replication);
-	if (conn->gpconntype && conn->gpconntype[0])
+	/*
+	 * We don't have an real pg_compatible option, it just
+	 * affects the version number.
+	 */
+	if (conn->gpconntype && conn->gpconntype[0]
+		&& strcmp(conn->gpconntype, GPCONN_TYPE_INTERNAL) != 0)
 		ADD_STARTUP_OPTION(GPCONN_TYPE, conn->gpconntype);
 	if (conn->pgoptions && conn->pgoptions[0])
 		ADD_STARTUP_OPTION("options", conn->pgoptions);

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -5524,13 +5524,13 @@ select * from
   (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
    int8_tbl b cross join int8_tbl c) ss
   on a.q2 = ss.bq1;
-ERROR:  could not devise a query plan for the given query (pathnode.c:469)
+ERROR:  could not devise a query plan for the given query (pathnode.c:472)
 select * from
   int8_tbl a left join lateral
   (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
    int8_tbl b cross join int8_tbl c) ss
   on a.q2 = ss.bq1;
-ERROR:  could not devise a query plan for the given query (pathnode.c:469)
+ERROR:  could not devise a query plan for the given query (pathnode.c:472)
 -- case requiring nested PlaceHolderVars
 explain (verbose, costs off)
 select * from

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1345,7 +1345,7 @@ select p from
           (box(point(0.8,0.8), point(1.0,1.0)))) as v(bb)
 cross join lateral
   (select p from gist_tbl_github9733 where p <@ bb order by p <-> bb[0] limit 2) ss;
-ERROR:  could not devise a query plan for the given query (pathnode.c:469)
+ERROR:  could not devise a query plan for the given query (pathnode.c:472)
 reset enable_seqscan;
 explain (costs off)
 select p from

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1343,7 +1343,7 @@ select p from
           (box(point(0.8,0.8), point(1.0,1.0)))) as v(bb)
 cross join lateral
   (select p from gist_tbl_github9733 where p <@ bb order by p <-> bb[0] limit 2) ss;
-ERROR:  could not devise a query plan for the given query (pathnode.c:469)
+ERROR:  could not devise a query plan for the given query (pathnode.c:472)
 reset enable_seqscan;
 explain (costs off)
 select p from

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -5603,13 +5603,13 @@ select * from
   (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
    int8_tbl b cross join int8_tbl c) ss
   on a.q2 = ss.bq1;
-ERROR:  could not devise a query plan for the given query (pathnode.c:469)
+ERROR:  could not devise a query plan for the given query (pathnode.c:472)
 select * from
   int8_tbl a left join lateral
   (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
    int8_tbl b cross join int8_tbl c) ss
   on a.q2 = ss.bq1;
-ERROR:  could not devise a query plan for the given query (pathnode.c:469)
+ERROR:  could not devise a query plan for the given query (pathnode.c:472)
 -- case requiring nested PlaceHolderVars
 explain (verbose, costs off)
 select * from

--- a/src/test/walrep/expected/walreceiver.out
+++ b/src/test/walrep/expected/walreceiver.out
@@ -1,8 +1,8 @@
 -- negative cases
 SELECT test_receive();
-ERROR:  could not receive data from WAL stream: connection pointer is NULL (libpqwalreceiver.c:628)
+ERROR:  could not receive data from WAL stream: connection pointer is NULL (libpqwalreceiver.c:631)
 SELECT test_send();
-ERROR:  could not send data to WAL stream: connection pointer is NULL (libpqwalreceiver.c:647)
+ERROR:  could not send data to WAL stream: connection pointer is NULL (libpqwalreceiver.c:650)
 SELECT test_disconnect();
  test_disconnect 
 -----------------


### PR DESCRIPTION
Please check the commit messages.

This PR is to make the postgres_fdw work, the major things I have done are:

1, complete the missing parts of the kernel, "Get the missing T_MergeAppend back in pathnode_walk_kids()" and "Add binary (de)serialize functions for RestrictInfo node"

2, hack the connection option GPCONN_TYPE with a new available value "pg_compatible", which makes the libpq connection to use PostgreSQL version number. (GPDB uses the high bits of the major version to indicate special internal communications at the backend, bypass the authentication, and FDW is happening at the backend), which fixed #7935

3, disable UPDATE/DELETE on foreign Greenplum servers, because UPDATE/DELETE requires
the hidden column gp_segment_id and the other "ModifyTable mixes distributed and entry-only tables" issue. However it would work fine on a foreign Postgres server.

And the things this PR hasn't done:

1, UPDATE/DELETE on foreign Greenplum servers. This extension will focus on the foreign Postgres servers.

2, pass all the postgres_fdw installcheck, I tested the functions work but I would like to defer it to next merge iteration. (to pass the installcheck, we need to either delete all UPDATE/DELETE queries or update the queries to not using loopback foreign server, they both will bring a lot of changes and make the merge work not happy)

