### PR TITLE
Frequently check fts probe request in loop for timely probe response.

### DIFF
--- a/src/test/walrep/sql/missing_xlog.sql
+++ b/src/test/walrep/sql/missing_xlog.sql
@@ -155,7 +155,7 @@ select count(*) = 2 as mirror_up from gp_segment_configuration
 select wait_for_mirror_sync(0::smallint);
 select role, preferred_role, content, mode, status from gp_segment_configuration;
 -- start_ignore
-\! gpconfig -c gp_fts_mark_mirror_down_grace_period -v 30
+\! gpconfig -r gp_fts_mark_mirror_down_grace_period
 \! gpconfig -r wal_keep_segments
 \! gpstop -u
 -- end_ignore


### PR DESCRIPTION
guc gp_fts_probe_interval is by default 60 so it is not unusual in real case
that fts probe request waits the response for that long, e.g. through
gp_request_fts_probe_scan() query or internal function FtsNotifyProber().
With this change the response is quicker since we wait at most 1 second
in each loop and then give a chance to handle the request.