### PR TITLE
Avoid possibility of out-of-bound write for neededColumnContextWalker

### DIFF
--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -6806,11 +6806,12 @@ neededColumnContextWalker(Node *node, neededColumnContext *c)
 	{
 		Var *var = (Var *)node;
 
-		if (var->varattno > 0)
-		{
-			Assert(var->varattno <= c->n);
+		if (IS_SPECIAL_VARNO(var->varno))
+			return false;
+
+		if (var->varattno > 0 && var->varattno <= c->n)
 			c->mask[var->varattno - 1] = true;
-		}
+
 		/*
 		 * If all attributes are included,
 		 * set all entries in mask to true.

--- a/src/test/regress/expected/indexjoin.out
+++ b/src/test/regress/expected/indexjoin.out
@@ -128,4 +128,42 @@ ORDER BY 1 asc ;
  201011261320 |     3
 (8 rows)
 
-set optimizer_enable_hashjoin = on;
+-- Test Index Scan on CO table as the right tree of a NestLoop join.
+create table no_index_table(fake_col1 int, fake_col2 int, fake_col3 int, a int, b int) distributed by (a, b);
+insert into no_index_table values (1,1,1,1,1);
+create table with_index_table(x int, y int) with (appendonly=true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index with_index_table_index on with_index_table (x);
+insert into with_index_table select i, 1 from generate_series(1, 20)i;
+set enable_material to off;
+set enable_seqscan to off;
+set enable_mergejoin to off;
+set enable_hashjoin to off;
+set enable_nestloop to on;
+set optimizer_enable_materialize to off;
+set optimizer_enable_hashjoin to off;
+explain (costs off)
+SELECT * from with_index_table td JOIN no_index_table ro ON td.y = ro.a AND td.x = ro.b;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: ro.b
+               ->  Seq Scan on no_index_table ro
+         ->  Bitmap Heap Scan on with_index_table td
+               Recheck Cond: (x = ro.b)
+               Filter: (ro.a = y)
+               ->  Bitmap Index Scan on with_index_table_index
+                     Index Cond: (x = ro.b)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+SELECT * from with_index_table td JOIN no_index_table ro ON td.y = ro.a AND td.x = ro.b;
+ x | y | fake_col1 | fake_col2 | fake_col3 | a | b 
+---+---+-----------+-----------+-----------+---+---
+ 1 | 1 |         1 |         1 |         1 | 1 | 1
+(1 row)
+
+reset all;

--- a/src/test/regress/expected/indexjoin_optimizer.out
+++ b/src/test/regress/expected/indexjoin_optimizer.out
@@ -131,4 +131,43 @@ ORDER BY 1 asc ;
  201011261320 |     3
 (8 rows)
 
-set optimizer_enable_hashjoin = on;
+-- Test Index Scan on CO table as the right tree of a NestLoop join.
+create table no_index_table(fake_col1 int, fake_col2 int, fake_col3 int, a int, b int) distributed by (a, b);
+insert into no_index_table values (1,1,1,1,1);
+create table with_index_table(x int, y int) with (appendonly=true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index with_index_table_index on with_index_table (x);
+insert into with_index_table select i, 1 from generate_series(1, 20)i;
+set enable_material to off;
+set enable_seqscan to off;
+set enable_mergejoin to off;
+set enable_hashjoin to off;
+set enable_nestloop to on;
+set optimizer_enable_materialize to off;
+set optimizer_enable_hashjoin to off;
+explain (costs off)
+SELECT * from with_index_table td JOIN no_index_table ro ON td.y = ro.a AND td.x = ro.b;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: no_index_table.b
+               ->  Seq Scan on no_index_table
+         ->  Bitmap Heap Scan on with_index_table
+               Recheck Cond: (x = no_index_table.b)
+               Filter: (y = no_index_table.a)
+               ->  Bitmap Index Scan on with_index_table_index
+                     Index Cond: (x = no_index_table.b)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.88.1
+(12 rows)
+
+SELECT * from with_index_table td JOIN no_index_table ro ON td.y = ro.a AND td.x = ro.b;
+ x | y | fake_col1 | fake_col2 | fake_col3 | a | b 
+---+---+-----------+-----------+-----------+---+---
+ 1 | 1 |         1 |         1 |         1 | 1 | 1
+(1 row)
+
+reset all;


### PR DESCRIPTION
neededColumnContextWalker() is called to scan through VARs for targetlist,
quals, etc.. It should only look at VARS for the table being scanned and
avoid all other VARS. Currently, we are not aware of any plans which can
produce situation where neededColumnContextWalker() will encounter some
other VARs. But for GPDB5, we get OUTER vars here if Index scan is right
tree for NestedLoop join. Hence, seems better to have the protective
code to not write out-of-bound.

Adds test to cover the scenario as well which is missing currently.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
