### PR TITLE
ci: do not generate ubuntu jobs if not specified

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -245,7 +245,9 @@ groups:
   - cli_cross_subnet
 {% for test in CLI_BEHAVE_TESTS %}
   - [[ test.name ]]
+{% if "ubuntu18.04" in os_types %}
   - [[ test.name ]]_ubuntu18
+{% endif %}
 {% endfor %}
   - check_centos
   - combine_cli_coverage
@@ -384,11 +386,15 @@ groups:
 - name: CLI
   jobs:
   - gate_cli_start
+{% if "ubuntu18.04" in os_types %}
   - compile_gpdb_ubuntu18.04
+{% endif %}
   - cli_cross_subnet
 {% for test in CLI_BEHAVE_TESTS %}
   - [[ test.name ]]
+{% if "ubuntu18.04" in os_types %}
   - [[ test.name ]]_ubuntu18
+{% endif %}
 {% endfor %}
   - check_centos
   - combine_cli_coverage
@@ -1725,6 +1731,7 @@ jobs:
               params:
                 JSON_KEY: ((concourse-gcs-resources-service-account-key))
 
+{% if "ubuntu18.04" in os_types %}
 - name: [[ test.name ]]_ubuntu18
   plan:
     - in_parallel:
@@ -1784,6 +1791,7 @@ jobs:
               BEHAVE_FLAGS: --tags=[[ test.name ]] --tags=~concourse_cluster,demo_cluster
               [[ test.env ]]
 
+{% endif %}
 {% endfor %}
 
 - name: cli_cross_subnet
@@ -2233,7 +2241,9 @@ jobs:
         - cli_cross_subnet
 {% for test in CLI_BEHAVE_TESTS %}
         - [[ test.name ]]
+{% if "ubuntu18.04" in os_types %}
         - [[ test.name ]]_ubuntu18
+{% endif %}
 {% endfor %}
  ##     - madlib_build_gppkg
  ##     - MADlib_Test_orca_centos6

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -326,6 +326,7 @@ groups:
 {% if "ubuntu18.04" in os_types %}
   - icw_gporca_ubuntu18.04
   - icw_planner_ubuntu18.04
+  - compile_gpdb_ubuntu18.04
 {% endif %}
   - gate_icw_end
 


### PR DESCRIPTION
We used to generate ubuntu only jobs even if ubuntu is not in the os
list, wrap them with os checkers now.

Also, include compile_gpdb_ubuntu18.04 in ICW group.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
