### PR TITLE
Remove unused function skipPadding

### DIFF
--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -76,12 +76,6 @@ addPadding(TupleChunkList tcList, TupleChunkListCache *cache, int size)
 		addCharToChunkList(tcList, 0, cache);
 }
 
-static inline void
-skipPadding(StringInfo serialTup)
-{
-	serialTup->cursor = TYPEALIGN(TUPLE_CHUNK_ALIGN, serialTup->cursor);
-}
-
 /* Look up all of the information that SerializeTuple() and DeserializeTuple()
  * need to perform their jobs quickly.	Also, scratchpad space is allocated
  * for serialization and desrialization of datum values, and for formation/


### PR DESCRIPTION
Commit a693c8896dd51410fda318e967b7fe637be20d1c removed all callers of skipPadding, but left the function in which generates a compiler warning. Fix by removing.

@hlinnaka or did you leave it for a reason?