### PR TITLE
Make to_timestamp() and to_date() range-check fields of their input

### DIFF
--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -3558,9 +3558,6 @@ to_date(PG_FUNCTION_ARGS)
  *
  * The TmFromChar is then analysed and converted into the final results in
  * struct 'tm' and 'fsec'.
- *
- * This function does very little error checking, e.g.
- * to_timestamp('20096040','YYYYMMDD') works
  */
 static void
 do_to_timestamp(text *date_txt, text *fmt,
@@ -3569,29 +3566,34 @@ do_to_timestamp(text *date_txt, text *fmt,
 	FormatNode *format;
 	TmFromChar	tmfc;
 	int			fmt_len;
+	char	   *date_str;
+	int			fmask;
+
+	date_str = text_to_cstring(date_txt);
 
 	ZERO_tmfc(&tmfc);
 	ZERO_tm(tm);
 	*fsec = 0;
+	fmask = 0;					/* bit mask for ValidateDate() */
 
 	fmt_len = VARSIZE_ANY_EXHDR(fmt);
 
 	if (fmt_len)
 	{
 		char	   *fmt_str;
-		char	   *date_str;
 		bool		incache;
 
 		fmt_str = text_to_cstring(fmt);
 
-		/*
-		 * Allocate new memory if format picture is bigger than static cache
-		 * and not use cache (call parser always)
-		 */
 		if (fmt_len > DCH_CACHE_SIZE)
 		{
-			format = (FormatNode *) palloc((fmt_len + 1) * sizeof(FormatNode));
+			/*
+			 * Allocate new memory if format picture is bigger than static
+			 * cache and not use cache (call parser always)
+			 */
 			incache = FALSE;
+
+			format = (FormatNode *) palloc((fmt_len + 1) * sizeof(FormatNode));
 
 			parse_format(format, fmt_str, DCH_keywords,
 						 DCH_suff, DCH_index, DCH_TYPE, NULL,
@@ -3610,34 +3612,28 @@ do_to_timestamp(text *date_txt, text *fmt,
 
 			if ((ent = DCH_cache_search(fmt_str)) == NULL)
 			{
-				ent = DCH_cache_getnew(fmt_str);
-
 				/*
 				 * Not in the cache, must run parser and save a new
 				 * format-picture to the cache.
 				 */
+				ent = DCH_cache_getnew(fmt_str);
+
 				parse_format(ent->format, fmt_str, DCH_keywords,
 							 DCH_suff, DCH_index, DCH_TYPE, NULL,
 							 "to_timestamp");
 
 				(ent->format + fmt_len)->type = NODE_TYPE_END;	/* Paranoia? */
-#ifdef DEBUG_TO_FROM_CHAR
-				/* dump_node(ent->format, fmt_len); */
-				/* dump_index(DCH_keywords, DCH_index); */
-#endif
 			}
 			format = ent->format;
 		}
 
 #ifdef DEBUG_TO_FROM_CHAR
 		/* dump_node(format, fmt_len); */
+		/* dump_index(DCH_keywords, DCH_index); */
 #endif
-
-		date_str = text_to_cstring(date_txt);
 
 		DCH_from_char(format, date_str, &tmfc);
 
-		pfree(date_str);
 		pfree(fmt_str);
 		if (!incache)
 			pfree(format);
@@ -3646,8 +3642,7 @@ do_to_timestamp(text *date_txt, text *fmt,
 	DEBUG_TMFC(&tmfc);
 
 	/*
-	 * Convert values that user define for FROM_CHAR (to_date/to_timestamp) to
-	 * standard 'tm'
+	 * Convert to_date/to_timestamp input fields to standard 'tm'
 	 */
 	if (tmfc.ssss)
 	{
@@ -3716,19 +3711,23 @@ do_to_timestamp(text *date_txt, text *fmt,
 					tm->tm_year = (tmfc.cc + 1) * 100 - tm->tm_year + 1;
 			}
 			else
+			{
 				/* find century year for dates ending in "00" */
 				tm->tm_year = tmfc.cc * 100 + ((tmfc.cc >= 0) ? 0 : 1);
+			}
 		}
 		else
-			/* If a 4-digit year is provided, we use that and ignore CC. */
 		{
+			/* If a 4-digit year is provided, we use that and ignore CC. */
 			tm->tm_year = tmfc.year;
 			if (tmfc.bc && tm->tm_year > 0)
 				tm->tm_year = -(tm->tm_year - 1);
 		}
+		fmask |= DTK_M(YEAR);
 	}
-	else if (tmfc.cc)			/* use first year of century */
+	else if (tmfc.cc)
 	{
+		/* use first year of century */
 		if (tmfc.bc)
 			tmfc.cc = -tmfc.cc;
 		if (tmfc.cc >= 0)
@@ -3737,10 +3736,14 @@ do_to_timestamp(text *date_txt, text *fmt,
 		else
 			/* +1 because year == 599 is 600 BC */
 			tm->tm_year = tmfc.cc * 100 + 1;
+		fmask |= DTK_M(YEAR);
 	}
 
 	if (tmfc.j)
+	{
 		j2date(tmfc.j, &tm->tm_year, &tm->tm_mon, &tm->tm_mday);
+		fmask |= DTK_DATE_M;
+	}
 
 	if (tmfc.ww)
 	{
@@ -3754,6 +3757,7 @@ do_to_timestamp(text *date_txt, text *fmt,
 				isoweekdate2date(tmfc.ww, tmfc.d, &tm->tm_year, &tm->tm_mon, &tm->tm_mday);
 			else
 				isoweek2date(tmfc.ww, &tm->tm_year, &tm->tm_mon, &tm->tm_mday);
+			fmask |= DTK_DATE_M;
 		}
 		else
 			tmfc.ddd = (tmfc.ww - 1) * 7 + 1;
@@ -3761,14 +3765,16 @@ do_to_timestamp(text *date_txt, text *fmt,
 
 	if (tmfc.w)
 		tmfc.dd = (tmfc.w - 1) * 7 + 1;
-	if (tmfc.d)
-		tm->tm_wday = tmfc.d - 1;		/* convert to native numbering */
 	if (tmfc.dd)
+	{
 		tm->tm_mday = tmfc.dd;
-	if (tmfc.ddd)
-		tm->tm_yday = tmfc.ddd;
+		fmask |= DTK_M(DAY);
+	}
 	if (tmfc.mm)
+	{
 		tm->tm_mon = tmfc.mm;
+		fmask |= DTK_M(MONTH);
+	}
 
 	if (tmfc.ddd && (tm->tm_mon <= 1 || tm->tm_mday <= 1))
 	{
@@ -3791,6 +3797,7 @@ do_to_timestamp(text *date_txt, text *fmt,
 			j0 = isoweek2j(tm->tm_year, 1) - 1;
 
 			j2date(j0 + tmfc.ddd, &tm->tm_year, &tm->tm_mon, &tm->tm_mday);
+			fmask |= DTK_DATE_M;
 		}
 		else
 		{
@@ -3805,7 +3812,7 @@ do_to_timestamp(text *date_txt, text *fmt,
 
 			for (i = 1; i <= MONTHS_PER_YEAR; i++)
 			{
-				if (tmfc.ddd < y[i])
+				if (tmfc.ddd <= y[i])
 					break;
 			}
 			if (tm->tm_mon <= 1)
@@ -3813,6 +3820,8 @@ do_to_timestamp(text *date_txt, text *fmt,
 
 			if (tm->tm_mday <= 1)
 				tm->tm_mday = tmfc.ddd - y[i - 1];
+
+			fmask |= DTK_M(MONTH) | DTK_M(DAY);
 		}
 	}
 
@@ -3828,7 +3837,38 @@ do_to_timestamp(text *date_txt, text *fmt,
 		*fsec += (double) tmfc.us / 1000000;
 #endif
 
+	/* Range-check date fields according to bit mask computed above */
+	if (fmask != 0)
+	{
+		/* We already dealt with AD/BC, so pass isjulian = true */
+		int			dterr = ValidateDate(fmask, true, false, false, tm);
+
+		if (dterr != 0)
+		{
+			/*
+			 * Force the error to be DTERR_FIELD_OVERFLOW even if ValidateDate
+			 * said DTERR_MD_FIELD_OVERFLOW, because we don't want to print an
+			 * irrelevant hint about datestyle.
+			 */
+			DateTimeParseError(DTERR_FIELD_OVERFLOW, date_str, "timestamp");
+		}
+	}
+
+	/* Range-check time fields too */
+	if (tm->tm_hour < 0 || tm->tm_hour >= HOURS_PER_DAY ||
+		tm->tm_min < 0 || tm->tm_min >= MINS_PER_HOUR ||
+		tm->tm_sec < 0 || tm->tm_sec >= SECS_PER_MINUTE ||
+#ifdef HAVE_INT64_TIMESTAMP
+		*fsec < INT64CONST(0) || *fsec >= USECS_PER_SEC
+#else
+		*fsec < 0 || *fsec >= 1
+#endif
+		)
+		DateTimeParseError(DTERR_FIELD_OVERFLOW, date_str, "timestamp");
+
 	DEBUG_TM(tm);
+
+	pfree(date_str);
 }
 
 

--- a/src/test/regress/expected/gp_types.out
+++ b/src/test/regress/expected/gp_types.out
@@ -190,27 +190,27 @@ DROP TABLE IF EXISTS dml_timestamp;
 NOTICE:  table "dml_timestamp" does not exist, skipping
 CREATE TABLE dml_timestamp( a timestamp) distributed by (a);
 -- Simple DML
-INSERT INTO dml_timestamp VALUES (to_date('2012-02-31', 'YYYY-MM-DD BC'));
+INSERT INTO dml_timestamp VALUES (to_date('2012-02-21', 'YYYY-MM-DD BC'));
 SELECT * FROM dml_timestamp ORDER BY 1;
           a          
 ---------------------
- 2012-03-02 00:00:00
+ 2012-02-21 00:00:00
 (1 row)
 
 INSERT INTO dml_timestamp VALUES (to_date('4714-01-27 AD', 'YYYY-MM-DD BC'));
 SELECT * FROM dml_timestamp ORDER BY 1;
           a          
 ---------------------
- 2012-03-02 00:00:00
+ 2012-02-21 00:00:00
  4714-01-27 00:00:00
 (2 rows)
 
-UPDATE dml_timestamp SET a = to_date('2012-02-31', 'YYYY-MM-DD BC');
+UPDATE dml_timestamp SET a = to_date('2012-02-21', 'YYYY-MM-DD BC');
 SELECT * FROM dml_timestamp ORDER BY 1;
           a          
 ---------------------
- 2012-03-02 00:00:00
- 2012-03-02 00:00:00
+ 2012-02-21 00:00:00
+ 2012-02-21 00:00:00
 (2 rows)
 
 -- out of range values
@@ -221,8 +221,8 @@ LINE 1: INSERT INTO dml_timestamp VALUES ('294277-01-27 AD'::timesta...
 SELECT * FROM dml_timestamp ORDER BY 1;
           a          
 ---------------------
- 2012-03-02 00:00:00
- 2012-03-02 00:00:00
+ 2012-02-21 00:00:00
+ 2012-02-21 00:00:00
 (2 rows)
 
 UPDATE dml_timestamp SET a = '294277-01-27 AD'::timestamp;
@@ -232,8 +232,19 @@ LINE 1: UPDATE dml_timestamp SET a = '294277-01-27 AD'::timestamp;
 SELECT * FROM dml_timestamp ORDER BY 1;
           a          
 ---------------------
- 2012-03-02 00:00:00
- 2012-03-02 00:00:00
+ 2012-02-21 00:00:00
+ 2012-02-21 00:00:00
+(2 rows)
+
+INSERT INTO dml_timestamp VALUES ('2012-02-31 AD'::timestamp);
+ERROR:  date/time field value out of range: "2012-02-31 AD"
+LINE 1: INSERT INTO dml_timestamp VALUES ('2012-02-31 AD'::timestamp...
+                                          ^
+SELECT * FROM dml_timestamp ORDER BY 1;
+          a          
+---------------------
+ 2012-02-21 00:00:00
+ 2012-02-21 00:00:00
 (2 rows)
 
 -- Greenplum 4.3 and 5 had support for YYYYMMDDHH24MISS, which was removed in

--- a/src/test/regress/expected/gp_types_optimizer.out
+++ b/src/test/regress/expected/gp_types_optimizer.out
@@ -190,27 +190,27 @@ DROP TABLE IF EXISTS dml_timestamp;
 NOTICE:  table "dml_timestamp" does not exist, skipping
 CREATE TABLE dml_timestamp( a timestamp) distributed by (a);
 -- Simple DML
-INSERT INTO dml_timestamp VALUES (to_date('2012-02-31', 'YYYY-MM-DD BC'));
+INSERT INTO dml_timestamp VALUES (to_date('2012-02-21', 'YYYY-MM-DD BC'));
 SELECT * FROM dml_timestamp ORDER BY 1;
           a          
 ---------------------
- 2012-03-02 00:00:00
+ 2012-02-21 00:00:00
 (1 row)
 
 INSERT INTO dml_timestamp VALUES (to_date('4714-01-27 AD', 'YYYY-MM-DD BC'));
 SELECT * FROM dml_timestamp ORDER BY 1;
           a          
 ---------------------
- 2012-03-02 00:00:00
+ 2012-02-21 00:00:00
  4714-01-27 00:00:00
 (2 rows)
 
-UPDATE dml_timestamp SET a = to_date('2012-02-31', 'YYYY-MM-DD BC');
+UPDATE dml_timestamp SET a = to_date('2012-02-21', 'YYYY-MM-DD BC');
 SELECT * FROM dml_timestamp ORDER BY 1;
           a          
 ---------------------
- 2012-03-02 00:00:00
- 2012-03-02 00:00:00
+ 2012-02-21 00:00:00
+ 2012-02-21 00:00:00
 (2 rows)
 
 -- out of range values
@@ -221,8 +221,8 @@ LINE 1: INSERT INTO dml_timestamp VALUES ('294277-01-27 AD'::timesta...
 SELECT * FROM dml_timestamp ORDER BY 1;
           a          
 ---------------------
- 2012-03-02 00:00:00
- 2012-03-02 00:00:00
+ 2012-02-21 00:00:00
+ 2012-02-21 00:00:00
 (2 rows)
 
 UPDATE dml_timestamp SET a = '294277-01-27 AD'::timestamp;
@@ -232,8 +232,19 @@ LINE 1: UPDATE dml_timestamp SET a = '294277-01-27 AD'::timestamp;
 SELECT * FROM dml_timestamp ORDER BY 1;
           a          
 ---------------------
- 2012-03-02 00:00:00
- 2012-03-02 00:00:00
+ 2012-02-21 00:00:00
+ 2012-02-21 00:00:00
+(2 rows)
+
+INSERT INTO dml_timestamp VALUES ('2012-02-31 AD'::timestamp);
+ERROR:  date/time field value out of range: "2012-02-31 AD"
+LINE 1: INSERT INTO dml_timestamp VALUES ('2012-02-31 AD'::timestamp...
+                                          ^
+SELECT * FROM dml_timestamp ORDER BY 1;
+          a          
+---------------------
+ 2012-02-21 00:00:00
+ 2012-02-21 00:00:00
 (2 rows)
 
 -- Greenplum 4.3 and 5 had support for YYYYMMDDHH24MISS, which was removed in

--- a/src/test/regress/expected/horology.out
+++ b/src/test/regress/expected/horology.out
@@ -3029,6 +3029,18 @@ SELECT to_timestamp('20000-1116', 'YYYY-MMDD');
  Thu Nov 16 00:00:00 20000 PST
 (1 row)
 
+SELECT to_timestamp('1997 AD 11 16', 'YYYY BC MM DD');
+         to_timestamp         
+------------------------------
+ Sun Nov 16 00:00:00 1997 PST
+(1 row)
+
+SELECT to_timestamp('1997 BC 11 16', 'YYYY BC MM DD');
+          to_timestamp           
+---------------------------------
+ Tue Nov 16 00:00:00 1997 PST BC
+(1 row)
+
 SELECT to_timestamp('9-1116', 'Y-MMDD');
          to_timestamp         
 ------------------------------
@@ -3113,6 +3125,18 @@ SELECT to_timestamp('  20050302', 'YYYYMMDD');
  Wed Mar 02 00:00:00 2005 PST
 (1 row)
 
+SELECT to_timestamp('2011-12-18 11:38 AM', 'YYYY-MM-DD HH12:MI PM');
+         to_timestamp         
+------------------------------
+ Sun Dec 18 11:38:00 2011 PST
+(1 row)
+
+SELECT to_timestamp('2011-12-18 11:38 PM', 'YYYY-MM-DD HH12:MI PM');
+         to_timestamp         
+------------------------------
+ Sun Dec 18 23:38:00 2011 PST
+(1 row)
+
 --
 -- Check handling of multiple spaces in format and/or input
 --
@@ -3189,7 +3213,7 @@ SELECT to_date('2011   12 18', 'YYYY  MM DD');
 (1 row)
 
 --
--- Check errors for some incorrect usages of to_timestamp()
+-- Check errors for some incorrect usages of to_timestamp() and to_date()
 --
 -- Mixture of date conventions (ISO week and Gregorian):
 SELECT to_timestamp('2005527', 'YYYYIWID');
@@ -3217,6 +3241,81 @@ DETAIL:  Value must be an integer.
 SELECT to_timestamp('10000000000', 'FMYYYY');
 ERROR:  value for "YYYY" in source string is out of range
 DETAIL:  Value must be in the range -2147483648 to 2147483647.
+-- Out-of-range and not-quite-out-of-range fields:
+SELECT to_timestamp('2016-06-13 25:00:00', 'YYYY-MM-DD HH24:MI:SS');
+ERROR:  date/time field value out of range: "2016-06-13 25:00:00"
+SELECT to_timestamp('2016-06-13 15:60:00', 'YYYY-MM-DD HH24:MI:SS');
+ERROR:  date/time field value out of range: "2016-06-13 15:60:00"
+SELECT to_timestamp('2016-06-13 15:50:60', 'YYYY-MM-DD HH24:MI:SS');
+ERROR:  date/time field value out of range: "2016-06-13 15:50:60"
+SELECT to_timestamp('2016-06-13 15:50:55', 'YYYY-MM-DD HH24:MI:SS');  -- ok
+         to_timestamp         
+------------------------------
+ Mon Jun 13 15:50:55 2016 PDT
+(1 row)
+
+SELECT to_timestamp('2016-06-13 15:50:55', 'YYYY-MM-DD HH:MI:SS');
+WARNING:  hour "15" is invalid for the 12-hour clock
+HINT:  Use the 24-hour clock, or give an hour between 1 and 12.
+         to_timestamp         
+------------------------------
+ Mon Jun 13 15:50:55 2016 PDT
+(1 row)
+
+SELECT to_timestamp('2016-13-01 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
+ERROR:  date/time field value out of range: "2016-13-01 15:50:55"
+SELECT to_timestamp('2016-02-30 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
+ERROR:  date/time field value out of range: "2016-02-30 15:50:55"
+SELECT to_timestamp('2016-02-29 15:50:55', 'YYYY-MM-DD HH24:MI:SS');  -- ok
+         to_timestamp         
+------------------------------
+ Mon Feb 29 15:50:55 2016 PST
+(1 row)
+
+SELECT to_timestamp('2015-02-29 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
+ERROR:  date/time field value out of range: "2015-02-29 15:50:55"
+SELECT to_timestamp('2015-02-11 86000', 'YYYY-MM-DD SSSS');  -- ok
+         to_timestamp         
+------------------------------
+ Wed Feb 11 23:53:20 2015 PST
+(1 row)
+
+SELECT to_timestamp('2015-02-11 86400', 'YYYY-MM-DD SSSS');
+ERROR:  date/time field value out of range: "2015-02-11 86400"
+SELECT to_date('2016-13-10', 'YYYY-MM-DD');
+ERROR:  date/time field value out of range: "2016-13-10"
+SELECT to_date('2016-02-30', 'YYYY-MM-DD');
+ERROR:  date/time field value out of range: "2016-02-30"
+SELECT to_date('2016-02-29', 'YYYY-MM-DD');  -- ok
+  to_date   
+------------
+ 02-29-2016
+(1 row)
+
+SELECT to_date('2015-02-29', 'YYYY-MM-DD');
+ERROR:  date/time field value out of range: "2015-02-29"
+SELECT to_date('2015 365', 'YYYY DDD');  -- ok
+  to_date   
+------------
+ 12-31-2015
+(1 row)
+
+SELECT to_date('2015 366', 'YYYY DDD');
+ERROR:  date/time field value out of range: "2015 366"
+SELECT to_date('2016 365', 'YYYY DDD');  -- ok
+  to_date   
+------------
+ 12-30-2016
+(1 row)
+
+SELECT to_date('2016 366', 'YYYY DDD');  -- ok
+  to_date   
+------------
+ 12-31-2016
+(1 row)
+
+SELECT to_date('2016 367', 'YYYY DDD');
+ERROR:  date/time field value out of range: "2016 367"
 --
 -- Check behavior with SQL-style fixed-GMT-offset time zone (cf bug #8572)
 --

--- a/src/test/regress/expected/horology_optimizer.out
+++ b/src/test/regress/expected/horology_optimizer.out
@@ -3029,6 +3029,18 @@ SELECT to_timestamp('20000-1116', 'YYYY-MMDD');
  Thu Nov 16 00:00:00 20000 PST
 (1 row)
 
+SELECT to_timestamp('1997 AD 11 16', 'YYYY BC MM DD');
+         to_timestamp         
+------------------------------
+ Sun Nov 16 00:00:00 1997 PST
+(1 row)
+
+SELECT to_timestamp('1997 BC 11 16', 'YYYY BC MM DD');
+          to_timestamp           
+---------------------------------
+ Tue Nov 16 00:00:00 1997 PST BC
+(1 row)
+
 SELECT to_timestamp('9-1116', 'Y-MMDD');
          to_timestamp         
 ------------------------------
@@ -3113,6 +3125,18 @@ SELECT to_timestamp('  20050302', 'YYYYMMDD');
  Wed Mar 02 00:00:00 2005 PST
 (1 row)
 
+SELECT to_timestamp('2011-12-18 11:38 AM', 'YYYY-MM-DD HH12:MI PM');
+         to_timestamp         
+------------------------------
+ Sun Dec 18 11:38:00 2011 PST
+(1 row)
+
+SELECT to_timestamp('2011-12-18 11:38 PM', 'YYYY-MM-DD HH12:MI PM');
+         to_timestamp         
+------------------------------
+ Sun Dec 18 23:38:00 2011 PST
+(1 row)
+
 --
 -- Check handling of multiple spaces in format and/or input
 --
@@ -3189,7 +3213,7 @@ SELECT to_date('2011   12 18', 'YYYY  MM DD');
 (1 row)
 
 --
--- Check errors for some incorrect usages of to_timestamp()
+-- Check errors for some incorrect usages of to_timestamp() and to_date()
 --
 -- Mixture of date conventions (ISO week and Gregorian):
 SELECT to_timestamp('2005527', 'YYYYIWID');
@@ -3217,6 +3241,81 @@ DETAIL:  Value must be an integer.
 SELECT to_timestamp('10000000000', 'FMYYYY');
 ERROR:  value for "YYYY" in source string is out of range
 DETAIL:  Value must be in the range -2147483648 to 2147483647.
+-- Out-of-range and not-quite-out-of-range fields:
+SELECT to_timestamp('2016-06-13 25:00:00', 'YYYY-MM-DD HH24:MI:SS');
+ERROR:  date/time field value out of range: "2016-06-13 25:00:00"
+SELECT to_timestamp('2016-06-13 15:60:00', 'YYYY-MM-DD HH24:MI:SS');
+ERROR:  date/time field value out of range: "2016-06-13 15:60:00"
+SELECT to_timestamp('2016-06-13 15:50:60', 'YYYY-MM-DD HH24:MI:SS');
+ERROR:  date/time field value out of range: "2016-06-13 15:50:60"
+SELECT to_timestamp('2016-06-13 15:50:55', 'YYYY-MM-DD HH24:MI:SS');  -- ok
+         to_timestamp         
+------------------------------
+ Mon Jun 13 15:50:55 2016 PDT
+(1 row)
+
+SELECT to_timestamp('2016-06-13 15:50:55', 'YYYY-MM-DD HH:MI:SS');
+WARNING:  hour "15" is invalid for the 12-hour clock
+HINT:  Use the 24-hour clock, or give an hour between 1 and 12.
+         to_timestamp         
+------------------------------
+ Mon Jun 13 15:50:55 2016 PDT
+(1 row)
+
+SELECT to_timestamp('2016-13-01 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
+ERROR:  date/time field value out of range: "2016-13-01 15:50:55"
+SELECT to_timestamp('2016-02-30 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
+ERROR:  date/time field value out of range: "2016-02-30 15:50:55"
+SELECT to_timestamp('2016-02-29 15:50:55', 'YYYY-MM-DD HH24:MI:SS');  -- ok
+         to_timestamp         
+------------------------------
+ Mon Feb 29 15:50:55 2016 PST
+(1 row)
+
+SELECT to_timestamp('2015-02-29 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
+ERROR:  date/time field value out of range: "2015-02-29 15:50:55"
+SELECT to_timestamp('2015-02-11 86000', 'YYYY-MM-DD SSSS');  -- ok
+         to_timestamp         
+------------------------------
+ Wed Feb 11 23:53:20 2015 PST
+(1 row)
+
+SELECT to_timestamp('2015-02-11 86400', 'YYYY-MM-DD SSSS');
+ERROR:  date/time field value out of range: "2015-02-11 86400"
+SELECT to_date('2016-13-10', 'YYYY-MM-DD');
+ERROR:  date/time field value out of range: "2016-13-10"
+SELECT to_date('2016-02-30', 'YYYY-MM-DD');
+ERROR:  date/time field value out of range: "2016-02-30"
+SELECT to_date('2016-02-29', 'YYYY-MM-DD');  -- ok
+  to_date   
+------------
+ 02-29-2016
+(1 row)
+
+SELECT to_date('2015-02-29', 'YYYY-MM-DD');
+ERROR:  date/time field value out of range: "2015-02-29"
+SELECT to_date('2015 365', 'YYYY DDD');  -- ok
+  to_date   
+------------
+ 12-31-2015
+(1 row)
+
+SELECT to_date('2015 366', 'YYYY DDD');
+ERROR:  date/time field value out of range: "2015 366"
+SELECT to_date('2016 365', 'YYYY DDD');  -- ok
+  to_date   
+------------
+ 12-30-2016
+(1 row)
+
+SELECT to_date('2016 366', 'YYYY DDD');  -- ok
+  to_date   
+------------
+ 12-31-2016
+(1 row)
+
+SELECT to_date('2016 367', 'YYYY DDD');
+ERROR:  date/time field value out of range: "2016 367"
 --
 -- Check behavior with SQL-style fixed-GMT-offset time zone (cf bug #8572)
 --

--- a/src/test/regress/sql/gp_types.sql
+++ b/src/test/regress/sql/gp_types.sql
@@ -88,17 +88,19 @@ DROP TABLE IF EXISTS dml_timestamp;
 CREATE TABLE dml_timestamp( a timestamp) distributed by (a);
 
 -- Simple DML
-INSERT INTO dml_timestamp VALUES (to_date('2012-02-31', 'YYYY-MM-DD BC'));
+INSERT INTO dml_timestamp VALUES (to_date('2012-02-21', 'YYYY-MM-DD BC'));
 SELECT * FROM dml_timestamp ORDER BY 1;
 INSERT INTO dml_timestamp VALUES (to_date('4714-01-27 AD', 'YYYY-MM-DD BC'));
 SELECT * FROM dml_timestamp ORDER BY 1;
-UPDATE dml_timestamp SET a = to_date('2012-02-31', 'YYYY-MM-DD BC');
+UPDATE dml_timestamp SET a = to_date('2012-02-21', 'YYYY-MM-DD BC');
 SELECT * FROM dml_timestamp ORDER BY 1;
 
 -- out of range values
 INSERT INTO dml_timestamp VALUES ('294277-01-27 AD'::timestamp);
 SELECT * FROM dml_timestamp ORDER BY 1;
 UPDATE dml_timestamp SET a = '294277-01-27 AD'::timestamp;
+SELECT * FROM dml_timestamp ORDER BY 1;
+INSERT INTO dml_timestamp VALUES ('2012-02-31 AD'::timestamp);
 SELECT * FROM dml_timestamp ORDER BY 1;
 
 -- Greenplum 4.3 and 5 had support for YYYYMMDDHH24MISS, which was removed in

--- a/src/test/regress/sql/horology.sql
+++ b/src/test/regress/sql/horology.sql
@@ -613,6 +613,9 @@ SELECT to_timestamp('19971116', 'YYYYMMDD');
 
 SELECT to_timestamp('20000-1116', 'YYYY-MMDD');
 
+SELECT to_timestamp('1997 AD 11 16', 'YYYY BC MM DD');
+SELECT to_timestamp('1997 BC 11 16', 'YYYY BC MM DD');
+
 SELECT to_timestamp('9-1116', 'Y-MMDD');
 
 SELECT to_timestamp('95-1116', 'YY-MMDD');
@@ -641,6 +644,9 @@ SELECT to_timestamp(' 2005 03 02', 'YYYYMMDD');
 
 SELECT to_timestamp('  20050302', 'YYYYMMDD');
 
+SELECT to_timestamp('2011-12-18 11:38 AM', 'YYYY-MM-DD HH12:MI PM');
+SELECT to_timestamp('2011-12-18 11:38 PM', 'YYYY-MM-DD HH12:MI PM');
+
 --
 -- Check handling of multiple spaces in format and/or input
 --
@@ -662,7 +668,7 @@ SELECT to_date('2011  12 18', 'YYYY  MM DD');
 SELECT to_date('2011   12 18', 'YYYY  MM DD');
 
 --
--- Check errors for some incorrect usages of to_timestamp()
+-- Check errors for some incorrect usages of to_timestamp() and to_date()
 --
 
 -- Mixture of date conventions (ISO week and Gregorian):
@@ -682,6 +688,28 @@ SELECT to_timestamp('199711xy', 'YYYYMMDD');
 
 -- Input that doesn't fit in an int:
 SELECT to_timestamp('10000000000', 'FMYYYY');
+
+-- Out-of-range and not-quite-out-of-range fields:
+SELECT to_timestamp('2016-06-13 25:00:00', 'YYYY-MM-DD HH24:MI:SS');
+SELECT to_timestamp('2016-06-13 15:60:00', 'YYYY-MM-DD HH24:MI:SS');
+SELECT to_timestamp('2016-06-13 15:50:60', 'YYYY-MM-DD HH24:MI:SS');
+SELECT to_timestamp('2016-06-13 15:50:55', 'YYYY-MM-DD HH24:MI:SS');  -- ok
+SELECT to_timestamp('2016-06-13 15:50:55', 'YYYY-MM-DD HH:MI:SS');
+SELECT to_timestamp('2016-13-01 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
+SELECT to_timestamp('2016-02-30 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
+SELECT to_timestamp('2016-02-29 15:50:55', 'YYYY-MM-DD HH24:MI:SS');  -- ok
+SELECT to_timestamp('2015-02-29 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
+SELECT to_timestamp('2015-02-11 86000', 'YYYY-MM-DD SSSS');  -- ok
+SELECT to_timestamp('2015-02-11 86400', 'YYYY-MM-DD SSSS');
+SELECT to_date('2016-13-10', 'YYYY-MM-DD');
+SELECT to_date('2016-02-30', 'YYYY-MM-DD');
+SELECT to_date('2016-02-29', 'YYYY-MM-DD');  -- ok
+SELECT to_date('2015-02-29', 'YYYY-MM-DD');
+SELECT to_date('2015 365', 'YYYY DDD');  -- ok
+SELECT to_date('2015 366', 'YYYY DDD');
+SELECT to_date('2016 365', 'YYYY DDD');  -- ok
+SELECT to_date('2016 366', 'YYYY DDD');  -- ok
+SELECT to_date('2016 367', 'YYYY DDD');
 
 --
 -- Check behavior with SQL-style fixed-GMT-offset time zone (cf bug #8572)


### PR DESCRIPTION
This is a backport of upstream commit d3cd36a133d96ad5578b6c10279b55fd5b538093 to add range checking to `to_timestamp()` and `to_date()`. Previously using an out of range date would calculate like so:

```
tvesely=# SELECT to_timestamp('2016-13-01 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
      to_timestamp      
------------------------
 2017-01-01 15:50:55-08
(1 row)
```

After adding range checking:

```
tvesely=# SELECT to_timestamp('2016-13-01 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
ERROR:  date/time field value out of range: "2016-13-01 15:50:55"
```

Original commit message:

```
commit d3cd36a133d96ad5578b6c10279b55fd5b538093                                                                                                    
Author: Tom Lane <tgl@sss.pgh.pa.us>                                                                                                               
Date:   Wed Sep 28 14:36:04 2016 -0400                                                                                                             
                                                                                                                                                   
    Make to_timestamp() and to_date() range-check fields of their input.                                                                           
                                                                                                                                                   
    Historically, something like to_date('2009-06-40','YYYY-MM-DD') would                                                                          
    return '2009-07-10' because there was no prohibition on out-of-range                                                                           
    month or day numbers.  This has been widely panned, and it also turns                                                                          
    out that Oracle throws an error in such cases.  Since these functions                                                                          
    are nominally Oracle-compatibility features, let's change that.                                                                                
                                                                                                                                                   
    There's no particular restriction on year (modulo the fact that the                                                                            
    scanner may not believe that more than 4 digits are year digits,                                                                               
    a matter to be addressed separately if at all).  But we now check month,                                                                       
    day, hour, minute, second, and fractional-second fields, as well as                                                                            
    day-of-year and second-of-day fields if those are used.                                                                                        
                                                                                                                                                   
    Currently, no checks are made on ISO-8601-style week numbers or day                                                                            
    numbers; it's not very clear what the appropriate rules would be there,                                                                        
    and they're probably so little used that it's not worth sweating over.                                                                         
                                                                                                                                                   
    Artur Zakirov, reviewed by Amul Sul, further adjustments by me                                                                                 
                                                                                                                                                   
    Discussion: <1873520224.1784572.1465833145330.JavaMail.yahoo@mail.yahoo.com>                                                                   
    See-Also: <57786490.9010201@wars-nicht.de>   
```