### PR TITLE
Simplify the logic in ShouldPrefetchJoinQual()

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1209,9 +1209,17 @@ ExecPrefetchJoinQual(JoinState *node)
 bool
 ShouldPrefetchJoinQual(EState *estate, Join *join)
 {
-	return (join->prefetch_joinqual &&
-			findSenderMotion(estate->es_plannedstmt,
-							 estate->currentSliceId));
+	ExecSlice  *localSlice;
+
+	if (!join->prefetch_joinqual)
+		return false;
+
+	/* Is this slice the sender of a Motion? */
+	if (!estate->es_sliceTable)
+		return false;
+	localSlice = &estate->es_sliceTable->slices[estate->currentSliceId];
+
+	return (localSlice->parentIndex != -1);
 }
 
 /* ----------------------------------------------------------------

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1219,7 +1219,12 @@ ShouldPrefetchJoinQual(EState *estate, Join *join)
 		return false;
 	localSlice = &estate->es_sliceTable->slices[estate->currentSliceId];
 
-	return (localSlice->parentIndex != -1);
+	bool result = (localSlice->parentIndex != -1);
+
+	Assert (result == (findSenderMotion(estate->es_plannedstmt,
+										estate->currentSliceId) != NULL));
+
+	return result;
 }
 
 /* ----------------------------------------------------------------


### PR DESCRIPTION
Now that we have a slice table with the slice parent-child relationships
readily available, we can use it to answer the question "is this slice the
sender of a Motion?". No need to dig into the plan tree looking for
Motions anymore.

Note: I'm not planning to push the second commit, which adds assertions, so please review just the first one.