### PR TITLE
Fix incorrect results with multi-arg DISTINCT-aggregates.

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -1417,6 +1417,12 @@ CTranslatorScalarToDXL::TranslateAggrefToDXL
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Aggregate functions with FILTER"));
 	}
 
+	// ORCA doesn't support DISTINCT with multiple arguments yet.
+	if (gpdb::ListLength(aggref->aggdistinct) > 1)
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Aggregate functions with multiple DISTINCT arguments"));
+	}
+
 	IMDId *mdid_return_type = CScalarAggFunc::PmdidLookupReturnType(agg_mdid, (EdxlaggstageNormal == agg_stage), m_md_accessor);
 	IMDId *resolved_ret_type = NULL;
 	if (m_md_accessor->RetrieveType(mdid_return_type)->IsAmbiguous())

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1180,6 +1180,8 @@ select aggfstr(distinct a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Aggregate functions with multiple DISTINCT arguments
+INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: ROW EXPRESSION
 CONTEXT:  SQL function "aggf_trans" during startup
                 aggfstr                
@@ -1190,6 +1192,8 @@ CONTEXT:  SQL function "aggf_trans" during startup
 select aggfns(distinct a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Aggregate functions with multiple DISTINCT arguments
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -784,7 +784,6 @@ explain (costs off) select sum(distinct d), count(distinct i), count(distinct c)
 (18 rows)
 
 -- multi args singledqa
--- FIXME: orca result is incorrect. recorde in issue #9374
 select corr(distinct d, i) from dqa_t1;
         corr        
 --------------------

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -777,24 +777,27 @@ explain (costs off) select sum(distinct d), count(distinct i), count(distinct c)
 (18 rows)
 
 -- multi args singledqa
--- FIXME: orca result is incorrect. recorde in issue #9374
 select corr(distinct d, i) from dqa_t1;
- corr 
-------
-     
+        corr        
+--------------------
+ 0.0824013341460019
 (1 row)
 
 explain (costs off) select corr(distinct d, i) from dqa_t1;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: ((d)::double precision)
-                     ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.88.0
-(7 rows)
+               ->  HashAggregate
+                     Group Key: ((d)::double precision), ((i)::double precision)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: ((d)::double precision), ((i)::double precision)
+                           ->  Streaming HashAggregate
+                                 Group Key: (d)::double precision, (i)::double precision
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(11 rows)
 
 -- multi args singledqa with group by
 select corr(distinct d, i) from dqa_t1 group by d;
@@ -826,15 +829,15 @@ select corr(distinct d, i) from dqa_t1 group by d;
 (23 rows)
 
 explain (costs off) select corr(distinct d, i) from dqa_t1 group by d;
-                      QUERY PLAN                      
-------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   ->  HashAggregate
          Group Key: d
-         ->  Sort
-               Sort Key: d
+         ->  HashAggregate
+               Group Key: d, (d)::double precision, (i)::double precision
                ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.88.0
+ Optimizer: Postgres query optimizer
 (7 rows)
 
 select corr(distinct d, i) from dqa_t1 group by c;
@@ -853,18 +856,20 @@ select corr(distinct d, i) from dqa_t1 group by c;
 (10 rows)
 
 explain (costs off) select corr(distinct d, i) from dqa_t1 group by c;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   ->  HashAggregate
          Group Key: c
-         ->  Sort
-               Sort Key: c
+         ->  HashAggregate
+               Group Key: c, ((d)::double precision), ((i)::double precision)
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: c
-                     ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.88.0
-(9 rows)
+                     ->  Streaming HashAggregate
+                           Group Key: c, (d)::double precision, (i)::double precision
+                           ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(11 rows)
 
 -- multi args multidqa
 select count(distinct c), corr(distinct d, i) from dqa_t1;

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -68,7 +68,6 @@ select sum(distinct d), count(distinct i), count(distinct c),i,c from dqa_t1 gro
 explain (costs off) select sum(distinct d), count(distinct i), count(distinct c),i,c from dqa_t1 group by i,c order by i,c;
 
 -- multi args singledqa
--- FIXME: orca result is incorrect. recorde in issue #9374
 select corr(distinct d, i) from dqa_t1;
 explain (costs off) select corr(distinct d, i) from dqa_t1;
 


### PR DESCRIPTION
For example:

    select corr(distinct d, i) from dqa_t1;

In master, the PostgreSQL planner handled this correctly, but ORCA assumes
that a DISTINCT-qualified aggregate has exactly one argument, and produces
incorrect results. Bail out if the query contains such aggregates.

In 6X_STABLE, the GPDB planner code in cdbgroup.c to produce multi-phase
agg plans also gets confused by that, and throws an error. Fall back to
single-stage plan.

The reason for this bad assumption in ORCA and in cdbgroup.c is that before
version 9.0, PostgreSQL also didn't support them. That limitation was
lifted from the executor with the PostgreSQL 9.0 merge (commit 34d26872ed),
but the GPDB-specific code was never updated accordingly. In master, it
got fixed again in the Postgres planner when we rewrote the multi-stage
agg planning code as part of the 9.6 merge.

Fixes https://github.com/greenplum-db/gpdb/issues/9374.
