### PR TITLE
initdb cleanup and alignment with upstream

### DIFF
--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -79,9 +79,6 @@
 /* Ideally this would be in a .h file, but it hardly seems worth the trouble */
 extern const char *select_default_timezone(const char *share_path);
 
-/* version string we expect back from postgres */
-#define PG_VERSIONSTR "postgres (Greenplum Database) " PG_VERSION "\n"
-
 static const char *const auth_methods_host[] = {
 	"trust", "reject", "md5", "password", "ident", "radius",
 #ifdef ENABLE_GSS
@@ -143,11 +140,6 @@ static bool debug = false;
 static bool noclean = false;
 static char *backend_output = DEVNULL;
 
-/**
- * Build the minimal set of files needed for a mirror db.  Note that this could be removed
- *  eventually if we do a smarter copy of files from primary (with postgresql.conf updates)
- */
-static bool forMirrorOnly = false;
 static bool do_sync = true;
 static bool sync_only = false;
 static bool show_setting = false;
@@ -2957,7 +2949,6 @@ usage(const char *progname)
 	printf(_("  -N, --nosync              do not wait for changes to be written safely to disk\n"));
 	printf(_("  -s, --show                show internal settings\n"));
 	printf(_("  -S, --sync-only           only sync data directory\n"));
-	printf(_("  -m, --formirror           only create data needed to start the backend in mirror mode\n"));
 	printf(_("\nOther options:\n"));
 	printf(_("  -V, --version             output version information, then exit\n"));
 	printf(_("      --gp-version          output Greenplum version information, then exit\n"));
@@ -3556,67 +3547,64 @@ initialize_data_directory(void)
 	/* Now create all the text config files */
 	setup_config();
 
-	if ( ! forMirrorOnly)
-	{
-		/* Bootstrap template1 */
-		bootstrap_template1();
+	/* Bootstrap template1 */
+	bootstrap_template1();
 
-		/*
-		 * Make the per-database PG_VERSION for template1 only after init'ing it
-		 */
-		write_version_file("base/1");
+	/*
+	 * Make the per-database PG_VERSION for template1 only after init'ing it
+	 */
+	write_version_file("base/1");
 
-		/*
-		 * Create the stuff we don't need to use bootstrap mode for, using a
-		 * backend running in simple standalone mode.
-		 */
-		fputs(_("performing post-bootstrap initialization ... "), stdout);
-		fflush(stdout);
-	
-		snprintf(cmd, sizeof(cmd),
-				 "\"%s\" %s template1 >%s",
-				 backend_exec, backend_options,
-				 backend_output);
-	
-		PG_CMD_OPEN;
-	
-		setup_auth(cmdfd);
-		if (pwprompt || pwfilename)
-			get_set_pwd(cmdfd);
-	
-		setup_depend(cmdfd);
-	
-		setup_sysviews(cmdfd);
-	
-		setup_description(cmdfd);
-	
+	/*
+	 * Create the stuff we don't need to use bootstrap mode for, using a
+	 * backend running in simple standalone mode.
+	 */
+	fputs(_("performing post-bootstrap initialization ... "), stdout);
+	fflush(stdout);
+
+	snprintf(cmd, sizeof(cmd),
+			 "\"%s\" %s template1 >%s",
+			 backend_exec, backend_options,
+			 backend_output);
+
+	PG_CMD_OPEN;
+
+	setup_auth(cmdfd);
+	if (pwprompt || pwfilename)
+		get_set_pwd(cmdfd);
+
+	setup_depend(cmdfd);
+
+	setup_sysviews(cmdfd);
+
+	setup_description(cmdfd);
+
 #if 0
 		setup_collation(cmdfd);
 #endif
 
-		setup_conversion(cmdfd);
-	
-		setup_dictionary(cmdfd);
+	setup_conversion(cmdfd);
 
-		setup_privileges(cmdfd);
+	setup_dictionary(cmdfd);
 
-		setup_schema(cmdfd);
-	
-		load_plpgsql(cmdfd);
-	
-		/* sets up the Greenplum Database admin schema */
-		setup_cdb_schema(cmdfd);
-	
-		vacuum_db(cmdfd);
-	
-		make_template0(cmdfd);
-	
-		make_postgres(cmdfd);
-	
-		PG_CMD_CLOSE;
-	
-		check_ok();
-	}
+	setup_privileges(cmdfd);
+
+	setup_schema(cmdfd);
+
+	load_plpgsql(cmdfd);
+
+	/* sets up the Greenplum Database admin schema */
+	setup_cdb_schema(cmdfd);
+
+	vacuum_db(cmdfd);
+
+	make_template0(cmdfd);
+
+	make_postgres(cmdfd);
+
+	PG_CMD_CLOSE;
+
+	check_ok();
 }
 
 
@@ -3755,9 +3743,6 @@ main(int argc, char *argv[])
 			case 'd':
 				debug = true;
 				printf(_("Running in debug mode.\n"));
-				break;
-			case 'm':
-				forMirrorOnly = true;
 				break;
 			case 'n':
 				noclean = true;

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -2792,7 +2792,7 @@ setlocales(void)
  * usual decimal, octal, or hexadecimal formats.
  */
 static long
-parse_long(const char *value, bool blckszUnit, const char* optname)
+parse_long(const char *value, bool blckszUnit, const char *optname)
 {
     long    val;
     char   *endptr;
@@ -3631,25 +3631,6 @@ main(int argc, char *argv[])
 
 	while ((c = getopt_long(argc, argv, "dD:E:kL:nNU:WA:sST:X:", long_options, &option_index)) != -1)
 	{
-        const char *optname;
-        char        shortopt[2];
-
-        /* CDB: Get option name for error reporting.  On Solaris, getopt_long
-         * may leave garbage in option_index after parsing a short option, so
-         * check carefully.
-         */
-        if (isalpha(c))
-        {
-            shortopt[0] = (char)c;
-            shortopt[1] = '\0';
-            optname = shortopt;
-        }
-        else if (option_index >= 0 &&
-                 option_index < sizeof(long_options)/sizeof(long_options[0]) - 1)
-            optname = long_options[option_index].name;
-        else
-            optname = "?!?";
-
 		switch (c)
 		{
 			case 'A':
@@ -3740,10 +3721,10 @@ main(int argc, char *argv[])
 				xlog_dir = pg_strdup(optarg);
 				break;
 			case 1001:
-                n_connections = parse_long(optarg, false, optname);
+				n_connections = parse_long(optarg, false, "max_connection");
 				break;
 			case 1003:
-                n_buffers = parse_long(optarg, true, optname);
+				n_buffers = parse_long(optarg, true, "shared_buffers");
 				break;
 			case 1005:
 				backend_output = pg_strdup(optarg);

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -234,9 +234,6 @@ static const char *const subdirs[] = {
 static char bin_path[MAXPGPATH];
 static char backend_exec[MAXPGPATH];
 
-static char **add_assignment(char **lines, const char *varname, const char *fmt, ...)
-                /* This extension allows gcc to check the format string */
-                pg_attribute_printf(3, 4);
 static char **replace_token(char **lines,
 			  const char *token, const char *replacement);
 
@@ -364,98 +361,6 @@ escape_quotes(const char *src)
 	}
 	return result;
 }
-
-/*
- * add_assignment
- *
- * Returns a copy of the array of lines, with an additional line inserted:
- * an assignment (maybe commented out) to the specified configuration variable.
- *
- * If there is already an assignment to the variable, that setting remains in
- * effect, taking precedence over the caller's requested setting, which is
- * inserted as a comment.  Else the caller's requested assignment is inserted.
- */
-static char **
-add_assignment(char **lines, const char *varname, const char *fmt, ...)
-{
-	va_list		args;
-	int			isrc;
-    int         iinsert = -1;
-    int         j;
-    int         varnamelen = strlen(varname);
-	char	  **result;
-    char        buf[200];
-    char       *bufp = buf;
-    char       *bufe = buf + sizeof(buf) - 3;
-    bool        superseded = false;
-
-    /* Look for an assignment to the given variable, maybe commented out. */
-    for (isrc = 0; lines[isrc] != NULL; isrc++)
-    {
-        char   *cp = lines[isrc];
-        bool    comment = false;
-
-        while (isspace((unsigned char)*cp))
-            cp++;
-
-        if (*cp == '#')
-        {
-            cp++;
-            comment = true;
-            while (isspace((unsigned char)*cp))
-                cp++;
-        }
-
-        if (0 != strncmp(cp, varname, varnamelen))
-            continue;
-        cp += varnamelen;
-        while (isspace((unsigned char)*cp))
-            cp++;
-        if (*cp != '=')
-            continue;
-
-        /* Found assignment (or commented-out assignment) to given varname. */
-        if (!comment)
-            superseded = true;
-        if (iinsert < 0)
-            iinsert = isrc;
-    }
-
-    if (iinsert < 0)
-    {
-        /* No assignment found? Insert at the end. */
-        iinsert = isrc;
-    }
-
-    /* Build assignment. */
-    va_start(args, fmt);
-    if (superseded)
-        bufp += snprintf(bufp, bufe-bufp, "#");
-    bufp += snprintf(bufp, bufe-bufp, "%s = ", varname);
-    bufp += vsnprintf(bufp, bufe-bufp, fmt, args);
-	va_end(args);
-
-    /* Tab to align comments */
-    j = (int)(bufp - buf);
-    do
-    {
-        *bufp++ = '\t';
-        j += 8;
-    } while (j < 40);
-
-    /* Append comment. */
-    bufp += snprintf(bufp, bufe-bufp, "# inserted by initdb\n");
-
-    /* Make a copy of the ptr array, opening up a hole after the chosen line. */
-    result = (char **)pg_malloc((isrc + 2) * sizeof(char *));
-    memcpy(result, lines, iinsert * sizeof(lines[0]));
-    memcpy(result+iinsert+1, lines+iinsert, (isrc - iinsert + 1) * sizeof(lines[0]));
-
-    /* Insert assignment. */
-    result[iinsert] = pg_strdup(buf);
-
-    return result;
-}                               /* add_assignment */
 
 /*
  * make a copy of the array of lines, with token replaced by replacement
@@ -1332,14 +1237,16 @@ setup_config(void)
 
 	conflines = readfile(conf_file);
 
-	conflines = add_assignment(conflines, "max_connections", "%d", n_connections);
+	snprintf(repltok, sizeof(repltok), "max_connections = %d", n_connections);
+	conflines = replace_token(conflines, "#max_connections = 200", repltok);
 
 	if ((n_buffers * (BLCKSZ / 1024)) % 1024 == 0)
-		conflines = add_assignment(conflines, "shared_buffers", "%dMB",
-								   (n_buffers * (BLCKSZ / 1024)) / 1024);
+		snprintf(repltok, sizeof(repltok), "shared_buffers = %dMB",
+				 (n_buffers * (BLCKSZ / 1024)) / 1024);
 	else
-		conflines = add_assignment(conflines, "shared_buffers", "%dkB",
-								   n_buffers * (BLCKSZ / 1024));
+		snprintf(repltok, sizeof(repltok), "shared_buffers = %dkB",
+				 n_buffers * (BLCKSZ / 1024));
+	conflines = replace_token(conflines, "#shared_buffers = 128MB", repltok);
 
 #ifdef HAVE_UNIX_SOCKETS
 	snprintf(repltok, sizeof(repltok), "#unix_socket_directories = '%s'",
@@ -1350,38 +1257,41 @@ setup_config(void)
 	conflines = replace_token(conflines, "#unix_socket_directories = '/tmp'",
 							  repltok);
 
-	/* Upd comment to document the default port configured by --with-pgport */
-	if (DEF_PGPORT != 5432)
-	{
-		snprintf(repltok, sizeof(repltok), "#port = %d", DEF_PGPORT);
-		conflines = replace_token(conflines, "#port = 5432", repltok);
-	}
+#if DEF_PGPORT != 5432
+	snprintf(repltok, sizeof(repltok), "#port = %d", DEF_PGPORT);
+	conflines = replace_token(conflines, "#port = 5432", repltok);
+#endif
 
-	conflines = add_assignment(conflines, "lc_messages", "'%s'",
-							   escape_quotes(lc_messages));
+	snprintf(repltok, sizeof(repltok), "lc_messages = '%s'",
+			 escape_quotes(lc_messages));
+	conflines = replace_token(conflines, "#lc_messages = 'C'", repltok);
 
-	conflines = add_assignment(conflines, "lc_monetary", "'%s'",
-							   escape_quotes(lc_monetary));
+	snprintf(repltok, sizeof(repltok), "lc_monetary = '%s'",
+			 escape_quotes(lc_monetary));
+	conflines = replace_token(conflines, "#lc_monetary = 'C'", repltok);
 
-	conflines = add_assignment(conflines, "lc_numeric", "'%s'",
-							   escape_quotes(lc_numeric));
+	snprintf(repltok, sizeof(repltok), "lc_numeric = '%s'",
+			 escape_quotes(lc_numeric));
+	conflines = replace_token(conflines, "#lc_numeric = 'C'", repltok);
 
-	conflines = add_assignment(conflines, "lc_time", "'%s'",
-							   escape_quotes(lc_time));
+	snprintf(repltok, sizeof(repltok), "lc_time = '%s'",
+			 escape_quotes(lc_time));
+	conflines = replace_token(conflines, "#lc_time = 'C'", repltok);
 
 	switch (locale_date_order(lc_time))
 	{
 		case DATEORDER_YMD:
-			conflines = add_assignment(conflines, "datestyle", "'iso, ymd'");
+			strcpy(repltok, "datestyle = 'iso, ymd'");
 			break;
 		case DATEORDER_DMY:
-			conflines = add_assignment(conflines, "datestyle", "'iso, dmy'");
+			strcpy(repltok, "datestyle = 'iso, dmy'");
 			break;
 		case DATEORDER_MDY:
 		default:
-			conflines = add_assignment(conflines, "datestyle", "'iso, mdy'");
+			strcpy(repltok, "datestyle = 'iso, mdy'");
 			break;
 	}
+	conflines = replace_token(conflines, "#datestyle = 'iso, mdy'", repltok);
 
 	snprintf(repltok, sizeof(repltok),
 			 "default_text_search_config = 'pg_catalog.%s'",
@@ -1412,8 +1322,9 @@ setup_config(void)
 							  "#effective_io_concurrency = 0");
 #endif
 
-	conflines = add_assignment(conflines, "include", "'%s'",
-							   GP_INTERNAL_AUTO_CONF_FILE_NAME);
+	snprintf(repltok, sizeof(repltok), "include = '%s'",
+			 GP_INTERNAL_AUTO_CONF_FILE_NAME);
+	conflines = replace_token(conflines, "#include = 'special.conf'", repltok);
 
 	snprintf(path, sizeof(path), "%s/postgresql.conf", pg_data);
 


### PR DESCRIPTION
Contained are a set of cleanup commits to initdb which further aligns initdb with upstream by removing unused (or not needed) Greenplum extensions, and adds back some pieces of upstream. See each commit message for more information.

One open question is how to handle the bgwriter section from the sample config, it's completely missing in Greenplum and the question is if that was intentional or an oversight.