### PR TITLE
Reduce fts_unblock_primary test time.

### DIFF
--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -1,5 +1,16 @@
 -- This test assumes 3 primaries and 3 mirrors from a gpdemo segwalrep cluster
 
+-- Set this to cut down test time.
+alter system set gp_fts_probe_interval to 10;
+ALTER
+alter system set gp_fts_probe_retries to 1;
+ALTER
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+
 -- function to wait for mirror to come up in sync (1 minute timeout)
 create or replace function wait_for_streaming(contentid smallint) returns void as $$ declare updated bool; /* in func */ begin /* in func */ for i in 1 .. 120 loop /* in func */ perform gp_request_fts_probe_scan(); /* in func */ select (mode = 's' and status = 'u') into updated /* in func */ from gp_segment_configuration /* in func */ where content = contentid and role = 'm'; /* in func */ exit when updated; /* in func */ perform pg_sleep(0.5); /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
 CREATE

--- a/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
+++ b/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
@@ -1,5 +1,10 @@
 -- This test assumes 3 primaries and 3 mirrors from a gpdemo segwalrep cluster
 
+-- Set this to cut down test time.
+alter system set gp_fts_probe_interval to 10;
+alter system set gp_fts_probe_retries to 1;
+select pg_reload_conf();
+
 -- function to wait for mirror to come up in sync (1 minute timeout)
 create or replace function wait_for_streaming(contentid smallint)
 returns void as $$

--- a/src/test/walrep/sql/missing_xlog.sql
+++ b/src/test/walrep/sql/missing_xlog.sql
@@ -155,7 +155,7 @@ select count(*) = 2 as mirror_up from gp_segment_configuration
 select wait_for_mirror_sync(0::smallint);
 select role, preferred_role, content, mode, status from gp_segment_configuration;
 -- start_ignore
-\! gpconfig -c gp_fts_mark_mirror_down_grace_period -v 30
+\! gpconfig -r gp_fts_mark_mirror_down_grace_period
 \! gpconfig -r wal_keep_segments
 \! gpstop -u
 -- end_ignore


### PR DESCRIPTION
It could often reduce the test time by 50 seconds (due to change
gp_fts_probe_interval from 60 to 10) especially on fast test environment (e.g.
our local dev environment).  (In my environment I 100% encounter this).
Pipeline is slow so it happens less frequently.

The root cause is that in the test:

!\retcode gpstop -u;

The above code wakes up the fts probe process.

2U: show gp_fts_mark_mirror_down_grace_period;

-- trigger fts probe and check to see primary marked n/u and mirror n/d
select gp_request_fts_probe_scan();

The above code signals fts process but fts could probably be working before
WaitLatch() so it will finally be stuck in WaitLatch() until timeout (i.e. 60
seconds).  Depends on timing, it could wait for 60 seconds or wait for 0
second.  That's why sometimes we see test time difference of 60 seconds.

With our change the test time difference is reduced to 10 seconds.