### PR TITLE
Estimate # of distinct rows more accurately in multi-stage agg paths.

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -492,7 +492,9 @@ add_twostage_group_agg_path(PlannerInfo *root,
 											  ctx->rollup_lists,
 											  ctx->rollup_groupclauses,
 											  ctx->agg_partial_costs,
-											  ctx->dNumGroups * getgpsegmentCount());
+											  estimate_num_groups_across_segments(ctx->dNumGroups,
+																				  path->rows,
+																				  getgpsegmentCount()));
 
 		motion_pathkeys = NIL;
 	}
@@ -510,7 +512,9 @@ add_twostage_group_agg_path(PlannerInfo *root,
 									 parse->groupClause,
 									 NIL,
 									 ctx->agg_partial_costs,
-									 ctx->dNumGroups * getgpsegmentCount(),
+									 estimate_num_groups_across_segments(ctx->dNumGroups,
+																	 path->rows,
+																	 getgpsegmentCount()),
 									 NULL);
 
 		motion_pathkeys = initial_agg_path->pathkeys;
@@ -631,7 +635,9 @@ add_twostage_hash_agg_path(PlannerInfo *root,
 												parse->groupClause,
 												NIL,
 												ctx->agg_partial_costs,
-												ctx->dNumGroups * getgpsegmentCount(),
+												estimate_num_groups_across_segments(ctx->dNumGroups,
+																				path->rows,
+																				getgpsegmentCount()),
 												&hash_info);
 
 	/*
@@ -745,7 +751,9 @@ static void add_single_mixed_dqa_hash_agg_path(PlannerInfo *root,
 		                                parse->groupClause,
 		                                NIL,
 		                                ctx->agg_partial_costs, /* FIXME */
-		                                ctx->dNumGroups * getgpsegmentCount(),
+										estimate_num_groups_across_segments(ctx->dNumGroups,
+																		path->rows,
+																		getgpsegmentCount()),
 		                                &hash_info);
 
 		if (group_need_redistribute)
@@ -767,6 +775,7 @@ static void add_single_mixed_dqa_hash_agg_path(PlannerInfo *root,
 		add_path(output_rel, path);
 	}
 }
+
 /*
  * Create Paths for an Aggregate with one DISTINCT-qualified aggregate.
  */
@@ -855,7 +864,9 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 										dqa_group_clause,
 										NIL,
 										ctx->agg_partial_costs, /* FIXME */
-										ctx->dNumGroups * getgpsegmentCount(),
+										estimate_num_groups_across_segments(ctx->dNumGroups,
+																		path->rows,
+																		getgpsegmentCount()),
 										&hash_info);
 
 		if (group_need_redistribute)
@@ -900,7 +911,9 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 											dqa_group_clause,
 											NIL,
 											ctx->agg_partial_costs, /* FIXME */
-											dNumDistinctGroups * getgpsegmentCount(),
+											estimate_num_groups_across_segments(dNumDistinctGroups,
+																			path->rows,
+																			getgpsegmentCount()),
 											&hash_info);
 
 		path = cdbpath_create_motion_path(root, path, NIL, false,
@@ -915,7 +928,9 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 										dqa_group_clause,
 										NIL,
 										ctx->agg_partial_costs, /* FIXME */
-										dNumDistinctGroups * getgpsegmentCount(),
+										estimate_num_groups_across_segments(dNumDistinctGroups,
+																		path->rows,
+																		getgpsegmentCount()),
 										&hash_info);
 
 		path = (Path *) create_agg_path(root,
@@ -953,7 +968,9 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 										dqa_group_clause,
 										NIL,
 										ctx->agg_partial_costs, /* FIXME */
-										dNumDistinctGroups * getgpsegmentCount(),
+										estimate_num_groups_across_segments(dNumDistinctGroups,
+																		path->rows,
+																		getgpsegmentCount()),
 										&hash_info);
 
 		path = cdbpath_create_motion_path(root, path, NIL, false,
@@ -968,7 +985,9 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 										dqa_group_clause,
 										NIL,
 										ctx->agg_partial_costs, /* FIXME */
-										ctx->dNumGroups * getgpsegmentCount(),
+										estimate_num_groups_across_segments(ctx->dNumGroups,
+																		path->rows,
+																		getgpsegmentCount()),
 										&hash_info);
 
 		path = (Path *) create_agg_path(root,
@@ -981,7 +1000,9 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 										parse->groupClause,
 										NIL,
 										ctx->agg_partial_costs,
-										ctx->dNumGroups * getgpsegmentCount(),
+										estimate_num_groups_across_segments(ctx->dNumGroups,
+																		path->rows,
+																		getgpsegmentCount()),
 										&hash_info);
 		path = cdbpath_create_motion_path(root, path, NIL, false,
 										  group_locus);
@@ -1101,7 +1122,9 @@ add_multi_dqas_hash_agg_path(PlannerInfo *root,
 										dummy_group_clause, /* only its length 1 is being used here */
 										NIL,
 										&DedupCost,
-										ctx->dNumGroups * getgpsegmentCount(),
+										estimate_num_groups_across_segments(ctx->dNumGroups,
+																		path->rows,
+																		getgpsegmentCount()),
 										&hash_info);
 
 		/* set the actual group clause back */
@@ -1133,7 +1156,9 @@ add_multi_dqas_hash_agg_path(PlannerInfo *root,
 										info->dqa_group_clause,
 										NIL,
 										&DedupCost,
-										ctx->dNumGroups * getgpsegmentCount(),
+										estimate_num_groups_across_segments(ctx->dNumGroups,
+																		path->rows,
+																		getgpsegmentCount()),
 										&hash_info);
 
 		split = AGG_HASHED;
@@ -1151,7 +1176,9 @@ add_multi_dqas_hash_agg_path(PlannerInfo *root,
 									root->parse->groupClause,
 									NIL,
 									ctx->agg_partial_costs,
-									ctx->dNumGroups * getgpsegmentCount(),
+									estimate_num_groups_across_segments(ctx->dNumGroups,
+																	path->rows,
+																	getgpsegmentCount()),
 									&hash_info);
 
 	CdbPathLocus singleQE_locus;

--- a/src/include/utils/selfuncs.h
+++ b/src/include/utils/selfuncs.h
@@ -255,5 +255,6 @@ extern Selectivity scalararraysel_containment(PlannerInfo *root,
 extern Datum arraycontsel(PG_FUNCTION_ARGS);
 extern Datum arraycontjoinsel(PG_FUNCTION_ARGS);
 extern double estimate_num_groups_per_segment(double groupNum, double numPerGroup, double numsegments);
+extern double estimate_num_groups_across_segments(double groupNum, double numPerGroup, double numsegments);
 
 #endif   /* SELFUNCS_H */


### PR DESCRIPTION
Commit 9936ca3bf1 improved the cost model of multi-stage Aggregates,
introducing a formula for estimating the number of distinct groups
seen in each segment (groupNumberPerSegment() function, later renamed
to estimate_num_groups_per_segment()). However, we lost that with the
rewrite of the multi-stage agg planning code in the 9.6 merge, and
reverted to a more naive estimate. Put back the more accurate formula.

Discussion: https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/zsl3m_Tcb1g/MCo7pY-vAgAJ
