### PR TITLE
Remove Alien memory account.

### DIFF
--- a/src/backend/utils/mmgr/test/aset_test.c
+++ b/src/backend/utils/mmgr/test/aset_test.c
@@ -9,7 +9,6 @@
 
 extern MemoryAccount* MemoryAccountMemoryAccount;
 extern MemoryAccount* RolloverMemoryAccount;
-extern MemoryAccount* AlienExecutorMemoryAccount;
 
 extern MemoryAccountIdType liveAccountStartId;
 extern MemoryAccountIdType nextAccountId;
@@ -67,7 +66,6 @@ TeardownMemoryDataStructures(void **state)
 	MemoryAccountMemoryAccount = NULL;
 	RolloverMemoryAccount = NULL;
 	SharedChunkHeadersMemoryAccount = NULL;
-	AlienExecutorMemoryAccount = NULL;
 	MemoryAccountMemoryContext = NULL;
 
 	ActiveMemoryAccountId = MEMORY_OWNER_TYPE_Undefined;

--- a/src/include/utils/memaccounting.h
+++ b/src/include/utils/memaccounting.h
@@ -84,7 +84,6 @@ typedef enum MemoryOwnerType
 	MEMORY_OWNER_TYPE_SharedChunkHeader,
 	MEMORY_OWNER_TYPE_Rollover,
 	MEMORY_OWNER_TYPE_MemAccount,
-	MEMORY_OWNER_TYPE_Exec_AlienShared,
 	MEMORY_OWNER_TYPE_Exec_RelinquishedPool,
 	MEMORY_OWNER_TYPE_END_LONG_LIVING = MEMORY_OWNER_TYPE_Exec_RelinquishedPool,
 	/* End of long-living accounts */

--- a/src/test/regress/expected/memconsumption.out
+++ b/src/test/regress/expected/memconsumption.out
@@ -12,6 +12,20 @@ insert into test select i, i % 100 from generate_series(1,1000) as i;
 -- start_ignore
 create language plpythonu;
 -- end_ignore
+create or replace function has_account_type(query text, search_text text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+comp_regex = re.compile("^\s+%s" % search_text)
+count = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    m = comp_regex.match(cur_line)
+    if m is not None:
+        count = count + 1
+return count
+$$
+language plpythonu;
 create or replace function sum_owner_consumption(query text, owner text) returns int as
 $$
 import re
@@ -31,33 +45,24 @@ for i in range(len(rv)):
 return total_consumption
 $$
 language plpythonu;
-select sum_owner_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_Alien') = 0;
+-- Fetch number of segments in psql variable.
+select count(*) as num_segments from gp_segment_configuration where role='p' and content >= 0
+\gset
+-- If alien node eliminate works, the HashJoin node should be initialized only on slice 1
+select has_account_type('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_HashJoin') / :num_segments;
  ?column? 
 ----------
- t
+        1
 (1 row)
 
+-- Otherwise, it's initialized on both slices.
 set execute_pruned_plan=off;
-select sum_owner_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_Alien') > 0;
+select has_account_type('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_HashJoin') / :num_segments;
  ?column? 
 ----------
- t
+        2
 (1 row)
 
-create or replace function has_account_type(query text, search_text text) returns int as
-$$
-import re
-rv = plpy.execute('EXPLAIN ANALYZE '+ query)
-comp_regex = re.compile("^\s+%s" % search_text)
-count = 0
-for i in range(len(rv)):
-    cur_line = rv[i]['QUERY PLAN']
-    m = comp_regex.match(cur_line)
-    if m is not None:
-        count = count + 1
-return count
-$$
-language plpythonu;
 -- Create functions that will generate nested SQL executors
 CREATE OR REPLACE FUNCTION simple_plpgsql_function(int) RETURNS int AS $$
  DECLARE RESULT int;

--- a/src/test/regress/sql/memconsumption.sql
+++ b/src/test/regress/sql/memconsumption.sql
@@ -16,6 +16,21 @@ insert into test select i, i % 100 from generate_series(1,1000) as i;
 create language plpythonu;
 -- end_ignore
 
+create or replace function has_account_type(query text, search_text text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+comp_regex = re.compile("^\s+%s" % search_text)
+count = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    m = comp_regex.match(cur_line)
+    if m is not None:
+        count = count + 1
+return count
+$$
+language plpythonu;
+
 create or replace function sum_owner_consumption(query text, owner text) returns int as
 $$
 import re
@@ -36,25 +51,17 @@ return total_consumption
 $$
 language plpythonu;
 
-select sum_owner_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_Alien') = 0;
+-- Fetch number of segments in psql variable.
+select count(*) as num_segments from gp_segment_configuration where role='p' and content >= 0
+\gset
 
+
+-- If alien node eliminate works, the HashJoin node should be initialized only on slice 1
+select has_account_type('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_HashJoin') / :num_segments;
+
+-- Otherwise, it's initialized on both slices.
 set execute_pruned_plan=off;
-select sum_owner_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_Alien') > 0;
-
-create or replace function has_account_type(query text, search_text text) returns int as
-$$
-import re
-rv = plpy.execute('EXPLAIN ANALYZE '+ query)
-comp_regex = re.compile("^\s+%s" % search_text)
-count = 0
-for i in range(len(rv)):
-    cur_line = rv[i]['QUERY PLAN']
-    m = comp_regex.match(cur_line)
-    if m is not None:
-        count = count + 1
-return count
-$$
-language plpythonu;
+select has_account_type('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_HashJoin') / :num_segments;
 
 -- Create functions that will generate nested SQL executors
 CREATE OR REPLACE FUNCTION simple_plpgsql_function(int) RETURNS int AS $$


### PR DESCRIPTION
When executor nodes are initialized at executor startup, in the
ExecInitPlan() stage, any nodes that are not going to be executed in the
current slice were assigned to so-called Alien memory account. Previously,
that was done to keep the useless nodes out of the "real" memory balances,
but nowadays we normally don't bother initializing alien nodes in the
first place. Alien node elimination can be disabled with 'set
execute_pruned_plan=off', but that's a developer option that people
shouldn't normally mess with. So in normal operation, the Alien memory
account is never used.

The Alien memory account was kept around when the alien node elimination
was implemented (see commit 9b8f5c0b6e). The idea was that we could turn
it on/off, and see how much we're saving by looking at the memory usage
in the Alien memory account when it's turned 'off'. But that's hardly
interesting anymore, we know that alien node elimination is useful, and
it has worked great in production for some time now.

We could probably get rid of the 'execute_pruned_plan' GUC altogether at
this point, but I kept it for now. If you do turn it off, all the alien
nodes will now get their own memory accounts, like non-alien nodes.
