### PR TITLE
Remove backend output redirection in initdb

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1206,7 +1206,7 @@ CREATE_QD_DB () {
 		LC_ALL_SETTINGS=" $LC_COLLATE_SETTING $LC_CTYPE_SETTING $LC_MESSAGES_SETTING $LC_MONETARY_SETTING $LC_NUMERIC_SETTING $LC_TIME_SETTING"
 
 
-		# build initdb command, capturing output in ${GP_DIR}.initdb
+		# build initdb command
 		cmd="$INITDB"
 		cmd="$cmd -E $ENCODING"
 		cmd="$cmd -D $GP_DIR"
@@ -1217,17 +1217,10 @@ CREATE_QD_DB () {
 		if [ x"$HEAP_CHECKSUM" == x"on" ]; then
 			cmd="$cmd --data-checksums"
 		fi
-		cmd="$cmd --backend_output=$GP_DIR.initdb"
-
 		LOG_MSG "[INFO]:-Commencing local $cmd"
 		$cmd >> $LOG_FILE 2>&1
 		RETVAL=$?
 
-		# if there was an error, copy ${GP_DIR}.initdb to the log
-		if [ $RETVAL -ne 0 ]; then
-		    $CAT ${GP_DIR}.initdb >> $LOG_FILE
-		fi    
-		$RM -f ${GP_DIR}.initdb
 		if [ $RETVAL -ne 0 ]; then
 		    ERROR_EXIT "[FATAL]:- Command $cmd failed with error status $RETVAL, see log file $LOG_FILE for more detail"
 		fi

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -114,7 +114,7 @@ ADD_PG_HBA_ENTRIES() {
 CREATE_QES_PRIMARY () {
     LOG_MSG "[INFO][$INST_COUNT]:-Start Function $FUNCNAME"
     LOG_MSG "[INFO][$INST_COUNT]:-Processing segment $GP_HOSTADDRESS"
-    # build initdb command, capturing output in ${GP_DIR}.initdb
+    # build initdb command
     cmd="$EXPORT_LIB_PATH;$INITDB"
     cmd="$cmd -E $ENCODING"
     cmd="$cmd -D $GP_DIR"
@@ -125,15 +125,10 @@ CREATE_QES_PRIMARY () {
     if [ x"$HEAP_CHECKSUM" == x"on" ]; then
         cmd="$cmd --data-checksums"
     fi
-    cmd="$cmd --backend_output=$GP_DIR.initdb"
     
     $TRUSTED_SHELL ${GP_HOSTADDRESS} $cmd >> $LOG_FILE 2>&1
     RETVAL=$?
     
-    if [ $RETVAL -ne 0 ]; then
-        $TRUSTED_SHELL ${GP_HOSTADDRESS} "cat $GP_DIR.initdb" >> $LOG_FILE 2>&1
-    fi
-    $TRUSTED_SHELL ${GP_HOSTADDRESS} "rm -f $GP_DIR.initdb" >> $LOG_FILE 2>&1
     BACKOUT_COMMAND "$TRUSTED_SHELL ${GP_HOSTADDRESS} \"$RM -rf $GP_DIR > /dev/null 2>&1\""
     BACKOUT_COMMAND "$ECHO \"removing directory $GP_DIR on $GP_HOSTADDRESS\""
     PARA_EXIT $RETVAL "to start segment instance database $GP_HOSTADDRESS $GP_DIR"

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -141,7 +141,6 @@ static const char *authmethodhost = "";
 static const char *authmethodlocal = "";
 static bool debug = false;
 static bool noclean = false;
-static char *backend_output = DEVNULL;
 
 /**
  * Build the minimal set of files needed for a mirror db.  Note that this could be removed
@@ -1257,7 +1256,7 @@ test_config_settings(void)
 				 "< \"%s\" > \"%s\" 2>&1",
 				 backend_exec, boot_options,
 				 test_conns, test_buffs,
-				 DEVNULL, backend_output);
+				 DEVNULL, DEVNULL);
 		status = system(cmd);
 		if (status == 0)
 		{
@@ -1295,7 +1294,7 @@ test_config_settings(void)
 				 "< \"%s\" > \"%s\" 2>&1",
 				 backend_exec, boot_options,
 				 n_connections, test_buffs,
-				 DEVNULL, backend_output);
+				 DEVNULL, DEVNULL);
 		status = system(cmd);
 		if (status == 0)
 		{
@@ -3576,7 +3575,7 @@ initialize_data_directory(void)
 		snprintf(cmd, sizeof(cmd),
 				 "\"%s\" %s template1 >%s",
 				 backend_exec, backend_options,
-				 backend_output);
+				 DEVNULL);
 	
 		PG_CMD_OPEN;
 	
@@ -3652,7 +3651,6 @@ main(int argc, char *argv[])
 		{"data-checksums", no_argument, NULL, 'k'},
         {"max_connections", required_argument, NULL, 1001},     /*CDB*/
         {"shared_buffers", required_argument, NULL, 1003},      /*CDB*/
-        {"backend_output", optional_argument, NULL, 1005},      /*CDB*/
 		{NULL, 0, NULL, 0}
 	};
 
@@ -3816,9 +3814,6 @@ main(int argc, char *argv[])
 				break;
 			case 1003:
                 n_buffers = parse_long(optarg, true, optname);
-				break;
-			case 1005:
-				backend_output = pg_strdup(optarg);
 				break;
 			default:
 				/* getopt_long already emitted a complaint */


### PR DESCRIPTION
The `--backend_output` parameter was used to redirect output from initdb executing the backend during probing to a separate logfile.  This log was then appended to the main `initdb` log in case of errors.  Blindly passing user parameters to system() is however problematic, as it will execute any arbitrary commands passed.  The below example will redir the output and also execute `echo`.
```
./bin/initdb -D data --backend_output="/tmp/out.log\" 2>&1; echo \"a"
```
There is no privilege escalation in `initdb`, so there is no security angle to this, but it's still a less than desirable capability. Fix by removing the parameter altogether (this feature does not exist in upstream).