### PR TITLE
Columns of unique or primary index on partition table should contain …

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -754,6 +754,17 @@ DefineIndex(Oid relationId,
 		index_check_primary_key(rel, indexInfo, is_alter_table);
 
 	/*
+	 * if the table is partitioned, a constraint must be
+	 * compatible with the partitioning key.
+	 */
+	if (partitioned && (stmt->unique || stmt->primary))
+		index_check_partitioning_compatible(rel,
+											indexInfo->ii_KeyAttrNumbers,
+											indexInfo->ii_ExclusionOps,
+											indexInfo->ii_NumIndexAttrs,
+											stmt->primary);
+	
+	/*
 	 * Check that the index is compatible with the distribution policy.
 	 *
 	 * If the index is unique, the index columns must include all the
@@ -868,17 +879,6 @@ DefineIndex(Oid relationId,
 			}
 		}
 	}
-
-	/*
-	 * Similar to the distribution keys, if the table is partitioned, a
-	 * constraint must be compatible with the partitioning key.
-	 */
-	if ( stmt->isconstraint && rel_is_partitioned(relationId) )
-		index_check_partitioning_compatible(rel,
-											indexInfo->ii_KeyAttrNumbers,
-											indexInfo->ii_ExclusionOps,
-											indexInfo->ii_NumIndexAttrs,
-											stmt->primary);
 
 	if (Gp_role == GP_ROLE_EXECUTE && stmt)
 		quiet = true;

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -39,19 +39,7 @@ NOTICE:  CREATE TABLE will create partition "direct_test_partition_1_prt_9" for 
 NOTICE:  CREATE TABLE will create partition "direct_test_partition_1_prt_10" for table "direct_test_partition"
 NOTICE:  CREATE TABLE will create partition "direct_test_partition_1_prt_11" for table "direct_test_partition"
 NOTICE:  CREATE TABLE will create partition "direct_test_partition_1_prt_12" for table "direct_test_partition"
-create unique index direct_test_uk on direct_test_partition(trans_id);
-NOTICE:  building index for child partition "direct_test_partition_1_prt_1"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_2"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_3"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_4"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_5"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_6"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_7"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_8"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_9"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_10"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_11"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_12"
+create unique index direct_test_uk on direct_test_partition(trans_id,date);
 create table direct_test_range_partition (a int, b int, c int, d int) distributed by (a) partition by range(d) (start(1) end(10) every(1));
 NOTICE:  CREATE TABLE will create partition "direct_test_range_partition_1_prt_1" for table "direct_test_range_partition"
 NOTICE:  CREATE TABLE will create partition "direct_test_range_partition_1_prt_2" for table "direct_test_range_partition"

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -39,19 +39,7 @@ NOTICE:  CREATE TABLE will create partition "direct_test_partition_1_prt_9" for 
 NOTICE:  CREATE TABLE will create partition "direct_test_partition_1_prt_10" for table "direct_test_partition"
 NOTICE:  CREATE TABLE will create partition "direct_test_partition_1_prt_11" for table "direct_test_partition"
 NOTICE:  CREATE TABLE will create partition "direct_test_partition_1_prt_12" for table "direct_test_partition"
-create unique index direct_test_uk on direct_test_partition(trans_id);
-NOTICE:  building index for child partition "direct_test_partition_1_prt_1"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_2"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_3"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_4"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_5"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_6"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_7"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_8"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_9"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_10"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_11"
-NOTICE:  building index for child partition "direct_test_partition_1_prt_12"
+create unique index direct_test_uk on direct_test_partition(trans_id,date);
 create table direct_test_range_partition (a int, b int, c int, d int) distributed by (a) partition by range(d) (start(1) end(10) every(1));
 NOTICE:  CREATE TABLE will create partition "direct_test_range_partition_1_prt_1" for table "direct_test_range_partition"
 NOTICE:  CREATE TABLE will create partition "direct_test_range_partition_1_prt_2" for table "direct_test_range_partition"

--- a/src/test/regress/expected/index_constraint_naming_partition.out
+++ b/src/test/regress/expected/index_constraint_naming_partition.out
@@ -1877,66 +1877,87 @@ CONTEXT:  SQL function "recreate_three_level_table" statement 2
  
 (1 row)
 
-CREATE UNIQUE INDEX myidx_onroot ON r USING btree(r_key);
+CREATE UNIQUE INDEX myidx_onroot ON r USING btree(r_key,r_name);
 SELECT * FROM dependencies_show_for_idx();
-           depname            |       refname        | deptype 
-------------------------------+----------------------+---------
- myidx_onroot                 | r                    | a
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_2_prt_a   | I
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_r_key_idx | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_2_prt_b   | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_r_key_idx | I
- r_1_prt_r1_r_key_idx         | myidx_onroot         | I
- r_1_prt_r1_r_key_idx         | r_1_prt_r1           | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_2_prt_a   | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_2_prt_b   | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_r_key_idx         | myidx_onroot         | I
- r_1_prt_r2_r_key_idx         | r_1_prt_r2           | I
-(13 rows)
+               depname               |           refname           | deptype 
+-------------------------------------+-----------------------------+---------
+ myidx_onroot                        | r                           | a
+ myidx_onroot                        | r                           | a
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_r_key_r_name_idx         | myidx_onroot                | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_r_key_r_name_idx         | myidx_onroot                | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+(20 rows)
 
-DROP INDEX r_1_prt_r2_r_key_idx;         --should fail: cannot drop from non-creating node
-ERROR:  cannot drop index r_1_prt_r2_r_key_idx because index myidx_onroot requires it
+DROP INDEX r_1_prt_r2_r_key_r_name_idx;         --should fail: cannot drop from non-creating node
+ERROR:  cannot drop index r_1_prt_r2_r_key_r_name_idx because index myidx_onroot requires it
 HINT:  You can drop index myidx_onroot instead.
 SELECT * FROM dependencies_show_for_idx();
-           depname            |       refname        | deptype 
-------------------------------+----------------------+---------
- myidx_onroot                 | r                    | a
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_2_prt_a   | I
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_r_key_idx | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_2_prt_b   | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_r_key_idx | I
- r_1_prt_r1_r_key_idx         | myidx_onroot         | I
- r_1_prt_r1_r_key_idx         | r_1_prt_r1           | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_2_prt_a   | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_2_prt_b   | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_r_key_idx         | myidx_onroot         | I
- r_1_prt_r2_r_key_idx         | r_1_prt_r2           | I
-(13 rows)
+               depname               |           refname           | deptype 
+-------------------------------------+-----------------------------+---------
+ myidx_onroot                        | r                           | a
+ myidx_onroot                        | r                           | a
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_r_key_r_name_idx         | myidx_onroot                | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_r_key_r_name_idx         | myidx_onroot                | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+(20 rows)
 
-DROP INDEX r_1_prt_r2_2_prt_b_r_key_idx; --should fail: cannot drop from non-creating node
-ERROR:  cannot drop index r_1_prt_r2_2_prt_b_r_key_idx because index r_1_prt_r2_r_key_idx requires it
-HINT:  You can drop index r_1_prt_r2_r_key_idx instead.
+DROP INDEX r_1_prt_r2_2_prt_b_r_key_r_name_idx; --should fail: cannot drop from non-creating node
+ERROR:  cannot drop index r_1_prt_r2_2_prt_b_r_key_r_name_idx because index r_1_prt_r2_r_key_r_name_idx requires it
+HINT:  You can drop index r_1_prt_r2_r_key_r_name_idx instead.
 SELECT * FROM dependencies_show_for_idx();
-           depname            |       refname        | deptype 
-------------------------------+----------------------+---------
- myidx_onroot                 | r                    | a
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_2_prt_a   | I
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_r_key_idx | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_2_prt_b   | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_r_key_idx | I
- r_1_prt_r1_r_key_idx         | myidx_onroot         | I
- r_1_prt_r1_r_key_idx         | r_1_prt_r1           | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_2_prt_a   | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_2_prt_b   | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_r_key_idx         | myidx_onroot         | I
- r_1_prt_r2_r_key_idx         | r_1_prt_r2           | I
-(13 rows)
+               depname               |           refname           | deptype 
+-------------------------------------+-----------------------------+---------
+ myidx_onroot                        | r                           | a
+ myidx_onroot                        | r                           | a
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_r_key_r_name_idx         | myidx_onroot                | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_r_key_r_name_idx         | myidx_onroot                | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+(20 rows)
 
 DROP INDEX myidx_onroot;                 --works: is root of index hierarchy
 SELECT * FROM dependencies_show_for_idx();
@@ -2014,56 +2035,77 @@ CONTEXT:  SQL function "recreate_three_level_table" statement 2
  
 (1 row)
 
-CREATE UNIQUE INDEX ON r USING btree(r_key);
+CREATE UNIQUE INDEX ON r USING btree(r_key,r_name);
 SELECT * FROM dependencies_show_for_idx();
-           depname            |       refname        | deptype 
-------------------------------+----------------------+---------
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_2_prt_a   | I
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_r_key_idx | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_2_prt_b   | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_r_key_idx | I
- r_1_prt_r1_r_key_idx         | r_1_prt_r1           | I
- r_1_prt_r1_r_key_idx         | r_r_key_idx          | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_2_prt_a   | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_2_prt_b   | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_r_key_idx         | r_1_prt_r2           | I
- r_1_prt_r2_r_key_idx         | r_r_key_idx          | I
- r_r_key_idx                  | r                    | a
-(13 rows)
+               depname               |           refname           | deptype 
+-------------------------------------+-----------------------------+---------
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r1_r_key_r_name_idx         | r_r_key_r_name_idx          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+ r_1_prt_r2_r_key_r_name_idx         | r_r_key_r_name_idx          | I
+ r_r_key_r_name_idx                  | r                           | a
+ r_r_key_r_name_idx                  | r                           | a
+(20 rows)
 
-CREATE UNIQUE INDEX ON r USING btree(r_key);
+CREATE UNIQUE INDEX ON r USING btree(r_key,r_name);
 SELECT * FROM dependencies_show_for_idx();
-            depname            |        refname        | deptype 
--------------------------------+-----------------------+---------
- r_1_prt_r1_2_prt_a_r_key_idx  | r_1_prt_r1_2_prt_a    | I
- r_1_prt_r1_2_prt_a_r_key_idx  | r_1_prt_r1_r_key_idx  | I
- r_1_prt_r1_2_prt_a_r_key_idx1 | r_1_prt_r1_2_prt_a    | I
- r_1_prt_r1_2_prt_a_r_key_idx1 | r_1_prt_r1_r_key_idx1 | I
- r_1_prt_r1_2_prt_b_r_key_idx  | r_1_prt_r1_2_prt_b    | I
- r_1_prt_r1_2_prt_b_r_key_idx  | r_1_prt_r1_r_key_idx  | I
- r_1_prt_r1_2_prt_b_r_key_idx1 | r_1_prt_r1_2_prt_b    | I
- r_1_prt_r1_2_prt_b_r_key_idx1 | r_1_prt_r1_r_key_idx1 | I
- r_1_prt_r1_r_key_idx          | r_1_prt_r1            | I
- r_1_prt_r1_r_key_idx          | r_r_key_idx           | I
- r_1_prt_r1_r_key_idx1         | r_1_prt_r1            | I
- r_1_prt_r1_r_key_idx1         | r_r_key_idx1          | I
- r_1_prt_r2_2_prt_a_r_key_idx  | r_1_prt_r2_2_prt_a    | I
- r_1_prt_r2_2_prt_a_r_key_idx  | r_1_prt_r2_r_key_idx  | I
- r_1_prt_r2_2_prt_a_r_key_idx1 | r_1_prt_r2_2_prt_a    | I
- r_1_prt_r2_2_prt_a_r_key_idx1 | r_1_prt_r2_r_key_idx1 | I
- r_1_prt_r2_2_prt_b_r_key_idx  | r_1_prt_r2_2_prt_b    | I
- r_1_prt_r2_2_prt_b_r_key_idx  | r_1_prt_r2_r_key_idx  | I
- r_1_prt_r2_2_prt_b_r_key_idx1 | r_1_prt_r2_2_prt_b    | I
- r_1_prt_r2_2_prt_b_r_key_idx1 | r_1_prt_r2_r_key_idx1 | I
- r_1_prt_r2_r_key_idx          | r_1_prt_r2            | I
- r_1_prt_r2_r_key_idx          | r_r_key_idx           | I
- r_1_prt_r2_r_key_idx1         | r_1_prt_r2            | I
- r_1_prt_r2_r_key_idx1         | r_r_key_idx1          | I
- r_r_key_idx                   | r                     | a
- r_r_key_idx1                  | r                     | a
-(26 rows)
+               depname                |           refname            | deptype 
+--------------------------------------+------------------------------+---------
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx  | r_1_prt_r1_2_prt_a           | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx  | r_1_prt_r1_2_prt_a           | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx  | r_1_prt_r1_r_key_r_name_idx  | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx1 | r_1_prt_r1_2_prt_a           | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx1 | r_1_prt_r1_2_prt_a           | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx1 | r_1_prt_r1_r_key_r_name_idx1 | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx  | r_1_prt_r1_2_prt_b           | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx  | r_1_prt_r1_2_prt_b           | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx  | r_1_prt_r1_r_key_r_name_idx  | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx1 | r_1_prt_r1_2_prt_b           | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx1 | r_1_prt_r1_2_prt_b           | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx1 | r_1_prt_r1_r_key_r_name_idx1 | I
+ r_1_prt_r1_r_key_r_name_idx          | r_1_prt_r1                   | I
+ r_1_prt_r1_r_key_r_name_idx          | r_1_prt_r1                   | I
+ r_1_prt_r1_r_key_r_name_idx          | r_r_key_r_name_idx           | I
+ r_1_prt_r1_r_key_r_name_idx1         | r_1_prt_r1                   | I
+ r_1_prt_r1_r_key_r_name_idx1         | r_1_prt_r1                   | I
+ r_1_prt_r1_r_key_r_name_idx1         | r_r_key_r_name_idx1          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx  | r_1_prt_r2_2_prt_a           | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx  | r_1_prt_r2_2_prt_a           | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx  | r_1_prt_r2_r_key_r_name_idx  | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx1 | r_1_prt_r2_2_prt_a           | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx1 | r_1_prt_r2_2_prt_a           | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx1 | r_1_prt_r2_r_key_r_name_idx1 | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx  | r_1_prt_r2_2_prt_b           | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx  | r_1_prt_r2_2_prt_b           | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx  | r_1_prt_r2_r_key_r_name_idx  | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx1 | r_1_prt_r2_2_prt_b           | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx1 | r_1_prt_r2_2_prt_b           | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx1 | r_1_prt_r2_r_key_r_name_idx1 | I
+ r_1_prt_r2_r_key_r_name_idx          | r_1_prt_r2                   | I
+ r_1_prt_r2_r_key_r_name_idx          | r_1_prt_r2                   | I
+ r_1_prt_r2_r_key_r_name_idx          | r_r_key_r_name_idx           | I
+ r_1_prt_r2_r_key_r_name_idx1         | r_1_prt_r2                   | I
+ r_1_prt_r2_r_key_r_name_idx1         | r_1_prt_r2                   | I
+ r_1_prt_r2_r_key_r_name_idx1         | r_r_key_r_name_idx1          | I
+ r_r_key_r_name_idx                   | r                            | a
+ r_r_key_r_name_idx                   | r                            | a
+ r_r_key_r_name_idx1                  | r                            | a
+ r_r_key_r_name_idx1                  | r                            | a
+(40 rows)
 
 --test subsumption of lower-level index from upper-level one
 SELECT recreate_three_level_table();
@@ -2095,24 +2137,36 @@ SELECT * FROM dependencies_show_for_idx();
  r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_2_prt_b | I
 (5 rows)
 
-CREATE UNIQUE INDEX myidx_onroot ON r USING btree(r_key);
+CREATE UNIQUE INDEX myidx_onroot ON r USING btree(r_key,r_name);
 SELECT * FROM dependencies_show_for_idx();
-           depname            |       refname        | deptype 
-------------------------------+----------------------+---------
- myidx_midlevel               | myidx_onroot         | I
- myidx_midlevel               | r_1_prt_r1           | a
- myidx_onroot                 | r                    | a
- r_1_prt_r1_2_prt_a_r_key_idx | myidx_midlevel       | I
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_2_prt_a   | I
- r_1_prt_r1_2_prt_b_r_key_idx | myidx_midlevel       | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_2_prt_b   | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_2_prt_a   | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_2_prt_b   | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_r_key_idx         | myidx_onroot         | I
- r_1_prt_r2_r_key_idx         | r_1_prt_r2           | I
-(13 rows)
+               depname               |           refname           | deptype 
+-------------------------------------+-----------------------------+---------
+ myidx_midlevel                      | r_1_prt_r1                  | a
+ myidx_onroot                        | r                           | a
+ myidx_onroot                        | r                           | a
+ r_1_prt_r1_2_prt_a_r_key_idx        | myidx_midlevel              | I
+ r_1_prt_r1_2_prt_a_r_key_idx        | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_2_prt_b_r_key_idx        | myidx_midlevel              | I
+ r_1_prt_r1_2_prt_b_r_key_idx        | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_r_key_r_name_idx         | myidx_onroot                | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_r_key_r_name_idx         | myidx_onroot                | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+(25 rows)
 
 --show subsumption works across rename
 SELECT recreate_three_level_table();
@@ -2155,24 +2209,36 @@ SELECT * FROM dependencies_show_for_idx();
  r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_2_prt_b     | I
 (5 rows)
 
-CREATE UNIQUE INDEX myidx_midlevel ON r USING btree(r_key);
+CREATE UNIQUE INDEX myidx_midlevel ON r USING btree(r_key,r_name);
 SELECT * FROM dependencies_show_for_idx();
-           depname            |        refname         | deptype 
-------------------------------+------------------------+---------
- myidx_midlevel               | r                      | a
- myidx_midlevel_renamed       | myidx_midlevel         | I
- myidx_midlevel_renamed       | r_1_prt_r1             | a
- r_1_prt_r1_2_prt_a_r_key_idx | myidx_midlevel_renamed | I
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_2_prt_a     | I
- r_1_prt_r1_2_prt_b_r_key_idx | myidx_midlevel_renamed | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_2_prt_b     | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_2_prt_a     | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_r_key_idx   | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_2_prt_b     | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_r_key_idx   | I
- r_1_prt_r2_r_key_idx         | myidx_midlevel         | I
- r_1_prt_r2_r_key_idx         | r_1_prt_r2             | I
-(13 rows)
+               depname               |           refname           | deptype 
+-------------------------------------+-----------------------------+---------
+ myidx_midlevel                      | r                           | a
+ myidx_midlevel                      | r                           | a
+ myidx_midlevel_renamed              | r_1_prt_r1                  | a
+ r_1_prt_r1_2_prt_a_r_key_idx        | myidx_midlevel_renamed      | I
+ r_1_prt_r1_2_prt_a_r_key_idx        | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_2_prt_b_r_key_idx        | myidx_midlevel_renamed      | I
+ r_1_prt_r1_2_prt_b_r_key_idx        | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_r_key_r_name_idx         | myidx_midlevel              | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_r_key_r_name_idx         | myidx_midlevel              | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+(25 rows)
 
 --show that renaming still does not allow a name conflict
 SELECT recreate_three_level_table();
@@ -2215,7 +2281,7 @@ SELECT * FROM dependencies_show_for_idx();
  r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_2_prt_b     | I
 (5 rows)
 
-CREATE UNIQUE INDEX myidx_midlevel_renamed ON r USING btree(r_key);   --should fail: index already exists
+CREATE UNIQUE INDEX myidx_midlevel_renamed ON r USING btree(r_key,r_name);   --should fail: index already exists
 ERROR:  relation "myidx_midlevel_renamed" already exists
 SELECT * FROM dependencies_show_for_idx();
            depname            |        refname         | deptype 
@@ -2246,61 +2312,80 @@ CONTEXT:  SQL function "recreate_three_level_table" statement 2
  
 (1 row)
 
-CREATE UNIQUE INDEX myidx_onroot ON r USING btree(r_key);
+CREATE UNIQUE INDEX myidx_onroot ON r USING btree(r_key,r_name);
 SELECT * FROM dependencies_show_for_idx();
-           depname            |       refname        | deptype 
-------------------------------+----------------------+---------
- myidx_onroot                 | r                    | a
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_2_prt_a   | I
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_r_key_idx | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_2_prt_b   | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_r_key_idx | I
- r_1_prt_r1_r_key_idx         | myidx_onroot         | I
- r_1_prt_r1_r_key_idx         | r_1_prt_r1           | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_2_prt_a   | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_2_prt_b   | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_r_key_idx         | myidx_onroot         | I
- r_1_prt_r2_r_key_idx         | r_1_prt_r2           | I
-(13 rows)
+               depname               |           refname           | deptype 
+-------------------------------------+-----------------------------+---------
+ myidx_onroot                        | r                           | a
+ myidx_onroot                        | r                           | a
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_r_key_r_name_idx | I
+ r_1_prt_r1_r_key_r_name_idx         | myidx_onroot                | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r1_r_key_r_name_idx         | r_1_prt_r1                  | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_r_key_r_name_idx         | myidx_onroot                | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+(20 rows)
 
-ALTER INDEX r_1_prt_r1_r_key_idx RENAME TO middle_index_renamed;
+ALTER INDEX r_1_prt_r1_r_key_r_name_idx RENAME TO middle_index_renamed;
 SELECT * FROM dependencies_show_for_idx();
-           depname            |       refname        | deptype 
-------------------------------+----------------------+---------
- middle_index_renamed         | myidx_onroot         | I
- myidx_onroot                 | r                    | a
- r_1_prt_r1_2_prt_a_r_key_idx | middle_index_renamed | I
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_2_prt_a   | I
- r_1_prt_r1_2_prt_b_r_key_idx | middle_index_renamed | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_2_prt_b   | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_2_prt_a   | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_2_prt_b   | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_r_key_idx         | myidx_onroot         | I
- r_1_prt_r2_r_key_idx         | r_1_prt_r2           | I
-(12 rows)
+               depname               |           refname           | deptype 
+-------------------------------------+-----------------------------+---------
+ middle_index_renamed                | myidx_onroot                | I
+ myidx_onroot                        | r                           | a
+ myidx_onroot                        | r                           | a
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | middle_index_renamed        | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | middle_index_renamed        | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_r_key_r_name_idx         | myidx_onroot                | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+(18 rows)
 
 DROP INDEX middle_index_renamed;  --should fail: this renamed index is still controlled by the root index that created it
 ERROR:  cannot drop index middle_index_renamed because index myidx_onroot requires it
 HINT:  You can drop index myidx_onroot instead.
 SELECT * FROM dependencies_show_for_idx();
-           depname            |       refname        | deptype 
-------------------------------+----------------------+---------
- middle_index_renamed         | myidx_onroot         | I
- myidx_onroot                 | r                    | a
- r_1_prt_r1_2_prt_a_r_key_idx | middle_index_renamed | I
- r_1_prt_r1_2_prt_a_r_key_idx | r_1_prt_r1_2_prt_a   | I
- r_1_prt_r1_2_prt_b_r_key_idx | middle_index_renamed | I
- r_1_prt_r1_2_prt_b_r_key_idx | r_1_prt_r1_2_prt_b   | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_2_prt_a   | I
- r_1_prt_r2_2_prt_a_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_2_prt_b   | I
- r_1_prt_r2_2_prt_b_r_key_idx | r_1_prt_r2_r_key_idx | I
- r_1_prt_r2_r_key_idx         | myidx_onroot         | I
- r_1_prt_r2_r_key_idx         | r_1_prt_r2           | I
-(12 rows)
+               depname               |           refname           | deptype 
+-------------------------------------+-----------------------------+---------
+ middle_index_renamed                | myidx_onroot                | I
+ myidx_onroot                        | r                           | a
+ myidx_onroot                        | r                           | a
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | middle_index_renamed        | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_a_r_key_r_name_idx | r_1_prt_r1_2_prt_a          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | middle_index_renamed        | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r1_2_prt_b_r_key_r_name_idx | r_1_prt_r1_2_prt_b          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_2_prt_a          | I
+ r_1_prt_r2_2_prt_a_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_2_prt_b          | I
+ r_1_prt_r2_2_prt_b_r_key_r_name_idx | r_1_prt_r2_r_key_r_name_idx | I
+ r_1_prt_r2_r_key_r_name_idx         | myidx_onroot                | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+ r_1_prt_r2_r_key_r_name_idx         | r_1_prt_r2                  | I
+(18 rows)
 
 DROP TABLE IF EXISTS r;

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -77,31 +77,7 @@ select gp_segment_id, relname from gp_dist_random('pg_class') where relkind = 'r
              0 | region_1_prt_region3
 (12 rows)
 
-create unique index region_pkey on region(r_regionkey);
-NOTICE:  building index for child partition "region_1_prt_region1"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_africa"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_america"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_asia"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_europe"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_mideast"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_australia"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_antarctica"
-NOTICE:  building index for child partition "region_1_prt_region2"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_africa"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_america"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_asia"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_europe"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_mideast"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_australia"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_antarctica"
-NOTICE:  building index for child partition "region_1_prt_region3" for table "region"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_africa"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_america"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_asia"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_europe"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_mideast"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_australia"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_antarctica"
+create unique index region_pkey on region(r_regionkey, r_name);
 copy region from stdin with delimiter '|';
 -- Test indexes
 set enable_seqscan to off;
@@ -153,8 +129,8 @@ select * from region where r_regionkey = '7';
 -- tables since we cannot enforce them. But since this insert maps to a
 -- single definitive partition, we can detect it.
 insert into region values(7, 'AUSTRALIA', 'def');
-ERROR:  duplicate key value violates unique constraint "region_1_prt_region3_2_prt_australia_r_regionkey_idx"  (seg0 127.0.1.1:25432 pid=1617)
-DETAIL:  Key (r_regionkey)=(7) already exists.
+ERROR:  duplicate key value violates unique constraint "region_1_prt_region3_2_prt_australia_r_regionkey_r_name_idx"  (seg0 127.0.1.1:7002 pid=122856)
+DETAIL:  Key (r_regionkey, r_name)=(7, AUSTRALIA                ) already exists.
 drop table region;
 -- exchange
 -- 1) test all sanity checking
@@ -4057,49 +4033,47 @@ partition by range (j)
 (start(1) end(3) every(1));
 NOTICE:  CREATE TABLE will create partition "ti_1_prt_1" for table "ti"
 NOTICE:  CREATE TABLE will create partition "ti_1_prt_2" for table "ti"
-create unique index ti_pkey on ti(i);
-NOTICE:  building index for child partition "ti_1_prt_1"
-NOTICE:  building index for child partition "ti_1_prt_2"
+create unique index ti_pkey on ti(i,j);
 select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
- schemaname | tablename  |    indexname     | tablespace |                                 indexdef                                  
-------------+------------+------------------+------------+---------------------------------------------------------------------------
- public     | ti         | ti_pkey          |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i)
- public     | ti_1_prt_1 | ti_1_prt_1_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_1_i_idx ON public.ti_1_prt_1 USING btree (i)
- public     | ti_1_prt_2 | ti_1_prt_2_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_2_i_idx ON public.ti_1_prt_2 USING btree (i)
+ schemaname | tablename  |     indexname      | tablespace |                                    indexdef                                    
+------------+------------+--------------------+------------+--------------------------------------------------------------------------------
+ public     | ti_1_prt_1 | ti_1_prt_1_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_1_i_j_idx ON public.ti_1_prt_1 USING btree (i, j)
+ public     | ti         | ti_pkey            |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i, j)
+ public     | ti_1_prt_2 | ti_1_prt_2_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_2_i_j_idx ON public.ti_1_prt_2 USING btree (i, j)
 (3 rows)
 
 create index ti_j_idx on ti using bitmap(j);
 NOTICE:  building index for child partition "ti_1_prt_1"
 NOTICE:  building index for child partition "ti_1_prt_2"
 select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
- schemaname | tablename  |    indexname     | tablespace |                                 indexdef                                  
-------------+------------+------------------+------------+---------------------------------------------------------------------------
- public     | ti         | ti_pkey          |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i)
- public     | ti_1_prt_1 | ti_1_prt_1_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_1_i_idx ON public.ti_1_prt_1 USING btree (i)
- public     | ti_1_prt_2 | ti_1_prt_2_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_2_i_idx ON public.ti_1_prt_2 USING btree (i)
- public     | ti         | ti_j_idx         |            | CREATE INDEX ti_j_idx ON public.ti USING bitmap (j)
- public     | ti_1_prt_1 | ti_1_prt_1_j_idx |            | CREATE INDEX ti_1_prt_1_j_idx ON public.ti_1_prt_1 USING bitmap (j)
- public     | ti_1_prt_2 | ti_1_prt_2_j_idx |            | CREATE INDEX ti_1_prt_2_j_idx ON public.ti_1_prt_2 USING bitmap (j)
+ schemaname | tablename  |     indexname      | tablespace |                                    indexdef                                    
+------------+------------+--------------------+------------+--------------------------------------------------------------------------------
+ public     | ti_1_prt_1 | ti_1_prt_1_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_1_i_j_idx ON public.ti_1_prt_1 USING btree (i, j)
+ public     | ti         | ti_pkey            |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i, j)
+ public     | ti_1_prt_2 | ti_1_prt_2_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_2_i_j_idx ON public.ti_1_prt_2 USING btree (i, j)
+ public     | ti_1_prt_1 | ti_1_prt_1_j_idx   |            | CREATE INDEX ti_1_prt_1_j_idx ON public.ti_1_prt_1 USING bitmap (j)
+ public     | ti         | ti_j_idx           |            | CREATE INDEX ti_j_idx ON public.ti USING bitmap (j)
+ public     | ti_1_prt_2 | ti_1_prt_2_j_idx   |            | CREATE INDEX ti_1_prt_2_j_idx ON public.ti_1_prt_2 USING bitmap (j)
 (6 rows)
 
 alter table ti add partition p3 start(3) end(10);
 NOTICE:  CREATE TABLE will create partition "ti_1_prt_p3" for table "ti"
 select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
- schemaname |  tablename  |     indexname     | tablespace |                                  indexdef                                   
-------------+-------------+-------------------+------------+-----------------------------------------------------------------------------
- public     | ti          | ti_pkey           |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i)
- public     | ti_1_prt_1  | ti_1_prt_1_i_idx  |            | CREATE UNIQUE INDEX ti_1_prt_1_i_idx ON public.ti_1_prt_1 USING btree (i)
- public     | ti_1_prt_2  | ti_1_prt_2_i_idx  |            | CREATE UNIQUE INDEX ti_1_prt_2_i_idx ON public.ti_1_prt_2 USING btree (i)
- public     | ti          | ti_j_idx          |            | CREATE INDEX ti_j_idx ON public.ti USING bitmap (j)
- public     | ti_1_prt_1  | ti_1_prt_1_j_idx  |            | CREATE INDEX ti_1_prt_1_j_idx ON public.ti_1_prt_1 USING bitmap (j)
- public     | ti_1_prt_2  | ti_1_prt_2_j_idx  |            | CREATE INDEX ti_1_prt_2_j_idx ON public.ti_1_prt_2 USING bitmap (j)
- public     | ti_1_prt_p3 | ti_1_prt_p3_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_p3_i_idx ON public.ti_1_prt_p3 USING btree (i)
- public     | ti_1_prt_p3 | ti_1_prt_p3_j_idx |            | CREATE INDEX ti_1_prt_p3_j_idx ON public.ti_1_prt_p3 USING bitmap (j)
+ schemaname |  tablename  |      indexname      | tablespace |                                     indexdef                                     
+------------+-------------+---------------------+------------+----------------------------------------------------------------------------------
+ public     | ti_1_prt_1  | ti_1_prt_1_i_j_idx  |            | CREATE UNIQUE INDEX ti_1_prt_1_i_j_idx ON public.ti_1_prt_1 USING btree (i, j)
+ public     | ti          | ti_pkey             |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i, j)
+ public     | ti_1_prt_2  | ti_1_prt_2_i_j_idx  |            | CREATE UNIQUE INDEX ti_1_prt_2_i_j_idx ON public.ti_1_prt_2 USING btree (i, j)
+ public     | ti_1_prt_1  | ti_1_prt_1_j_idx    |            | CREATE INDEX ti_1_prt_1_j_idx ON public.ti_1_prt_1 USING bitmap (j)
+ public     | ti          | ti_j_idx            |            | CREATE INDEX ti_j_idx ON public.ti USING bitmap (j)
+ public     | ti_1_prt_2  | ti_1_prt_2_j_idx    |            | CREATE INDEX ti_1_prt_2_j_idx ON public.ti_1_prt_2 USING bitmap (j)
+ public     | ti_1_prt_p3 | ti_1_prt_p3_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_p3_i_j_idx ON public.ti_1_prt_p3 USING btree (i, j)
+ public     | ti_1_prt_p3 | ti_1_prt_p3_j_idx   |            | CREATE INDEX ti_1_prt_p3_j_idx ON public.ti_1_prt_p3 USING bitmap (j)
 (8 rows)
 
 -- Should not be able to drop child indexes added implicitly via ADD PARTITION
-drop index ti_1_prt_p3_i_idx;
-ERROR:  cannot drop index ti_1_prt_p3_i_idx because index ti_pkey requires it
+drop index ti_1_prt_p3_i_j_idx;
+ERROR:  cannot drop index ti_1_prt_p3_i_j_idx because index ti_pkey requires it
 HINT:  You can drop index ti_pkey instead.
 drop index ti_1_prt_p3_j_idx;
 ERROR:  cannot drop index ti_1_prt_p3_j_idx because index ti_j_idx requires it
@@ -4110,29 +4084,29 @@ NOTICE:  dropped partition "p3" for relation "ti"
 NOTICE:  CREATE TABLE will create partition "ti_1_prt_pnew1" for table "ti"
 NOTICE:  CREATE TABLE will create partition "ti_1_prt_pnew2" for table "ti"
 select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
- schemaname |   tablename    |      indexname       | tablespace |                                     indexdef                                      
-------------+----------------+----------------------+------------+-----------------------------------------------------------------------------------
- public     | ti             | ti_pkey              |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i)
- public     | ti_1_prt_1     | ti_1_prt_1_i_idx     |            | CREATE UNIQUE INDEX ti_1_prt_1_i_idx ON public.ti_1_prt_1 USING btree (i)
- public     | ti_1_prt_2     | ti_1_prt_2_i_idx     |            | CREATE UNIQUE INDEX ti_1_prt_2_i_idx ON public.ti_1_prt_2 USING btree (i)
- public     | ti             | ti_j_idx             |            | CREATE INDEX ti_j_idx ON public.ti USING bitmap (j)
- public     | ti_1_prt_1     | ti_1_prt_1_j_idx     |            | CREATE INDEX ti_1_prt_1_j_idx ON public.ti_1_prt_1 USING bitmap (j)
- public     | ti_1_prt_2     | ti_1_prt_2_j_idx     |            | CREATE INDEX ti_1_prt_2_j_idx ON public.ti_1_prt_2 USING bitmap (j)
- public     | ti_1_prt_pnew1 | ti_1_prt_pnew1_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_pnew1_i_idx ON public.ti_1_prt_pnew1 USING btree (i)
- public     | ti_1_prt_pnew1 | ti_1_prt_pnew1_j_idx |            | CREATE INDEX ti_1_prt_pnew1_j_idx ON public.ti_1_prt_pnew1 USING bitmap (j)
- public     | ti_1_prt_pnew2 | ti_1_prt_pnew2_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_pnew2_i_idx ON public.ti_1_prt_pnew2 USING btree (i)
- public     | ti_1_prt_pnew2 | ti_1_prt_pnew2_j_idx |            | CREATE INDEX ti_1_prt_pnew2_j_idx ON public.ti_1_prt_pnew2 USING bitmap (j)
+ schemaname |   tablename    |       indexname        | tablespace |                                        indexdef                                        
+------------+----------------+------------------------+------------+----------------------------------------------------------------------------------------
+ public     | ti_1_prt_1     | ti_1_prt_1_i_j_idx     |            | CREATE UNIQUE INDEX ti_1_prt_1_i_j_idx ON public.ti_1_prt_1 USING btree (i, j)
+ public     | ti             | ti_pkey                |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i, j)
+ public     | ti_1_prt_2     | ti_1_prt_2_i_j_idx     |            | CREATE UNIQUE INDEX ti_1_prt_2_i_j_idx ON public.ti_1_prt_2 USING btree (i, j)
+ public     | ti_1_prt_1     | ti_1_prt_1_j_idx       |            | CREATE INDEX ti_1_prt_1_j_idx ON public.ti_1_prt_1 USING bitmap (j)
+ public     | ti             | ti_j_idx               |            | CREATE INDEX ti_j_idx ON public.ti USING bitmap (j)
+ public     | ti_1_prt_2     | ti_1_prt_2_j_idx       |            | CREATE INDEX ti_1_prt_2_j_idx ON public.ti_1_prt_2 USING bitmap (j)
+ public     | ti_1_prt_pnew1 | ti_1_prt_pnew1_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_pnew1_i_j_idx ON public.ti_1_prt_pnew1 USING btree (i, j)
+ public     | ti_1_prt_pnew1 | ti_1_prt_pnew1_j_idx   |            | CREATE INDEX ti_1_prt_pnew1_j_idx ON public.ti_1_prt_pnew1 USING bitmap (j)
+ public     | ti_1_prt_pnew2 | ti_1_prt_pnew2_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_pnew2_i_j_idx ON public.ti_1_prt_pnew2 USING btree (i, j)
+ public     | ti_1_prt_pnew2 | ti_1_prt_pnew2_j_idx   |            | CREATE INDEX ti_1_prt_pnew2_j_idx ON public.ti_1_prt_pnew2 USING bitmap (j)
 (10 rows)
 
 -- Should not be able to drop child indexes added implicitly via SPLIT PARTITION
-drop index ti_1_prt_pnew1_i_idx;
-ERROR:  cannot drop index ti_1_prt_pnew1_i_idx because index ti_pkey requires it
+drop index ti_1_prt_pnew1_i_j_idx;
+ERROR:  cannot drop index ti_1_prt_pnew1_i_j_idx because index ti_pkey requires it
 HINT:  You can drop index ti_pkey instead.
 drop index ti_1_prt_pnew1_j_idx;
 ERROR:  cannot drop index ti_1_prt_pnew1_j_idx because index ti_j_idx requires it
 HINT:  You can drop index ti_j_idx instead.
-drop index ti_1_prt_pnew2_i_idx;
-ERROR:  cannot drop index ti_1_prt_pnew2_i_idx because index ti_pkey requires it
+drop index ti_1_prt_pnew2_i_j_idx;
+ERROR:  cannot drop index ti_1_prt_pnew2_i_j_idx because index ti_pkey requires it
 HINT:  You can drop index ti_pkey instead.
 drop index ti_1_prt_pnew2_j_idx;
 ERROR:  cannot drop index ti_1_prt_pnew2_j_idx because index ti_j_idx requires it

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -2894,3 +2894,76 @@ SELECT user_name FROM users_test_1_prt_extra;
  C
 (1 row)
 
+-- Github issue: https://github.com/greenplum-db/gpdb/issues/9460
+-- When creating unique or primary key index on Partition table,
+-- the cols in index must contain all partition keys.
+CREATE TABLE t_idx_col_contain_partkey(a int, b int) DISTRIBUTED BY (a)
+PARTITION BY list (b)
+(PARTITION t1 values (1),
+ PARTITION t2 values (2));
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_t1" for table "t_idx_col_contain_partkey"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_t2" for table "t_idx_col_contain_partkey"
+-- the following statement should fail because index cols does not contain part key
+CREATE UNIQUE INDEX uidx_t_idx_col_contain_partkey on t_idx_col_contain_partkey(a);
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "t_idx_col_contain_partkey"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
+-- the following statement should work
+CREATE UNIQUE INDEX uidx_t_idx_col_contain_partkey on t_idx_col_contain_partkey(a, b);
+DROP INDEX uidx_t_idx_col_contain_partkey;
+DROP TABLE t_idx_col_contain_partkey;
+-- test unique index for multi level partition table
+CREATE TABLE t_idx_col_contain_partkey
+(
+        r_regionkey integer not null,
+        r_name char(25),
+        r_comment varchar(152)
+)
+DISTRIBUTED BY (r_regionkey)
+PARTITION BY RANGE (r_regionkey)
+SUBPARTITION BY LIST (r_name) SUBPARTITION TEMPLATE
+(
+        SUBPARTITION africa VALUES ('AFRICA'),
+        SUBPARTITION america VALUES ('AMERICA'),
+        SUBPARTITION asia VALUES ('ASIA'),
+        SUBPARTITION europe VALUES ('EUROPE'),
+        SUBPARTITION mideast VALUES ('MIDDLE EAST'),
+        SUBPARTITION australia VALUES ('AUSTRALIA'),
+        SUBPARTITION antarctica VALUES ('ANTARCTICA')
+)
+(
+        PARTITION region1 start (0),
+        PARTITION region2 start (3),
+        PARTITION region3 start (5) end (8)
+);
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region1" for table "t_idx_col_contain_partkey"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region1_2_prt_africa" for table "t_idx_col_contain_partkey_1_prt_region1"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region1_2_prt_america" for table "t_idx_col_contain_partkey_1_prt_region1"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region1_2_prt_asia" for table "t_idx_col_contain_partkey_1_prt_region1"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region1_2_prt_europe" for table "t_idx_col_contain_partkey_1_prt_region1"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region1_2_prt_mideast" for table "t_idx_col_contain_partkey_1_prt_region1"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region1_2_prt_australia" for table "t_idx_col_contain_partkey_1_prt_region1"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region1_2_prt_antarctica" for table "t_idx_col_contain_partkey_1_prt_region1"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region2" for table "t_idx_col_contain_partkey"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region2_2_prt_africa" for table "t_idx_col_contain_partkey_1_prt_region2"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region2_2_prt_america" for table "t_idx_col_contain_partkey_1_prt_region2"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region2_2_prt_asia" for table "t_idx_col_contain_partkey_1_prt_region2"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region2_2_prt_europe" for table "t_idx_col_contain_partkey_1_prt_region2"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region2_2_prt_mideast" for table "t_idx_col_contain_partkey_1_prt_region2"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region2_2_prt_australia" for table "t_idx_col_contain_partkey_1_prt_region2"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region2_2_prt_antarctica" for table "t_idx_col_contain_partkey_1_prt_region2"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region3" for table "t_idx_col_contain_partkey"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region3_2_prt_africa" for table "t_idx_col_contain_partkey_1_prt_region3"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region3_2_prt_america" for table "t_idx_col_contain_partkey_1_prt_region3"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region3_2_prt_asia" for table "t_idx_col_contain_partkey_1_prt_region3"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region3_2_prt_europe" for table "t_idx_col_contain_partkey_1_prt_region3"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region3_2_prt_mideast" for table "t_idx_col_contain_partkey_1_prt_region3"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region3_2_prt_australia" for table "t_idx_col_contain_partkey_1_prt_region3"
+NOTICE:  CREATE TABLE will create partition "t_idx_col_contain_partkey_1_prt_region3_2_prt_antarctica" for table "t_idx_col_contain_partkey_1_prt_region3"
+-- should fail, must contain all the partition keys of all levels
+CREATE UNIQUE INDEX uidx_t_idx_col_contain_partkey on t_idx_col_contain_partkey(r_regionkey);
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "t_idx_col_contain_partkey"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
+-- should work
+CREATE UNIQUE INDEX uidx_t_idx_col_contain_partkey on t_idx_col_contain_partkey(r_regionkey, r_name);
+DROP INDEX uidx_t_idx_col_contain_partkey;
+DROP TABLE t_idx_col_contain_partkey;

--- a/src/test/regress/expected/partition_indexing.out
+++ b/src/test/regress/expected/partition_indexing.out
@@ -235,57 +235,26 @@ NOTICE:  building index for child partition "mpp3033a_1_prt_aa"
 NOTICE:  building index for child partition "mpp3033a_1_prt_bb"
 NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
 CREATE UNIQUE INDEX mpp3033a_unique2 ON mpp3033a (unique2);
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa"
-NOTICE:  building index for child partition "mpp3033a_1_prt_bb"
-NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
-ERROR:  UNIQUE index must contain all columns in the table's distribution key
-DETAIL:  Distribution key column "unique1" is not included in the constraint.
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033a"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 CREATE UNIQUE INDEX mpp3033a_hundred ON mpp3033a (hundred);
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa"
-NOTICE:  building index for child partition "mpp3033a_1_prt_bb"
-NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
-ERROR:  UNIQUE index must contain all columns in the table's distribution key
-DETAIL:  Distribution key column "unique1" is not included in the constraint.
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033a"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 CREATE UNIQUE INDEX mpp3033a_stringu1 ON mpp3033a (stringu1);
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa"
-NOTICE:  building index for child partition "mpp3033a_1_prt_bb"
-NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
-ERROR:  UNIQUE index must contain all columns in the table's distribution key
-DETAIL:  Distribution key column "unique1" is not included in the constraint.
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033a"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 CREATE UNIQUE INDEX mpp3033b_unique1 ON mpp3033b (unique1);
-NOTICE:  building index for child partition "mpp3033b_1_prt_aa"
-NOTICE:  building index for child partition "mpp3033b_1_prt_bb"
-NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_cc"
-NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_dd"
-NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_cc"
-NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_dd"
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033b"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 CREATE UNIQUE INDEX mpp3033b_unique2 ON mpp3033b (unique2);
-NOTICE:  building index for child partition "mpp3033b_1_prt_aa"
-NOTICE:  building index for child partition "mpp3033b_1_prt_bb"
-NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_cc"
-NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_dd"
-NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_cc"
-NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_dd"
-ERROR:  UNIQUE index must contain all columns in the table's distribution key
-DETAIL:  Distribution key column "unique1" is not included in the constraint.
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033b"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 CREATE UNIQUE INDEX mpp3033b_hundred ON mpp3033b (hundred);
-NOTICE:  building index for child partition "mpp3033b_1_prt_aa"
-NOTICE:  building index for child partition "mpp3033b_1_prt_bb"
-NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_cc"
-NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_dd"
-NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_cc"
-NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_dd"
-ERROR:  UNIQUE index must contain all columns in the table's distribution key
-DETAIL:  Distribution key column "unique1" is not included in the constraint.
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033b"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 CREATE UNIQUE INDEX mpp3033b_stringu1 ON mpp3033b (stringu1);
-NOTICE:  building index for child partition "mpp3033b_1_prt_aa"
-NOTICE:  building index for child partition "mpp3033b_1_prt_bb"
-NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_cc"
-NOTICE:  building index for child partition "mpp3033b_1_prt_aa_2_prt_dd"
-NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_cc"
-NOTICE:  building index for child partition "mpp3033b_1_prt_bb_2_prt_dd"
-ERROR:  UNIQUE index must contain all columns in the table's distribution key
-DETAIL:  Distribution key column "unique1" is not included in the constraint.
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033b"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 select count(*) from mpp3033a;
  count 
 -------
@@ -306,6 +275,7 @@ ERROR:  relation "mpp3033a_hundred" does not exist
 reindex index mpp3033a_stringu1;
 ERROR:  relation "mpp3033a_stringu1" does not exist
 reindex index mpp3033b_unique1;
+ERROR:  relation "mpp3033b_unique1" does not exist
 reindex index mpp3033b_unique2;
 ERROR:  relation "mpp3033b_unique2" does not exist
 reindex index mpp3033b_hundred;
@@ -326,6 +296,7 @@ ERROR:  index "mpp3033a_hundred" does not exist
 drop index mpp3033a_stringu1;
 ERROR:  index "mpp3033a_stringu1" does not exist
 drop index mpp3033b_unique1;
+ERROR:  index "mpp3033b_unique1" does not exist
 drop index mpp3033b_unique2;
 ERROR:  index "mpp3033b_unique2" does not exist
 drop index mpp3033b_hundred;
@@ -840,129 +811,26 @@ NOTICE:  building index for child partition "mpp3033a_1_prt_aa_8"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_9"
 NOTICE:  building index for child partition "mpp3033a_1_prt_aa_10"
 CREATE UNIQUE INDEX mpp3033a_unique2 ON mpp3033a (unique2);
-NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_1"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_2"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_3"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_4"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_5"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_6"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_7"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_8"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_9"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_10"
-DETAIL:  Distribution key column "unique1" is not included in the constraint.
-ERROR:  UNIQUE index must contain all columns in the table's distribution key
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033a"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 CREATE UNIQUE INDEX mpp3033a_hundred ON mpp3033a (hundred);
-NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_1"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_2"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_3"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_4"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_5"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_6"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_7"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_8"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_9"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_10"
-DETAIL:  Distribution key column "unique1" is not included in the constraint.
-ERROR:  UNIQUE index must contain all columns in the table's distribution key
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033a"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 CREATE UNIQUE INDEX mpp3033a_stringu1 ON mpp3033a (stringu1);
-NOTICE:  building index for child partition "mpp3033a_1_prt_default_part"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_1"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_2"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_3"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_4"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_5"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_6"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_7"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_8"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_9"
-NOTICE:  building index for child partition "mpp3033a_1_prt_aa_10"
-DETAIL:  Distribution key column "unique1" is not included in the constraint.
-ERROR:  UNIQUE index must contain all columns in the table's distribution key
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033a"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 CREATE UNIQUE INDEX mpp3033b_unique1 ON mpp3033b (unique1);
-NOTICE:  building index for child partition "mpp3033b_1_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_4"
-NOTICE:  building index for child partition "mpp3033b_1_prt_3"
-NOTICE:  building index for child partition "mpp3033b_1_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_5"
-NOTICE:  building index for child partition "mpp3033b_1_prt_default_part"
-NOTICE:  building index for child partition "mpp3033b_1_prt_2_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_2_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_4_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_4_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_3_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_3_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_1_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_1_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_2"
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033b"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 CREATE UNIQUE INDEX mpp3033b_unique2 ON mpp3033b (unique2);
-NOTICE:  building index for child partition "mpp3033b_1_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_4"
-NOTICE:  building index for child partition "mpp3033b_1_prt_3"
-NOTICE:  building index for child partition "mpp3033b_1_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_5"
-NOTICE:  building index for child partition "mpp3033b_1_prt_default_part"
-NOTICE:  building index for child partition "mpp3033b_1_prt_2_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_2_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_4_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_4_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_3_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_3_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_1_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_1_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_2"
-DETAIL:  Distribution key column "unique1" is not included in the constraint.
-ERROR:  UNIQUE index must contain all columns in the table's distribution key
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033b"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 CREATE UNIQUE INDEX mpp3033b_hundred ON mpp3033b (hundred);
-NOTICE:  building index for child partition "mpp3033b_1_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_4"
-NOTICE:  building index for child partition "mpp3033b_1_prt_3"
-NOTICE:  building index for child partition "mpp3033b_1_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_5"
-NOTICE:  building index for child partition "mpp3033b_1_prt_default_part"
-NOTICE:  building index for child partition "mpp3033b_1_prt_2_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_2_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_4_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_4_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_3_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_3_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_1_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_1_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_2"
-DETAIL:  Distribution key column "unique1" is not included in the constraint.
-ERROR:  UNIQUE index must contain all columns in the table's distribution key
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033b"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 CREATE UNIQUE INDEX mpp3033b_stringu1 ON mpp3033b (stringu1);
-NOTICE:  building index for child partition "mpp3033b_1_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_4"
-NOTICE:  building index for child partition "mpp3033b_1_prt_3"
-NOTICE:  building index for child partition "mpp3033b_1_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_5"
-NOTICE:  building index for child partition "mpp3033b_1_prt_default_part"
-NOTICE:  building index for child partition "mpp3033b_1_prt_2_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_2_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_4_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_4_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_3_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_3_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_1_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_1_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_5_2_prt_2"
-NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_1"
-NOTICE:  building index for child partition "mpp3033b_1_prt_default_part_2_prt_2"
-DETAIL:  Distribution key column "unique1" is not included in the constraint.
-ERROR:  UNIQUE index must contain all columns in the table's distribution key
+ERROR:  UNIQUE constraint must contain all columns in the partition key of relation "mpp3033b"
+HINT:  Include the partition key or create a part-wise UNIQUE index instead.
 select count(*) from mpp3033a;
  count 
 -------
@@ -983,6 +851,7 @@ ERROR:  relation "mpp3033a_hundred" does not exist
 reindex index mpp3033a_stringu1;
 ERROR:  relation "mpp3033a_stringu1" does not exist
 reindex index mpp3033b_unique1;
+ERROR:  relation "mpp3033b_unique1" does not exist
 reindex index mpp3033b_unique2;
 ERROR:  relation "mpp3033b_unique2" does not exist
 reindex index mpp3033b_hundred;
@@ -1009,6 +878,7 @@ ERROR:  index "mpp3033a_hundred" does not exist
 drop index mpp3033a_stringu1;
 ERROR:  index "mpp3033a_stringu1" does not exist
 drop index mpp3033b_unique1;
+ERROR:  index "mpp3033b_unique1" does not exist
 drop index mpp3033b_unique2;
 ERROR:  index "mpp3033b_unique2" does not exist
 drop index mpp3033b_hundred;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -81,31 +81,7 @@ select gp_segment_id, relname from gp_dist_random('pg_class') where relkind = 'r
              2 | region_1_prt_region3
 (12 rows)
 
-create unique index region_pkey on region(r_regionkey);
-NOTICE:  building index for child partition "region_1_prt_region1"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_africa"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_america"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_asia"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_europe"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_mideast"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_australia"
-NOTICE:  building index for child partition "region_1_prt_region1_2_prt_antarctica"
-NOTICE:  building index for child partition "region_1_prt_region2"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_africa"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_america"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_asia"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_europe"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_mideast"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_australia"
-NOTICE:  building index for child partition "region_1_prt_region2_2_prt_antarctica"
-NOTICE:  building index for child partition "region_1_prt_region3" for table "region"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_africa"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_america"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_asia"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_europe"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_mideast"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_australia"
-NOTICE:  building index for child partition "region_1_prt_region3_2_prt_antarctica"
+create unique index region_pkey on region(r_regionkey, r_name);
 copy region from stdin with delimiter '|';
 -- Test indexes
 set enable_seqscan to off;
@@ -157,8 +133,8 @@ select * from region where r_regionkey = '7';
 -- tables since we cannot enforce them. But since this insert maps to a
 -- single definitive partition, we can detect it.
 insert into region values(7, 'AUSTRALIA', 'def');
-ERROR:  duplicate key value violates unique constraint "region_1_prt_region3_2_prt_australia_r_regionkey_idx"  (seg0 127.0.1.1:25432 pid=8607)
-DETAIL:  Key (r_regionkey)=(7) already exists.
+ERROR:  duplicate key value violates unique constraint "region_1_prt_region3_2_prt_australia_r_regionkey_r_name_idx"  (seg0 127.0.1.1:7002 pid=122565)
+DETAIL:  Key (r_regionkey, r_name)=(7, AUSTRALIA                ) already exists.
 drop table region;
 -- exchange
 -- 1) test all sanity checking
@@ -4070,49 +4046,47 @@ partition by range (j)
 (start(1) end(3) every(1));
 NOTICE:  CREATE TABLE will create partition "ti_1_prt_1" for table "ti"
 NOTICE:  CREATE TABLE will create partition "ti_1_prt_2" for table "ti"
-create unique index ti_pkey on ti(i);
-NOTICE:  building index for child partition "ti_1_prt_1"
-NOTICE:  building index for child partition "ti_1_prt_2"
+create unique index ti_pkey on ti(i,j);
 select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
- schemaname | tablename  |    indexname     | tablespace |                                 indexdef                                  
-------------+------------+------------------+------------+---------------------------------------------------------------------------
- public     | ti         | ti_pkey          |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i)
- public     | ti_1_prt_1 | ti_1_prt_1_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_1_i_idx ON public.ti_1_prt_1 USING btree (i)
- public     | ti_1_prt_2 | ti_1_prt_2_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_2_i_idx ON public.ti_1_prt_2 USING btree (i)
+ schemaname | tablename  |     indexname      | tablespace |                                    indexdef                                    
+------------+------------+--------------------+------------+--------------------------------------------------------------------------------
+ public     | ti_1_prt_1 | ti_1_prt_1_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_1_i_j_idx ON public.ti_1_prt_1 USING btree (i, j)
+ public     | ti         | ti_pkey            |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i, j)
+ public     | ti_1_prt_2 | ti_1_prt_2_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_2_i_j_idx ON public.ti_1_prt_2 USING btree (i, j)
 (3 rows)
 
 create index ti_j_idx on ti using bitmap(j);
 NOTICE:  building index for child partition "ti_1_prt_1"
 NOTICE:  building index for child partition "ti_1_prt_2"
 select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
- schemaname | tablename  |    indexname     | tablespace |                                 indexdef                                  
-------------+------------+------------------+------------+---------------------------------------------------------------------------
- public     | ti         | ti_pkey          |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i)
- public     | ti_1_prt_1 | ti_1_prt_1_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_1_i_idx ON public.ti_1_prt_1 USING btree (i)
- public     | ti_1_prt_2 | ti_1_prt_2_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_2_i_idx ON public.ti_1_prt_2 USING btree (i)
- public     | ti         | ti_j_idx         |            | CREATE INDEX ti_j_idx ON public.ti USING bitmap (j)
- public     | ti_1_prt_1 | ti_1_prt_1_j_idx |            | CREATE INDEX ti_1_prt_1_j_idx ON public.ti_1_prt_1 USING bitmap (j)
- public     | ti_1_prt_2 | ti_1_prt_2_j_idx |            | CREATE INDEX ti_1_prt_2_j_idx ON public.ti_1_prt_2 USING bitmap (j)
+ schemaname | tablename  |     indexname      | tablespace |                                    indexdef                                    
+------------+------------+--------------------+------------+--------------------------------------------------------------------------------
+ public     | ti_1_prt_1 | ti_1_prt_1_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_1_i_j_idx ON public.ti_1_prt_1 USING btree (i, j)
+ public     | ti         | ti_pkey            |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i, j)
+ public     | ti_1_prt_2 | ti_1_prt_2_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_2_i_j_idx ON public.ti_1_prt_2 USING btree (i, j)
+ public     | ti_1_prt_1 | ti_1_prt_1_j_idx   |            | CREATE INDEX ti_1_prt_1_j_idx ON public.ti_1_prt_1 USING bitmap (j)
+ public     | ti         | ti_j_idx           |            | CREATE INDEX ti_j_idx ON public.ti USING bitmap (j)
+ public     | ti_1_prt_2 | ti_1_prt_2_j_idx   |            | CREATE INDEX ti_1_prt_2_j_idx ON public.ti_1_prt_2 USING bitmap (j)
 (6 rows)
 
 alter table ti add partition p3 start(3) end(10);
 NOTICE:  CREATE TABLE will create partition "ti_1_prt_p3" for table "ti"
 select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
- schemaname |  tablename  |     indexname     | tablespace |                                  indexdef                                   
-------------+-------------+-------------------+------------+-----------------------------------------------------------------------------
- public     | ti          | ti_pkey           |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i)
- public     | ti_1_prt_1  | ti_1_prt_1_i_idx  |            | CREATE UNIQUE INDEX ti_1_prt_1_i_idx ON public.ti_1_prt_1 USING btree (i)
- public     | ti_1_prt_2  | ti_1_prt_2_i_idx  |            | CREATE UNIQUE INDEX ti_1_prt_2_i_idx ON public.ti_1_prt_2 USING btree (i)
- public     | ti          | ti_j_idx          |            | CREATE INDEX ti_j_idx ON public.ti USING bitmap (j)
- public     | ti_1_prt_1  | ti_1_prt_1_j_idx  |            | CREATE INDEX ti_1_prt_1_j_idx ON public.ti_1_prt_1 USING bitmap (j)
- public     | ti_1_prt_2  | ti_1_prt_2_j_idx  |            | CREATE INDEX ti_1_prt_2_j_idx ON public.ti_1_prt_2 USING bitmap (j)
- public     | ti_1_prt_p3 | ti_1_prt_p3_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_p3_i_idx ON public.ti_1_prt_p3 USING btree (i)
- public     | ti_1_prt_p3 | ti_1_prt_p3_j_idx |            | CREATE INDEX ti_1_prt_p3_j_idx ON public.ti_1_prt_p3 USING bitmap (j)
+ schemaname |  tablename  |      indexname      | tablespace |                                     indexdef                                     
+------------+-------------+---------------------+------------+----------------------------------------------------------------------------------
+ public     | ti_1_prt_1  | ti_1_prt_1_i_j_idx  |            | CREATE UNIQUE INDEX ti_1_prt_1_i_j_idx ON public.ti_1_prt_1 USING btree (i, j)
+ public     | ti          | ti_pkey             |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i, j)
+ public     | ti_1_prt_2  | ti_1_prt_2_i_j_idx  |            | CREATE UNIQUE INDEX ti_1_prt_2_i_j_idx ON public.ti_1_prt_2 USING btree (i, j)
+ public     | ti_1_prt_1  | ti_1_prt_1_j_idx    |            | CREATE INDEX ti_1_prt_1_j_idx ON public.ti_1_prt_1 USING bitmap (j)
+ public     | ti          | ti_j_idx            |            | CREATE INDEX ti_j_idx ON public.ti USING bitmap (j)
+ public     | ti_1_prt_2  | ti_1_prt_2_j_idx    |            | CREATE INDEX ti_1_prt_2_j_idx ON public.ti_1_prt_2 USING bitmap (j)
+ public     | ti_1_prt_p3 | ti_1_prt_p3_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_p3_i_j_idx ON public.ti_1_prt_p3 USING btree (i, j)
+ public     | ti_1_prt_p3 | ti_1_prt_p3_j_idx   |            | CREATE INDEX ti_1_prt_p3_j_idx ON public.ti_1_prt_p3 USING bitmap (j)
 (8 rows)
 
 -- Should not be able to drop child indexes added implicitly via ADD PARTITION
-drop index ti_1_prt_p3_i_idx;
-ERROR:  cannot drop index ti_1_prt_p3_i_idx because index ti_pkey requires it
+drop index ti_1_prt_p3_i_j_idx;
+ERROR:  cannot drop index ti_1_prt_p3_i_j_idx because index ti_pkey requires it
 HINT:  You can drop index ti_pkey instead.
 drop index ti_1_prt_p3_j_idx;
 ERROR:  cannot drop index ti_1_prt_p3_j_idx because index ti_j_idx requires it
@@ -4123,29 +4097,29 @@ NOTICE:  dropped partition "p3" for relation "ti"
 NOTICE:  CREATE TABLE will create partition "ti_1_prt_pnew1" for table "ti"
 NOTICE:  CREATE TABLE will create partition "ti_1_prt_pnew2" for table "ti"
 select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
- schemaname |   tablename    |      indexname       | tablespace |                                     indexdef                                      
-------------+----------------+----------------------+------------+-----------------------------------------------------------------------------------
- public     | ti_1_prt_pnew2 | ti_1_prt_pnew2_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_pnew2_i_idx ON public.ti_1_prt_pnew2 USING btree (i)
- public     | ti_1_prt_pnew2 | ti_1_prt_pnew2_j_idx |            | CREATE INDEX ti_1_prt_pnew2_j_idx ON public.ti_1_prt_pnew2 USING bitmap (j)
- public     | ti             | ti_pkey              |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i)
- public     | ti_1_prt_1     | ti_1_prt_1_i_idx     |            | CREATE UNIQUE INDEX ti_1_prt_1_i_idx ON public.ti_1_prt_1 USING btree (i)
- public     | ti_1_prt_2     | ti_1_prt_2_i_idx     |            | CREATE UNIQUE INDEX ti_1_prt_2_i_idx ON public.ti_1_prt_2 USING btree (i)
- public     | ti             | ti_j_idx             |            | CREATE INDEX ti_j_idx ON public.ti USING bitmap (j)
- public     | ti_1_prt_1     | ti_1_prt_1_j_idx     |            | CREATE INDEX ti_1_prt_1_j_idx ON public.ti_1_prt_1 USING bitmap (j)
- public     | ti_1_prt_2     | ti_1_prt_2_j_idx     |            | CREATE INDEX ti_1_prt_2_j_idx ON public.ti_1_prt_2 USING bitmap (j)
- public     | ti_1_prt_pnew1 | ti_1_prt_pnew1_i_idx |            | CREATE UNIQUE INDEX ti_1_prt_pnew1_i_idx ON public.ti_1_prt_pnew1 USING btree (i)
- public     | ti_1_prt_pnew1 | ti_1_prt_pnew1_j_idx |            | CREATE INDEX ti_1_prt_pnew1_j_idx ON public.ti_1_prt_pnew1 USING bitmap (j)
+ schemaname |   tablename    |       indexname        | tablespace |                                        indexdef                                        
+------------+----------------+------------------------+------------+----------------------------------------------------------------------------------------
+ public     | ti_1_prt_1     | ti_1_prt_1_i_j_idx     |            | CREATE UNIQUE INDEX ti_1_prt_1_i_j_idx ON public.ti_1_prt_1 USING btree (i, j)
+ public     | ti             | ti_pkey                |            | CREATE UNIQUE INDEX ti_pkey ON public.ti USING btree (i, j)
+ public     | ti_1_prt_2     | ti_1_prt_2_i_j_idx     |            | CREATE UNIQUE INDEX ti_1_prt_2_i_j_idx ON public.ti_1_prt_2 USING btree (i, j)
+ public     | ti_1_prt_1     | ti_1_prt_1_j_idx       |            | CREATE INDEX ti_1_prt_1_j_idx ON public.ti_1_prt_1 USING bitmap (j)
+ public     | ti             | ti_j_idx               |            | CREATE INDEX ti_j_idx ON public.ti USING bitmap (j)
+ public     | ti_1_prt_2     | ti_1_prt_2_j_idx       |            | CREATE INDEX ti_1_prt_2_j_idx ON public.ti_1_prt_2 USING bitmap (j)
+ public     | ti_1_prt_pnew1 | ti_1_prt_pnew1_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_pnew1_i_j_idx ON public.ti_1_prt_pnew1 USING btree (i, j)
+ public     | ti_1_prt_pnew1 | ti_1_prt_pnew1_j_idx   |            | CREATE INDEX ti_1_prt_pnew1_j_idx ON public.ti_1_prt_pnew1 USING bitmap (j)
+ public     | ti_1_prt_pnew2 | ti_1_prt_pnew2_i_j_idx |            | CREATE UNIQUE INDEX ti_1_prt_pnew2_i_j_idx ON public.ti_1_prt_pnew2 USING btree (i, j)
+ public     | ti_1_prt_pnew2 | ti_1_prt_pnew2_j_idx   |            | CREATE INDEX ti_1_prt_pnew2_j_idx ON public.ti_1_prt_pnew2 USING bitmap (j)
 (10 rows)
 
 -- Should not be able to drop child indexes added implicitly via SPLIT PARTITION
-drop index ti_1_prt_pnew1_i_idx;
-ERROR:  cannot drop index ti_1_prt_pnew1_i_idx because index ti_pkey requires it
+drop index ti_1_prt_pnew1_i_j_idx;
+ERROR:  cannot drop index ti_1_prt_pnew1_i_j_idx because index ti_pkey requires it
 HINT:  You can drop index ti_pkey instead.
 drop index ti_1_prt_pnew1_j_idx;
 ERROR:  cannot drop index ti_1_prt_pnew1_j_idx because index ti_j_idx requires it
 HINT:  You can drop index ti_j_idx instead.
-drop index ti_1_prt_pnew2_i_idx;
-ERROR:  cannot drop index ti_1_prt_pnew2_i_idx because index ti_pkey requires it
+drop index ti_1_prt_pnew2_i_j_idx;
+ERROR:  cannot drop index ti_1_prt_pnew2_i_j_idx because index ti_pkey requires it
 HINT:  You can drop index ti_pkey instead.
 drop index ti_1_prt_pnew2_j_idx;
 ERROR:  cannot drop index ti_1_prt_pnew2_j_idx because index ti_j_idx requires it

--- a/src/test/regress/sql/direct_dispatch.sql
+++ b/src/test/regress/sql/direct_dispatch.sql
@@ -33,7 +33,7 @@ create index direct_test_bitmap_idx on direct_test_bitmap using bitmap (ind, dt)
 
 CREATE TABLE direct_test_partition (trans_id int, date date, amount decimal(9,2), region text) DISTRIBUTED BY (trans_id) PARTITION BY RANGE (date) (START (date '2008-01-01') INCLUSIVE END (date '2009-01-01') EXCLUSIVE EVERY (INTERVAL '1month') );
 
-create unique index direct_test_uk on direct_test_partition(trans_id);
+create unique index direct_test_uk on direct_test_partition(trans_id,date);
 
 create table direct_test_range_partition (a int, b int, c int, d int) distributed by (a) partition by range(d) (start(1) end(10) every(1));
 insert into direct_test_range_partition select i, i+1, i+2, i+3 from generate_series(1, 2) i;

--- a/src/test/regress/sql/index_constraint_naming_partition.sql
+++ b/src/test/regress/sql/index_constraint_naming_partition.sql
@@ -469,11 +469,11 @@ SELECT * FROM partition_tables_show_all();
 --  node.
 --create the index at the root; should only be able to drop it from root
 SELECT recreate_three_level_table();
-CREATE UNIQUE INDEX myidx_onroot ON r USING btree(r_key);
+CREATE UNIQUE INDEX myidx_onroot ON r USING btree(r_key,r_name);
 SELECT * FROM dependencies_show_for_idx();
-DROP INDEX r_1_prt_r2_r_key_idx;         --should fail: cannot drop from non-creating node
+DROP INDEX r_1_prt_r2_r_key_r_name_idx;         --should fail: cannot drop from non-creating node
 SELECT * FROM dependencies_show_for_idx();
-DROP INDEX r_1_prt_r2_2_prt_b_r_key_idx; --should fail: cannot drop from non-creating node
+DROP INDEX r_1_prt_r2_2_prt_b_r_key_r_name_idx; --should fail: cannot drop from non-creating node
 SELECT * FROM dependencies_show_for_idx();
 DROP INDEX myidx_onroot;                 --works: is root of index hierarchy
 SELECT * FROM dependencies_show_for_idx();
@@ -491,16 +491,16 @@ SELECT * FROM dependencies_show_for_idx();
 --yes, this is inconsistent with index subsumption but upstream does it this way
 --in particular, there's no subsumption going on here.
 SELECT recreate_three_level_table();
-CREATE UNIQUE INDEX ON r USING btree(r_key);
+CREATE UNIQUE INDEX ON r USING btree(r_key,r_name);
 SELECT * FROM dependencies_show_for_idx();
-CREATE UNIQUE INDEX ON r USING btree(r_key);
+CREATE UNIQUE INDEX ON r USING btree(r_key,r_name);
 SELECT * FROM dependencies_show_for_idx();
 
 --test subsumption of lower-level index from upper-level one
 SELECT recreate_three_level_table();
 CREATE UNIQUE INDEX myidx_midlevel ON r_1_prt_r1 USING btree(r_key);
 SELECT * FROM dependencies_show_for_idx();
-CREATE UNIQUE INDEX myidx_onroot ON r USING btree(r_key);
+CREATE UNIQUE INDEX myidx_onroot ON r USING btree(r_key,r_name);
 SELECT * FROM dependencies_show_for_idx();
 
 --show subsumption works across rename
@@ -509,7 +509,7 @@ CREATE UNIQUE INDEX myidx_midlevel ON r_1_prt_r1 USING btree(r_key);
 SELECT * FROM dependencies_show_for_idx();
 ALTER INDEX myidx_midlevel RENAME TO myidx_midlevel_renamed;
 SELECT * FROM dependencies_show_for_idx();
-CREATE UNIQUE INDEX myidx_midlevel ON r USING btree(r_key);
+CREATE UNIQUE INDEX myidx_midlevel ON r USING btree(r_key,r_name);
 SELECT * FROM dependencies_show_for_idx();
 
 --show that renaming still does not allow a name conflict
@@ -518,14 +518,14 @@ CREATE UNIQUE INDEX myidx_midlevel ON r_1_prt_r1 USING btree(r_key);
 SELECT * FROM dependencies_show_for_idx();
 ALTER INDEX myidx_midlevel RENAME TO myidx_midlevel_renamed;
 SELECT * FROM dependencies_show_for_idx();
-CREATE UNIQUE INDEX myidx_midlevel_renamed ON r USING btree(r_key);   --should fail: index already exists
+CREATE UNIQUE INDEX myidx_midlevel_renamed ON r USING btree(r_key,r_name);   --should fail: index already exists
 SELECT * FROM dependencies_show_for_idx();
 
 --show that renaming a mid-level index still prevents it from being dropped.
 SELECT recreate_three_level_table();
-CREATE UNIQUE INDEX myidx_onroot ON r USING btree(r_key);
+CREATE UNIQUE INDEX myidx_onroot ON r USING btree(r_key,r_name);
 SELECT * FROM dependencies_show_for_idx();
-ALTER INDEX r_1_prt_r1_r_key_idx RENAME TO middle_index_renamed;
+ALTER INDEX r_1_prt_r1_r_key_r_name_idx RENAME TO middle_index_renamed;
 SELECT * FROM dependencies_show_for_idx();
 DROP INDEX middle_index_renamed;  --should fail: this renamed index is still controlled by the root index that created it
 SELECT * FROM dependencies_show_for_idx();

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -32,7 +32,7 @@ subpartition by list (r_name) subpartition template
 select relname from pg_class where relkind = 'r' and relname like 'region%' and relfrozenxid=0;
 select gp_segment_id, relname from gp_dist_random('pg_class') where relkind = 'r' and relname like 'region%' and relfrozenxid=0;
 
-create unique index region_pkey on region(r_regionkey);
+create unique index region_pkey on region(r_regionkey, r_name);
 
 copy region from stdin with delimiter '|';
 0|AFRICA|lar deposits. blithely final packages cajole. regular waters are 
@@ -2108,7 +2108,7 @@ create table ti (i int not null, j int)
 distributed by (i)
 partition by range (j) 
 (start(1) end(3) every(1));
-create unique index ti_pkey on ti(i);
+create unique index ti_pkey on ti(i,j);
 
 select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
 create index ti_j_idx on ti using bitmap(j);
@@ -2116,14 +2116,14 @@ select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
 alter table ti add partition p3 start(3) end(10);
 select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
 -- Should not be able to drop child indexes added implicitly via ADD PARTITION
-drop index ti_1_prt_p3_i_idx;
+drop index ti_1_prt_p3_i_j_idx;
 drop index ti_1_prt_p3_j_idx;
 alter table ti split partition p3 at (7) into (partition pnew1, partition pnew2);
 select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
 -- Should not be able to drop child indexes added implicitly via SPLIT PARTITION
-drop index ti_1_prt_pnew1_i_idx;
+drop index ti_1_prt_pnew1_i_j_idx;
 drop index ti_1_prt_pnew1_j_idx;
-drop index ti_1_prt_pnew2_i_idx;
+drop index ti_1_prt_pnew2_i_j_idx;
 drop index ti_1_prt_pnew2_j_idx;
 -- Index drop should cascade to all partitions- including those later added via
 -- ADD PARTITION or SPLIT PARTITION


### PR DESCRIPTION
…partition keys.

Greenplum has code to implement such logic. But the
`if condition` is just to test the `isconstraint` filed
of the IndexStmt struct. That field is only set true
in the Create Table statement. So when user runs `create
unique index` the check logic is never reached.

This commit changes the `if condition` to the logic same
as upstream: `(stmt->unique || stmt->primary))`.

Fix github issue: https://github.com/greenplum-db/gpdb/issues/9460

------------------------------

Before this PR, the following statement work:

```sql
gpadmin=# create table t(a int primary key , b int) partition by list (b)
( partition t1 values (1),
  partition t2 values (2));
ERROR:  PRIMARY KEY constraint must contain all columns in the partition key
HINT:  Include column "b" in the PRIMARY KEY constraint or create a part-wise UNIQUE index after creating the table instead.
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
