### PR TITLE
Store containing slice's ID in every Plan node.

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -1243,8 +1243,18 @@ build_slice_table_walker(Node *node, build_slice_table_context *context)
 
 		context->currentSliceIndex = save_currentSliceIndex;
 
+		/*
+		 * sliceId in Motion nodes are labeled with the *receiving* slice's
+		 * id. The sender's ID is stored in motion->motionID.
+		 */
+		motion->plan.sliceId = context->currentSliceIndex;
+
 		return result;
 	}
+
+	/* set 'sliceId' on every Plan node to the slice that it's contained in. */
+	if (is_plan_node(node))
+		((Plan *) node)->sliceId = context->currentSliceIndex;
 
 	return plan_tree_walker(node,
 							build_slice_table_walker,

--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -112,6 +112,13 @@ ExecReScan(PlanState *node)
 			SubPlanState *sstate = (SubPlanState *) lfirst(l);
 			PlanState  *splan = sstate->planstate;
 
+			/*
+			 * If 'splan' is NULL, then InitPlan() thought it was "alien".  We
+			 * should not get here then, but let's sanity check.
+			 */
+			if (splan == NULL)
+				elog(ERROR, "subplan not initialized in this slice");
+
 			if (splan->plan->extParam != NULL)	/* don't care about child
 												 * local Params */
 				UpdateChangedParamSet(splan, node->chgParam);
@@ -122,6 +129,13 @@ ExecReScan(PlanState *node)
 		{
 			SubPlanState *sstate = (SubPlanState *) lfirst(l);
 			PlanState  *splan = sstate->planstate;
+
+			/*
+			 * If 'splan' is NULL, then InitPlan() thought it was "alien".  We
+			 * should not get here then, but let's sanity check.
+			 */
+			if (splan == NULL)
+				elog(ERROR, "subplan not initialized in this slice");
 
 			if (splan->plan->extParam != NULL)
 				UpdateChangedParamSet(splan, node->chgParam);

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1210,8 +1210,7 @@ bool
 ShouldPrefetchJoinQual(EState *estate, Join *join)
 {
 	return (join->prefetch_joinqual &&
-			findSenderMotion(estate->es_plannedstmt,
-							 estate->currentSliceId));
+			findSenderMotion(estate->es_plannedstmt, join->plan.sliceId));
 }
 
 /* ----------------------------------------------------------------
@@ -2104,87 +2103,6 @@ ExtractParamsFromInitPlans(PlannedStmt *plannedstmt, Plan *root, EState *estate)
 	Assert(Gp_role == GP_ROLE_EXECUTE);
 
 	ParamExtractorWalker(root, &ctx);
-}
-
-typedef struct MotionAssignerContext
-{
-	plan_tree_base_prefix base; /* Required prefix for plan_tree_walker/mutator */
-	List *motStack; /* Motion Stack */
-} MotionAssignerContext;
-
-/*
- * Walker to set plan->motionNode for every Plan node to its corresponding parent
- * motion node.
- *
- * This function maintains a stack of motion nodes. When we encounter a motion node
- * we push it on to the stack, walk its subtree, and then pop it off the stack.
- * When we encounter any plan node (motion nodes included) we assign its plan->motionNode
- * to the top of the stack.
- *
- * NOTE: Motion nodes will have their motionNode value set to the previous motion node
- * we encountered while walking the subtree.
- */
-static bool
-MotionAssignerWalker(Plan *node,
-				  void *context)
-{
-	if (node == NULL) return false;
-
-	Assert(context);
-	MotionAssignerContext *ctx = (MotionAssignerContext *) context;
-
-	if (is_plan_node((Node*)node))
-	{
-		Plan *plan = (Plan *) node;
-		/*
-		 * TODO: For cached plan we may be assigning multiple times.
-		 * The eventual goal is to relocate it to planner. For now,
-		 * ignore already assigned nodes.
-		 */
-		if (NULL != plan->motionNode)
-			return true;
-		plan->motionNode = ctx->motStack != NIL ? (Plan *) lfirst(list_head(ctx->motStack)) : NULL;
-	}
-
-	/*
-	 * Subplans get dynamic motion assignment as they can be executed from
-	 * arbitrary expressions. So, we don't assign any motion to these nodes.
-	 */
-	if (IsA(node, SubPlan))
-	{
-		return false;
-	}
-
-	if (IsA(node, Motion))
-	{
-		ctx->motStack = lcons(node, ctx->motStack);
-		plan_tree_walker((Node *)node, MotionAssignerWalker, ctx, true);
-		ctx->motStack = list_delete_first(ctx->motStack);
-
-		return false;
-	}
-
-	/* Continue walking */
-	return plan_tree_walker((Node*)node, MotionAssignerWalker, ctx, true);
-}
-
-/*
- * Assign every node in plannedstmt->planTree its corresponding
- * parent Motion Node if it has one
- *
- * NOTE: Some plans may not be rooted by a motion on the segment so
- * this function does not guarantee that every node will have a non-NULL
- * motionNode value.
- */
-void AssignParentMotionToPlanNodes(PlannedStmt *plannedstmt)
-{
-	MotionAssignerContext ctx;
-	ctx.base.node = (Node*)plannedstmt;
-	ctx.motStack = NIL;
-
-	MotionAssignerWalker(plannedstmt->planTree, &ctx);
-	/* The entire motion stack should have been unwounded */
-	Assert(ctx.motStack == NIL);
 }
 
 /**

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -87,9 +87,9 @@ ExecMaterial(MaterialState *node)
 		{
 			char rwfile_prefix[100];
 
-			if(ma->driver_slice != currentSliceId)
+			if(ma->driver_slice != estate->currentSliceId)
 			{
-				elog(LOG, "Material Exec on CrossSlice, current slice %d", currentSliceId);
+				elog(LOG, "Material Exec on CrossSlice, current slice %d", estate->currentSliceId);
 				return NULL;
 			}
 
@@ -165,7 +165,7 @@ ExecMaterial(MaterialState *node)
 			 */
 			if (ma->share_type == SHARE_MATERIAL_XSLICE)
 			{
-				if (ma->driver_slice == currentSliceId)
+				if (ma->driver_slice == estate->currentSliceId)
 				{
 					ntuplestore_flush(ts);
 

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -390,8 +390,7 @@ ExecInitResult(Result *node, EState *estate, int eflags)
 	 */
 	if (node->numHashFilterCols > 0)
 	{
-		int			currentSliceId = estate->currentSliceId;
-		ExecSlice *currentSlice = &estate->es_sliceTable->slices[currentSliceId];
+		ExecSlice *currentSlice = &estate->es_sliceTable->slices[node->plan.sliceId];
 
 		resstate->hashFilter = makeCdbHash(currentSlice->planNumSegments,
 										   node->numHashFilterCols,

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -427,6 +427,7 @@ CTranslatorDXLToPlStmt::TranslateDXLTblScan
 	}
 
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate operator costs
 	TranslatePlanCosts
@@ -591,6 +592,7 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 
 	Plan *plan = &(index_scan->scan.plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate operator costs
 	TranslatePlanCosts
@@ -894,6 +896,7 @@ CTranslatorDXLToPlStmt::TranslateDXLLimit
 
 	Plan *plan = &(limit->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate operator costs
 	TranslatePlanCosts
@@ -978,6 +981,7 @@ CTranslatorDXLToPlStmt::TranslateDXLHashJoin
 	Join *join = &(hashjoin->join);
 	Plan *plan = &(join->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	CDXLPhysicalHashJoin *hashjoin_dxlop = CDXLPhysicalHashJoin::Cast(hj_dxlnode->GetOperator());
 
@@ -1169,6 +1173,7 @@ CTranslatorDXLToPlStmt::TranslateDXLTvf
 	m_dxl_to_plstmt_context->AddRTE(rte);
 
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate operator costs
 	TranslatePlanCosts
@@ -1435,6 +1440,7 @@ CTranslatorDXLToPlStmt::TranslateDXLNLJoin
 	Join *join = &(nested_loop->join);
 	Plan *plan = &(join->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	CDXLPhysicalNLJoin *dxl_nlj = CDXLPhysicalNLJoin::PdxlConvert(nl_join_dxlnode->GetOperator());
 
@@ -1578,6 +1584,7 @@ CTranslatorDXLToPlStmt::TranslateDXLMergeJoin
 	Join *join = &(merge_join->join);
 	Plan *plan = &(join->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	CDXLPhysicalMergeJoin *merge_join_dxlop = CDXLPhysicalMergeJoin::Cast(merge_join_dxlnode->GetOperator());
 
@@ -1738,6 +1745,7 @@ CTranslatorDXLToPlStmt::TranslateDXLHash
 
 	Plan *plan = &(hash->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate dxl node
 	CDXLTranslateContext dxl_translate_ctxt(m_mp, false, output_context->GetColIdToParamIdMap());
@@ -1819,6 +1827,9 @@ CTranslatorDXLToPlStmt::TranslateDXLMotion
 
 	Plan *plan = &(motion->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	// 'sliceId' is the *receiving* slice's ID. The sender's ID is stored in
+	// 'motionID'.
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate operator costs
 	TranslatePlanCosts
@@ -2045,6 +2056,7 @@ CTranslatorDXLToPlStmt::TranslateDXLRedistributeMotionToResultHashFilters
 
 	Plan *plan = &(result->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	CDXLPhysicalMotion *motion_dxlop = CDXLPhysicalMotion::Cast(motion_dxlnode->GetOperator());
 
@@ -2176,6 +2188,7 @@ CTranslatorDXLToPlStmt::TranslateDXLAgg
 
 	Plan *plan = &(agg->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	CDXLPhysicalAgg *dxl_phy_agg_dxlop = CDXLPhysicalAgg::Cast(agg_dxlnode->GetOperator());
 
@@ -2307,6 +2320,7 @@ CTranslatorDXLToPlStmt::TranslateDXLWindow
 
 	Plan *plan = &(window->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	CDXLPhysicalWindow *window_dxlop = CDXLPhysicalWindow::Cast(window_dxlnode->GetOperator());
 
@@ -2550,6 +2564,7 @@ CTranslatorDXLToPlStmt::TranslateDXLSort
 
 	Plan *plan = &(sort->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	CDXLPhysicalSort *sort_dxlop = CDXLPhysicalSort::Cast(sort_dxlnode->GetOperator());
 
@@ -2634,6 +2649,7 @@ CTranslatorDXLToPlStmt::TranslateDXLSubQueryScan
 
 	Plan *plan = &(subquery_scan->scan.plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	CDXLPhysicalSubqueryScan *subquery_scan_dxlop = CDXLPhysicalSubqueryScan::Cast(subquery_scan_dxlnode->GetOperator());
 
@@ -2740,6 +2756,7 @@ CTranslatorDXLToPlStmt::TranslateDXLResult
 
 	Plan *plan = &(result->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate operator costs
 	TranslatePlanCosts
@@ -2828,6 +2845,7 @@ CTranslatorDXLToPlStmt::TranslateDXLPartSelector
 
 	Plan *plan = &(partition_selector->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	CDXLPhysicalPartitionSelector *partition_selector_dxlop = CDXLPhysicalPartitionSelector::Cast(partition_selector_dxlnode->GetOperator());
 	const ULONG num_of_levels = partition_selector_dxlop->GetPartitioningLevel();
@@ -2986,6 +3004,7 @@ CTranslatorDXLToPlStmt::TranslateDXLAppend
 
 	Plan *plan = &(append->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate operator costs
 	TranslatePlanCosts
@@ -3095,6 +3114,7 @@ CTranslatorDXLToPlStmt::TranslateDXLMaterialize
 
 	Plan *plan = &(materialize->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	CDXLPhysicalMaterialize *materialize_dxlop = CDXLPhysicalMaterialize::Cast(materialize_dxlnode->GetOperator());
 
@@ -3183,6 +3203,7 @@ CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan
 	shared_input_scan->share_id = cte_id;
 	Plan *plan = &(shared_input_scan->scan.plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// store share scan node for the translation of CTE Consumers
 	m_dxl_to_plstmt_context->AddCTEConsumerInfo(cte_id, shared_input_scan);
@@ -3224,6 +3245,7 @@ CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan
 
 		Plan *materialize_plan = &(materialize->plan);
 		materialize_plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+		plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 		TranslatePlanCosts
 			(
@@ -3348,6 +3370,7 @@ CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan
 
 	Plan *plan = &(share_input_scan_cte_consumer->scan.plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate operator costs
 	TranslatePlanCosts
@@ -3419,6 +3442,7 @@ CTranslatorDXLToPlStmt::TranslateDXLSequence
 
 	Plan *plan = &(psequence->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate operator costs
 	TranslatePlanCosts
@@ -3516,6 +3540,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDynTblScan
 
 	Plan *plan = &(dyn_seq_scan->seqscan.plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate operator costs
 	TranslatePlanCosts
@@ -3594,6 +3619,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan
 
 	Plan *plan = &(dyn_idx_scan->indexscan.scan.plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate operator costs
 	TranslatePlanCosts
@@ -3787,6 +3813,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDml
 	Plan *result_plan = &(result->plan);
 
 	result_plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	result_plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 	result_plan->lefttree = child_plan;
 
 	result_plan->targetlist = target_list_with_dropped_cols;
@@ -3807,6 +3834,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDml
 
 	plan->targetlist = NIL;
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	SetParamIds(plan);
 
@@ -3987,6 +4015,7 @@ CTranslatorDXLToPlStmt::TranslateDXLSplit
 
 	plan->lefttree = child_plan;
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	SetParamIds(plan);
 
@@ -4027,6 +4056,7 @@ CTranslatorDXLToPlStmt::TranslateDXLAssert
 
 	Plan *plan = &(assert_node->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	CDXLPhysicalAssert *assert_dxlop = CDXLPhysicalAssert::Cast(assert_dxlnode->GetOperator());
 
@@ -4163,6 +4193,7 @@ CTranslatorDXLToPlStmt::TranslateDXLRowTrigger
 
 	plan->lefttree = child_plan;
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	SetParamIds(plan);
 
@@ -5035,6 +5066,7 @@ CTranslatorDXLToPlStmt::TranslateDXLCtas
 	Result *result = MakeNode(Result);
 	Plan *result_plan = &(result->plan);
 	result_plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	result_plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 	result_plan->lefttree = plan;
 
 	result_plan->targetlist = target_list;
@@ -5288,6 +5320,7 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan
 
 	Plan *plan = &(bitmap_tbl_scan->scan.plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate operator costs
 	TranslatePlanCosts
@@ -5517,6 +5550,7 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapIndexProbe
 	OID oidRel = CMDIdGPDB::CastMdid(table_descr->MDId())->Oid();
 	Plan *plan = &(bitmap_idx_scan->scan.plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	GPOS_ASSERT(1 == bitmap_index_probe_dxlnode->Arity());
 	CDXLNode *index_cond_list_dxlnode = (*bitmap_index_probe_dxlnode)[0];
@@ -5592,6 +5626,7 @@ CTranslatorDXLToPlStmt::TranslateDXLValueScan
 	m_dxl_to_plstmt_context->AddRTE(rte);
 
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	plan->sliceId = m_dxl_to_plstmt_context->GetCurrentSlice()->sliceIndex;
 
 	// translate operator costs
 	TranslatePlanCosts

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -208,10 +208,7 @@ CopyPlanFields(const Plan *from, Plan *newnode)
 	COPY_NODE_FIELD(flow);
 
 	COPY_SCALAR_FIELD(operatorMemKB);
-	/*
-	 * Don't copy memoryAccountId and this is an index to the account array
-	 * specific to this process only.
-	 */
+	COPY_SCALAR_FIELD(sliceId);
 }
 
 /*

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -419,6 +419,7 @@ _outPlanInfo(StringInfo str, const Plan *node)
 #endif /* COMPILING_BINARY_FUNCS */
 
 	WRITE_UINT64_FIELD(operatorMemKB);
+	WRITE_INT_FIELD(sliceId);
 }
 
 /*

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2401,6 +2401,7 @@ ReadCommonPlan(Plan *local_node)
 #endif /* COMPILING_BINARY_FUNCS */
 
 	READ_UINT64_FIELD(operatorMemKB);
+	READ_INT_FIELD(sliceId);
 }
 
 /*

--- a/src/backend/utils/error/assert.c
+++ b/src/backend/utils/error/assert.c
@@ -20,7 +20,7 @@
 #include "postgres.h"
 
 #include "libpq/pqsignal.h"
-#include "cdb/cdbvars.h"                /* currentSliceId */
+#include "cdb/cdbvars.h"                /* gp_reraise_signal */
 
 #include <unistd.h>
 

--- a/src/backend/utils/sort/logtape.c
+++ b/src/backend/utils/sort/logtape.c
@@ -84,9 +84,6 @@
 
 #include "utils/logtape.h"
 
-#include "cdb/cdbvars.h"                /* currentSliceId */
-
-
 /* A logical tape block, log tape blocks are organized into doulbe linked lists */
 #define LOGTAPE_BLK_PAYLOAD_SIZE ((BLCKSZ - sizeof(long)*2 - sizeof(int) ))
 typedef struct LogicalTapeBlock

--- a/src/backend/utils/sort/tuplestorenew.c
+++ b/src/backend/utils/sort/tuplestorenew.c
@@ -26,8 +26,6 @@
 #include "utils/tuplestorenew.h"
 #include "utils/memutils.h"
 
-#include "cdb/cdbvars.h"                /* currentSliceId */
-
 
 typedef struct NTupleStorePageHeader
 {

--- a/src/include/executor/execUtils.h
+++ b/src/include/executor/execUtils.h
@@ -31,7 +31,6 @@ extern void AssignGangs(struct CdbDispatcherState *ds, QueryDesc *queryDesc);
 extern Motion *findSenderMotion(PlannedStmt *plannedstmt, int sliceIndex);
 extern Bitmapset *getLocallyExecutableSubplans(PlannedStmt *plannedstmt, Plan *root);
 extern void ExtractParamsFromInitPlans(PlannedStmt *plannedstmt, Plan *root, EState *estate);
-extern void AssignParentMotionToPlanNodes(PlannedStmt *plannedstmt);
 
 #ifdef USE_ASSERT_CHECKING
 struct PlannedStmt;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -656,8 +656,10 @@ typedef struct EState
 
 	/*
 	 * The slice number for the current node that is being processed.
-	 * During the tree traversal in ExecInitPlan stage, this field is set
-	 * by Motion and InitPlan nodes.
+	 * During plan initialization, in ExecInitPlan(), it is set to the
+	 * slice we're currently initializing, even if it's an "alien" node.
+	 * When executing a plan (ExecProcNode()), it is always set to the
+	 * local slice we're currently executing, never to an alien slice.
 	 */
 	int			currentSliceId;
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -321,9 +321,9 @@ typedef struct Plan
 	uint64 operatorMemKB;
 
 	/*
-	 * The parent motion node of a plan node.
+	 * The containing slice of the plan node.
 	 */
-	struct Plan *motionNode;
+	int			sliceId;
 } Plan;
 
 /* ----------------


### PR DESCRIPTION
This gets rid of the step in executor startup that walked through the plan
tree, and labeled every plan node with the parent Motion node. We can do
that conveniently at the same time that we build the slice table. Modifying
the motionNode field in the Plan tree in an already-built plan tree
always felt iffy.
