### PR TITLE
Remove hard-coded limit on LISTEN_BACKLOG for sequence server

### DIFF
--- a/src/backend/postmaster/seqserver.c
+++ b/src/backend/postmaster/seqserver.c
@@ -64,7 +64,6 @@
  /*
   * backlog for listen() call:
   */
-#define LISTEN_BACKLOG 64
 #define getInt16(pNetData)	  ntohs(*((int16 *)(pNetData)))
 #define getInt32(pNetData)	  ntohl(*((int32 *)(pNetData)))
 #define getOid(pNetData)	
@@ -1012,7 +1011,7 @@ listenerSetup(void)
 		
 	}
 
-	if (listen(listenerFd, LISTEN_BACKLOG) < 0)
+	if (listen(listenerFd, listenerBacklog) < 0)
 	{
 		ereport(ERROR, (errcode(ERRCODE_GP_INTERNAL_ERROR),
 						errmsg("SeqServer Error: Could not setup listener socket: %s", strerror(errno)),

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -128,8 +128,6 @@ extern struct config_generic *find_option(const char *name, bool create_placehol
 
 extern bool enable_partition_rules;
 
-extern int listenerBacklog;
-
 /* GUC lists for gp_guc_list_show().  (List of struct config_generic) */
 List	   *gp_guc_list_for_explain;
 List	   *gp_guc_list_for_no_plan;
@@ -4116,7 +4114,7 @@ struct config_int ConfigureNamesInt_gp[] =
 
 	{
 		{"gp_interconnect_tcp_listener_backlog", PGC_USERSET, GP_ARRAY_TUNING,
-			gettext_noop("Size of the listening queue for each TCP interconnect socket"),
+			gettext_noop("Size of the listening queue for each TCP interconnect socket and sequence server socket"),
 			gettext_noop("Cooperate with kernel parameter net.core.somaxconn and net.ipv4.tcp_max_syn_backlog to tune network performance."),
 			GUC_NOT_IN_SAMPLE | GUC_GPDB_ADDOPT
 		},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -363,6 +363,8 @@ extern int	tcp_keepalives_count;
 
 extern int	gp_connection_send_timeout;
 
+extern int	listenerBacklog;
+
 extern int	gp_filerep_tcp_keepalives_idle;
 extern int	gp_filerep_tcp_keepalives_interval;
 extern int	gp_filerep_tcp_keepalives_count;


### PR DESCRIPTION
With the hard-coded limit of 64, the following error can happen (if
number of connections to sequence server is greater than 64):
```
Error: Could not read() message from seqserver.(error:104). Closing
connection.
```
When the limit of the listen backlog is reached, the kernel silently
drops the acknowledgements of the new connections.

So, to better deal with the situation, reuse the GUC used for
interconnect listen backlog limit for sequence server. Hard-coded value
64 does not provide user control over the configuration. The limit will
be the minimum of the value set by this GUC and the system setting
`net.core.somaxconn`, which is 128 by default.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>
