### PR TITLE
5X Backport: Allow cluster to start when standby host is down

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -212,7 +212,7 @@ pylint:
 $(MOCK_BIN):
 	@echo "--- mock for platform $(UBUNTU_PLATFORM)"
 	@if [ $(UBUNTU_PLATFORM) = "Ubuntu" ]; then\
-       pip install mock;\
+       pip install mock==1.0.1;\
      else\
        mkdir -p $(PYTHONSRC_INSTALL_SITE) && \
 	   cd $(PYLIB_SRC_EXT)/ && $(TAR) xzf $(MOCK_DIR).tar.gz && \

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -348,7 +348,7 @@ class ExecutionError(Exception):
 
     def __str__(self):
         # TODO: improve dumping of self.cmd
-        return "ExecutionError: '%s' occured.  Details: '%s'  %s" % \
+        return "ExecutionError: '%s' occurred.  Details: '%s'  %s" % \
                (self.summary, self.cmd.cmdStr, self.cmd.get_results().printResult())
 
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
@@ -5,10 +5,13 @@ import sys
 
 from mock import Mock, patch
 
-from gparray import GpDB, GpArray
+from gppylib.gparray import GpDB, GpArray
 from gppylib.operations.startSegments import StartSegmentsResult
 from gppylib.test.unit.gp_unittest import GpTestCase, run_tests
 from gppylib.commands import gp
+from gppylib.commands.base import ExecutionError
+from gppylib.commands.pg import PgControlData
+from gppylib.mainUtils import UserAbortedException
 
 
 class GpStart(GpTestCase):
@@ -56,7 +59,6 @@ class GpStart(GpTestCase):
             patch("gpstart.gp.MasterStart.local"),
             patch("gpstart.pg.DbStatus.local"),
             patch("gpstart.TableLogger"),
-            patch('gpstart.PgControlData'),
         ])
 
         self.mockFilespaceConsistency = self.get_mock_from_apply_patch("CheckFilespaceConsistency")
@@ -85,6 +87,12 @@ class GpStart(GpTestCase):
     def tearDown(self):
         super(GpStart, self).tearDown()
 
+    def setup_gpstart(self):
+        parser = self.subject.GpStart.createParser()
+        options, args = parser.parse_args()
+        gpstart = self.subject.GpStart.createProgram(options, args)
+        return gpstart
+
     def test_option_master_success_without_auto_accept(self):
         sys.argv = ["gpstart", "-m"]
         self.mock_userinput.ask_yesno.return_value = True
@@ -92,10 +100,7 @@ class GpStart(GpTestCase):
 
         self.mock_os_path_exists.side_effect = os_exists_check
 
-        parser = self.subject.GpStart.createParser()
-        options, args = parser.parse_args()
-
-        gpstart = self.subject.GpStart.createProgram(options, args)
+        gpstart = self.setup_gpstart()
         return_code = gpstart.run()
 
         self.assertEqual(self.mock_userinput.ask_yesno.call_count, 1)
@@ -111,10 +116,7 @@ class GpStart(GpTestCase):
 
         self.mock_os_path_exists.side_effect = os_exists_check
 
-        parser = self.subject.GpStart.createParser()
-        options, args = parser.parse_args()
-
-        gpstart = self.subject.GpStart.createProgram(options, args)
+        gpstart = self.setup_gpstart()
         return_code = gpstart.run()
 
         self.assertEqual(self.mock_userinput.ask_yesno.call_count, 0)
@@ -127,9 +129,7 @@ class GpStart(GpTestCase):
         self.mock_userinput.ask_yesno.return_value = True
         self.subject.unix.PgPortIsActive.local.return_value = False
         self.mock_os_path_exists.side_effect = os_exists_check
-        parser = self.subject.GpStart.createParser()
-        options, args = parser.parse_args()
-        gpstart = self.subject.GpStart.createProgram(options, args)
+        gpstart = self.setup_gpstart()
 
         return_code = gpstart.run()
 
@@ -146,9 +146,7 @@ class GpStart(GpTestCase):
         self.mock_heap_checksum.return_value.get_segments_checksum_settings.return_value = ([1], [1])
         self.subject.unix.PgPortIsActive.local.return_value = False
         self.mock_os_path_exists.side_effect = os_exists_check
-        parser = self.subject.GpStart.createParser()
-        options, args = parser.parse_args()
-        gpstart = self.subject.GpStart.createProgram(options, args)
+        gpstart = self.setup_gpstart()
 
         return_code = gpstart.run()
 
@@ -167,9 +165,7 @@ class GpStart(GpTestCase):
         start_failure.addFailure(self.mirror1, "fictitious reason", gp.SEGSTART_ERROR_CHECKSUM_MISMATCH)
         self.mock_start_result.return_value.startSegments.return_value.getFailedSegmentObjs.return_value = start_failure.getFailedSegmentObjs()
 
-        parser = self.subject.GpStart.createParser()
-        options, args = parser.parse_args()
-        gpstart = self.subject.GpStart.createProgram(options, args)
+        gpstart = self.setup_gpstart()
 
         return_code = gpstart.run()
         self.assertEqual(return_code, 1)
@@ -200,6 +196,59 @@ class GpStart(GpTestCase):
         self.assertItemsEqual(up, [primary1, mirror0])
         self.assertItemsEqual(down, [primary0, mirror1])
 
+
+    @patch("gppylib.commands.pg.PgControlData.run")
+    @patch("gppylib.commands.pg.PgControlData.get_value", return_value="2")
+    def test_fetch_tli_returns_TimeLineID_when_standby_is_accessible(self, mock1, mock2):
+        gpstart = self.setup_gpstart()
+
+        self.assertEqual(gpstart.fetch_tli("", "foo"), 2)
+
+    @patch("gpstart.GpStart.shutdown_master_only")
+    @patch("gppylib.commands.pg.PgControlData.run")
+    @patch("gppylib.commands.pg.PgControlData.get_value", side_effect=ExecutionError("foobar", Mock()))
+    def test_fetch_tli_returns_0_when_standby_is_not_accessible_and_user_proceeds(self, mock_value, mock_run, mock_shutdown):
+        gpstart = self.setup_gpstart()
+        self.mock_userinput.ask_yesno.return_value = True
+
+        self.assertEqual(gpstart.fetch_tli("", "foo"), 0)
+        self.assertFalse(mock_shutdown.called)
+
+    @patch("gpstart.GpStart.shutdown_master_only")
+    @patch("gppylib.commands.pg.PgControlData.run")
+    @patch("gppylib.commands.pg.PgControlData.get_value", side_effect=ExecutionError("foobar", Mock()))
+    def test_fetch_tli_raises_exception_when_standby_is_not_accessible_and_user_aborts(self, mock_value, mock_run, mock_shutdown):
+        gpstart = self.setup_gpstart()
+        self.mock_userinput.ask_yesno.return_value = False
+
+        with self.assertRaises(UserAbortedException):
+            gpstart.fetch_tli("", "foo")
+        self.assertTrue(mock_shutdown.called)
+
+    @patch("gpstart.GpStart.shutdown_master_only")
+    @patch("gppylib.commands.pg.PgControlData.run")
+    @patch("gppylib.commands.pg.PgControlData.get_value", side_effect=ExecutionError("cmd foobar failed", Mock()))
+    def test_fetch_tli_logs_warning_when_standby_is_not_accessible(self, mock_value, mock_run, mock_shutdown):
+        gpstart = self.setup_gpstart()
+        self.mock_userinput.ask_yesno.return_value = False
+
+        with self.assertRaises(UserAbortedException):
+            gpstart.fetch_tli("", "foo")
+        self.subject.logger.warning.assert_any_call(StringContains("Received error: ExecutionError: 'cmd foobar failed' occurred."))
+        self.subject.logger.warning.assert_any_call("Continue only if you are certain that the standby is not acting as the master.")
+
+    @patch("gpstart.GpStart.shutdown_master_only")
+    @patch("gppylib.commands.pg.PgControlData.run")
+    @patch("gppylib.commands.pg.PgControlData.get_value", side_effect=ExecutionError("foobar", Mock()))
+    def test_fetch_tli_logs_non_interactive_warning_when_standby_is_not_accessible(self, mock_value, mock_run, mock_shutdown):
+        gpstart = self.setup_gpstart()
+        gpstart.interactive = False
+
+        with self.assertRaises(UserAbortedException):
+            gpstart.fetch_tli("", "foo")
+        self.assertTrue(mock_shutdown.called)
+        self.subject.logger.warning.assert_any_call("Non interactive mode detected. Not starting the cluster. Start the cluster in interactive mode.")
+
     def _createGpArrayWith2Primary2Mirrors(self):
         self.master = GpDB.initFromString(
             "1|-1|p|p|s|u|mdw|mdw|5432|5532|/data/master||/data/master/base/10899,/data/master/base/1,/data/master/base/10898,/data/master/base/25780,/data/master/base/34782")
@@ -228,6 +277,11 @@ def os_exists_check(arg):
     elif 'postmaster.pid' in arg or '.s.PGSQL' in arg:
         return False
     return False
+
+
+class StringContains(str):
+    def __eq__(self, other):
+        return self in other
 
 
 if __name__ == '__main__':

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -153,14 +153,7 @@ class GpStart:
                     inconsistent_filespace = True
 
             logger.info("Shutting down master")
-            cmd = gp.GpStop("Shutting down master", masterOnly=True,
-                            fast=True, quiet=logging_is_quiet(),
-                            verbose=logging_is_verbose(),
-                            datadir=self.master_datadir,
-                            parallel=self.parallel,
-                            logfileDirectory=self.logfileDirectory)
-            cmd.run()
-            logger.debug("results of forcing master shutdown: %s" % cmd)
+            self.shutdown_master_only()
             # TODO: check results of command.
 
             # in order to fail out here we must have filespace configured and also
@@ -259,14 +252,34 @@ class GpStart:
 
         self._remove_postmaster_tmpfile(self.port)
 
+    def shutdown_master_only(self):
+        cmd = gp.GpStop("Shutting down master", masterOnly=True,
+                        fast=True, quiet=logging_is_quiet(),
+                        verbose=logging_is_verbose(),
+                        datadir=self.master_datadir,
+                        parallel=self.parallel,
+                        logfileDirectory=self.logfileDirectory)
+        cmd.run()
+        logger.debug("results of forcing master shutdown: %s" % cmd)
+
     def fetch_tli(self, data_dir_path, remoteHost=None):
         if not remoteHost:
-            controldata = PgControlData("Latest checkpoint's TimeLineID", data_dir_path)
+            controldata = PgControlData("fetching pg_controldata locally", data_dir_path)
         else:
-            controldata = PgControlData("Latest checkpoint's TimeLineID", data_dir_path, REMOTE, remoteHost)
+            controldata = PgControlData("fetching pg_controldata remotely", data_dir_path, REMOTE, remoteHost)
 
-        controldata.run(validateAfter=True)
-        return int(controldata.get_value("Latest checkpoint's TimeLineID"))
+        try:
+            controldata.run(validateAfter=True)
+            return int(controldata.get_value("Latest checkpoint's TimeLineID"))
+        except base.ExecutionError as err:
+            logger.warning("Standby host is unreachable, cannot determine whether the standby is currently acting as the master. Received error: %s" % err)
+            logger.warning("Continue only if you are certain that the standby is not acting as the master.")
+            if not self.interactive or not userinput.ask_yesno(None, "\nContinue with startup", 'N'):
+                if not self.interactive:
+                    logger.warning("Non interactive mode detected. Not starting the cluster. Start the cluster in interactive mode.")
+                self.shutdown_master_only()
+                raise UserAbortedException()
+            return 0  # a 0 won't lead to standby promotion, as TimeLineIDs start at 1
 
     def _check_standby_activated(self):
         logger.debug("Checking if standby has been activated...")


### PR DESCRIPTION
Previously, gpstart could not start the cluster if a standby master host was configured but currently down. In order to check whether the standby was supposed to be the acting master (and prevent the master from being started if that was the case), gpstart needed to access the standby host to retrieve the TimeLineID of the standby, and if the standby host was down the master would not start.

This commit modifies gpstart to assume that the master host is the acting master if the standby is unreachable, so that it never gets into a state where neither the master nor the standby can be started.

This PR is a backport of #9526; it was _manual_ cherry-pick that was applied cleanly, no modifications aside from the typo fix.