### PR TITLE
packaging gpversion.py into gpdb clients tarball

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -194,6 +194,9 @@ function export_gpdb_clients() {
   TARBALL="${GPDB_ARTIFACTS_DIR}/${GPDB_CL_FILENAME}"
   pushd ${GREENPLUM_CL_INSTALL_DIR}
     source ./greenplum_clients_path.sh
+    mkdir -p bin/ext/gppylib
+    cp ${GREENPLUM_INSTALL_DIR}/lib/python/gppylib/__init__.py ./bin/ext/gppylib
+    cp  ${GREENPLUM_INSTALL_DIR}/lib/python/gppylib/gpversion.py ./bin/ext/gppylib
     chmod -R 755 .
     tar -czf "${TARBALL}" ./*
   popd


### PR DESCRIPTION
gpload uses gpversion.py to parse gpdb version. So that it can compatible with gpdb5 and gpdb6.
Then we can only maintain one gpload version and some new features or bug fix could be used by gpdb5 customers.
so we package gppylib.gpversion into gpdb clients tarball
