### PR TITLE
V2: gpexpand: exclude master-only tables from the template

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1417,10 +1417,11 @@ class gpexpand:
                                                          , sqlCommandList=statements
                                                          )
                 self.pool.addCommand(execSQLCmd)
-                self.pool.join()
-                ### need to fix self.pool.check_results(). Call getCompletedItems to clear the queue for now.
-                self.pool.check_results()
-                self.pool.getCompletedItems()
+
+        self.pool.join()
+        ### need to fix self.pool.check_results(). Call getCompletedItems to clear the queue for now.
+        self.pool.check_results()
+        self.pool.getCompletedItems()
 
     # --------------------------------------------------------------------------
     def restore_master(self):

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -53,6 +53,11 @@ SEGMENT_CONFIGURATION_BACKUP_FILE = "gpexpand.gp_segment_configuration"
 
 DBNAME = 'postgres'
 
+# an empty b-tree index file is considered invalid, it needs to contain a meta
+# page, so we use the pg_partition_oid_index of template0 as a template of
+# empty index file.
+EMPTY_INDEX = 'base/13199/5112'
+
 #global var
 _gp_expand = None
 
@@ -627,9 +632,9 @@ class SegmentTemplate:
         """Builds segment template tar file"""
         self.statusLogger.set_status('BUILD_SEGMENT_TEMPLATE_STARTED', self.tempDir)
         # build segment template should consider tablespace files
-        excludes = self._list_master_only_files()
-        self._create_template(newTableSpaceInfo, excludes=excludes)
-        self._fixup_template(excludes=excludes)
+        self._list_master_only_files()
+        self._create_template(newTableSpaceInfo)
+        self._fixup_template()
         self._tar_template()
         self.statusLogger.set_status('BUILD_SEGMENT_TEMPLATE_DONE')
 
@@ -662,37 +667,45 @@ class SegmentTemplate:
         regclasses = "(" + ", ".join(regclasses) + ")"
         self.logger.debug("master only tables: %s" % regclasses)
 
-        global_sql = """
-/* relation files */
+        global_relation_sql = """
 SELECT pg_catalog.pg_relation_filepath(c.oid)
   FROM pg_catalog.pg_class c
  WHERE c.oid IN %s
    AND c.relfilenode = 0
+""" % (regclasses)
 
-UNION ALL
-
-/* index files */
+        global_index_sql = """
 SELECT pg_catalog.pg_relation_filepath(i.indexrelid)
   FROM pg_catalog.pg_index i
   JOIN pg_catalog.pg_class c
     ON i.indexrelid = c.oid
  WHERE i.indrelid IN %s
    AND c.relfilenode = 0
-""" % (regclasses, regclasses)
+""" % (regclasses)
 
-        per_db_sql = """
-/* relation files */
+        per_db_relation_sql = """
 SELECT pg_catalog.pg_relation_filepath(c.oid)
   FROM pg_catalog.pg_class c
  WHERE c.oid IN %s
    AND c.relfilenode <> 0
 """ % (regclasses)
 
-        result = []
+        per_db_index_sql = """
+SELECT pg_catalog.pg_relation_filepath(i.indexrelid)
+  FROM pg_catalog.pg_index i
+  JOIN pg_catalog.pg_class c
+    ON i.indexrelid = c.oid
+ WHERE i.indrelid IN %s
+   AND c.relfilenode <> 0
+""" % (regclasses)
 
-        def add_paths(paths):
+        self.master_only_relation_paths = []
+        self.master_only_index_paths = []
+
+        def scan_paths(paths):
             """we need to include not only the relation/index files,
             but also visibility, free space and seg files"""
+            result = []
             for path in paths:
                 # ${filenode}: the relation file itself
                 result.append(os.path.join('.', path))
@@ -701,6 +714,7 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
                 result.extend(glob.glob('./%s_*' % path))
                 # ${filenode}.[1-9][0-9]*: the seg files
                 result.extend(glob.glob('./%s.*' % path))
+            return result
 
         # the file list will be passed to pg_basebackup as the exclude list,
         # it expects the paths are like "./global/1234", so we must chdir to
@@ -710,12 +724,19 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
 
         # first list the global master-only tables
         with dbconn.connect(self.dburl, encoding='UTF8') as conn:
+            # the relation paths
             paths = [str(row[0])
-                     for row in dbconn.execSQL(conn, global_sql).fetchall()]
-            self.logger.debug("raw files of global master-only tables: %s" % paths)
-            add_paths(paths)
+                     for row in dbconn.execSQL(conn, global_relation_sql).fetchall()]
+            self.logger.debug("raw relation files of global master-only tables: %s" % paths)
+            self.master_only_relation_paths.extend(scan_paths(paths))
 
-            # also get a list of all the databases
+            # the index paths
+            paths = [str(row[0])
+                     for row in dbconn.execSQL(conn, global_index_sql).fetchall()]
+            self.logger.debug("raw index files of global master-only tables: %s" % paths)
+            self.master_only_index_paths.extend(scan_paths(paths))
+
+            # also get a list of the databases
             databases = [str(row[0])
                          for row in catalog.getDatabaseList(conn)]
             self.logger.debug("list of databases: %s" % databases)
@@ -732,18 +753,24 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
                                 , port=self.dburl.pgport
                                 , dbname=database)
             with dbconn.connect(dburl, encoding='UTF8') as conn:
+                # the relation paths
                 paths = [str(row[0])
-                         for row in dbconn.execSQL(conn, per_db_sql).fetchall()]
-                self.logger.debug("raw files of per-database master-only tables: %s" % paths)
-                add_paths(paths)
+                         for row in dbconn.execSQL(conn, per_db_relation_sql).fetchall()]
+                self.logger.debug("raw relation files of per-database master-only tables: %s" % paths)
+                self.master_only_relation_paths.extend(scan_paths(paths))
 
-        self.logger.debug("files of master only tables: %s" % result)
+                # the index paths
+                paths = [str(row[0])
+                         for row in dbconn.execSQL(conn, per_db_index_sql).fetchall()]
+                self.logger.debug("raw index files of per-database master-only tables: %s" % paths)
+                self.master_only_relation_paths.extend(scan_paths(paths))
 
         os.chdir(oldcwd)
 
-        return result
+        self.logger.debug("relation files of master only tables: %s" % self.master_only_relation_paths)
+        self.logger.debug("index files of master only tables: %s" % self.master_only_index_paths)
 
-    def _create_template(self, newTableSpaceInfo=None, excludes=[]):
+    def _create_template(self, newTableSpaceInfo=None):
         """Creates the schema template that is used by new segments"""
         self.logger.info('Creating segment template')
 
@@ -762,6 +789,7 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
 
         try:
             masterSeg = self.gparray.master
+            excludes = self.master_only_relation_paths + self.master_only_index_paths
             cmd = PgBaseBackup(pgdata=self.tempDir,
                                host=masterSeg.getSegmentHostName(),
                                port=str(masterSeg.getSegmentPort()),
@@ -777,11 +805,9 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
         # then there are no user-created tablespaces in the system,
         # no need to consider tablespace problems in gpexpand.
         if newTableSpaceInfo:
-            self._handle_tablespace_template(dummyDBID, newTableSpaceInfo,
-                                             excludes)
+            self._handle_tablespace_template(dummyDBID, newTableSpaceInfo)
 
-    def _handle_tablespace_template(self, dummyDBID, newTableSpaceInfo,
-                                    excludes=[]):
+    def _handle_tablespace_template(self, dummyDBID, newTableSpaceInfo):
         """
         If there are user-created tablespaces in GreenplumDB cluster, we
         have to pack them into the template. The logic here contains two
@@ -822,7 +848,9 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
 
         # build a list of master-only files that are under tablespaces, these
         # files will be ignored during the dumping.
-        full_excludes = []
+        excludes = self.master_only_relation_paths + self.master_only_index_paths
+        full_exclude_relations = []
+        full_exclude_indices = []
         for pathname in excludes:
             if not pathname.startswith('./pg_tblspc/'):
                 # only tablespaces are handled here
@@ -831,9 +859,14 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
             # we need to change it to './16385/<dummyDBID>/GPDB_7_301911081/16386/6052_vm'
             seps = pathname.split(os.sep)
             pathname = os.sep.join([seps[2], str(dummyDBID)] + seps[3:])
-            full_excludes.append(os.path.join(tablespace_template_dir,
-                                              pathname))
+            if pathname in self.master_only_relation_paths:
+                full_exclude_relations.append(os.path.join(tablespace_template_dir,
+                                                           pathname))
+            else:
+                full_exclude_indices.append(os.path.join(tablespace_template_dir,
+                                                         pathname))
 
+        full_excludes = full_exclude_relations + full_exclude_indices
         for tbcspc_oid in tbcspc_oids:
             symlink_path = os.path.join(master_tblspc_dir, tbcspc_oid)
             target_path = os.readlink(symlink_path)
@@ -846,26 +879,34 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
             shutil.rmtree(os.path.join(os.path.dirname(target_path),
                                        str(dummyDBID)))
 
+        with open(os.path.join(self.tempDir,
+                               "pg_tblspc",
+                               "newTableSpaceInfo.json"), "w") as f:
+            json.dump(newTableSpaceInfo, f)
+
+        empty_index = os.path.join(tablespace_template_dir, EMPTY_INDEX)
+
         # the files of the master only tables are already deleted, now add an
         # empty copy of them, so they are seen as empty on the new segments,
         # and we do not need to delete them via sql separately.
         for fullname in full_excludes:
+            # the file should not already exist, however in case it does, which
+            # indicates an error in the excluding logic, raise an error.
+            if os.path.exists(fullname):
+                self.logger.error("Master-only catalog file '%s' is not correctly skipped" % fullname)
+                raise Exception('Invalid exclude list')
             dirname = os.path.dirname(fullname)
             # the template dir is not expected to be updated concurrently,
             # so it is safe to use a check-and-create style to create dirs.
             if not os.path.isdir(dirname):
                 os.makedirs(dirname)
-            # the file should not already exist, however in case it does, which
-            # indicates an error in the excluding logic, raise an error.
-            if os.path.exists(fullname):
-                self.logger.error("Could not exclude file '%s' from the template: file exists" % fullname)
-                raise Exception('Invalid exclude list')
-            open(fullname, 'ab')
-
-        with open(os.path.join(self.tempDir,
-                               "pg_tblspc",
-                               "newTableSpaceInfo.json"), "w") as f:
-            json.dump(newTableSpaceInfo, f)
+            if fullname in full_exclude_relations:
+                # an empty relation file is valid, so touch it directly
+                open(fullname, 'ab')
+            else:
+                # an empty index file is invalid, in needs to contain a b-tree
+                # meta page, so we copy such a file from an existing one
+                shutil.copyfile(empty_index, fullname)
 
     def _gen_DummyDBID(self):
         """gen a random int that surely beyond the possible dbid range"""
@@ -985,7 +1026,7 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
         self._start_new_primary_segments()
         self._stop_new_primary_segments()
 
-    def _fixup_template(self, excludes=[]):
+    def _fixup_template(self):
         """Copies postgresql.conf and pg_hba.conf files from a valid segment on the system.
         Then modifies the template copy of pg_hba.conf"""
 
@@ -1007,6 +1048,9 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
                     remoteHost=self.srcSegHostname)
         cpCmd.run(validateAfter=True)
 
+        excludes = self.master_only_relation_paths + self.master_only_index_paths
+        empty_index = os.path.join(self.tempDir, EMPTY_INDEX)
+
         # the files of the master only tables are already deleted, now add an
         # empty copy of them, so they are seen as empty on the new segments,
         # and we do not need to delete them via sql separately.
@@ -1022,17 +1066,24 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
                 if '.' in filename:
                     # ignore seg files
                     continue
-                # the template dir is not expected to be updated concurrently,
-                # so it is safe to use a check-and-create style to create dirs.
-                if not os.path.isdir(dirname):
-                    os.makedirs(dirname)
                 # the file should not already exist, however in case it does,
                 # which indicates an error in the excluding logic, raise an
                 # error.
                 if os.path.exists(fullname):
-                    self.logger.error("Could not exclude file '%s' from the template: file exists" % fullname)
+                    self.logger.error("Master-only catalog file '%s' is not correctly skipped" % fullname)
                     raise Exception('Invalid exclude list')
-                open(fullname, 'ab')
+                # the template dir is not expected to be updated concurrently,
+                # so it is safe to use a check-and-create style to create dirs.
+                if not os.path.isdir(dirname):
+                    os.makedirs(dirname)
+                if pathname in self.master_only_relation_paths:
+                    # an empty relation file is valid, so touch it directly
+                    open(fullname, 'ab')
+                else:
+                    # an empty index file is invalid, in needs to contain a
+                    # b-tree meta page, so we copy such a file from an existing
+                    # one
+                    shutil.copyfile(empty_index, fullname)
 
     def _tar_template(self):
         """Tars up the template files"""
@@ -1534,15 +1585,8 @@ class gpexpand:
         conn.close()
 
         """
-        Connect to each database in each segment and do some cleanup of tables
-        that have stuff in them as a result of copying the segment from the
-        master.  Note, this functionality used to be in segcopy and was
-        therefore done just once to the original copy of the master.
-
-        Need to start the new segments with the system indexes disabled, this
-        is necessary because the master-only catalog tables are copied as empty
-        files, as well as their index files, the indexes are invalid and should
-        not be used until being reindexed.
+        Connect to each database in each segment and do some cleanup of tables that have stuff in them as a result of copying the segment from the master.
+        Note, this functionality used to be in segcopy and was therefore done just once to the original copy of the master.
         """
         for seg in newSegments:
             if seg.isSegmentMirror() == True:
@@ -1558,8 +1602,7 @@ class gpexpand:
                 , ctxt=REMOTE
                 , remoteHost=seg.getSegmentHostName()
                 , pg_ctl_wait=True
-                , timeout=SEGMENT_TIMEOUT_DEFAULT
-                , disableSystemIndexes=True)
+                , timeout=SEGMENT_TIMEOUT_DEFAULT)
             self.pool.addCommand(segStartCmd)
         self.pool.join()
         self.pool.check_results()
@@ -1596,43 +1639,6 @@ class gpexpand:
         ### need to fix self.pool.check_results(). Call getCompletedItems to clear the queue for now.
         self.pool.check_results()
         self.pool.getCompletedItems()
-
-        # stop the segments
-        for seg in newSegments:
-            if seg.isSegmentMirror():
-                continue
-            """ Stop all the new segments. """
-            segStartCmd = SegmentStop(
-                name="Stopping new segment dbid %s on host %s." % (str(seg.getSegmentDbId()),
-                                                                   seg.getSegmentHostName())
-                , dataDir=seg.getSegmentDataDirectory()
-                , ctxt=REMOTE
-                , remoteHost=seg.getSegmentHostName()
-                , timeout=SEGMENT_TIMEOUT_DEFAULT)
-            self.pool.addCommand(segStartCmd)
-        self.pool.join()
-        self.pool.check_results()
-
-        # restart the segments with index enabled
-        for seg in newSegments:
-            if seg.isSegmentMirror() == True:
-                continue
-            """ Start all the new segments in utilty mode. """
-            segStartCmd = SegmentStart(
-                name="Starting new segment dbid %s on host %s." % (str(seg.getSegmentDbId()),
-                                                                   seg.getSegmentHostName())
-                , gpdb=seg
-                , numContentsInCluster=self.newPrimaryCount  # Starting seg on it's own.
-                , era=None
-                , mirrormode=MIRROR_MODE_MIRRORLESS
-                , utilityMode=True
-                , ctxt=REMOTE
-                , remoteHost=seg.getSegmentHostName()
-                , pg_ctl_wait=True
-                , timeout=SEGMENT_TIMEOUT_DEFAULT)
-            self.pool.addCommand(segStartCmd)
-        self.pool.join()
-        self.pool.check_results()
 
     # --------------------------------------------------------------------------
     def restore_master(self):

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -829,8 +829,8 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
                 continue
             # a pathname is like './pg_tblspc/16385/GPDB_7_301911081/16386/6052_vm'
             # we need to change it to './16385/<dummyDBID>/GPDB_7_301911081/16386/6052_vm'
-            pathname = os.sep.join([pathname.split(os.sep)[2], str(dummyDBID)] +
-                                   pathname.split(os.sep)[3:])
+            seps = pathname.split(os.sep)
+            pathname = os.sep.join([seps[2], str(dummyDBID)] + seps[3:])
             full_excludes.append(os.path.join(tablespace_template_dir,
                                               pathname))
 
@@ -855,7 +855,12 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
             # so it is safe to use a check-and-create style to create dirs.
             if not os.path.isdir(dirname):
                 os.makedirs(dirname)
-            open(fullname, 'wb')
+            # the file should not already exist, however in case it does, which
+            # indicates an error in the excluding logic, raise an error.
+            if os.path.exists(fullname):
+                self.logger.error("Could not exclude file '%s' from the template: file exists" % fullname)
+                raise Exception('Invalid exclude list')
+            open(fullname, 'ab')
 
         with open(os.path.join(self.tempDir,
                                "pg_tblspc",
@@ -1021,7 +1026,13 @@ SELECT pg_catalog.pg_relation_filepath(c.oid)
                 # so it is safe to use a check-and-create style to create dirs.
                 if not os.path.isdir(dirname):
                     os.makedirs(dirname)
-                open(fullname, 'wb')
+                # the file should not already exist, however in case it does,
+                # which indicates an error in the excluding logic, raise an
+                # error.
+                if os.path.exists(fullname):
+                    self.logger.error("Could not exclude file '%s' from the template: file exists" % fullname)
+                    raise Exception('Invalid exclude list')
+                open(fullname, 'ab')
 
     def _tar_template(self):
         """Tars up the template files"""

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -8,6 +8,7 @@ from gppylib.mainUtils import getProgramName
 
 import copy
 import datetime
+import glob
 import os
 import random
 import sys
@@ -626,8 +627,9 @@ class SegmentTemplate:
         """Builds segment template tar file"""
         self.statusLogger.set_status('BUILD_SEGMENT_TEMPLATE_STARTED', self.tempDir)
         # build segment template should consider tablespace files
-        self._create_template(newTableSpaceInfo)
-        self._fixup_template()
+        excludes = self._list_master_only_files()
+        self._create_template(newTableSpaceInfo, excludes=excludes)
+        self._fixup_template(excludes=excludes)
         self._tar_template()
         self.statusLogger.set_status('BUILD_SEGMENT_TEMPLATE_DONE')
 
@@ -640,7 +642,108 @@ class SegmentTemplate:
         numNewSegments = len(self.gparray.getExpansionSegDbList())
         self.statusLogger.set_status('BUILD_SEGMENTS_DONE', numNewSegments)
 
-    def _create_template(self, newTableSpaceInfo=None):
+    def _list_master_only_files(self):
+        """Build a list of files of master only tables and their indexes.
+
+        The content of master only tables should be cleared or refilled on the
+        new segments, by including an empty copy of the heap & index files less
+        data is transferred via network and there is no need to delete the
+        content on the segments explicitly.
+
+        However empty index files are actually invalid, we need to reindex the
+        master only tables on the new segments to rebuild the index files, this
+        is fast as the heap files are all empty.
+        """
+
+        self.logger.info("Building the file list of master only tables")
+
+        regclasses = ["'%s'::regclass::oid" % tab
+                      for tab in MASTER_ONLY_TABLES]
+        regclasses = "(" + ", ".join(regclasses) + ")"
+        self.logger.debug("master only tables: %s" % regclasses)
+
+        global_sql = """
+/* relation files */
+SELECT pg_catalog.pg_relation_filepath(c.oid)
+  FROM pg_catalog.pg_class c
+ WHERE c.oid IN %s
+   AND c.relfilenode = 0
+
+UNION ALL
+
+/* index files */
+SELECT pg_catalog.pg_relation_filepath(i.indexrelid)
+  FROM pg_catalog.pg_index i
+  JOIN pg_catalog.pg_class c
+    ON i.indexrelid = c.oid
+ WHERE i.indrelid IN %s
+   AND c.relfilenode = 0
+""" % (regclasses, regclasses)
+
+        per_db_sql = """
+/* relation files */
+SELECT pg_catalog.pg_relation_filepath(c.oid)
+  FROM pg_catalog.pg_class c
+ WHERE c.oid IN %s
+   AND c.relfilenode <> 0
+""" % (regclasses)
+
+        result = []
+
+        def add_paths(paths):
+            """we need to include not only the relation/index files,
+            but also visibility, free space and seg files"""
+            for path in paths:
+                # ${filenode}: the relation file itself
+                result.append(os.path.join('.', path))
+                # ${filenode}_vm: the visibility map
+                # ${filenode}_fsm: the free space map
+                result.extend(glob.glob('./%s_*' % path))
+                # ${filenode}.[1-9][0-9]*: the seg files
+                result.extend(glob.glob('./%s.*' % path))
+
+        # the file list will be passed to pg_basebackup as the exclude list,
+        # it expects the paths are like "./global/1234", so we must chdir to
+        # the master data dir.
+        oldcwd = os.getcwd()
+        os.chdir(self.masterDataDirectory)
+
+        # first list the global master-only tables
+        with dbconn.connect(self.dburl, encoding='UTF8') as conn:
+            paths = [str(row[0])
+                     for row in dbconn.execSQL(conn, global_sql).fetchall()]
+            self.logger.debug("raw files of global master-only tables: %s" % paths)
+            add_paths(paths)
+
+            # also get a list of all the databases
+            databases = [str(row[0])
+                         for row in catalog.getDatabaseList(conn)]
+            self.logger.debug("list of databases: %s" % databases)
+
+        # then list the per-database master-only tables
+        for database in databases:
+            # template0 does not accept connections, so we have no chance to
+            # clear the master-only tables on it, however we expect this
+            # database to be small enough, so it can be safely ignored.
+            if database == 'template0':
+                continue
+
+            dburl = dbconn.DbURL( hostname=self.dburl.pghost
+                                , port=self.dburl.pgport
+                                , dbname=database)
+            with dbconn.connect(dburl, encoding='UTF8') as conn:
+                paths = [str(row[0])
+                         for row in dbconn.execSQL(conn, per_db_sql).fetchall()]
+                self.logger.debug("raw files of per-database master-only tables: %s" % paths)
+                add_paths(paths)
+
+        self.logger.debug("files of master only tables: %s" % result)
+
+        os.chdir(oldcwd)
+
+        return result
+
+    def _create_template(self, newTableSpaceInfo=None, excludes=[]):
         """Creates the schema template that is used by new segments"""
         self.logger.info('Creating segment template')
 
@@ -663,6 +766,7 @@ class SegmentTemplate:
                                host=masterSeg.getSegmentHostName(),
                                port=str(masterSeg.getSegmentPort()),
                                recovery_mode=False,
+                               excludePaths=excludes,
                                target_gp_dbid=dummyDBID)
             cmd.run(validateAfter=True)
         except Exception, msg:
@@ -673,9 +777,11 @@ class SegmentTemplate:
         # then there are no user-created tablespaces in the system,
         # no need to consider tablespace problems in gpexpand.
         if newTableSpaceInfo:
-            self._handle_tablespace_template(dummyDBID, newTableSpaceInfo)
+            self._handle_tablespace_template(dummyDBID, newTableSpaceInfo,
+                                             excludes)
 
-    def _handle_tablespace_template(self, dummyDBID, newTableSpaceInfo):
+    def _handle_tablespace_template(self, dummyDBID, newTableSpaceInfo,
+                                    excludes=[]):
         """
         If there are user-created tablespaces in GreenplumDB cluster, we
         have to pack them into the template. The logic here contains two
@@ -714,15 +820,42 @@ class SegmentTemplate:
                                                "dumps")
         os.mkdir(tablespace_template_dir)
 
+        # build a list of master-only files that are under tablespaces, these
+        # files will be ignored during the dumping.
+        full_excludes = []
+        for pathname in excludes:
+            if not pathname.startswith('./pg_tblspc/'):
+                # only tablespaces are handled here
+                continue
+            # a pathname is like './pg_tblspc/16385/GPDB_7_301911081/16386/6052_vm'
+            # we need to change it to './16385/<dummyDBID>/GPDB_7_301911081/16386/6052_vm'
+            pathname = os.sep.join([pathname.split(os.sep)[2], str(dummyDBID)] +
+                                   pathname.split(os.sep)[3:])
+            full_excludes.append(os.path.join(tablespace_template_dir,
+                                              pathname))
+
         for tbcspc_oid in tbcspc_oids:
             symlink_path = os.path.join(master_tblspc_dir, tbcspc_oid)
             target_path = os.readlink(symlink_path)
             os.mkdir(os.path.join(tablespace_template_dir, tbcspc_oid))
             # the target name for copytree does not impact anything
             shutil.copytree(target_path,
-                        os.path.join(tablespace_template_dir, tbcspc_oid, str(dummyDBID)))
+                            os.path.join(tablespace_template_dir,
+                                         tbcspc_oid, str(dummyDBID)),
+                            shutil.ignore_patterns(full_excludes))
             shutil.rmtree(os.path.join(os.path.dirname(target_path),
                                        str(dummyDBID)))
+
+        # the files of the master only tables are already deleted, now add an
+        # empty copy of them, so they are seen as empty on the new segments,
+        # and we do not need to delete them via sql separately.
+        for fullname in full_excludes:
+            dirname = os.path.dirname(fullname)
+            # the template dir is not expected to be updated concurrently,
+            # so it is safe to use a check-and-create style to create dirs.
+            if not os.path.isdir(dirname):
+                os.makedirs(dirname)
+            open(fullname, 'wb')
 
         with open(os.path.join(self.tempDir,
                                "pg_tblspc",
@@ -847,7 +980,7 @@ class SegmentTemplate:
         self._start_new_primary_segments()
         self._stop_new_primary_segments()
 
-    def _fixup_template(self):
+    def _fixup_template(self, excludes=[]):
         """Copies postgresql.conf and pg_hba.conf files from a valid segment on the system.
         Then modifies the template copy of pg_hba.conf"""
 
@@ -868,6 +1001,27 @@ class SegmentTemplate:
                     dstFile=self.tempDir, dstHost=localHostname,ctxt=REMOTE,
                     remoteHost=self.srcSegHostname)
         cpCmd.run(validateAfter=True)
+
+        # the files of the master only tables are already deleted, now add an
+        # empty copy of them, so they are seen as empty on the new segments,
+        # and we do not need to delete them via sql separately.
+        if excludes:
+            self.logger.info('Creating an empty copy of excluded files')
+            for pathname in excludes:
+                if pathname.startswith('./pg_tblspc/'):
+                    # tablespaces are handled separately
+                    continue
+                fullname = os.path.join(self.tempDir, pathname)
+                filename = os.path.basename(fullname)
+                dirname = os.path.dirname(fullname)
+                if '.' in filename:
+                    # ignore seg files
+                    continue
+                # the template dir is not expected to be updated concurrently,
+                # so it is safe to use a check-and-create style to create dirs.
+                if not os.path.isdir(dirname):
+                    os.makedirs(dirname)
+                open(fullname, 'wb')
 
     def _tar_template(self):
         """Tars up the template files"""
@@ -1369,8 +1523,15 @@ class gpexpand:
         conn.close()
 
         """
-        Connect to each database in each segment and do some cleanup of tables that have stuff in them as a result of copying the segment from the master.
-        Note, this functionality used to be in segcopy and was therefore done just once to the original copy of the master.
+        Connect to each database in each segment and do some cleanup of tables
+        that have stuff in them as a result of copying the segment from the
+        master.  Note, this functionality used to be in segcopy and was
+        therefore done just once to the original copy of the master.
+
+        Need to start the new segments with the system indexes disabled, this
+        is necessary because the master-only catalog tables are copied as empty
+        files, as well as their index files, the indexes are invalid and should
+        not be used until being reindexed.
         """
         for seg in newSegments:
             if seg.isSegmentMirror() == True:
@@ -1386,16 +1547,18 @@ class gpexpand:
                 , ctxt=REMOTE
                 , remoteHost=seg.getSegmentHostName()
                 , pg_ctl_wait=True
-                , timeout=SEGMENT_TIMEOUT_DEFAULT)
+                , timeout=SEGMENT_TIMEOUT_DEFAULT
+                , disableSystemIndexes=True)
             self.pool.addCommand(segStartCmd)
         self.pool.join()
         self.pool.check_results()
 
         """
-        Build the list of delete statements based on the MASTER_ONLY_TABLES
+        Build the list of reindex statements based on the MASTER_ONLY_TABLES
         defined in gpcatalog.py
         """
-        statements = ["delete from pg_catalog.%s" % tab for tab in MASTER_ONLY_TABLES]
+        statements = ["REINDEX TABLE pg_catalog.%s" % tab
+                      for tab in MASTER_ONLY_TABLES]
 
         """
           Connect to each database in the new segments, and clean up the catalog tables.
@@ -1422,6 +1585,43 @@ class gpexpand:
         ### need to fix self.pool.check_results(). Call getCompletedItems to clear the queue for now.
         self.pool.check_results()
         self.pool.getCompletedItems()
+
+        # stop the segments
+        for seg in newSegments:
+            if seg.isSegmentMirror():
+                continue
+            """ Stop all the new segments. """
+            segStartCmd = SegmentStop(
+                name="Stopping new segment dbid %s on host %s." % (str(seg.getSegmentDbId()),
+                                                                   seg.getSegmentHostName())
+                , dataDir=seg.getSegmentDataDirectory()
+                , ctxt=REMOTE
+                , remoteHost=seg.getSegmentHostName()
+                , timeout=SEGMENT_TIMEOUT_DEFAULT)
+            self.pool.addCommand(segStartCmd)
+        self.pool.join()
+        self.pool.check_results()
+
+        # restart the segments with index enabled
+        for seg in newSegments:
+            if seg.isSegmentMirror() == True:
+                continue
+            """ Start all the new segments in utilty mode. """
+            segStartCmd = SegmentStart(
+                name="Starting new segment dbid %s on host %s." % (str(seg.getSegmentDbId()),
+                                                                   seg.getSegmentHostName())
+                , gpdb=seg
+                , numContentsInCluster=self.newPrimaryCount  # Starting seg on it's own.
+                , era=None
+                , mirrormode=MIRROR_MODE_MIRRORLESS
+                , utilityMode=True
+                , ctxt=REMOTE
+                , remoteHost=seg.getSegmentHostName()
+                , pg_ctl_wait=True
+                , timeout=SEGMENT_TIMEOUT_DEFAULT)
+            self.pool.addCommand(segStartCmd)
+        self.pool.join()
+        self.pool.check_results()
 
     # --------------------------------------------------------------------------
     def restore_master(self):

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -210,6 +210,13 @@ class PgCtlBackendOptions(CmdArgs):
         if restricted:  self.append("-c superuser_reserved_connections=%s" % max_connections)
         return self
 
+    def set_disable_system_indexes(self, disable):
+        """
+        @param disable: true if disabling system indexes
+        """
+        if disable: self.append("-P")
+        return self
+
 
 class PgCtlStartArgs(CmdArgs):
     """
@@ -337,7 +344,8 @@ class SegmentStart(Command):
     def __init__(self, name, gpdb, numContentsInCluster, era, mirrormode,
                  utilityMode=False, ctxt=LOCAL, remoteHost=None,
                  pg_ctl_wait=True, timeout=SEGMENT_TIMEOUT_DEFAULT,
-                 specialMode=None, wrapper=None, wrapper_args=None):
+                 specialMode=None, wrapper=None, wrapper_args=None,
+                 disableSystemIndexes=False):
 
         # This is referenced from calling code
         self.segment = gpdb
@@ -350,6 +358,7 @@ class SegmentStart(Command):
         b = PgCtlBackendOptions(port)
         b.set_utility(utilityMode)
         b.set_special(specialMode)
+        b.set_disable_system_indexes(disableSystemIndexes)
 
         # build pg_ctl command
         c = PgCtlStartArgs(datadir, b, era, wrapper, wrapper_args, pg_ctl_wait, timeout)

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -210,13 +210,6 @@ class PgCtlBackendOptions(CmdArgs):
         if restricted:  self.append("-c superuser_reserved_connections=%s" % max_connections)
         return self
 
-    def set_disable_system_indexes(self, disable):
-        """
-        @param disable: true if disabling system indexes
-        """
-        if disable: self.append("-P")
-        return self
-
 
 class PgCtlStartArgs(CmdArgs):
     """
@@ -344,8 +337,7 @@ class SegmentStart(Command):
     def __init__(self, name, gpdb, numContentsInCluster, era, mirrormode,
                  utilityMode=False, ctxt=LOCAL, remoteHost=None,
                  pg_ctl_wait=True, timeout=SEGMENT_TIMEOUT_DEFAULT,
-                 specialMode=None, wrapper=None, wrapper_args=None,
-                 disableSystemIndexes=False):
+                 specialMode=None, wrapper=None, wrapper_args=None):
 
         # This is referenced from calling code
         self.segment = gpdb
@@ -358,7 +350,6 @@ class SegmentStart(Command):
         b = PgCtlBackendOptions(port)
         b.set_utility(utilityMode)
         b.set_special(specialMode)
-        b.set_disable_system_indexes(disableSystemIndexes)
 
         # build pg_ctl command
         c = PgCtlStartArgs(datadir, b, era, wrapper, wrapper_args, pg_ctl_wait, timeout)

--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -23,25 +23,24 @@ class GPCatalogException(Exception):
 
 # Hard coded since "master only" is not defined in the catalog
 MASTER_ONLY_TABLES = [
-    'gp_segment_configuration',
     'gp_configuration_history',
     'gp_segment_configuration',
+    'pg_auth_time_constraint',
     'pg_description',
     'pg_partition',
+    'pg_partition_encoding',
     'pg_partition_rule',
     'pg_shdescription',
     'pg_stat_last_operation',
     'pg_stat_last_shoperation',
     'pg_statistic',
-    'pg_partition_encoding',
-    'pg_auth_time_constraint',
     ]
 
 # Hard coded tables that have different values on every segment
 SEGMENT_LOCAL_TABLES = [
+    'gp_fastsequence', # AO segment row id allocations
     'gp_id',
     'pg_shdepend', # (not if we fix oid inconsistencies)
-    'gp_fastsequence', # AO segment row id allocations
     'pg_statistic',
     ]
 

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -4,8 +4,8 @@ Feature: expand the cluster by adding more segments
     @gpexpand_no_mirrors
     @gpexpand_timing
     Scenario: after resuming a duration interrupted redistribution, tables are restored
-	Given the database is not running
-	And a working directory of the test as '/data/gpdata/gpexpand'
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And a cluster is created with no mirrors on "mdw" and "sdw1"
         And the master pid has been saved
@@ -30,7 +30,7 @@ Feature: expand the cluster by adding more segments
     @gpexpand_timing
     @gpexpand_standby
     Scenario: after a duration interrupted redistribution, state file on standby matches master
-    	Given the database is not running
+        Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
         And a cluster is created with no mirrors on "mdw" and "sdw1"
@@ -87,7 +87,7 @@ Feature: expand the cluster by adding more segments
 
     @gpexpand_no_mirrors
     @gpexpand_host
-    Scenario: expand a cluster that has no mirrors with one new hosts
+    Scenario: expand a cluster that has no mirrors on one new host
         Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
@@ -103,7 +103,7 @@ Feature: expand the cluster by adding more segments
 
     @gpexpand_no_mirrors
     @gpexpand_host_and_segment
-    Scenario: expand a cluster that has no mirrors with one new hosts
+    Scenario: expand a cluster that has no mirrors on both old and new hosts
         Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
@@ -153,7 +153,7 @@ Feature: expand the cluster by adding more segments
 
     @gpexpand_mirrors
     @gpexpand_host
-    Scenario: expand a cluster that has mirrors with one new hosts
+    Scenario: expand a cluster that has mirrors on one new host
         Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
@@ -170,7 +170,7 @@ Feature: expand the cluster by adding more segments
     @gpexpand_mirrors
     @gpexpand_host_and_segment
     @gpexpand_standby
-    Scenario: expand a cluster that has mirrors with one new host
+    Scenario: expand a cluster that has mirrors on both old and new hosts
         Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
@@ -181,7 +181,7 @@ Feature: expand the cluster by adding more segments
         And the cluster is setup for an expansion on hosts "mdw,sdw1,sdw2,sdw3"
         And the new host "sdw2,sdw3" is ready to go
         When the user runs gpexpand interview to add 1 new segment and 2 new host "sdw2,sdw3"
-       Then the number of segments have been saved
+        Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 14 new segments
 
@@ -195,8 +195,8 @@ Feature: expand the cluster by adding more segments
         And a cluster is created with mirrors on "mdw" and "sdw1"
         And the user runs gpinitstandby with options " "
         And database "gptest" exists
-	And a tablespace is created with data
-	And another tablespace is created with data
+        And a tablespace is created with data
+        And another tablespace is created with data
         And there are no gpexpand_inputfiles
         And the cluster is setup for an expansion on hosts "mdw,sdw1,sdw2,sdw3"
         And the new host "sdw2,sdw3" is ready to go
@@ -204,8 +204,8 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 14 new segments
-	When the user runs gpexpand to redistribute
-	Then the tablespace is valid after gpexpand
+        When the user runs gpexpand to redistribute
+        Then the tablespace is valid after gpexpand
 
     @gpexpand_verify_redistribution
     Scenario: Verify data is correctly redistributed after expansion
@@ -289,7 +289,7 @@ Feature: expand the cluster by adding more segments
     @gpexpand_no_mirrors
     @gpexpand_no_restart
     @gpexpand_conf_copied
-    Scenario: expand a cluster without restarting db and conf has been copie
+    Scenario: expand a cluster without restarting db and conf has been copied
         Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And the user runs command "rm -rf /data/gpdata/gpexpand/*"
@@ -426,7 +426,7 @@ Feature: expand the cluster by adding more segments
     @gpexpand_mirrors
     @gpexpand_retry_failing_work_in_phase1_after_releasing_catalog_lock
     Scenario: inject a fail and test if retry is ok
-    	Given the database is not running
+        Given the database is not running
         And a working directory of the test as '/data/gpdata/gpexpand'
         And the user runs command "rm -rf /data/gpdata/gpexpand/*"
         And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -84,6 +84,7 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 2 new segments
+        And verify that the master-only tables are empty on one new segment
 
     @gpexpand_no_mirrors
     @gpexpand_host
@@ -100,6 +101,7 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 2 new segments
+        And verify that the master-only tables are empty on one new segment
 
     @gpexpand_no_mirrors
     @gpexpand_host_and_segment
@@ -116,6 +118,7 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 4 new segments
+        And verify that the master-only tables are empty on one new segment
 
     @gpexpand_mirrors
     @gpexpand_segment
@@ -130,6 +133,7 @@ Feature: expand the cluster by adding more segments
         And the number of segments have been saved
         When the user runs gpexpand with a static inputfile for a single-node cluster with mirrors
         Then verify that the cluster has 4 new segments
+        And verify that the master-only tables are empty on one new segment
 
     @gpexpand_mirrors
     @gpexpand_segment
@@ -166,6 +170,7 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 8 new segments
+        And verify that the master-only tables are empty on one new segment
 
     @gpexpand_mirrors
     @gpexpand_host_and_segment
@@ -184,6 +189,7 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that the cluster has 14 new segments
+        And verify that the master-only tables are empty on one new segment
 
     @gpexpand_mirrors
     @gpexpand_host_and_segment

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -30,6 +30,7 @@ from time import sleep
 from os import path
 
 from gppylib.gparray import GpArray, ROLE_PRIMARY, ROLE_MIRROR
+from gppylib.gpcatalog import MASTER_ONLY_TABLES
 from gppylib.commands.gp import SegmentStart, GpStandbyStart, MasterStop
 from gppylib.commands import gp
 from gppylib.commands.unix import findCmdInPath, Scp
@@ -2375,6 +2376,31 @@ def impl(context, num_of_segments):
     raise Exception("Incorrect amount of segments.\nprevious: %s\ncurrent:"
             "%s\ndump of gp_segment_configuration: %s" %
             (context.start_data_segments, end_data_segments, rows))
+
+@then('verify that the master-only tables are empty on one new segment')
+def impl(context):
+    dbname = 'gptest'
+
+    # lookup the port of the newest primary segment
+    with dbconn.connect(dbconn.DbURL(dbname=dbname),
+                        unsetSearchPath=False) as conn:
+        query = """SELECT address, port
+                     FROM gp_segment_configuration
+                    WHERE role = 'p'
+                    ORDER BY content DESC
+                    LIMIT 1;"""
+        row = dbconn.execSQLForSingletonRow(conn, query)
+        address = str(row[0])
+        port = int(row[1])
+
+    # verify that all the master-only tables are empty on this new segment
+    with dbconn.connect(dbconn.DbURL(dbname=dbname, hostname=address, port=port),
+                        unsetSearchPath=False, utility=True) as conn:
+        for tab in MASTER_ONLY_TABLES:
+            query = "SELECT count(*) FROM %s;" % tab
+            count = int(dbconn.execSQLForSingleton(conn, query))
+            if count > 0:
+                raise Exception("Master-only table '%s' is not empty on the new segments" % tab)
 
 @given('the cluster is setup for an expansion on hosts "{hostnames}"')
 def impl(context, hostnames):


### PR DESCRIPTION
Gpexpand creates new primary segments by first creating a template from
the master datadir and then copying it to the new segments. Some
catalog tables are only meaningful on master, such as
gp_segment_configuration, their content are then cleared on each new
segment with the "delete from ..." commands.

This works but is slow because we have to include the content of the
master-only tables in the archive, distribute them via network, and
clear them via the slow "delete from ..." commands -- the "truncate"
command is fast but it is disallowed on catalog tables as filenode must
not be changed for catalog tables.

To make it faster we now exclude these tables from the template
directly, so less data are transferred and there is no need to "delete
from" them explicitly.

---

This is the V2 of https://github.com/greenplum-db/gpdb/pull/9481, which was merged but reverted, the problem of that PR is that it didn't do the filenode mapping correctly and didn't put tablespaces into consideration.

In this V2 patchset we have corrected the problems.  It has been verified on devel pipelines for both master and 6X.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
