### PR TITLE
GUC should be synchronized after change/restore.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5497,12 +5497,12 @@ AtEOXact_GUC(bool isCommit, int nestLevel)
 			if (changed && (gconf->flags & GUC_REPORT))
 				ReportGUCOption(gconf);
 
-			/* if a guc restore in QD, record it and restore QE before next query start */
+			/*
+			 * If a guc's value changed on QD,
+			 * record it and restore QE before next query start
+			 */
 			if (Gp_role == GP_ROLE_DISPATCH
-					&& !IsTransactionBlock()
-					&& changed
-					&& !isCommit
-					&& gp_guc_need_restore
+					&& (changed || gp_guc_need_restore)
 					&& (gconf->flags & GUC_GPDB_NEED_SYNC))
 			{
 				MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5502,7 +5502,9 @@ AtEOXact_GUC(bool isCommit, int nestLevel)
 			 * record it and restore QE before next query start
 			 */
 			if (Gp_role == GP_ROLE_DISPATCH
-					&& (changed || gp_guc_need_restore)
+					&& !IsTransactionBlock()
+					&& changed
+					&& ((isCommit) || (!isCommit && gp_guc_need_restore))
 					&& (gconf->flags & GUC_GPDB_NEED_SYNC))
 			{
 				MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);

--- a/src/test/regress/expected/guc.out
+++ b/src/test/regress/expected/guc.out
@@ -799,3 +799,39 @@ SHOW "request.header.user-agent";
  curl/7.29.0
 (1 row)
 
+-- Test function with SET search_path
+create schema n1;
+create type ty1 as (i int);
+CREATE OR REPLACE FUNCTION n1.drop_table(v_schema character varying, v_table character varying) RETURNS text
+AS $$
+BEGIN
+    EXECUTE 'DROP TABLE IF EXISTS ' || quote_ident(v_schema) || '.' || quote_ident(v_table) || ';';
+    RETURN '0';
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN SQLSTATE;
+END;
+$$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = n1, pg_temp;
+-- Destroy the QD-QE libpq connections.
+select cleanupAllGangs();
+ cleanupallgangs 
+-----------------
+ t
+(1 row)
+
+select n1.drop_table('public','t1');
+NOTICE:  table "t1" does not exist, skipping
+ drop_table 
+------------
+ 0
+(1 row)
+
+-- After funtion drop table, public schema is still in search_path
+create table public.t1(i ty1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+drop table public.t1;
+drop type public.ty1;
+drop function n1.drop_table(v_schema character varying, v_table character varying);
+drop schema n1;


### PR DESCRIPTION
Function with `SET search_path = t1` will change the
search_path inside function but restore it back after
function finishes.

After search_path is restored on QD, we should also sync
it to all the cached QEs.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
