### PR TITLE
Remove obsolete optimized code from EncodeDateTime.

### DIFF
--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -4247,41 +4247,6 @@ EncodeDateTime(struct pg_tm * tm, fsec_t fsec, bool print_tz, int tz, const char
 		case USE_ISO_DATES:
 		case USE_XSD_DATES:
 			/* Compatible with ISO-8601 date formats */
-
-			/* GPDB_96_MERGE_FIXME: We had this faster version in GPDB. PostgreSQL
-			 * also added faster versions in commit aa2387e2fd. Performance test is
-			 * the old GPDB variants are even faster, or if we could drop the diff
-			 * and just use upstream code. For now, the GPDB version is disabled
-			 * and we use the upstream code.
-			 */
-#if 0
-
-			{
-                int j = 0;
-				/*
-				 * sprintf is very slow so we just convert the numbers to
-				 * a string manually. Since we allow dates in the range
-				 * 4713 BC to 5874897 AD, we have to check for years
-				 * with 7, 6 and 5 digits, being careful to not add
-				 * leading zeros for those. We only zero pad to four digits.
-				 */
-				fast_encode_date(tm, str, &j);
-				if (style == USE_ISO_DATES)
-					str[j++] = ' ';
-				else
-					str[j++] = 'T';	// XSD uses a T between date and time
-				
-				str[j++] = tm->tm_hour/10 + '0';
-				str[j++] = tm->tm_hour % 10 + '0';
-				str[j++] = ':';
-				str[j++] = tm->tm_min/10 + '0';
-				str[j++] = tm->tm_min % 10 + '0';
-				str[j++] = ':';
-				str[j] = '\0';
-
-				str = AppendTimestampSeconds(str + j, tm, fsec);
-			}
-#else
 			str = pg_ltostr_zeropad(str,
 					(tm->tm_year > 0) ? tm->tm_year : -(tm->tm_year - 1), 4);
 			*str++ = '-';
@@ -4294,7 +4259,6 @@ EncodeDateTime(struct pg_tm * tm, fsec_t fsec, bool print_tz, int tz, const char
 			str = pg_ltostr_zeropad(str, tm->tm_min, 2);
 			*str++ = ':';
 			str = AppendTimestampSeconds(str, tm, fsec);
-#endif
 			if (print_tz)
 				str = EncodeTimezone(str, tz, style);
 			break;

--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -4278,9 +4278,9 @@ EncodeDateTime(struct pg_tm * tm, fsec_t fsec, bool print_tz, int tz, const char
 				str[j++] = tm->tm_min % 10 + '0';
 				str[j++] = ':';
 				str[j] = '\0';
-			}
 
-			AppendTimestampSeconds(str + strlen(str), tm, fsec);
+				str = AppendTimestampSeconds(str + j, tm, fsec);
+			}
 #else
 			str = pg_ltostr_zeropad(str,
 					(tm->tm_year > 0) ? tm->tm_year : -(tm->tm_year - 1), 4);


### PR DESCRIPTION

We had optimized this piece of code in Greenplum, but in PostgreSQL 9.6,
commit aa2387e2fd, PostgreSQL made a similar optimization. In the 9.6
merge, I picked up the PostgreSQL version, but left the Greenplum version
in a commented out block, with the plan to do some performance testing to
see if we can switch to the PostgreSQL version now.

I did that performance testing now, and it seems that the old GPDB version
was about the same speed as the new PostgreSQL version. I used this to
test it:

    -- generate test data
    create table tstest  (distkey int4, ts timestamp) distributed by (distkey);
    insert into tstest
      select 1, g from generate_series(now(), now()+ '1 year', '1 second') g;
    vacuum tstest;

    -- test query
    \timing on
    select min(ts::text) from tstest;

The query took about 15 seconds on my laptop, and 'perf' says that about
10% of the CPU time was spent in EncodeDateTime, with both versions.

