### PR TITLE
Print physical file path when checksum check fails

### DIFF
--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -994,17 +994,20 @@ ReadBuffer_common(SMgrRelation smgr, char relpersistence, ForkNumber forkNum,
 				{
 					ereport(WARNING,
 							(errcode(ERRCODE_DATA_CORRUPTED),
-							 errmsg("invalid page in block %u of relation %s; zeroing out page",
+							 errmsg("invalid page in block %u of relation %s, "
+									"file path %s; zeroing out page",
 									blockNum,
-									relpath(smgr->smgr_rnode, forkNum))));
+									relpath(smgr->smgr_rnode, forkNum),
+									relfilepath(smgr->smgr_rnode, forkNum, blockNum))));
 					MemSet((char *) bufBlock, 0, BLCKSZ);
 				}
 				else
 					ereport(ERROR,
 							(errcode(ERRCODE_DATA_CORRUPTED),
-							 errmsg("invalid page in block %u of relation %s",
+							 errmsg("invalid page in block %u of relation %s, file path %s",
 									blockNum,
-									relpath(smgr->smgr_rnode, forkNum))));
+									relpath(smgr->smgr_rnode, forkNum),
+									relfilepath(smgr->smgr_rnode, forkNum, blockNum))));
 			}
 		}
 	}

--- a/src/common/relpath.c
+++ b/src/common/relpath.c
@@ -214,3 +214,30 @@ GetRelationPath(Oid dbNode, Oid spcNode, Oid relNode,
 	}
 	return path;
 }
+
+/*
+ * GetRelationFilePath - construct path to a relation's physical file
+ * given its block number.
+ */
+	char *
+GetRelationFilePath(Oid dbNode, Oid spcNode, Oid relNode,
+					int backendId, ForkNumber forkNumber, BlockNumber blkno)
+{
+	char	   *path;
+	char	   *fullpath;
+	BlockNumber	segno;
+
+	path = GetRelationPath(dbNode, spcNode, relNode, backendId, forkNumber);
+
+	segno = blkno / ((BlockNumber) RELSEG_SIZE);
+
+	if (segno > 0)
+	{
+		fullpath = psprintf("%s.%u", path, segno);
+		pfree(path);
+	}
+	else
+		fullpath = path;
+
+	return fullpath;
+}

--- a/src/include/common/relpath.h
+++ b/src/include/common/relpath.h
@@ -13,6 +13,8 @@
 #ifndef RELPATH_H
 #define RELPATH_H
 
+#include "storage/block.h"
+
 /*
  * Stuff for fork names.
  *
@@ -58,7 +60,10 @@ extern int	forkname_chars(const char *str, ForkNumber *fork);
 extern char *GetDatabasePath(Oid dbNode, Oid spcNode);
 
 extern char *GetRelationPath(Oid dbNode, Oid spcNode, Oid relNode,
-				int backendId, ForkNumber forkNumber);
+							 int backendId, ForkNumber forkNumber);
+
+extern char *GetRelationFilePath(Oid dbNode, Oid spcNode, Oid relNode,
+								 int backendId, ForkNumber forkNumber, BlockNumber blkno);
 
 /*
  * Wrapper macros for GetRelationPath.  Beware of multiple
@@ -80,5 +85,21 @@ extern char *GetRelationPath(Oid dbNode, Oid spcNode, Oid relNode,
 
 #define aorelpath(rnode, segno) \
 		aorelpathbackend((rnode).node, (rnode).backend, (segno))
+
+/*
+ * File path of a relation given the block number.
+ * Note that a file can contain at most RELSEG_SIZE number
+ * of blocks. We supply relfilepath macro to display the
+ * physical file name for a relation given the block number.
+ */
+
+/* First argument is a RelFileNode */
+#define relfilepathbackend(rnode, backend, forknum, blkno) \
+	GetRelationFilePath((rnode).dbNode, (rnode).spcNode, (rnode).relNode, \
+						backend, forknum, blkno)
+
+/* First argument is a RelFileNodeBackend */
+#define relfilepath(rnode, forknum, blkno) \
+	relfilepathbackend((rnode).node, (rnode).backend, forknum, blkno)
 
 #endif   /* RELPATH_H */


### PR DESCRIPTION
DBA needs to calculate and locate the broken file manually
when checksum check fails.
Better to print this file path in error message as well.

heap_checksum test cases cover the case for file's segno is zero.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
