### PR TITLE
Revert "gpexpand: exclude master-only tables from the template"

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -10,7 +10,6 @@ import copy
 import datetime
 import os
 import random
-import re
 import sys
 import json
 import shutil
@@ -627,9 +626,8 @@ class SegmentTemplate:
         """Builds segment template tar file"""
         self.statusLogger.set_status('BUILD_SEGMENT_TEMPLATE_STARTED', self.tempDir)
         # build segment template should consider tablespace files
-        excludes = self._list_master_only_files()
-        self._create_template(newTableSpaceInfo, excludes=excludes)
-        self._fixup_template(excludes=excludes)
+        self._create_template(newTableSpaceInfo)
+        self._fixup_template()
         self._tar_template()
         self.statusLogger.set_status('BUILD_SEGMENT_TEMPLATE_DONE')
 
@@ -642,72 +640,7 @@ class SegmentTemplate:
         numNewSegments = len(self.gparray.getExpansionSegDbList())
         self.statusLogger.set_status('BUILD_SEGMENTS_DONE', numNewSegments)
 
-    def _list_master_only_files(self):
-        """Build a list of files of master only tables and their indexes.
-
-        The content of master only tables should be cleared or refilled on the
-        new segments, by including an empty copy of the heap & index files less
-        data is transferred via network and there is no need to delete the
-        content on the segments explicitly.
-
-        However empty index files are actually invalid, we still need to
-        reindex the master only tables on the new segments to rebuild the index
-        files, this is fast as the heap files are all empty.
-
-        One exception is pg_auth_time_constraint, the segment cannot start if
-        the index of this table is invalid, so we have to copy the content of
-        this table, both heap and index, from master to the new segments, then
-        delete from it on the segments explicitly.
-        """
-
-        self.logger.info("Building the file list of master only tables")
-
-        self.conn = dbconn.connect(self.dburl, encoding='UTF8')
-
-        master_only_tables = copy.copy(MASTER_ONLY_TABLES)
-        master_only_tables.remove('pg_auth_time_constraint')
-
-        fake_oids = ["'%s'::regclass::oid" % tab
-                     for tab in master_only_tables]
-        fake_oids = "(" + ", ".join(fake_oids) + ")"
-        self.logger.debug("master only tables: %s" % fake_oids)
-
-        sql = "SELECT oid FROM pg_catalog.pg_class WHERE oid IN %s" % fake_oids
-        table_oids = [str(row[0])
-                      for row in dbconn.execSQL(self.conn, sql).fetchall()]
-        self.logger.debug("table oids of master only tables: %s" % table_oids)
-
-        sql = "SELECT indexrelid FROM pg_catalog.pg_index WHERE indrelid IN %s" % fake_oids
-        index_oids = [str(row[0])
-                      for row in dbconn.execSQL(self.conn, sql).fetchall()]
-        self.logger.debug("index oids of master only tables: %s" % index_oids)
-
-        # ${oid}: the relation file itself
-        # ${oid}_vm: the visibility map
-        # ${oid}_fsm: the free space map
-        # ${oid}.[1-9][0-9]*: the seg files; we use [0-9]+ for simplify
-        oids = table_oids + index_oids
-        pattern = '^(%s)(|_vm|_vsm|\\.\d+)$' % '|'.join(oids)
-        reprog = re.compile(pattern)
-        self.logger.debug("regex pattern of master only tables: %s" % pattern)
-
-        result = []
-
-        # the file list will be passed to pg_basebackup as the exclude list,
-        # it expects the paths are like "./global/1234", so we must chdir to
-        # the master data dir.
-        oldcwd = os.getcwd()
-        os.chdir(self.masterDataDirectory)
-        for root, dirs, files in os.walk(".", followlinks=False):
-            for fname in files:
-                if reprog.match(fname):
-                    result.append(os.path.join(root, fname))
-        os.chdir(oldcwd)
-        self.logger.debug("files of master only tables: %s" % result)
-
-        return result
-
-    def _create_template(self, newTableSpaceInfo=None, excludes=[]):
+    def _create_template(self, newTableSpaceInfo=None):
         """Creates the schema template that is used by new segments"""
         self.logger.info('Creating segment template')
 
@@ -730,7 +663,6 @@ class SegmentTemplate:
                                host=masterSeg.getSegmentHostName(),
                                port=str(masterSeg.getSegmentPort()),
                                recovery_mode=False,
-                               excludePaths=excludes,
                                target_gp_dbid=dummyDBID)
             cmd.run(validateAfter=True)
         except Exception, msg:
@@ -915,7 +847,7 @@ class SegmentTemplate:
         self._start_new_primary_segments()
         self._stop_new_primary_segments()
 
-    def _fixup_template(self, excludes=[]):
+    def _fixup_template(self):
         """Copies postgresql.conf and pg_hba.conf files from a valid segment on the system.
         Then modifies the template copy of pg_hba.conf"""
 
@@ -936,24 +868,6 @@ class SegmentTemplate:
                     dstFile=self.tempDir, dstHost=localHostname,ctxt=REMOTE,
                     remoteHost=self.srcSegHostname)
         cpCmd.run(validateAfter=True)
-
-        # the files of the master only tables are already deleted, now add an
-        # empty copy of them, so they are seen as empty on the new segments,
-        # and we do not need to delete them via sql separately.
-        if excludes:
-            self.logger.info('Creating an empty copy of excluded files')
-            for pathname in excludes:
-                fullname = os.path.join(self.tempDir, pathname)
-                filename = os.path.basename(fullname)
-                dirname = os.path.dirname(fullname)
-                if '.' in filename:
-                    # ignore seg files
-                    continue
-                # the template dir is not expected to be updated concurrently,
-                # so it is safe to use a check-and-create style to create dirs.
-                if not os.path.isdir(dirname):
-                    os.makedirs(dirname)
-                open(fullname, 'wb')
 
     def _tar_template(self):
         """Tars up the template files"""
@@ -1478,14 +1392,10 @@ class gpexpand:
         self.pool.check_results()
 
         """
-        Build the list of reindex and delete statements based on the
-        MASTER_ONLY_TABLES defined in gpcatalog.py
+        Build the list of delete statements based on the MASTER_ONLY_TABLES
+        defined in gpcatalog.py
         """
-        statements = ["REINDEX TABLE pg_catalog.%s" % tab
-                      for tab in MASTER_ONLY_TABLES]
-
-        # refer to _list_master_only_files() on why we have to do so
-        statements.append("DELETE FROM pg_catalog.pg_auth_time_constraint")
+        statements = ["delete from pg_catalog.%s" % tab for tab in MASTER_ONLY_TABLES]
 
         """
           Connect to each database in the new segments, and clean up the catalog tables.

--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -23,24 +23,25 @@ class GPCatalogException(Exception):
 
 # Hard coded since "master only" is not defined in the catalog
 MASTER_ONLY_TABLES = [
+    'gp_segment_configuration',
     'gp_configuration_history',
     'gp_segment_configuration',
-    'pg_auth_time_constraint',
     'pg_description',
     'pg_partition',
-    'pg_partition_encoding',
     'pg_partition_rule',
     'pg_shdescription',
     'pg_stat_last_operation',
     'pg_stat_last_shoperation',
     'pg_statistic',
+    'pg_partition_encoding',
+    'pg_auth_time_constraint',
     ]
 
 # Hard coded tables that have different values on every segment
 SEGMENT_LOCAL_TABLES = [
-    'gp_fastsequence', # AO segment row id allocations
     'gp_id',
     'pg_shdepend', # (not if we fix oid inconsistencies)
+    'gp_fastsequence', # AO segment row id allocations
     'pg_statistic',
     ]
 

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -84,7 +84,6 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 2 new segments
-        And verify that the master-only tables are empty on one new segment
 
     @gpexpand_no_mirrors
     @gpexpand_host
@@ -101,7 +100,6 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 2 new segments
-        And verify that the master-only tables are empty on one new segment
 
     @gpexpand_no_mirrors
     @gpexpand_host_and_segment
@@ -118,7 +116,6 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 4 new segments
-        And verify that the master-only tables are empty on one new segment
 
     @gpexpand_mirrors
     @gpexpand_segment
@@ -133,7 +130,6 @@ Feature: expand the cluster by adding more segments
         And the number of segments have been saved
         When the user runs gpexpand with a static inputfile for a single-node cluster with mirrors
         Then verify that the cluster has 4 new segments
-        And verify that the master-only tables are empty on one new segment
 
     @gpexpand_mirrors
     @gpexpand_segment
@@ -170,7 +166,6 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 8 new segments
-        And verify that the master-only tables are empty on one new segment
 
     @gpexpand_mirrors
     @gpexpand_host_and_segment
@@ -189,7 +184,6 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 14 new segments
-        And verify that the master-only tables are empty on one new segment
 
     @gpexpand_mirrors
     @gpexpand_host_and_segment

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -4,8 +4,8 @@ Feature: expand the cluster by adding more segments
     @gpexpand_no_mirrors
     @gpexpand_timing
     Scenario: after resuming a duration interrupted redistribution, tables are restored
-        Given the database is not running
-        And a working directory of the test as '/data/gpdata/gpexpand'
+	Given the database is not running
+	And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And a cluster is created with no mirrors on "mdw" and "sdw1"
         And the master pid has been saved
@@ -30,7 +30,7 @@ Feature: expand the cluster by adding more segments
     @gpexpand_timing
     @gpexpand_standby
     Scenario: after a duration interrupted redistribution, state file on standby matches master
-        Given the database is not running
+    	Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And a cluster is created with no mirrors on "mdw" and "sdw1"
@@ -87,7 +87,7 @@ Feature: expand the cluster by adding more segments
 
     @gpexpand_no_mirrors
     @gpexpand_host
-    Scenario: expand a cluster that has no mirrors on one new host
+    Scenario: expand a cluster that has no mirrors with one new hosts
         Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
@@ -103,7 +103,7 @@ Feature: expand the cluster by adding more segments
 
     @gpexpand_no_mirrors
     @gpexpand_host_and_segment
-    Scenario: expand a cluster that has no mirrors on both old and new hosts
+    Scenario: expand a cluster that has no mirrors with one new hosts
         Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
@@ -153,7 +153,7 @@ Feature: expand the cluster by adding more segments
 
     @gpexpand_mirrors
     @gpexpand_host
-    Scenario: expand a cluster that has mirrors on one new host
+    Scenario: expand a cluster that has mirrors with one new hosts
         Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
@@ -170,7 +170,7 @@ Feature: expand the cluster by adding more segments
     @gpexpand_mirrors
     @gpexpand_host_and_segment
     @gpexpand_standby
-    Scenario: expand a cluster that has mirrors on both old and new hosts
+    Scenario: expand a cluster that has mirrors with one new host
         Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
@@ -181,7 +181,7 @@ Feature: expand the cluster by adding more segments
         And the cluster is setup for an expansion on hosts "mdw,sdw1,sdw2,sdw3"
         And the new host "sdw2,sdw3" is ready to go
         When the user runs gpexpand interview to add 1 new segment and 2 new host "sdw2,sdw3"
-        Then the number of segments have been saved
+       Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 14 new segments
 
@@ -195,8 +195,8 @@ Feature: expand the cluster by adding more segments
         And a cluster is created with mirrors on "mdw" and "sdw1"
         And the user runs gpinitstandby with options " "
         And database "gptest" exists
-        And a tablespace is created with data
-        And another tablespace is created with data
+	And a tablespace is created with data
+	And another tablespace is created with data
         And there are no gpexpand_inputfiles
         And the cluster is setup for an expansion on hosts "mdw,sdw1,sdw2,sdw3"
         And the new host "sdw2,sdw3" is ready to go
@@ -204,8 +204,8 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 14 new segments
-        When the user runs gpexpand to redistribute
-        Then the tablespace is valid after gpexpand
+	When the user runs gpexpand to redistribute
+	Then the tablespace is valid after gpexpand
 
     @gpexpand_verify_redistribution
     Scenario: Verify data is correctly redistributed after expansion
@@ -289,7 +289,7 @@ Feature: expand the cluster by adding more segments
     @gpexpand_no_mirrors
     @gpexpand_no_restart
     @gpexpand_conf_copied
-    Scenario: expand a cluster without restarting db and conf has been copied
+    Scenario: expand a cluster without restarting db and conf has been copie
         Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And the user runs command "rm -rf /data/gpdata/gpexpand/*"
@@ -426,7 +426,7 @@ Feature: expand the cluster by adding more segments
     @gpexpand_mirrors
     @gpexpand_retry_failing_work_in_phase1_after_releasing_catalog_lock
     Scenario: inject a fail and test if retry is ok
-        Given the database is not running
+    	Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And the user runs command "rm -rf /data/gpdata/gpexpand/*"
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -30,7 +30,6 @@ from time import sleep
 from os import path
 
 from gppylib.gparray import GpArray, ROLE_PRIMARY, ROLE_MIRROR
-from gppylib.gpcatalog import MASTER_ONLY_TABLES
 from gppylib.commands.gp import SegmentStart, GpStandbyStart, MasterStop
 from gppylib.commands import gp
 from gppylib.commands.unix import findCmdInPath, Scp
@@ -2499,31 +2498,6 @@ def impl(context, num_of_segments):
     raise Exception("Incorrect amount of segments.\nprevious: %s\ncurrent:"
             "%s\ndump of gp_segment_configuration: %s" %
             (context.start_data_segments, end_data_segments, rows))
-
-@then('verify that the master-only tables are empty on one new segment')
-def impl(context):
-    dbname = 'gptest'
-
-    # lookup the port of the newest primary segment
-    with dbconn.connect(dbconn.DbURL(dbname=dbname),
-                        unsetSearchPath=False) as conn:
-        query = """SELECT address, port
-                     FROM gp_segment_configuration
-                    WHERE role = 'p'
-                    ORDER BY content DESC
-                    LIMIT 1;"""
-        row = dbconn.execSQLForSingletonRow(conn, query)
-        address = str(row[0])
-        port = int(row[1])
-
-    # verify that all the master-only tables are empty on this new segment
-    with dbconn.connect(dbconn.DbURL(dbname=dbname, hostname=address, port=port),
-                        unsetSearchPath=False, utility=True) as conn:
-        for tab in MASTER_ONLY_TABLES:
-            query = "SELECT count(*) FROM %s;" % tab
-            count = int(dbconn.execSQLForSingleton(conn, query))
-            if count > 0:
-                raise Exception("Master-only table '%s' is not empty on the new segments" % tab)
 
 @given('the cluster is setup for an expansion on hosts "{hostnames}"')
 def impl(context, hostnames):

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -71,7 +71,7 @@ static pg_time_t last_progress_report = 0;
 static int32 maxrate = 0;		/* no limit by default */
 
 static bool forceoverwrite = false;
-#define MAX_EXCLUDE 65535
+#define MAX_EXCLUDE 255
 static int	num_exclude = 0;
 static char *excludes[MAX_EXCLUDE];
 static int target_gp_dbid = 0;


### PR DESCRIPTION
Reverts greenplum-db/gpdb#9481

The file mapping is not always correct, until we fix the issue let's revert it.