### PR TITLE
Fix plan when join lateral inner plan contains limit clause.

### DIFF
--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1169,3 +1169,53 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 (9 rows)
 
 drop table t_randomly_dist_table;
+-- test join lateral of this special case:
+--   1. inner plan contains limit clause
+--   2. inner plan refers outer params in projections
+create table t1_lateral_limit_proj(a int, b int, c int) distributed by (a);
+create table t2_lateral_limit_proj(a int, b int, c int) distributed by (a);
+insert into t1_lateral_limit_proj select i,i,i from generate_series(1, 5)i;
+insert into t2_lateral_limit_proj select i,i,i from generate_series(1, 5)i;
+-- previously, we do not handle such query correctly and leads to a plan
+-- that need passing params across motions (because for partitioned locus
+-- relation, we can only do limit after gathering).
+-- Now the following plan should first gather t2 and then use result node
+-- to compute projection and then do limit.
+explain
+select t1.a, x.y from t1_lateral_limit_proj as t1 join lateral
+(select (t1.a+t2.b) as y from t2_lateral_limit_proj as t2 order by t2.b limit 1) x
+on true order by t1.a;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=10000000006.57..10000000006.59 rows=5 width=8)
+   Sort Key: t1.a
+   ->  Nested Loop  (cost=10000000003.26..10000000006.52 rows=5 width=8)
+         ->  Materialize  (cost=0.00..3.17 rows=5 width=4)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.15 rows=5 width=4)
+                     ->  Seq Scan on t1_lateral_limit_proj t1  (cost=0.00..3.05 rows=2 width=4)
+         ->  Materialize  (cost=3.26..3.28 rows=1 width=4)
+               ->  Subquery Scan on x  (cost=3.26..3.27 rows=1 width=4)
+                     ->  Limit  (cost=3.26..3.26 rows=1 width=8)
+                           ->  Sort  (cost=3.26..3.27 rows=5 width=8)
+                                 Sort Key: t2.b
+                                 ->  Result  (cost=0.00..3.24 rows=5 width=8)
+                                       ->  Materialize  (cost=0.00..3.17 rows=5 width=4)
+                                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..3.15 rows=5 width=4)
+                                                   ->  Seq Scan on t2_lateral_limit_proj t2  (cost=0.00..3.05 rows=2 width=4)
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select t1.a, x.y from t1_lateral_limit_proj as t1 join lateral
+(select (t1.a+t2.b) as y from t2_lateral_limit_proj as t2 order by t2.b limit 1) x
+on true order by t1.a;
+ a | y 
+---+---
+ 1 | 2
+ 2 | 3
+ 3 | 4
+ 4 | 5
+ 5 | 6
+(5 rows)
+
+drop table t1_lateral_limit_proj;
+drop table t2_lateral_limit_proj;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1167,3 +1167,53 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 (13 rows)
 
 drop table t_randomly_dist_table;
+-- test join lateral of this special case:
+--   1. inner plan contains limit clause
+--   2. inner plan refers outer params in projections
+create table t1_lateral_limit_proj(a int, b int, c int) distributed by (a);
+create table t2_lateral_limit_proj(a int, b int, c int) distributed by (a);
+insert into t1_lateral_limit_proj select i,i,i from generate_series(1, 5)i;
+insert into t2_lateral_limit_proj select i,i,i from generate_series(1, 5)i;
+-- previously, we do not handle such query correctly and leads to a plan
+-- that need passing params across motions (because for partitioned locus
+-- relation, we can only do limit after gathering).
+-- Now the following plan should first gather t2 and then use result node
+-- to compute projection and then do limit.
+explain
+select t1.a, x.y from t1_lateral_limit_proj as t1 join lateral
+(select (t1.a+t2.b) as y from t2_lateral_limit_proj as t2 order by t2.b limit 1) x
+on true order by t1.a;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=10000000006.57..10000000006.59 rows=5 width=8)
+   Sort Key: t1.a
+   ->  Nested Loop  (cost=10000000003.26..10000000006.52 rows=5 width=8)
+         ->  Materialize  (cost=0.00..3.17 rows=5 width=4)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.15 rows=5 width=4)
+                     ->  Seq Scan on t1_lateral_limit_proj t1  (cost=0.00..3.05 rows=2 width=4)
+         ->  Materialize  (cost=3.26..3.28 rows=1 width=4)
+               ->  Subquery Scan on x  (cost=3.26..3.27 rows=1 width=4)
+                     ->  Limit  (cost=3.26..3.26 rows=1 width=8)
+                           ->  Sort  (cost=3.26..3.27 rows=5 width=8)
+                                 Sort Key: t2.b
+                                 ->  Result  (cost=0.00..3.24 rows=5 width=8)
+                                       ->  Materialize  (cost=0.00..3.17 rows=5 width=4)
+                                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..3.15 rows=5 width=4)
+                                                   ->  Seq Scan on t2_lateral_limit_proj t2  (cost=0.00..3.05 rows=2 width=4)
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select t1.a, x.y from t1_lateral_limit_proj as t1 join lateral
+(select (t1.a+t2.b) as y from t2_lateral_limit_proj as t2 order by t2.b limit 1) x
+on true order by t1.a;
+ a | y 
+---+---
+ 1 | 2
+ 2 | 3
+ 3 | 4
+ 4 | 5
+ 5 | 6
+(5 rows)
+
+drop table t1_lateral_limit_proj;
+drop table t2_lateral_limit_proj;


### PR DESCRIPTION
Previously, when join lateral inner plan contains limit
clause and the exec params are in targetlist of the query,
for the inner plan it may put a gather motion and then do
limit. This is not correct since it leads to passing params
across motion nodes. A typical case is shown below:

```
create table t1(a int, b int, c int) distributed by (a);
create table t2(a int, b int, c int) distributed by (a);
explain verbose select * from t1 join lateral
(select t1.b + t2.a from t2 limit 1)x on true;
                       QUERY PLAN
--------------------------------------------------------
 Nested Loop
   Output: t1.a, t1.b, t1.c, ((t1.b + t2.a))
   ->  Gather Motion 3:1
         Output: t1.a, t1.b, t1.c
         ->  Seq Scan on public.t1
               Output: t1.a, t1.b, t1.c
   ->  Materialize
         Output: ((t1.b + t2.a))
         ->  Limit
               Output: ((t1.b + t2.a))
               ->  Gather Motion 3:1
                     Output: ((t1.b + t2.a))
                     ->  Limit
                           Output: ((t1.b + t2.a))
                           ->  Seq Scan on public.t2
                                 Output: (t1.b + t2.a)
```

The above plan is invalid because NestLoop has to pass
params down to the scan of t2. Greenplum does not support
this yet.

This commit fixes the bug by gathering the table firstly.
When the subquery contains outer params and it has limit
clause, planner will try this. After this commit, the above
plan becomes:

```
explain verbose select * from t1 join lateral
(select t1.b + t2.a from t2 limit 1)x on true;
                      QUERY PLAN
------------------------------------------------------------
 Nested Loop
   Output: t1.a, t1.b, t1.c, ((t1.b + t2.a))
   ->  Materialize
         Output: t1.a, t1.b, t1.c
         ->  Gather Motion 3:1
               Output: t1.a, t1.b, t1.c
               ->  Seq Scan on public.t1
                     Output: t1.a, t1.b, t1.c
   ->  Materialize
         Output: ((t1.b + t2.a))
         ->  Limit
               Output: ((t1.b + t2.a))
               ->  Result
                     Output: (t1.b + t2.a)
                     ->  Materialize
                           Output: t2.a
                           ->  Gather Motion 3:1
                                 Output: t2.a
                                 ->  Seq Scan on public.t2
                                       Output: t2.a
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
