### PR TITLE
Fix CATALOG_VARLEN markings in header files.

### DIFF
--- a/src/include/catalog/pg_attribute_encoding.h
+++ b/src/include/catalog/pg_attribute_encoding.h
@@ -32,7 +32,9 @@ CATALOG(pg_attribute_encoding,6231) BKI_WITHOUT_OIDS
 {
 	Oid		attrelid;		
 	int16	attnum;			
+#ifdef CATALOG_VARLEN			/* variable-length fields start here */
 	text	attoptions[1];	
+#endif
 } FormData_pg_attribute_encoding;
 
 /* GPDB added foreign key definitions for gpcheckcat. */

--- a/src/include/catalog/pg_authid.h
+++ b/src/include/catalog/pg_authid.h
@@ -60,7 +60,6 @@ CATALOG(pg_authid,1260) BKI_SHARED_RELATION BKI_ROWTYPE_OID(2842) BKI_SCHEMA_MAC
 #ifdef CATALOG_VARLEN			/* variable-length fields start here */
 	text		rolpassword;	/* password, if any */
 	timestamptz rolvaliduntil;	/* password expiration time, if any */
-#endif
 
 	/* GP added fields */
 	Oid			rolresqueue;	/* ID of resource queue for this role */
@@ -68,6 +67,7 @@ CATALOG(pg_authid,1260) BKI_SHARED_RELATION BKI_ROWTYPE_OID(2842) BKI_SCHEMA_MAC
 	bool		rolcreaterexthttp;	/* allowed to create readable http tbl?  */
 	bool		rolcreatewextgpfd;	/* allowed to create writable gpfdist tbl?  */
 	Oid			rolresgroup;		/* ID of resource group for this role  */
+#endif
 } FormData_pg_authid;
 
 /* GPDB added foreign key definitions for gpcheckcat. */

--- a/src/include/catalog/pg_extprotocol.h
+++ b/src/include/catalog/pg_extprotocol.h
@@ -34,7 +34,9 @@ CATALOG(pg_extprotocol,7175)
 	Oid			ptcvalidatorfn;	
 	Oid			ptcowner;		
 	bool		ptctrusted;		
+#ifdef CATALOG_VARLEN			/* variable-length fields start here */
 	aclitem		ptcacl[1];		
+#endif
 } FormData_pg_extprotocol;
 
 /* GPDB added foreign key definitions for gpcheckcat. */

--- a/src/include/catalog/pg_partition_encoding.h
+++ b/src/include/catalog/pg_partition_encoding.h
@@ -28,7 +28,9 @@ CATALOG(pg_partition_encoding,9903) BKI_WITHOUT_OIDS
 {
 	Oid		parencoid;				
 	int16	parencattnum;			
+#ifdef CATALOG_VARLEN			/* variable-length fields start here */
 	text	parencattoptions[1];	
+#endif
 } FormData_pg_partition_encoding;
 
 /* GPDB added foreign key definitions for gpcheckcat. */

--- a/src/include/catalog/pg_partition_rule.h
+++ b/src/include/catalog/pg_partition_rule.h
@@ -35,12 +35,14 @@ CATALOG(pg_partition_rule,5011)
 	int16		parruleord;			
 	bool		parrangestartincl;	
 	bool		parrangeendincl;	
+#ifdef CATALOG_VARLEN			/* variable-length fields start here */
 	pg_node_tree parrangestart;
 	pg_node_tree parrangeend;
 	pg_node_tree parrangeevery;
 	pg_node_tree parlistvalues;
 	text		parreloptions[1];	
 	Oid			partemplatespace;	
+#endif
 } FormData_pg_partition_rule;
 
 /* GPDB added foreign key definitions for gpcheckcat. */

--- a/src/include/catalog/pg_resqueuecapability.h
+++ b/src/include/catalog/pg_resqueuecapability.h
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * pg_resqueuecapabiltiy.h
+ * pg_resqueuecapability.h
  *	  definition of the system "pg_resqueuecapability" relation.
  *
  *
@@ -32,7 +32,9 @@ CATALOG(pg_resqueuecapability,6060) BKI_SHARED_RELATION
 {
 	Oid		resqueueid;	/* OID of the queue with this capability  */
 	int16	restypid;	/* resource type id (key to pg_resourcetype)  */
+#ifdef CATALOG_VARLEN			/* variable-length fields start here */
 	text	ressetting;	/* resource setting (opaque type)  */
+#endif
 } FormData_pg_resqueuecapability;
 
 /* GPDB added foreign key definitions for gpcheckcat. */

--- a/src/include/catalog/pg_type_encoding.h
+++ b/src/include/catalog/pg_type_encoding.h
@@ -27,7 +27,9 @@
 CATALOG(pg_type_encoding,6220) BKI_WITHOUT_OIDS
 {
 	Oid		typid;			
+#ifdef CATALOG_VARLEN			/* variable-length fields start here */
 	text	typoptions[1];	
+#endif
 } FormData_pg_type_encoding;
 
 /* GPDB added foreign key definitions for gpcheckcat. */


### PR DESCRIPTION
Some GPDB-added system tables and colums in upstream catalogs were missing
CATALOG_VARLEN markings or they were wrong. It doesn't cause any ill
effect, but it's a hazard if someone tries to access the fields through
the Form_pg_* struct. Let's be tidy.
