### PR TITLE
Remove long-deprecated -u option from pg_dump/pg_restore

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -604,7 +604,7 @@ main(int argc, char **argv)
 
 	InitDumpOptions(&dopt);
 
-	while ((c = getopt_long(argc, argv, "abcCd:E:f:F:h:j:n:N:oOp:RsS:t:T:uU:vwWxZ:",
+	while ((c = getopt_long(argc, argv, "abcCd:E:f:F:h:j:n:N:oOp:RsS:t:T:U:vwWxZ:",
 							long_options, &optindex)) != -1)
 	{
 		switch (c)
@@ -689,11 +689,6 @@ main(int argc, char **argv)
 
 			case 'T':			/* exclude table(s) */
 				simple_string_list_append(&table_exclude_patterns, optarg);
-				break;
-
-			case 'u':
-				prompt_password = TRI_YES;
-				dopt.username = simple_prompt("User name: ", 100, true);
 				break;
 
 			case 'U':

--- a/src/bin/pg_dump/pg_restore.c
+++ b/src/bin/pg_dump/pg_restore.c
@@ -153,7 +153,7 @@ main(int argc, char **argv)
 		}
 	}
 
-	while ((c = getopt_long(argc, argv, "acCd:ef:F:h:I:j:lL:n:Op:P:RsS:t:T:uU:vwWx:1",
+	while ((c = getopt_long(argc, argv, "acCd:ef:F:h:I:j:lL:n:Op:P:RsS:t:T:U:vwWx:1",
 							cmdopts, NULL)) != -1)
 	{
 		switch (c)
@@ -238,11 +238,6 @@ main(int argc, char **argv)
 				opts->selTypes = 1;
 				opts->selTable = 1;
 				simple_string_list_append(&opts->tableNames, optarg);
-				break;
-
-			case 'u':
-				opts->promptPassword = TRI_YES;
-				opts->username = simple_prompt("User name: ", 100, true);
 				break;
 
 			case 'U':


### PR DESCRIPTION
The -u option was removed a very long time ago, but remnants of the the patch was left in pg_dump and pg_restore. Finally remove -u as it's not useful, not documented and not used in any Greenplum management utility.

The below commit performed the removal in upstream:
```
commit 1161f1ae1474e373ac02fd24898f12d9c7c43436
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Tue Dec 11 19:01:06 2007 +0000

    Remove the long-deprecated -u option from psql, since it does nothing very
    useful and confuses people who think it is the same as -U.  (Eventually
    we might want to re-introduce it as being an alias for -U, but that should
    not happen until the switch has actually not been there for a few releases.)
    Likewise in pg_dump and pg_restore.  Per gripe from Robert Treat and
    subsequent discussion. 
```