### PR TITLE
Use the mem_manager concistently when dealing with transValues

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -975,12 +975,11 @@ advance_combine_function(AggState *aggstate,
 			 */
 			if (!pertrans->transtypeByVal)
 			{
-				oldContext = MemoryContextSwitchTo(
-												   aggstate->aggcontexts[aggstate->current_set]->ecxt_per_tuple_memory);
-				pergroupstate->transValue = datumCopy(fcinfo->arg[1],
-													pertrans->transtypeByVal,
-													  pertrans->transtypeLen);
-				MemoryContextSwitchTo(oldContext);
+				pergroupstate->transValue = datumCopyWithMemManager(pergroupstate->transValue,
+											 fcinfo->arg[1],
+											 pertrans->transtypeByVal,
+											 pertrans->transtypeLen,
+											 &aggstate->mem_manager);
 			}
 			else
 				pergroupstate->transValue = fcinfo->arg[1];
@@ -1018,13 +1017,12 @@ advance_combine_function(AggState *aggstate,
 	{
 		if (!fcinfo->isnull)
 		{
-			MemoryContextSwitchTo(aggstate->aggcontexts[aggstate->current_set]->ecxt_per_tuple_memory);
-			newVal = datumCopy(newVal,
-							   pertrans->transtypeByVal,
-							   pertrans->transtypeLen);
+			newVal = datumCopyWithMemManager(pergroupstate->transValue,
+											 newVal,
+											 pertrans->transtypeByVal,
+											 pertrans->transtypeLen,
+											 &aggstate->mem_manager);
 		}
-		if (!pergroupstate->transValueIsNull)
-			pfree(DatumGetPointer(pergroupstate->transValue));
 	}
 
 	pergroupstate->transValue = newVal;


### PR DESCRIPTION
In greenplum, a mem_manager is used when dealing with transvalues which handles
the allocation and freeing via specific functions. This is a deviation from
upstream and during the merge, a use case was missed.

This code path was triggered via madlib, which officially does not support the
current version (7) of greenplum.

Addresses issue: https://github.com/greenplum-db/gpdb/issues/9357

Reported-by: zhongyibill
