### PR TITLE
Fix confusion with dropped columns in ANALYZE dispatching. (6X_STABLE)

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -736,7 +736,7 @@ do_analyze_rel(Relation onerel, VacuumStmt *vacstmt,
 			}
 			Assert(sample_needed);
 
-			Bitmapset  *rowIndexes = colLargeRowIndexes[i];
+			Bitmapset  *rowIndexes = colLargeRowIndexes[stats->attr->attnum - 1];
 			int			validRowsLength;
 
 			/* If there are too wide rows in the sample, remove them

--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -292,14 +292,7 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 			toolarge_str = palloc((natts + 1) * sizeof(char));
 			i = 0;
 			for (attno = 1; attno <= natts; attno++)
-			{
-				Form_pg_attribute relatt = (Form_pg_attribute) relDesc->attrs[attno - 1];
-
-				if (relatt->attisdropped)
-					continue;
-
 				toolarge_str[i++] = bms_is_member(attno, toolarge) ? '1' : '0';
-			}
 			toolarge_str[i] = '\0';
 
 			outvalues[2] = CStringGetTextDatum(toolarge_str);

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -918,3 +918,19 @@ select relname, reltuples from pg_class where relname like 'aocs_analyze_test%' 
 (2 rows)
 
 reset default_statistics_target;
+--
+-- Test with both a dropped column and an oversized column
+-- (github issue https://github.com/greenplum-db/gpdb/issues/9503)
+--
+create table analyze_dropped_col (a text, b text, c text, d text);
+insert into analyze_dropped_col values('a','bbb', repeat('x', 5000), 'dddd');
+alter table analyze_dropped_col drop column b;
+analyze analyze_dropped_col;
+select attname, null_frac, avg_width, n_distinct from pg_stats where tablename ='analyze_dropped_col';
+ attname | null_frac | avg_width | n_distinct 
+---------+-----------+-----------+------------
+ a       |         0 |         2 |         -1
+ c       |         0 |      1024 |          0
+ d       |         0 |         5 |         -1
+(3 rows)
+

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -449,3 +449,13 @@ analyze aocs_analyze_test;
 select relname, reltuples from pg_class where relname like 'aocs_analyze_test%' order by relname;
 
 reset default_statistics_target;
+
+--
+-- Test with both a dropped column and an oversized column
+-- (github issue https://github.com/greenplum-db/gpdb/issues/9503)
+--
+create table analyze_dropped_col (a text, b text, c text, d text);
+insert into analyze_dropped_col values('a','bbb', repeat('x', 5000), 'dddd');
+alter table analyze_dropped_col drop column b;
+analyze analyze_dropped_col;
+select attname, null_frac, avg_width, n_distinct from pg_stats where tablename ='analyze_dropped_col';


### PR DESCRIPTION
This is backport of https://github.com/greenplum-db/gpdb/pull/9504 to 6X_STABLE. It's the same patch, but I'm opening a separate PR to have the concourse pipeline run it.