### PR TITLE
Backport: Single set command failed, rollback guc value

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3343,7 +3343,9 @@ AbortTransaction(void)
 
 		AtAbort_TablespaceStorage();
 		AtEOXact_AppendOnly();
+		gp_guc_need_restore = true;
 		AtEOXact_GUC(false, 1);
+		gp_guc_need_restore = false;
 		AtEOXact_SPI(false);
 		AtEOXact_on_commit_actions(false);
 		AtEOXact_Namespace(false);

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1551,6 +1551,36 @@ CheckDebugDtmActionSqlCommandTag(const char *sqlCommandTag)
 	return result;
 }
 
+static void
+restore_guc_to_QE(void )
+{
+	Assert(Gp_role == GP_ROLE_DISPATCH && gp_guc_restore_list);
+	ListCell *lc;
+
+	start_xact_command();
+
+	foreach(lc, gp_guc_restore_list)
+	{
+		struct config_generic* gconfig = (struct config_generic *)lfirst(lc);
+		PG_TRY();
+		{
+			DispatchSyncPGVariable(gconfig);
+		}
+		PG_CATCH();
+		{
+			/* if some guc can not restore successful
+			 * we can not keep alive gang anymore.
+			 */
+			DisconnectAndDestroyAllGangs(false);
+		}
+		PG_END_TRY();
+	}
+
+	finish_xact_command();
+	list_free(gp_guc_restore_list);
+	gp_guc_restore_list = NIL;
+}
+
 /*
  * exec_simple_query
  *
@@ -5191,6 +5221,11 @@ PostgresMain(int argc, char *argv[],
 		 */
 		if (ignore_till_sync && firstchar != EOF)
 			continue;
+
+		/* last txn abort, try to synchronize guc to cached QE */
+		if(Gp_role == GP_ROLE_DISPATCH && gp_guc_restore_list)
+			restore_guc_to_QE();
+
 
 		ereport((Debug_print_full_dtm ? LOG : DEBUG5),
 				(errmsg_internal("First char: '%c'; gp_role = '%s'.", firstchar, role_to_string(Gp_role))));

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -76,6 +76,7 @@
 #include "tsearch/ts_cache.h"
 #include "utils/builtins.h"
 #include "utils/bytea.h"
+#include "utils/faultinjector.h"
 #include "utils/guc_tables.h"
 #include "utils/memutils.h"
 #include "utils/pg_locale.h"
@@ -5158,6 +5159,19 @@ AtEOXact_GUC(bool isCommit, int nestLevel)
 			/* Report new value if we changed it */
 			if (changed && (gconf->flags & GUC_REPORT))
 				ReportGUCOption(gconf);
+
+			/* if a guc restore in QD, record it and restore QE before next query start */
+			if (Gp_role == GP_ROLE_DISPATCH
+					&& !IsTransactionBlock()
+					&& changed
+					&& !isCommit
+					&& gp_guc_need_restore
+					&& (gconf->flags & GUC_GPDB_NEED_SYNC))
+			{
+				MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+				gp_guc_restore_list = lappend(gp_guc_restore_list, gconf);
+				MemoryContextSwitchTo(oldcontext);
+			}
 		}						/* end of stack-popping loop */
 
 		if (stack != NULL)
@@ -7188,6 +7202,8 @@ ExecSetVariableStmt(VariableSetStmt *stmt, bool isTopLevel)
 			{
 				WarnNoTransactionChain(isTopLevel, "SET LOCAL");
 			}
+
+			SIMPLE_FAULT_INJECTOR("set_variable_fault");
 			(void) set_config_option(stmt->name,
 									 ExtractSetVariableArgs(stmt),
 									 (superuser() ? PGC_SUSET : PGC_USERSET),

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -25,6 +25,7 @@
 #include "access/xlog_internal.h"
 #include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbdisp.h"
+#include "cdb/cdbdisp_query.h"
 #include "cdb/cdbhash.h"
 #include "cdb/cdbsreh.h"
 #include "cdb/cdbvars.h"
@@ -99,6 +100,12 @@ extern int listenerBacklog;
 /* GUC lists for gp_guc_list_show().  (List of struct config_generic) */
 List	   *gp_guc_list_for_explain;
 List	   *gp_guc_list_for_no_plan;
+
+/* For synchornized GUC value is cache in HashTable,
+ * dispatch value along with query when some guc changed
+ */
+List       *gp_guc_restore_list = NIL;
+bool        gp_guc_need_restore = false;
 
 char	   *Debug_dtm_action_sql_command_tag;
 
@@ -5146,4 +5153,88 @@ check_gp_workfile_compression(bool *newval, void **extra, GucSource source)
 	}
 #endif
 	return true;
+}
+
+void
+DispatchSyncPGVariable(struct config_generic * gconfig)
+{
+	ListCell   *l;
+	StringInfoData buffer;
+
+	if (Gp_role != GP_ROLE_DISPATCH || IsBootstrapProcessingMode())
+		return;
+
+	initStringInfo( &buffer );
+
+	appendStringInfo(&buffer, "SET ");
+
+	switch (gconfig->vartype)
+	{
+		case PGC_BOOL:
+		{
+			struct config_bool *bguc = (struct config_bool *) gconfig;
+
+			appendStringInfo(&buffer, "%s TO %s", gconfig->name, *(bguc->variable) ? "true" : "false");
+			break;
+		}
+		case PGC_INT:
+		{
+			struct config_int *iguc = (struct config_int *) gconfig;
+
+			appendStringInfo(&buffer, "%s TO %d", gconfig->name, *iguc->variable);
+			break;
+		}
+		case PGC_REAL:
+		{
+			struct config_real *rguc = (struct config_real *) gconfig;
+
+			appendStringInfo(&buffer, " %s TO %f", gconfig->name, *rguc->variable);
+			break;
+		}
+		case PGC_STRING:
+		{
+			struct config_string *sguc = (struct config_string *) gconfig;
+			const char *str = *sguc->variable;
+			int			i;
+
+			appendStringInfo(&buffer, "%s TO ", gconfig->name);
+
+			/*
+			 * All whitespace characters must be escaped. See
+			 * pg_split_opts() in the backend.
+			 */
+			for (i = 0; str[i] != '\0'; i++)
+				appendStringInfoChar(&buffer, str[i]);
+
+			break;
+		}
+		case PGC_ENUM:
+		{
+			struct config_enum *eguc = (struct config_enum *) gconfig;
+			int			value = *eguc->variable;
+			const char *str = config_enum_lookup_by_value(eguc, value);
+			int			i;
+
+			appendStringInfo(&buffer, "%s TO ", gconfig->name);
+
+			/*
+			 * All whitespace characters must be escaped. See
+			 * pg_split_opts() in the backend. (Not sure if an enum value
+			 * can have whitespace, but let's be prepared.)
+			 */
+			for (i = 0; str[i] != '\0'; i++)
+			{
+				if (isspace((unsigned char) str[i]))
+					appendStringInfoChar(&buffer, '\\');
+
+				appendStringInfoChar(&buffer, str[i]);
+			}
+			break;
+		}
+		default:
+			Insist(false);
+
+	}
+
+	CdbDispatchSetCommand(buffer.data, false);
 }

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -228,6 +228,10 @@ typedef enum
 extern List    *gp_guc_list_for_explain;
 extern List    *gp_guc_list_for_no_plan;
 
+/* Changed GUC which need to be pass to QE from QD */
+extern List *gp_guc_restore_list;
+extern bool gp_guc_need_restore;
+
 /* GUC vars that are actually declared in guc.c, rather than elsewhere */
 extern bool log_duration;
 extern bool Debug_print_plan;
@@ -776,6 +780,7 @@ extern bool gpvars_check_statement_mem(int *newval, void **extra, GucSource sour
 extern bool gpvars_check_gp_enable_gpperfmon(bool *newval, void **extra, GucSource source);
 extern bool gpvars_check_gp_gpperfmon_send_interval(int *newval, void **extra, GucSource source);
 extern int guc_name_compare(const char *namea, const char *nameb);
+extern void DispatchSyncPGVariable(struct config_generic * gconfig);
 
 
 extern StdRdOptions *defaultStdRdOptions(char relkind);

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -257,3 +257,45 @@ NOTICE:  command without clusterwide effect
 HINT:  Concider alternatives as DEALLOCATE ALL, or DISCARD TEMP if a clusterwide effect is desired.
 CREATE TEMP TABLE reset_test ( data text ) ON COMMIT PRESERVE ROWS;
 ERROR:  relation "reset_test" already exists  (seg0 127.0.1.1:7002 pid=26153)
+-- Test single query guc rollback
+set allow_segment_DML to on;
+set datestyle='german';
+select gp_inject_fault('set_variable_fault', 'error', dbid)
+from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+set datestyle='sql, mdy';
+ERROR:  fault triggered, fault name:'set_variable_fault' fault type:'error'  (seg0 10.34.58.103:25432 pid=31389)
+-- after guc set failed, before next query handle, qd will sync guc
+-- to qe. using `select 1` trigger guc reset.
+select 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+select current_setting('datestyle') from gp_dist_random('gp_id');
+ current_setting 
+-----------------
+ German, DMY
+ German, DMY
+ German, DMY
+(3 rows)
+
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+(8 rows)
+
+set allow_segment_DML to off;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -41,8 +41,8 @@ test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp li
 # below test(s) inject faults so each of them need to be in a separate group
 test: gpcopy
 
-test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions explain_format
-
+test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format
+test: guc_gp
 # namespace_gp test will show diff if concurrent tests use temporary tables.
 # So run it separately.
 test: namespace_gp

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -172,3 +172,18 @@ SELECT * FROM reset_test;
 -- table will not be dropped in the segments.
 DISCARD ALL;
 CREATE TEMP TABLE reset_test ( data text ) ON COMMIT PRESERVE ROWS;
+
+-- Test single query guc rollback
+set allow_segment_DML to on;
+
+set datestyle='german';
+select gp_inject_fault('set_variable_fault', 'error', dbid)
+from gp_segment_configuration where content=0 and role='p';
+set datestyle='sql, mdy';
+-- after guc set failed, before next query handle, qd will sync guc
+-- to qe. using `select 1` trigger guc reset.
+select 1;
+select current_setting('datestyle') from gp_dist_random('gp_id');
+
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+set allow_segment_DML to off;


### PR DESCRIPTION
* Single set command failed, rollback guc value

In gpdb, guc set flow is that:
	1. QD set guc
	2. QD dispatch job to all QE
	3. QE set guc

For single set command, in gpdb, it is not 2pc safe. If the set command
failed in QE, only QD guc value can rollback. For the guc which has
GUC_GPDB_NEED_SYNC flag, it requires guc value is same in the whole session-level.

To deal with it, record rollback guc in AbortTransaction to a restore
guc list. Re-set these guc when next query coming.
However, if it failed again, destroy all QE, since we can not have the same
value in that session. Hopefully, guc value can synchronize success in
later creategang stage using '-c' command.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
