### PR TITLE
Fix flaky test case gdd/end

### DIFF
--- a/src/test/isolation2/expected/ao_same_trans_truncate_crash.out
+++ b/src/test/isolation2/expected/ao_same_trans_truncate_crash.out
@@ -55,23 +55,11 @@ TRUNCATE
 ABORT
 -- restart (immediate) to invoke crash recovery
 1: SELECT pg_ctl(datadir, 'restart') FROM gp_segment_configuration WHERE role = 'p' AND content <> -1;
- pg_ctl                                                                                               
-------------------------------------------------------------------------------------------------------
- waiting for server to shut down done
-server stopped
-waiting for server to start done
-server started
- 
- waiting for server to shut down done
-server stopped
-waiting for server to start done
-server started
- 
- waiting for server to shut down done
-server stopped
-waiting for server to start done
-server started
- 
+ pg_ctl 
+--------
+ OK     
+ OK     
+ OK     
 (3 rows)
 -- validate the segments recovered fine and able to serve queries
 2: SELECT oid from gp_dist_random('pg_class') WHERE relname='ao_same_trans_truncate';

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -227,13 +227,9 @@ ALTER
  Success:                      
 (1 row)
 11: SELECT pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 0;
- pg_ctl                                                                                               
-------------------------------------------------------------------------------------------------------
- waiting for server to shut down done
-server stopped
-waiting for server to start done
-server started
- 
+ pg_ctl 
+--------
+ OK     
 (1 row)
 12<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=25361: server closed the connection unexpectedly

--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -87,11 +87,9 @@ select gp_request_fts_probe_scan();
 (1 row)
 -- stop a primary in order to trigger a mirror promotion for content 1
 select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=1), 'stop');
- pg_ctl                                               
-------------------------------------------------------
- waiting for server to shut down done
-server stopped
- 
+ pg_ctl 
+--------
+ OK     
 (1 row)
 
 -- trigger a DNS error. This fault internally gets trigerred for content 0
@@ -187,11 +185,9 @@ END
 -- step gprecovertseg will do the same but it uses gpstop fast mode and not
 -- immediate, which add time to tests.
 select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'stop');
- pg_ctl                                               
-------------------------------------------------------
- waiting for server to shut down done
-server stopped
- 
+ pg_ctl 
+--------
+ OK     
 (1 row)
 
 -- fully recover the failed primary as new mirror

--- a/src/test/isolation2/expected/gdd/end.out
+++ b/src/test/isolation2/expected/gdd/end.out
@@ -10,13 +10,9 @@ ALTER
 -- situation where session issuing the restart doesn't disappear
 -- itself.
 1U:SELECT pg_ctl(dir, 'restart') from datadir;
- pg_ctl                                                                                               
-------------------------------------------------------------------------------------------------------
- waiting for server to shut down done
-server stopped
-waiting for server to start done
-server started
- 
+ pg_ctl 
+--------
+ OK     
 (1 row)
 -- Start new session on master to make sure it has fully completed
 -- recovery and up and running again.

--- a/src/test/isolation2/expected/gdd/prepare.out
+++ b/src/test/isolation2/expected/gdd/prepare.out
@@ -77,13 +77,9 @@ ALTER
 -- situation where session issuing the restart doesn't disappear
 -- itself.
 1U:SELECT pg_ctl(dir, 'restart') from datadir;
- pg_ctl                                                                                               
-------------------------------------------------------------------------------------------------------
- waiting for server to shut down done
-server stopped
-waiting for server to start done
-server started
- 
+ pg_ctl 
+--------
+ OK     
 (1 row)
 -- Start new session on master to make sure it has fully completed
 -- recovery and up and running again.

--- a/src/test/isolation2/expected/segwalrep/commit_blocking.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking.out
@@ -56,11 +56,9 @@ select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 
 -- stop a mirror and show commit on dbid 2 will block
 -1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=0), 'stop');
- pg_ctl                                               
-------------------------------------------------------
- waiting for server to shut down done
-server stopped
- 
+ pg_ctl 
+--------
+ OK     
 (1 row)
 -- We should insert a tuple to segment 0.
 -- With jump consistent hash as the underlying hash algorithm,
@@ -69,13 +67,9 @@ server stopped
 
 -- restart primary dbid 2
 -1U: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'restart');
- pg_ctl                                                                                               
-------------------------------------------------------------------------------------------------------
- waiting for server to shut down done
-server stopped
-waiting for server to start done
-server started
- 
+ pg_ctl 
+--------
+ OK     
 (1 row)
 
 -- should show dbid 2 utility mode connection closed because of primary restart

--- a/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
@@ -55,10 +55,9 @@ select gp_wait_until_triggered_fault('transaction_abort_failure', 1, dbid) from 
 
 -- Promote standby
 select pg_ctl(datadir, 'promote') from gp_segment_configuration where content = -1 and role = 'm';
- pg_ctl            
--------------------
- server promoting
- 
+ pg_ctl 
+--------
+ OK     
 (1 row)
 
 -- "-1S" means connect to standby's port assuming it's accepting
@@ -95,11 +94,9 @@ ERROR:  fault triggered, fault name:'transaction_abort_after_distributed_prepare
 
 -- Destroy and recreate the standby
 select pg_ctl(datadir, 'stop', 'immediate') from gp_segment_configuration where content = -1 and role = 'm';
- pg_ctl                                               
-------------------------------------------------------
- waiting for server to shut down done
-server stopped
- 
+ pg_ctl 
+--------
+ OK     
 (1 row)
 -- Standby details need to be stored in a separate table because
 -- reinitialize_standby() first removes standby from catalog and then

--- a/src/test/isolation2/expected/segwalrep/failover_with_many_records.out
+++ b/src/test/isolation2/expected/segwalrep/failover_with_many_records.out
@@ -49,11 +49,9 @@ CHECKPOINT
 -- checkpoint otherwise we would undo all of our previous work to ensure that
 -- checkpoint record has redo record on another wal segment.
 -1U: SELECT pg_ctl((SELECT datadir FROM gp_segment_configuration c WHERE c.role='p' AND c.content=1), 'stop', 'immediate');
- pg_ctl                                               
-------------------------------------------------------
- waiting for server to shut down done
-server stopped
- 
+ pg_ctl 
+--------
+ OK     
 (1 row)
 
 -- Make sure we see the segment is down before trying to recover...

--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -70,11 +70,9 @@ select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 
 -- stop a mirror
 -1U: select pg_ctl((select get_data_directory_for(2, 'm')), 'stop');
- pg_ctl                                               
-------------------------------------------------------
- waiting for server to shut down done
-server stopped
- 
+ pg_ctl 
+--------
+ OK     
 (1 row)
 
 -- this should block since mirror is not up and sync replication is on

--- a/src/test/isolation2/expected/segwalrep/mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/mirror_promotion.out
@@ -28,11 +28,9 @@ SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration
 (8 rows)
 -- stop a primary in order to trigger a mirror promotion
 select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');
- pg_ctl                                               
-------------------------------------------------------
- waiting for server to shut down done
-server stopped
- 
+ pg_ctl 
+--------
+ OK     
 (1 row)
 
 -- trigger failover

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -616,13 +616,9 @@ UPDATE 10
 CHECKPOINT
 -- Restart the primary to interrupt vacuum at that exact point.
 5:select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'restart');
- pg_ctl                                                                                               
-------------------------------------------------------------------------------------------------------
- waiting for server to shut down done
-server stopped
-waiting for server to start done
-server started
- 
+ pg_ctl 
+--------
+ OK     
 (1 row)
 4<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29553: server closed the connection unexpectedly


### PR DESCRIPTION
The test suite isolation2/gdd is for global-deadlock-detector.
Previous commit has done some optimization to make it faster.
gdd/end is using to reset the cluster's state of global-deadlock
-detector. It invokes helper UDF pg_ctl to only restart the
Master's postmaster. pg_ctl may invoke test_postmaster_connection
to check the restart status, and if it takes more time than the
checking interval, it will print different message that making
this case flaky. Since at the end of gdd/end.sql, we have tests
to make sure the cluster is under correct condition, so this
commit fixes the flakiness by modifying the code of UDF pg_ctl,
now if it works correctly (return value is 0) then it just prints
'OK', if something is wrong, it raise an exception contains the
stdout and stderr for debugging.

-------------------------------

I have noticed this flaky case several times.

https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master/jobs/icw_gporca_centos7/builds/978

```
--- /tmp/build/e18b2f02/gpdb_src/src/test/isolation2/expected/gdd/end.out	2020-01-31 09:18:42.667281588 +0000
+++ /tmp/build/e18b2f02/gpdb_src/src/test/isolation2/results/gdd/end.out	2020-01-31 09:18:42.671281937 +0000
@@ -11,13 +11,13 @@
 -- situation where session issuing the restart doesn't disappear
 -- itself.
 1U:SELECT pg_ctl(dir, 'restart') from datadir;
- pg_ctl                                                                                               
-------------------------------------------------------------------------------------------------------
+ pg_ctl                                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------
  
  waiting for server to shut down done
-server started
+server is still starting up
 server stopped
-waiting for server to start done
+waiting for server to start stopped waiting
 (1 row)
 -- Start new session on master to make sure it has fully completed
 -- recovery and up and running again.

======================================================================
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
