### PR TITLE
Fix incorrect spelling in docs/comments

### DIFF
--- a/concourse/scripts/configurations/pg_upgrade_gpinitsystem_config
+++ b/concourse/scripts/configurations/pg_upgrade_gpinitsystem_config
@@ -63,5 +63,5 @@ ENCODING=UNICODE
 #DATABASE_NAME=name_of_database
 
 #### Specify the location of the host address file here instead of
-#### with the the -h option of gpinitsystem.
+#### with the -h option of gpinitsystem.
 #MACHINE_LIST_FILE=/home/gpadmin/gpconfigs/hostfile_gpinitsystem

--- a/doc/src/sgml/ref/create_role.sgml
+++ b/doc/src/sgml/ref/create_role.sgml
@@ -324,7 +324,7 @@ CREATE ROLE <replaceable class="PARAMETER">name</replaceable> [ [ WITH ] <replac
       <term><literal>RESOURCE GROUP</> <replaceable class="parameter">group_name</replaceable></term>
       <listitem>
        <para>
-        The name of the resource group to assign to the the new role. The
+        The name of the resource group to assign to the new role. The
         role will be subject to the concurrent transaction, memory, and
         CPU limits configured for the resource group. You can assign a
         single resource group to one or more roles.

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1574,7 +1574,7 @@ class gpexpand:
         self.statusLogger.set_status('PREPARE_EXPANSION_SCHEMA_DONE')
         self.statusLogger.set_status('EXPANSION_PREPARE_DONE')
 
-        # At this point, no rollback is possible and the the system
+        # At this point, no rollback is possible and the system
         # including new segments has been started once before so finalize
         self.finalize_prepare()
 

--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -1499,7 +1499,7 @@ class GpArray:
     def reOrderExpansionSegs(self):
         """
         The expansion segments content ID may have changed during the expansion.
-        This method will re-order the the segments into their proper positions.
+        This method will re-order the segments into their proper positions.
         Since there can be no gaps in the content id (see validateExpansionSegs),
         the self.expansionSegmentPairs list is the same length.
         """

--- a/gpMgmt/bin/gppylib/system/info.py
+++ b/gpMgmt/bin/gppylib/system/info.py
@@ -29,7 +29,7 @@ def get_max_available_thread_count():
     # assuming a generous 10K bytes per line of error output,
     # 20 MB allows 2000 errors in a single run; if user has more,
     # we will explain in the manual
-    # the the user can always set batch (number of threads) manually
+    # the user can always set batch (number of threads) manually
     thread_size = 20 * MB + stack_size
 
     mem = psutil.virtual_memory()

--- a/gpMgmt/bin/gpssh-exkeys
+++ b/gpMgmt/bin/gpssh-exkeys
@@ -541,7 +541,7 @@ try:
     ######################
     #  step 1
     #
-    #    Creates an SSH id_rsa key pair for for the current user if not already available
+    #    Creates an SSH id_rsa key pair for the current user if not already available
     #    and appends the id_rsa.pub key to the local authorized_keys file.
     #
     print '[STEP 1 of 5] create local ID and authorize on local host'

--- a/gpMgmt/doc/gpconfigs/gpinitsystem_config
+++ b/gpMgmt/doc/gpconfigs/gpinitsystem_config
@@ -63,5 +63,5 @@ ENCODING=UNICODE
 #DATABASE_NAME=name_of_database
 
 #### Specify the location of the host address file here instead of
-#### with the the -h option of gpinitsystem.
+#### with the -h option of gpinitsystem.
 #MACHINE_LIST_FILE=/home/gpadmin/gpconfigs/hostfile_gpinitsystem

--- a/gpMgmt/doc/gpconfigs/gpinitsystem_test
+++ b/gpMgmt/doc/gpconfigs/gpinitsystem_test
@@ -63,5 +63,5 @@ declare -a MIRROR_DATA_DIRECTORY=(/media/ephemeral1/mirror /media/ephemeral1/mir
 #DATABASE_NAME=name_of_database
 
 #### Specify the location of the host address file here instead of
-#### with the the -h option of gpinitsystem.
+#### with the -h option of gpinitsystem.
 MACHINE_LIST_FILE=hostfile_gpinitsystem

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -245,7 +245,7 @@ Feature: gprecoverseg tests
         And gprecoverseg should print "Heap checksum setting is consistent between master and the segments that are candidates for recoverseg" to stdout
         And all the segments are running
         And the segments are synchronized
-        # validate the the new segment has the correct setting by getting admin connection to that segment
+        # validate the new segment has the correct setting by getting admin connection to that segment
         Then the saved primary segment reports the same value for sql "show data_checksums" db "template1" as was saved
 
     @concourse_cluster

--- a/gpdb-doc/dita/admin_guide/kerberos-lin-client.xml
+++ b/gpdb-doc/dita/admin_guide/kerberos-lin-client.xml
@@ -103,7 +103,7 @@
           for the Greenplum Database user. </li>
         <li id="kd158478">Run <codeph>kinit</codeph> specifying the keytab file to create a ticket
           on the client machine. For this example, the keytab file
-            <codeph>gpdb-kerberos.keytab</codeph> is in the the current directory. The ticket cache
+            <codeph>gpdb-kerberos.keytab</codeph> is in the current directory. The ticket cache
           file is in the <codeph>gpadmin</codeph> user home directory.
           <codeblock>&gt; kinit -k -t gpdb-kerberos.keytab -c /home/gpadmin/cache.txt 
    gpadmin/kerberos-gpdb@KRB.EXAMPLE.COM</codeblock></li>

--- a/gpdb-doc/dita/admin_guide/managing/maintain.xml
+++ b/gpdb-doc/dita/admin_guide/managing/maintain.xml
@@ -35,7 +35,7 @@
           <codeph>VACUUM FULL</codeph> ignores the value of
           <codeph>gp_appendonly_compaction_threshold</codeph> and rewrites the segment file
         regardless of the ratio.</p>
-      <p>You can use the <codeph>__gp_aovisimap_compaction_info()</codeph> function in the the
+      <p>You can use the <codeph>__gp_aovisimap_compaction_info()</codeph> function in the
           <i>gp_toolkit</i> schema to investigate the effectiveness of a <cmdname>VACUUM</cmdname>
         operation on append-optimized tables. </p>
       <p>For information about the <codeph>__gp_aovisimap_compaction_info()</codeph> function see,

--- a/gpdb-doc/dita/analytics/madlib.xml
+++ b/gpdb-doc/dita/analytics/madlib.xml
@@ -40,7 +40,7 @@
         unsupervised learning methods. </p>
       <p dir="ltr">In the area of model selection, MADlib supports cross validation and the most
         common prediction metrics for evaluating the quality of predictions of a model. Please refer
-        the the <xref href="http://madlib.apache.org/docs/latest/index.html" format="html"
+        the <xref href="http://madlib.apache.org/docs/latest/index.html" format="html"
           scope="external">MADlib user guide</xref> for more information on these methods.</p>
       <p> </p>
     </section>

--- a/gpdb-doc/dita/best_practices/encryption.xml
+++ b/gpdb-doc/dita/best_practices/encryption.xml
@@ -277,7 +277,7 @@ ssb   2048R/4FD2EFBB 2015-01-13
 # gpg -a --export-secret-keys 2027CC30 &gt; secret.key</codeblock></li>
       </ol>
       <p>See the <xref href="https://www.postgresql.org/docs/9.4/pgcrypto.html" format="html"
-          scope="external">pgcrypto</xref> documentation for for more information about PGP
+          scope="external">pgcrypto</xref> documentation for more information about PGP
         encryption functions. </p>
     </section>
     <section id="section_emf_3kr_bs">

--- a/gpdb-doc/dita/install_guide/ansible-example.xml
+++ b/gpdb-doc/dita/install_guide/ansible-example.xml
@@ -21,7 +21,7 @@
     <p>Following are steps to use this Ansible playbook.</p>
     <ol id="ol_umm_h25_yhb">
       <li>Install Ansible on the control node using your package manager. See the <xref
-          href="https://docs.ansible.com" format="html" scope="external">Ansible documention</xref>
+          href="https://docs.ansible.com" format="html" scope="external">Ansible documentation</xref>
         for help with installation.</li>
       <li>Set up passwordless SSH from the control node to all hosts that will be a part of the
         Greenplum Database cluster. You can use the <codeph>ssh-copy-id</codeph> command to install

--- a/gpdb-doc/dita/install_guide/prep_os.xml
+++ b/gpdb-doc/dita/install_guide/prep_os.xml
@@ -243,7 +243,7 @@ kernel.shmmax = 810810728448</codeblock>
             65535</codeph>, set the Greenplum Database base port numbers to these values. </p>
         <codeblock>PORT_BASE = 6000
 MIRROR_PORT_BASE = 7000</codeblock>
-        <p>For information about the the <codeph>gpinitsystem</codeph> cluster configuration file,
+        <p>For information about the <codeph>gpinitsystem</codeph> cluster configuration file,
           see <xref href="../install_guide/init_gpdb.html#topic4" scope="peer" format="dita"
             >Initializing a Greenplum Database System</xref>.</p>
         <p>For Azure deployments with Greenplum Database avoid using port 65330; add the following

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_ROLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_ROLE.xml
@@ -185,7 +185,7 @@
                 </plentry>
                 <plentry>
                     <pt>RESOURCE GROUP <varname>group_name</varname></pt>
-                    <pd> The name of the resource group to assign to the the new role. The role will
+                    <pd> The name of the resource group to assign to the new role. The role will
                         be subject to the concurrent transaction, memory, and CPU limits configured
                         for the resource group. You can assign a single resource group to one or
                         more roles.</pd>

--- a/gpdb-doc/dita/security-guide/topics/Authorization.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authorization.xml
@@ -343,7 +343,7 @@ DENY DAY 'Sunday'</codeblock>
       <p> The following examples demonstrate creating a role with time-based constraints and
         modifying a role to add time-based constraints. Only the statements needed for time-based
         constraints are shown. For more details on creating and altering roles see the descriptions
-        of <codeph>CREATE ROLE</codeph> and <codeph>ALTER ROLE</codeph> in in the <i>Greenplum
+        of <codeph>CREATE ROLE</codeph> and <codeph>ALTER ROLE</codeph> in the <i>Greenplum
           Database Reference Guide</i>. </p>
       <section>
         <title> Example 1 – Create a New Role with Time-based Constraints </title>

--- a/gpdb-doc/dita/utility_guide/ref/gpmapreduce.xml
+++ b/gpdb-doc/dita/utility_guide/ref/gpmapreduce.xml
@@ -34,7 +34,7 @@
         <li id="kx141310">You must be a Greenplum Database superuser to run MapReduce jobs with
             <codeph>EXEC</codeph> and <codeph>FILE</codeph> inputs.</li>
         <li id="kx141334">You must be a Greenplum Database superuser to run MapReduce jobs with
-            <codeph>GPFDIST</codeph> input unless the the user has the appropriate rights granted.
+            <codeph>GPFDIST</codeph> input unless the user has the appropriate rights granted.
         </li>
       </ul>
     </section>

--- a/gpdb-doc/markdown/pxf/cfg_server.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfg_server.html.md.erb
@@ -94,7 +94,7 @@ PXF includes a template file named `pxf-site.xml`. You use the `pxf-site.xml` te
 You configure properties in the `pxf-site.xml` file for a PXF server when one or more of the following conditions hold:
 
 - The remote Hadoop system utilizes Kerberos authentication.
-- You want to enable/disable user impersonation on the the remote Hadoop or external database system.
+- You want to enable/disable user impersonation on the remote Hadoop or external database system.
 
 `pxf-site.xml` includes the following properties:
 

--- a/gpdb-doc/markdown/pxf/gphdfs-pxf-migrate.html.md.erb
+++ b/gpdb-doc/markdown/pxf/gphdfs-pxf-migrate.html.md.erb
@@ -218,7 +218,7 @@ Ensure that you can read from, or write to, each `pxf` external table that you h
 
 ## <a id="remove_gphdfs_ext_table"></a>Removing the gphdfs External Tables
 
-You must remove all `gphdfs` external tables before you can successfuly migrate a Greenplum Database 4 or 5 database to Greenplum 6.
+You must remove all `gphdfs` external tables before you can successfully migrate a Greenplum Database 4 or 5 database to Greenplum 6.
 
 Drop an external table as follows:
 

--- a/gpdb-doc/markdown/pxf/hdfs_json.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_json.html.md.erb
@@ -115,7 +115,7 @@ The single-JSON-record-per-line data set follows:
 "id":287819058,"location":""}, "coordinates": null}
 ```  
 
-This is the data set for for the multi-line JSON record data set:
+This is the data set for the multi-line JSON record data set:
 
 ``` json
 {

--- a/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
+++ b/gpdb-doc/markdown/pxf/jdbc_cfg.html.md.erb
@@ -218,7 +218,7 @@ By default, PXF JDBC user impersonation is disabled.  Perform the following proc
     <property>
         <name>pxf.service.user.impersonation</name>
         <value>true</value>
-    </propery>
+    </property>
     ```
 
 7. Save the `jdbc-site.xml` file and exit the editor.

--- a/gpdb-doc/markdown/pxf/pxfuserimpers.html.md.erb
+++ b/gpdb-doc/markdown/pxf/pxfuserimpers.html.md.erb
@@ -96,7 +96,7 @@ PXF user impersonation is enabled by default for Hadoop servers. You can configu
     <property>
         <name>pxf.service.user.impersonation</name>
         <value>true</value>
-    </propery>
+    </property>
     ```
 
 3. If you enabled user impersonation, you must configure Hadoop proxying as described in [Configure Hadoop Proxying](#hadoop). You must also configure [Hive User Impersonation](#hive) and [HBase User Impersonation](#hbase) if you plan to use those services.

--- a/src/backend/access/transam/xlogreader.c
+++ b/src/backend/access/transam/xlogreader.c
@@ -877,7 +877,7 @@ XLogReaderValidatePageHeader(XLogReaderState *state, XLogRecPtr recptr,
 }
 
 /*
- * In GPDB, this is used in in the test in src/test/walrep, so we need it in the
+ * In GPDB, this is used in the test in src/test/walrep, so we need it in the
  * backend, too.
  */
 /* #ifdef FRONTEND */

--- a/src/backend/cdb/cdbappendonlystorageread.c
+++ b/src/backend/cdb/cdbappendonlystorageread.c
@@ -336,7 +336,7 @@ AppendOnlyStorageRead_OpenFile(AppendOnlyStorageRead *storageRead,
 	Assert(filePathName != NULL);
 
 	/*
-	 * The EOF must be be greater than 0, otherwise we risk transactionally
+	 * The EOF must be greater than 0, otherwise we risk transactionally
 	 * created segment files from disappearing if a concurrent write
 	 * transaction aborts.
 	 */

--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -469,7 +469,7 @@ PreprocessByteaData(char *src)
 /*
  * IsRejectLimitValid
  *
- * verify that the the reject limit specified by the user is within the
+ * verify that the reject limit specified by the user is within the
  * allowed values for ROWS or PERCENT.
  */
 void

--- a/src/backend/cdb/cdbvarblock.c
+++ b/src/backend/cdb/cdbvarblock.c
@@ -524,7 +524,7 @@ VarBlockIsValid(
 	}
 
 	/*
-	 * Verify the data security zero pad between the last item and the the
+	 * Verify the data security zero pad between the last item and the
 	 * offset array.
 	 */
 	for (z = VARBLOCK_HEADER_LEN + itemLenSum; z < offsetToOffsetArray; z++)

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -462,7 +462,7 @@ cdbconn_get_motion_listener_port(PGconn *conn)
  *
  * The callback is very limited in what it can do, so it cannot directly
  * forward the Notice to the user->QD connection. Instead, it queues the
- * Notices as a list of QENotice structs. Later, when we are out of of the
+ * Notices as a list of QENotice structs. Later, when we are out of the
  * callback, forwardQENotices() sends the queued Notices to the client.
  *-------------------------------------------------------------------------
  */

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1051,7 +1051,7 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 	 * allocate gangs, and associate them with slices.
 	 *
 	 * On return, gangs have been allocated and CDBProcess lists have
-	 * been filled in in the slice table.)
+	 * been filled in the slice table.)
 	 * 
 	 * Notice: This must be done before cdbdisp_buildPlanQueryParms
 	 */

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -919,7 +919,7 @@ initCursorICHistoryTable(CursorICHistoryTable *t)
 
 /*
  * addCursorIcEntry
- * 		Add an entry to the the cursor ic table.
+ * 		Add an entry to the cursor ic table.
  */
 static void
 addCursorIcEntry(CursorICHistoryTable *t, uint32 icId, uint32 cid)

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -867,7 +867,7 @@ ExplainPrintTriggers(ExplainState *es, QueryDesc *queryDesc)
 	/*
 	 * GPDB_91_MERGE_FIXME: If the target is a partitioned table, we
 	 * should also report information on the triggers in the partitions.
-	 * I.e. we should scan the the 'ri_partition_hash' of each
+	 * I.e. we should scan the 'ri_partition_hash' of each
 	 * ResultRelInfo as well. This is somewhat academic, though, as long
 	 * as we don't support triggers in GPDB in general..
 	 */
@@ -3377,7 +3377,7 @@ ExplainTargetRel(Plan *plan, Index rti, ExplainState *es)
 
 				/*
 				 * Unlike in a FunctionScan, in a TableFunctionScan the call
-				 * should always be a a function call of a single function.
+				 * should always be a function call of a single function.
 				 * Get the real name of the function.
 				 */
 				{

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15697,7 +15697,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 													 ldistro->numsegments);
 
 				/*
-				 * See if the the old policy is the same as the new one but
+				 * See if the old policy is the same as the new one but
 				 * remember, we still might have to rebuild if there are new
 				 * storage options.
 				 */

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1687,7 +1687,7 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 			{
 				/*
 				 * On QD, the lock on the table has already been taken during parsing, so if it's a child
-				 * partition, we don't need to take a lock. If there a a deadlock GDD will come in place
+				 * partition, we don't need to take a lock. If there a deadlock GDD will come in place
 				 * and resolve the deadlock. ORCA Update / Delete plans only contains the root relation, so
 				 * no locks on leaf partition are taken here. The below changes makes planner as well to not
 				 * take locks on leaf partitions with GDD on.
@@ -3290,7 +3290,7 @@ ExecWithCheckOptions(WCOKind kind, ResultRelInfo *resultRelInfo,
 					 * the permissions on the relation (that is, if the user
 					 * could view it directly anyway).  For RLS violations, we
 					 * don't include the data since we don't know if the user
-					 * should be able to view the tuple as as that depends on
+					 * should be able to view the tuple as that depends on
 					 * the USING policy.
 					 */
 				case WCO_VIEW_CHECK:

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -910,7 +910,7 @@ ExecEagerFreeShareInputScan(ShareInputScanState *node)
 	}
 
 	/* 
-	 * Reset our copy of the pointer to the the ts_state. The tuplestore can still be accessed by 
+	 * Reset our copy of the pointer to the ts_state. The tuplestore can still be accessed by
 	 * the other consumers, but we don't have a pointer to it anymore
 	 */ 
 	node->ts_state = NULL; 

--- a/src/backend/fts/README
+++ b/src/backend/fts/README
@@ -15,7 +15,7 @@ Fault Tolerance Service (FTS):
 
    Two functions pointers are important members of the
    BackgroundWorker structure. One points to main entry function of
-   the GP background process. The other points to the the function
+   the GP background process. The other points to the function
    that determine if the process should be started or not. For FTS,
    these two functions are FtsProbeMain() and FtsProbeStartRule(),
    respectively.  This is hard-coded in postmaster.c.
@@ -154,7 +154,7 @@ requests 1, 2, and 3 which should share the same results since they request
 before the start of a new fts loop, and after the results of the previous probe
 - that is in the lower portion.
 
-2) Ensuring fresh results from an external probe. This is depicted as as request
+2) Ensuring fresh results from an external probe. This is depicted as request
 4 incoming during a current probe in progress. This request should get fresh
 results rather than using the current results (ie: "piggybacking").
 

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -4170,7 +4170,7 @@ CTranslatorQueryToDXL::TranslateExprToDXLProject
 
 	if (IsA(expr, Var) && !insist_new_colids)
 	{
-		// project elem is a a reference to a column - use the colref id
+		// project elem is a reference to a column - use the colref id
 		GPOS_ASSERT(EdxlopScalarIdent == child_dxlnode->GetOperator()->GetDXLOperator());
 		CDXLScalarIdent *dxl_ident = (CDXLScalarIdent *) child_dxlnode->GetOperator();
 		project_elem_id = dxl_ident->GetDXLColRef()->Id();

--- a/src/backend/replication/logical/reorderbuffer.c
+++ b/src/backend/replication/logical/reorderbuffer.c
@@ -1594,7 +1594,7 @@ ReorderBufferCommit(ReorderBuffer *rb, TransactionId xid,
 					/*
 					 * Mapped catalog tuple without data, emitted while
 					 * catalog table was in the process of being rewritten. We
-					 * can fail to look up the relfilenode, because the the
+					 * can fail to look up the relfilenode, because the
 					 * relmapper has no "historic" view, in contrast to normal
 					 * the normal catalog during decoding. Thus repeated
 					 * rewrites can cause a lookup failure. That's OK because

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1451,7 +1451,7 @@ GetOldestXmin(Relation rel, bool ignoreVacuum)
 	 * In QD node, all distributed transactions have an entry in the proc array,
 	 * so we're done.
 	 *
-	 * During binary upgrade and in in maintenance mode, we don't have
+	 * During binary upgrade and in maintenance mode, we don't have
 	 * distributed transactions, so we're done there too. This ensures correct
 	 * operation of VACUUM FREEZE during pg_upgrade and maintenance mode.
 	 *

--- a/src/backend/utils/adt/complex_type.c
+++ b/src/backend/utils/adt/complex_type.c
@@ -777,7 +777,7 @@ pg_cpow_n(Complex x, int k)
 		 *	Loop invariant: r = z*x^k
 		 *			 x is the base
 		 *			 k is the power
-		 *			 z is the the remaining which makes the loop invariant valid
+		 *			 z is the remaining which makes the loop invariant valid
 		 *	End condition: k == 0, r = z*x^0, so r = z
 		 *
 		 *	while k > 1:

--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -4032,7 +4032,7 @@ EncodeTimezone(char *str, int tz, int style)
 
 /* 
  * Convenience routine for encoding dates faster than sprintf does.
- * tm is the the timestamp structure, str is the string, pos is position in
+ * tm is the timestamp structure, str is the string, pos is position in
  * the string which we are at. Upon returning, it is set to the offset of the
  * last character we set in str.
  */

--- a/src/backend/utils/datumstream/test/datumstreamblock_test.c
+++ b/src/backend/utils/datumstream/test/datumstreamblock_test.c
@@ -58,7 +58,7 @@ test__DeltaCompression__Core(void **state)
 	assert_int_equal(dsw->delta_bitmap.bitOnCount, 0);
 	assert_int_equal(dsw->delta_bitmap.bitCount, 0);
 
-	/* Since physical datum, test the the routines for processing the same */
+	/* Since physical datum, test the routines for processing the same */
 	DatumStreamBlockWrite_DenseIncrItem(dsw, 0, 4);
 	DatumStreamBlockWrite_DeltaMaintain(dsw, UInt32GetDatum(32));
 	assert_int_equal(dsw->physical_datum_count, 1);
@@ -131,7 +131,7 @@ test__DeltaCompression__Core(void **state)
 	assert_true(DatumStreamBitMapWrite_CurrentIsOn(&dsw->delta_bitmap));
 	assert_true(dsw->not_first_datum);
 
-	/* Again since physical datum, test the the routines for processing the same */
+	/* Again since physical datum, test the routines for processing the same */
 	DatumStreamBlockWrite_DenseIncrItem(dsw, 0, 4);
 	DatumStreamBlockWrite_DeltaMaintain(dsw, UInt32GetDatum(23 + MAX_DELTA_SUPPORTED_DELTA_COMPRESSION + 1));
 	assert_int_equal(dsw->physical_datum_count, 2);

--- a/src/backend/utils/hyperloglog/gp_hyperloglog.c
+++ b/src/backend/utils/hyperloglog/gp_hyperloglog.c
@@ -825,7 +825,7 @@ gp_hyperloglog_merge_counters(GpHLLCounter counter1, GpHLLCounter counter2)
 		return gp_hll_copy(counter2);
 	}
 	else if (counter2 == NULL) {
-		/* if second counter is null just return the the first estimator */
+		/* if second counter is null just return the first estimator */
 		return gp_hll_copy(counter1);
 	}
 	else
@@ -1173,7 +1173,7 @@ gp_hyperloglog_merge(PG_FUNCTION_ARGS)
 		counter1_merged = PG_GETARG_HLL_P_COPY(1);
 
 	} else if (PG_ARGISNULL(1)) {
-		/* if second counter is null just return the the first estimator */
+		/* if second counter is null just return the first estimator */
 		counter1_merged = PG_GETARG_HLL_P_COPY(0);
 
 	} else {

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4402,7 +4402,7 @@ struct config_string ConfigureNamesString_gp[] =
 	},
 	{
 		{"pljava_classpath", PGC_SUSET, CUSTOM_OPTIONS,
-			gettext_noop("classpath used by the the JVM"),
+			gettext_noop("classpath used by the JVM"),
 			NULL,
 			GUC_NOT_IN_SAMPLE
 		},

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -419,7 +419,7 @@ ResAlterQueue(Oid queueid, Cost limits[NUM_RES_LIMIT_TYPES], bool overcommit,
 	}
 
 	/*
-	 * If threshold and overcommit alterations are all ok, do the the changes.
+	 * If threshold and overcommit alterations are all ok, do the changes.
 	 */
 	if (result == ALTERQUEUE_OK)
 	{

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -84,7 +84,7 @@ typedef struct ExecSlice
 	 * A list of CDBProcess nodes corresponding to the worker processes
 	 * allocated to implement this plan slice.
 	 *
-	 * The number of processes must agree with the the plan slice to be
+	 * The number of processes must agree with the plan slice to be
 	 * implemented.
 	 */
 	List		*primaryProcesses;

--- a/src/include/gppc/gppc_config.h
+++ b/src/include/gppc/gppc_config.h
@@ -15,7 +15,7 @@
  *
  * The number consists of the first number as ten thousands,
  * the second number as hundreds and the third number.  For example,
- * if the the backend is 4.2.1, the number is 40201
+ * if the backend is 4.2.1, the number is 40201
  */
 #define GP_VERSION_NUM 40305
 #endif

--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -8,7 +8,7 @@
 # A GUC gp_enable_global_deadlock_detector is introduced to control GDD.
 # When GDD is enabled, update|delete on heap tables will lock the table in
 # RowExclusiveLock mode. Otherwise, it locks the whole table in ExlusiveLock mode.
-# By default, GDD is set distabled and most the the cases are tested under this
+# By default, GDD is set distabled and most the cases are tested under this
 # condition.
 # Greenplum's logic for Select-Statement with locking clause (for update|no key update|share|key share)
 # is different from upstream:

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1614,7 +1614,7 @@ select avg('1000000000000000000'::int8) from generate_series(1, 100000);
 
 -- Test cases where the planner would like to distribute on a column, to implement
 -- grouping or distinct, but can't because the datatype isn't GPDB-hashable.
--- These are all variants of the the same issue; all of these used to miss the
+-- These are all variants of the same issue; all of these used to miss the
 -- check on whether the column is GPDB_hashble, producing an assertion failure.
 create table int2vectortab (distkey int, t int2vector,t2 int2vector) distributed by (distkey);
 insert into int2vectortab values

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1613,7 +1613,7 @@ select avg('1000000000000000000'::int8) from generate_series(1, 100000);
 
 -- Test cases where the planner would like to distribute on a column, to implement
 -- grouping or distinct, but can't because the datatype isn't GPDB-hashable.
--- These are all variants of the the same issue; all of these used to miss the
+-- These are all variants of the same issue; all of these used to miss the
 -- check on whether the column is GPDB_hashble, producing an assertion failure.
 create table int2vectortab (distkey int, t int2vector,t2 int2vector) distributed by (distkey);
 insert into int2vectortab values

--- a/src/test/regress/expected/db_size_functions.out
+++ b/src/test/regress/expected/db_size_functions.out
@@ -299,7 +299,7 @@ select pg_total_relation_size('aocssizetest') = pg_table_size('aocssizetest');
 (1 row)
 
 -- Also test pg_relation_size() in a query that selects from pg_class. It is a
--- very typical way to use the the functions, so make sure it works. (A
+-- very typical way to use the functions, so make sure it works. (A
 -- plausible difference to the above scenarios would be that the function
 -- might get executed on different nodes, for example.)
 select pg_relation_size(oid) between 3000000 and 5000000 from pg_class where relname = 'heapsizetest'; -- 3637248

--- a/src/test/regress/expected/gp_constraints.out
+++ b/src/test/regress/expected/gp_constraints.out
@@ -3,7 +3,7 @@
 -- As of Postgres 9.2, the executor provides details in errors for offending
 -- tuples when constraints are violated during an INSERT / UPDATE. However, we
 -- are generally masking out these details (using matchsubs) in upstream tests
--- because failing tuples might land on multiple segments, and the the precise
+-- because failing tuples might land on multiple segments, and the precise
 -- error becomes time-sensitive and less predictable.
 -- To preserve coverage, we test those error details here (with greater care).
 --

--- a/src/test/regress/explain.pl
+++ b/src/test/regress/explain.pl
@@ -155,8 +155,8 @@ Options:
 
 explain.pl reads EXPLAIN output from a text file (or standard
 input) and formats it in several ways.  The text file must contain
-output in one of the the following formats.  The first is a regular
-EXPLAIN format, starting the the QUERY PLAN header and ending with the
+output in one of the following formats.  The first is a regular
+EXPLAIN format, starting the QUERY PLAN header and ending with the
 number of rows in parentheses.  Indenting must be on:
 
                                                 QUERY PLAN                                                

--- a/src/test/regress/gpsourcify.pl
+++ b/src/test/regress/gpsourcify.pl
@@ -168,7 +168,7 @@ if (1)
     exit(0) unless (defined($bigh));
 
     # make an array of the token names (keys), sorted descending by
-    # the length of of the replacement value.
+    # the length of the replacement value.
     my @sortlen;
     @sortlen = 
         sort {length($bigh->{$b}) <=> length($bigh->{$a})} keys %{$bigh};

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1397,7 +1397,7 @@ select avg('1000000000000000000'::int8) from generate_series(1, 100000);
 
 -- Test cases where the planner would like to distribute on a column, to implement
 -- grouping or distinct, but can't because the datatype isn't GPDB-hashable.
--- These are all variants of the the same issue; all of these used to miss the
+-- These are all variants of the same issue; all of these used to miss the
 -- check on whether the column is GPDB_hashble, producing an assertion failure.
 create table int2vectortab (distkey int, t int2vector,t2 int2vector) distributed by (distkey);
 insert into int2vectortab values

--- a/src/test/regress/sql/db_size_functions.sql
+++ b/src/test/regress/sql/db_size_functions.sql
@@ -93,7 +93,7 @@ select pg_total_relation_size('aocssizetest') = pg_table_size('aocssizetest');
 
 
 -- Also test pg_relation_size() in a query that selects from pg_class. It is a
--- very typical way to use the the functions, so make sure it works. (A
+-- very typical way to use the functions, so make sure it works. (A
 -- plausible difference to the above scenarios would be that the function
 -- might get executed on different nodes, for example.)
 select pg_relation_size(oid) between 3000000 and 5000000 from pg_class where relname = 'heapsizetest'; -- 3637248

--- a/src/test/regress/sql/gp_constraints.sql
+++ b/src/test/regress/sql/gp_constraints.sql
@@ -3,7 +3,7 @@
 -- As of Postgres 9.2, the executor provides details in errors for offending
 -- tuples when constraints are violated during an INSERT / UPDATE. However, we
 -- are generally masking out these details (using matchsubs) in upstream tests
--- because failing tuples might land on multiple segments, and the the precise
+-- because failing tuples might land on multiple segments, and the precise
 -- error becomes time-sensitive and less predictable.
 -- To preserve coverage, we test those error details here (with greater care).
 --


### PR DESCRIPTION
This fixes multiple occurrences of duplicated words in sentences, like "the the" and "is is" etc. Spotted one instance while reading code, and threw some regexes at it to shake a few more.