### PR TITLE
Correct the count of numMotions for subqueury.

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -3446,6 +3446,8 @@ create_subqueryscan_plan(PlannerInfo *root, SubqueryScanPath *best_path,
 	 */
 	subplan = create_plan(rel->subroot, best_path->subpath, root->curSlice);
 
+	root->numMotions += rel->subroot->numMotions;
+
 	/* Sort clauses into best execution order */
 	scan_clauses = order_qual_clauses(root, scan_clauses);
 


### PR DESCRIPTION
Previously the number motions in subquery plan is not
counted. This commit fixes this.

-------------------

I happen to meet this issue when I want to compute the number of motions
in nestloop plan's inner plan (and the inner plan is from a subquery). 

No test cases added. Since this field is only used to check if it is ok to remove explicit motion when dealing with update|delete plan (We already have some test cases for this).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
