### PR TITLE
5X: Add experimental value for `optimizer_cost_model`

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.91.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.92.", GPORCA_VERSION_STRING, 5);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.91.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.92.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12523,7 +12523,7 @@ int
 main ()
 {
 
-return strncmp("3.91.", GPORCA_VERSION_STRING, 5);
+return strncmp("3.92.", GPORCA_VERSION_STRING, 5);
 
   ;
   return 0;
@@ -12533,7 +12533,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.91.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.92.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.91.0@gpdb/stable
+orca/v3.92.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.91.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.92.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -549,6 +549,11 @@ CConfigParamMapping::PackConfigParamInBitset
 		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfExpandFullOuterJoin));
 	}
 
+	if (OPTIMIZER_GPDB_EXPERIMENTAL == optimizer_cost_model)
+	{
+		traceflag_bitset->ExchangeSet(EopttraceCalibratedBitmapIndexCostModel);
+	}
+
 	return traceflag_bitset;
 }
 

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -811,7 +811,7 @@ COptTasks::SetCostModelParams
 	{
 		// change NLJ cost factor
 		ICostModelParams::SCostParam *cost_param = NULL;
-		if (OPTIMIZER_GPDB_CALIBRATED == optimizer_cost_model)
+		if (OPTIMIZER_GPDB_CALIBRATED == optimizer_cost_model || OPTIMIZER_GPDB_EXPERIMENTAL == optimizer_cost_model)
 		{
 			cost_param = cost_model->GetCostModelParams()->PcpLookup(CCostModelParamsGPDB::EcpNLJFactor);
 		}
@@ -827,7 +827,7 @@ COptTasks::SetCostModelParams
 	{
 		// change sort cost factor
 		ICostModelParams::SCostParam *cost_param = NULL;
-		if (OPTIMIZER_GPDB_CALIBRATED == optimizer_cost_model)
+		if (OPTIMIZER_GPDB_CALIBRATED == optimizer_cost_model || OPTIMIZER_GPDB_EXPERIMENTAL == optimizer_cost_model)
 		{
 			cost_param = cost_model->GetCostModelParams()->PcpLookup(CCostModelParamsGPDB::EcpSortTupWidthCostUnit);
 
@@ -854,7 +854,7 @@ COptTasks::GetCostModel
 	)
 {
 	ICostModel *cost_model = NULL;
-	if (OPTIMIZER_GPDB_CALIBRATED == optimizer_cost_model)
+	if (OPTIMIZER_GPDB_CALIBRATED == optimizer_cost_model || OPTIMIZER_GPDB_EXPERIMENTAL == optimizer_cost_model)
 	{
 		cost_model = GPOS_NEW(mp) CCostModelGPDB(mp, num_segments);
 	}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5125,7 +5125,7 @@ struct config_string ConfigureNamesString_gp[] =
 	{
 		{"optimizer_cost_model", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Set optimizer cost model."),
-			gettext_noop("Valid values are legacy, calibrated"),
+			gettext_noop("Valid values are legacy, calibrated, experimental"),
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_cost_model_str,
@@ -5836,6 +5836,10 @@ assign_optimizer_cost_model(const char *val, bool assign, GucSource source)
 	else if (pg_strcasecmp(val, "calibrated") == 0 && assign)
 	{
 		optimizer_cost_model = OPTIMIZER_GPDB_CALIBRATED;
+	}
+	else if (pg_strcasecmp(val, "experimental") == 0 && assign)
+	{
+		optimizer_cost_model = OPTIMIZER_GPDB_EXPERIMENTAL;
 	}
 	else
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -389,6 +389,7 @@ extern char  *data_directory;
 /* optimizer cost model */
 #define OPTIMIZER_GPDB_LEGACY           0       /* GPDB's legacy cost model */
 #define OPTIMIZER_GPDB_CALIBRATED       1       /* GPDB's calibrated cost model */
+#define OPTIMIZER_GPDB_EXPERIMENTAL     2       /* GPDB's experimental cost model */
 
 /* Optimizer related gucs */
 extern bool	optimizer;

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -187,6 +187,53 @@ AND ft.id = dt1.id;
  Optimizer status: legacy query optimizer
 (36 rows)
 
+-- experimental cost model guc generates bitmap scan
+set optimizer_cost_model=experimental;
+explain SELECT count(*) 
+FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
+WHERE ft.wk_id = dt.wk_id
+AND ft.id = dt1.id;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=27.51..27.52 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=27.44..27.49 rows=1 width=8)
+         ->  Aggregate  (cost=27.44..27.45 rows=1 width=8)
+               ->  Hash Join  (cost=6.84..27.43 rows=2 width=0)
+                     Hash Cond: ft.wk_id = dt.wk_id
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3.61..24.14 rows=3 width=2)
+                           Hash Key: ft.wk_id
+                           ->  Hash Join  (cost=3.61..23.99 rows=3 width=2)
+                                 Hash Cond: ft.id = dt1.id
+                                 ->  Append  (cost=0.00..20.20 rows=7 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_dflt ft  (cost=0.00..1.00 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_2 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_3 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_4 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_5 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_6 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_7 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_8 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_9 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_10 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_11 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_12 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_13 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_14 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_15 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_16 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_17 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_18 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_19 ft  (cost=0.00..1.01 rows=1 width=6)
+                                       ->  Append-only Columnar Scan on bfv_tab2_facttable1_1_prt_20 ft  (cost=0.00..1.02 rows=1 width=6)
+                                 ->  Hash  (cost=3.35..3.35 rows=7 width=4)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.35 rows=7 width=4)
+                                             ->  Seq Scan on bfv_tab2_dimtabl1 dt1  (cost=0.00..3.07 rows=3 width=4)
+                     ->  Hash  (cost=3.10..3.10 rows=4 width=2)
+                           ->  Seq Scan on bfv_tab2_dimdate dt  (cost=0.00..3.10 rows=4 width=2)
+ Optimizer status: legacy query optimizer
+(36 rows)
+
+reset optimizer_cost_model;
 -- start_ignore
 create language plpythonu;
 ERROR:  language "plpythonu" already exists

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -175,6 +175,38 @@ AND ft.id = dt1.id;
  Optimizer status: PQO version 2.48.9
 (20 rows)
 
+-- experimental cost model guc generates bitmap scan
+set optimizer_cost_model=experimental;
+explain SELECT count(*) 
+FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
+WHERE ft.wk_id = dt.wk_id
+AND ft.id = dt1.id;
+                                                                                                                                               QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..879.28 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..879.28 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..879.28 rows=1 width=8)
+               ->  Hash Join  (cost=0.00..879.28 rows=2 width=1)
+                     Hash Cond: bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id
+                     ->  Table Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
+                     ->  Hash  (cost=448.28..448.28 rows=3 width=2)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..448.28 rows=3 width=2)
+                                 Hash Key: bfv_tab2_facttable1.wk_id
+                                 ->  Nested Loop  (cost=0.00..448.28 rows=3 width=2)
+                                       Join Filter: true
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                             ->  Table Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
+                                       ->  Sequence  (cost=0.00..17.28 rows=1 width=2)
+                                             ->  Partition Selector for bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                                   Partitions selected: 20 (out of 20)
+                                             ->  Bitmap Table Scan on bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=0.00..17.28 rows=1 width=2)
+                                                   Recheck Cond: bfv_tab2_facttable1.id = bfv_tab2_dimtabl1.id
+                                                   ->  Bitmap Index Scan on idx_bfv_tab2_facttable1_1_prt_dflt  (cost=0.00..0.00 rows=0 width=0)
+                                                         Index Cond: bfv_tab2_facttable1.id = bfv_tab2_dimtabl1.id
+ Optimizer status: PQO version 3.90.0
+(21 rows)
+
+reset optimizer_cost_model;
 -- start_ignore
 create language plpythonu;
 -- end_ignore

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -88,6 +88,14 @@ FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
 
+-- experimental cost model guc generates bitmap scan
+set optimizer_cost_model=experimental;
+explain SELECT count(*)
+FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
+WHERE ft.wk_id = dt.wk_id
+AND ft.id = dt1.id;
+
+reset optimizer_cost_model;
 -- start_ignore
 create language plpythonu;
 -- end_ignore


### PR DESCRIPTION
This commit adds a new optimizer cost model value to use for
experimental features and developer testing in ORCA. Setting
`optimizer_cost_model=experimental` will use the new costing
formula.

Currently it is only used for a bitmap costing change.

Co-authored-by: Chris Hajas <chajas@pivotal.io>
Co-authored-by: Ashuka Xue <axue@pivotal.io>

Corresponding ORCA PR: https://github.com/greenplum-db/gporca/pull/570

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
