### PR TITLE
Allow cluster to start when standby is down

### DIFF
--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -265,8 +265,11 @@ class GpStart:
         else:
             controldata = PgControlData("Latest checkpoint's TimeLineID", data_dir_path, REMOTE, remoteHost)
 
-        controldata.run(validateAfter=True)
-        return int(controldata.get_value("Latest checkpoint's TimeLineID"))
+        try:
+            controldata.run(validateAfter=True)
+            return int(controldata.get_value("Latest checkpoint's TimeLineID"))
+        except: # Can't access the standby, so return a value that won't lead to standby promotion
+            return 0
 
     def _check_standby_activated(self):
         logger.debug("Checking if standby has been activated...")


### PR DESCRIPTION
Previously, gpstart could not start the cluster if a standby master host was configured but currently down, because gpstart could not access the standby to ensure that the standby was not supposed to be the acting master.  Changing gpstart to assume that the master host is the current master is if the standby is unreachable addresses the issue.