### PR TITLE
Skip column acl check in gp_acquire_sample_rows

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2514,6 +2514,10 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 			 * NULLs are not allowed in data columns.
 			 */
 			char * rowStr = PQgetvalue(pgresult, rowno, 0);
+
+			if (rowStr == NULL)
+				elog(ERROR, "got NULL pointer from return value of gp_acquire_sample_rows");
+
 			parse_record_to_string(rowStr, funcTupleDesc, funcRetValues, funcRetNulls);
 
 			if (!funcRetNulls[0])

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2192,6 +2192,12 @@ acquire_index_number_of_blocks(Relation indexrel, Relation tablerel)
 	}
 }
 
+/*
+ * parse_record_to_string
+ *
+ * CDB: a copy of record_in, but only parse the record string
+ * into separate strs for each column.
+ */
 static void
 parse_record_to_string(char *string, TupleDesc tupdesc, char** values, bool *nulls)
 {
@@ -2199,9 +2205,12 @@ parse_record_to_string(char *string, TupleDesc tupdesc, char** values, bool *nul
 	int	ncolumns;
 	int	i;
 	bool	needComma;
-
 	StringInfoData	buf;
 
+	Assert(string != NULL);
+	Assert(values != NULL);
+	Assert(nulls != NULL);
+	
 	ncolumns = tupdesc->natts;
 	needComma = false;
 

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -116,6 +116,7 @@
 #include "utils/syscache.h"
 #include "utils/timestamp.h"
 #include "utils/tqual.h"
+#include "utils/typcache.h"
 
 #include "catalog/heap.h"
 #include "cdb/cdbappendonlyam.h"
@@ -141,6 +142,9 @@
  * we consider everything as distinct.
  */
 #define GP_HLL_ERROR_MARGIN  0.003
+
+/* Fix attr number of return record of function gp_acquire_sample_rows */
+#define FIX_ATTR_NUM  3
 
 /* Per-index data for ANALYZE */
 typedef struct AnlIndexData
@@ -2188,6 +2192,145 @@ acquire_index_number_of_blocks(Relation indexrel, Relation tablerel)
 	}
 }
 
+static void
+parse_record_to_string(char *string, TupleDesc tupdesc, char** values, bool *nulls)
+{
+	char	*ptr;
+	int	ncolumns;
+	int	i;
+	bool	needComma;
+
+	StringInfoData	buf;
+
+	ncolumns = tupdesc->natts;
+	needComma = false;
+
+	/*
+	 * Scan the string.  We use "buf" to accumulate the de-quoted data for
+	 * each column, which is then fed to the appropriate input converter.
+	 */
+	ptr = string;
+
+	/* Allow leading whitespace */
+	while (*ptr && isspace((unsigned char) *ptr))
+		ptr++;
+	if (*ptr++ != '(')
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("malformed record literal: \"%s\"", string),
+				 errdetail("Missing left parenthesis.")));
+	}
+
+	initStringInfo(&buf);
+
+	for (i = 0; i < ncolumns; i++)
+	{
+		/* Ignore dropped columns in datatype, but fill with nulls */
+		if (tupdesc->attrs[i]->attisdropped)
+		{
+			values[i] = NULL;
+			nulls[i] = true;
+			continue;
+		}
+
+		if (needComma)
+		{
+			/* Skip comma that separates prior field from this one */
+			if (*ptr == ',')
+				ptr++;
+			else
+			{
+				/* *ptr must be ')' */
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+						 errmsg("malformed record literal: \"%s\"", string),
+						 errdetail("Too few columns.")));
+			}
+		}
+
+		/* Check for null: completely empty input means null */
+		if (*ptr == ',' || *ptr == ')')
+		{
+			values[i] = NULL;
+			nulls[i] = true;
+		}
+		else
+		{
+			/* Extract string for this column */
+			bool		inquote = false;
+
+			resetStringInfo(&buf);
+			while (inquote || !(*ptr == ',' || *ptr == ')'))
+			{
+				char		ch = *ptr++;
+
+				if (ch == '\0')
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+							 errmsg("malformed record literal: \"%s\"",
+									string),
+							 errdetail("Unexpected end of input.")));
+				}
+				if (ch == '\\')
+				{
+					if (*ptr == '\0')
+					{
+						ereport(ERROR,
+								(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+								 errmsg("malformed record literal: \"%s\"",
+										string),
+								 errdetail("Unexpected end of input.")));
+					}
+					appendStringInfoChar(&buf, *ptr++);
+				}
+				else if (ch == '"')
+				{
+					if (!inquote)
+						inquote = true;
+					else if (*ptr == '"')
+					{
+						/* doubled quote within quote sequence */
+						appendStringInfoChar(&buf, *ptr++);
+					}
+					else
+						inquote = false;
+				}
+				else
+					appendStringInfoChar(&buf, ch);
+			}
+
+			values[i] = palloc(strlen(buf.data) + 1);
+			memcpy(values[i], buf.data, strlen(buf.data) + 1);
+			nulls[i] = false;
+		}
+
+		/*
+		 * Prep for next column
+		 */
+		needComma = true;
+	}
+
+	if (*ptr++ != ')')
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("malformed record literal: \"%s\"", string),
+				 errdetail("Too many columns.")));
+	}
+	/* Allow trailing whitespace */
+	while (*ptr && isspace((unsigned char) *ptr))
+		ptr++;
+	if (*ptr)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("malformed record literal: \"%s\"", string),
+				 errdetail("Junk after right parenthesis.")));
+	}
+}
+
 /*
  * Collect a sample from segments.
  *
@@ -2205,15 +2348,20 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	 */
 	Bitmapset **colLargeRowIndexes = acquire_func_colLargeRowIndexes;
 	TupleDesc	relDesc = RelationGetDescr(onerel);
-	TupleDesc	newDesc;
+	TupleDesc	funcTupleDesc;
+	TupleDesc	sampleTupleDesc;
 	AttInMetadata *attinmeta;
 	StringInfoData str;
 	int			sampleTuples;	/* 32 bit - assume that number of tuples will not > 2B */
-	char	  **values;
+	char 	  **funcRetValues;
+	bool 	   *funcRetNulls;
+	char 	  **values;
 	int			numLiveColumns;
 	int			perseg_targrows;
+	int			ncolumns;
 	CdbPgResults cdb_pgresults = {NULL, 0};
 	int			i;
+	int			index = 0;
 
 	Assert(targrows > 0.0);
 
@@ -2253,34 +2401,17 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 
 	/*
 	 * Construct SQL command to dispatch to segments.
+	 *
+	 * Did not use 'select * from pg_catalog.gp_acquire_sample_rows(...) as (..);'
+	 * here. Because it requires to specify columns explicitly which leads to
+	 * permission check on each columns. This is not consistent with GPDB5 and
+	 * may result in different behaviour under different acl configuration.
 	 */
 	initStringInfo(&str);
-	appendStringInfo(&str, "select * from pg_catalog.gp_acquire_sample_rows(%u, %d, '%s')",
+	appendStringInfo(&str, "select pg_catalog.gp_acquire_sample_rows(%u, %d, '%s');",
 					 RelationGetRelid(onerel),
 					 perseg_targrows,
 					 inh ? "t" : "f");
-
-	/* special columns */
-	appendStringInfoString(&str, " as (");
-	appendStringInfoString(&str, "totalrows pg_catalog.float8, ");
-	appendStringInfoString(&str, "totaldeadrows pg_catalog.float8, ");
-	appendStringInfoString(&str, "oversized_cols_bitmap pg_catalog.text");
-
-	/* table columns */
-	for (i = 0; i < relDesc->natts; i++)
-	{
-		Form_pg_attribute attr = relDesc->attrs[i];
-		Oid			typid = gp_acquire_sample_rows_col_type(attr->atttypid);
-
-		if (attr->attisdropped)
-			continue;
-
-		appendStringInfo(&str, ", %s %s",
-						 quote_identifier(NameStr(attr->attname)),
-						 format_type_be(typid));
-	}
-
-	appendStringInfoString(&str, ")");
 
 	/*
 	 * Execute it.
@@ -2293,21 +2424,46 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	 *
 	 * Some datatypes need special treatment, so we cannot use the relation's
 	 * original tupledesc.
+	 *
+	 * Also create tupledesc of return record of function gp_acquire_sample_rows.
 	 */
-	newDesc = CreateTupleDescCopy(relDesc);
+	sampleTupleDesc = CreateTupleDescCopy(relDesc);
+	ncolumns = numLiveColumns + FIX_ATTR_NUM;
+	
+	funcTupleDesc = CreateTemplateTupleDesc(ncolumns, false);
+	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 1, "", FLOAT8OID, -1, 0);
+	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 2, "", FLOAT8OID, -1, 0);
+	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 3, "", TEXTOID, -1, 0);
+	
 	for (i = 0; i < relDesc->natts; i++)
 	{
 		Form_pg_attribute attr = relDesc->attrs[i];
+		
 		Oid			typid = gp_acquire_sample_rows_col_type(attr->atttypid);
 
-		newDesc->attrs[i]->atttypid = typid;
+		sampleTupleDesc->attrs[i]->atttypid = typid;
+
+		if (!attr->attisdropped)
+		{
+			TupleDescInitEntry(funcTupleDesc, (AttrNumber) 4 + index, "",
+							   typid, attr->atttypmod, attr->attndims);
+		
+			index++;
+		}
 	}
-	attinmeta = TupleDescGetAttInMetadata(newDesc);
+
+	/* For RECORD results, make sure a typmod has been assigned */
+	Assert(funcTupleDesc->tdtypeid == RECORDOID && funcTupleDesc->tdtypmod < 0);
+	assign_record_type_typmod(funcTupleDesc);
+
+	attinmeta = TupleDescGetAttInMetadata(sampleTupleDesc);
 
 	/*
 	 * Read the result set from each segment. Gather the sample rows *rows,
 	 * and sum up the summary rows for grand 'totalrows' and 'totaldeadrows'.
 	 */
+	funcRetValues = (char **) palloc0(funcTupleDesc->natts * sizeof(char *));
+	funcRetNulls = (bool *) palloc(funcTupleDesc->natts * sizeof(bool));
 	values = (char **) palloc0(relDesc->natts * sizeof(char *));
 	sampleTuples = 0;
 	*totalrows = 0;
@@ -2342,32 +2498,38 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 
 		for (int rowno = 0; rowno < PQntuples(pgresult); rowno++)
 		{
-			if (!PQgetisnull(pgresult, rowno, 0))
+			/*
+			 * We cannot use record_in function to get row record here.
+			 * Since the result row may contain just the totalrows info where the data columns
+			 * are NULLs. Consider domain: 'create domain dnotnull varchar(15) NOT NULL;'
+			 * NULLs are not allowed in data columns.
+			 */
+			char * rowStr = PQgetvalue(pgresult, rowno, 0);
+			parse_record_to_string(rowStr, funcTupleDesc, funcRetValues, funcRetNulls);
+
+			if (!funcRetNulls[0])
 			{
 				/* This is a summary row. */
 				if (got_summary)
 					elog(ERROR, "got duplicate summary row from gp_acquire_sample_rows");
 
 				this_totalrows = DatumGetFloat8(DirectFunctionCall1(float8in,
-																	CStringGetDatum(PQgetvalue(pgresult, rowno, 0))));
+																	CStringGetDatum(funcRetValues[0])));
 				this_totaldeadrows = DatumGetFloat8(DirectFunctionCall1(float8in,
-																		CStringGetDatum(PQgetvalue(pgresult, rowno, 1))));
+																		CStringGetDatum(funcRetValues[1])));
 				got_summary = true;
 			}
 			else
 			{
 				/* This is a sample row. */
-				int			index;
-
 				if (sampleTuples >= targrows)
 					elog(ERROR, "too many sample rows received from gp_acquire_sample_rows");
 
 				/* Read the 'toolarge' bitmap, if any */
-				if (colLargeRowIndexes && !PQgetisnull(pgresult, rowno, 2))
+				if (colLargeRowIndexes && !funcRetNulls[2])
 				{
 					char	   *toolarge;
-
-					toolarge = PQgetvalue(pgresult, rowno, 2);
+					toolarge = funcRetValues[2];
 					if (strlen(toolarge) != numLiveColumns)
 						elog(ERROR, "'toolarge' bitmap has incorrect length");
 
@@ -2394,10 +2556,10 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 					if (attr->attisdropped)
 						continue;
 
-					if (PQgetisnull(pgresult, rowno, 3 + index))
+					if (funcRetNulls[3 + index])
 						values[i] = NULL;
 					else
-						values[i] = PQgetvalue(pgresult, rowno, 3 + index);
+						values[i] = funcRetValues[3 + index];
 					index++; /* Move index to the next result set attribute */
 				}
 
@@ -2428,6 +2590,14 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 		(*totalrows) += this_totalrows;
 		(*totaldeadrows) += this_totaldeadrows;
 	}
+	for (i = 0; i < funcTupleDesc->natts; i++)
+	{
+		if (funcRetValues[i])
+			pfree(funcRetValues[i]);
+	}
+	pfree(funcRetValues);
+	pfree(funcRetNulls);
+	pfree(values);
 
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -918,6 +918,10 @@ select relname, reltuples from pg_class where relname like 'aocs_analyze_test%' 
 (2 rows)
 
 reset default_statistics_target;
+-- Test column name called totalrows
+create table test_tr (totalrows int4);
+analyze test_tr;
+drop table test_tr;
 --
 -- Test with both a dropped column and an oversized column
 -- (github issue https://github.com/greenplum-db/gpdb/issues/9503)

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -934,3 +934,17 @@ select attname, null_frac, avg_width, n_distinct from pg_stats where tablename =
  d       |         0 |         5 |         -1
 (3 rows)
 
+-- Test analyze without USAGE privilege on schema
+create schema test_ns;
+revoke all on schema test_ns from public;
+create role nsuser1;
+grant create on schema test_ns to nsuser1;
+set search_path to 'test_ns';
+create extension citext;
+create table testid (id int , test citext);
+alter table testid owner to nsuser1;
+analyze testid;
+drop table testid;
+drop extension citext;
+drop schema test_ns;
+drop role nsuser1;

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1696,7 +1696,7 @@ INSERT INTO foo SELECT i, i%9, i%100 FROM generate_series(1,500)i;
 ANALYZE VERBOSE rootpartition foo;
 INFO:  analyzing "public.foo" inheritance tree
 INFO:  column c of partition foo_1_prt_1 is not analyzed, so ANALYZE will collect sample for stats calculation
-INFO:  Executing SQL: select * from pg_catalog.gp_acquire_sample_rows(17861, 400, 't') as (totalrows pg_catalog.float8, totaldeadrows pg_catalog.float8, oversized_cols_bitmap pg_catalog.text, a integer, b integer, c integer)
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(17861, 400, 't')
 -- Testing auto merging root statistics for all columns
 -- where column attnums are differents due to dropped columns
 -- and split partitions.

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -459,3 +459,17 @@ insert into analyze_dropped_col values('a','bbb', repeat('x', 5000), 'dddd');
 alter table analyze_dropped_col drop column b;
 analyze analyze_dropped_col;
 select attname, null_frac, avg_width, n_distinct from pg_stats where tablename ='analyze_dropped_col';
+-- Test analyze without USAGE privilege on schema
+create schema test_ns;
+revoke all on schema test_ns from public;
+create role nsuser1;
+grant create on schema test_ns to nsuser1;
+set search_path to 'test_ns';
+create extension citext;
+create table testid (id int , test citext);
+alter table testid owner to nsuser1;
+analyze testid;
+drop table testid;
+drop extension citext;
+drop schema test_ns;
+drop role nsuser1;

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -450,6 +450,11 @@ select relname, reltuples from pg_class where relname like 'aocs_analyze_test%' 
 
 reset default_statistics_target;
 
+-- Test column name called totalrows
+create table test_tr (totalrows int4);
+analyze test_tr;
+drop table test_tr;
+
 --
 -- Test with both a dropped column and an oversized column
 -- (github issue https://github.com/greenplum-db/gpdb/issues/9503)


### PR DESCRIPTION
Using 'select pg_catalog.gp_acquire_sample_rows(...)' instead of
'select * from pg_catalog.gp_acquire_sample_rows(...) as (...)'.
The old one requires USAGE privilege on each columns which is not
consistent with GPDB 5X.

The following SQL failed to pass acl check in master now:
revoke all on schema public from public;
create role gmuser1;
grant create on schema public to gmuser1;
create extension citext;
create table testid (id int , test citext);
alter table testid owner to gmuser1;
analyze testid;

Idea from Ashwin Agrawal <aagrawal@pivotal.io>
Idea from Taylor Vesely <tvesely@pivotal.io>

## Here are some reminders before you submit the pull request
- [X] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
