### PR TITLE
Fix incorrect results with multi-arg DISTINCT-aggregates. (6X_STABLE)

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -1431,6 +1431,12 @@ CTranslatorScalarToDXL::TranslateAggrefToDXL
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Aggregate functions with FILTER"));
 	}
 
+	// ORCA doesn't support DISTINCT with multiple arguments yet.
+	if (gpdb::ListLength(aggref->aggdistinct) > 1)
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature, GPOS_WSZ_LIT("Aggregate functions with multiple DISTINCT arguments"));
+	}
+
 	IMDId *mdid_return_type = CScalarAggFunc::PmdidLookupReturnType(agg_mdid, (EdxlaggstageNormal == agg_stage), m_md_accessor);
 	IMDId *resolved_ret_type = NULL;
 	if (m_md_accessor->RetrieveType(mdid_return_type)->IsAmbiguous())

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1079,6 +1079,8 @@ select aggfstr(distinct a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Aggregate functions with multiple DISTINCT arguments
+INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: ROW EXPRESSION
 CONTEXT:  SQL function "aggf_trans" during startup
                 aggfstr                
@@ -1089,6 +1091,8 @@ CONTEXT:  SQL function "aggf_trans" during startup
 select aggfns(distinct a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Aggregate functions with multiple DISTINCT arguments
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: ROW EXPRESSION
 CONTEXT:  SQL function "aggfns_trans" during startup

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -701,6 +701,23 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
  Optimizer: Postgres query optimizer
 (19 rows)
 
+-- multi args singledqa (not supported by cdbgroup.c nor ORCA, falls back to
+-- gathering all rows to QD.)
+select corr(distinct d, i) from dqa_t1;
+        corr        
+--------------------
+ 0.0824013341460019
+(1 row)
+
+explain (costs off) select corr(distinct d, i) from dqa_t1;
+                   QUERY PLAN                   
+------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(4 rows)
+
 -- MPP-19037
 drop table if exists fact_route_aggregation;
 NOTICE:  table "fact_route_aggregation" does not exist, skipping

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -694,6 +694,23 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
 (18 rows)
 
+-- multi args singledqa (not supported by cdbgroup.c nor ORCA, falls back to
+-- gathering all rows to QD.)
+select corr(distinct d, i) from dqa_t1;
+        corr        
+--------------------
+ 0.0824013341460019
+(1 row)
+
+explain (costs off) select corr(distinct d, i) from dqa_t1;
+                   QUERY PLAN                   
+------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on dqa_t1
+ Optimizer: Postgres query optimizer
+(4 rows)
+
 -- MPP-19037
 drop table if exists fact_route_aggregation;
 NOTICE:  table "fact_route_aggregation" does not exist, skipping

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -57,6 +57,10 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
 select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
 explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
 
+-- multi args singledqa (not supported by cdbgroup.c nor ORCA, falls back to
+-- gathering all rows to QD.)
+select corr(distinct d, i) from dqa_t1;
+explain (costs off) select corr(distinct d, i) from dqa_t1;
 
 -- MPP-19037
 drop table if exists fact_route_aggregation;


### PR DESCRIPTION
For example:

    select corr(distinct d, i) from dqa_t1;

In master, the PostgreSQL planner handled this correctly, but ORCA assumes
that a DISTINCT-qualified aggregate has exactly one argument, and produces
incorrect results. Bail out if the query contains such aggregates.

In 6X_STABLE, the GPDB planner code in cdbgroup.c to produce multi-phase
agg plans also gets confused by that, and throws an error. Fall back to
single-stage plan.

The reason for this bad assumption in ORCA and in cdbgroup.c is that before
version 9.0, PostgreSQL also didn't support them. That limitation was
lifted from the executor with the PostgreSQL 9.0 merge (commit 34d26872ed),
but the GPDB-specific code was never updated accordingly. In master, it
got fixed again in the Postgres planner when we rewrote the multi-stage
agg planning code as part of the 9.6 merge.

Fixes https://github.com/greenplum-db/gpdb/issues/9374.
