### PR TITLE
Sanity check BackgroundWorker's function entry

### DIFF
--- a/src/backend/postmaster/bgworker.c
+++ b/src/backend/postmaster/bgworker.c
@@ -528,6 +528,16 @@ SanityCheckBackgroundWorker(BackgroundWorker *worker, int elevel)
 		return false;
 	}
 
+	if (!worker->bgw_main &&
+		(!worker->bgw_library_name[0] || !worker->bgw_function_name[0]))
+	{
+		ereport(elevel,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("background worker \"%s\": invalid entry function",
+						worker->bgw_name)));
+		return false;
+	}
+
 	return true;
 }
 

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -401,7 +401,7 @@ static BackgroundWorker PMAuxProcList[MaxPMAuxProc] =
 	 BackoffSweeperStartRule},
 
 	/*
-	 * Remember to set the MaxPMAuxProc to the number of this list
+	 * Remember to set the MaxPMAuxProc to the number of items in this list
 	 *
 	 * It's used as a number at other places, so end-of-list marker doesn't
 	 * work here.


### PR DESCRIPTION
Without this, the error we got would be "can not find file/function" in
the load_external_function(), which is not obvious enough.