### PR TITLE
Backport Correctly use atomic variable in ResGroupControl.freeChunks. (#8434)

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -420,7 +420,6 @@ transientrel_init(QueryDesc *queryDesc)
 	Oid			tableSpace;
 	Oid			OIDNewHeap;
 	bool		concurrent;
-	char		relpersistence;
 	LOCKMODE	lockmode;
 	RefreshClause *refreshClause;
 


### PR DESCRIPTION
This variable was used mixing with atomic api functions and direct access.
This is not wrong usually in real scenario but is not a good implementation
since 1) that depends on compiler and H/W to ensure the correctness of direct
access. 2) code is not graceful.

Changing to all use atomic api functions.

Reviewed-by: Georgios Kokolatos <gkokolatos@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
