### PR TITLE
docs - pxf cluster restart

### DIFF
--- a/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/cfginitstart_pxf.html.md.erb
@@ -27,7 +27,7 @@ PXF provides two management commands:
 - `pxf cluster` - manage all PXF service instances in the Greenplum Database cluster
 - `pxf` - manage the PXF service instance on a specific Greenplum Database host
 
-The [`pxf cluster`](ref/pxf-cluster.html) command supports `init`, `start`, `status`, `stop`, and `sync` subcommands. When you run a `pxf cluster` subcommand on the Greenplum Database master host, you perform the operation on all segment hosts in the Greenplum Database cluster. PXF also runs the `init` and `sync` commands on the standby master host.
+The [`pxf cluster`](ref/pxf-cluster.html) command supports `init`, `start`, `restart`, `status`, `stop`, and `sync` subcommands. When you run a `pxf cluster` subcommand on the Greenplum Database master host, you perform the operation on all segment hosts in the Greenplum Database cluster. PXF also runs the `init` and `sync` commands on the standby master host.
 
 The [`pxf`](ref/pxf.html) command supports `init`, `start`, `stop`, `restart`, and `status` operations. These operations run locally. That is, if you want to start or stop the PXF agent on a specific Greenplum Database segment host, you log in to the host and run the command. 
 
@@ -110,7 +110,7 @@ Perform the following procedure to stop PXF on each segment host in your Greenpl
 
 ## <a id="restart_pxf"></a>Restarting PXF
 
-If you must restart PXF, for example if you updated PXF user configuration files in `$PXF_CONF/conf`, you can stop, and then start, PXF in your Greenplum Database cluster.
+If you must restart PXF, for example if you updated PXF user configuration files in `$PXF_CONF/conf`, you run `pxf cluster restart` to stop, and then start, PXF on all segment hosts in your Greenplum Database cluster.
 
 Only the `gpadmin` user can restart the PXF service.
 
@@ -131,7 +131,6 @@ Perform the following procedure to restart PXF in your Greenplum Database cluste
 2. Restart PXF:
 
     ```shell
-    gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster stop
-    gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster start
+    gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster restart
     ```
 

--- a/gpdb-doc/markdown/pxf/pxf_kerbhdfs.html.md.erb
+++ b/gpdb-doc/markdown/pxf/pxf_kerbhdfs.html.md.erb
@@ -119,8 +119,7 @@ When you configure PXF for secure HDFS using an AD Kerberos KDC server, you will
 
     ``` shell
     gpadmin@master$ $GPHOME/pxf/bin/pxf cluster sync
-    gpadmin@master$ $GPHOME/pxf/bin/pxf cluster stop
-    gpadmin@master$ $GPHOME/pxf/bin/pxf cluster start
+    gpadmin@master$ $GPHOME/pxf/bin/pxf cluster restart
     ```
 
 6. Step 7 does not synchronize the keytabs in `$PXF_CONF`. You must distribute the keytab file to `$PXF_CONF/keytabs/`. Locate the keytab file, copy the file to the `$PXF_CONF` user configuration directory, and set required permissions. For example:

--- a/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
@@ -16,6 +16,7 @@ where `<command>` is:
 help
 init
 reset
+restart
 start
 status
 stop
@@ -28,7 +29,7 @@ The `pxf cluster` utility command manages PXF on the master, standby master, and
 
 - Initialize PXF configuration on all hosts in the Greenplum Database cluster.
 - Reset the PXF service instance on all hosts to its uninitialized state.
-- Start and stop the PXF service instance on all segment hosts.
+- Start, stop, and restart the PXF service instance on all segment hosts.
 - Display the status of the PXF service instance on all segment hosts.
 - Synchronize the PXF configuration from the Greenplum Database master host to the standby master and to all segment hosts.
 
@@ -46,6 +47,9 @@ The `pxf cluster` utility command manages PXF on the master, standby master, and
 
 <dt>reset</dt>
 <dd>Reset the PXF service instance on the master, standby master, and on all segment hosts. Resetting removes PXF runtime files and directories, and returns PXF to an uninitialized state. You must stop the PXF service instance running on each segment host before you reset PXF in your Greenplum Database cluster.</dd>
+
+<dt>restart</dt>
+<dd>Stop, and then start, the PXF service instance on all segment hosts.</dd>
 
 <dt>start</dt>
 <dd>Start the PXF service instance on all segment hosts.</dd>

--- a/gpdb-doc/markdown/pxf/reg_jar_depend.html.md.erb
+++ b/gpdb-doc/markdown/pxf/reg_jar_depend.html.md.erb
@@ -31,7 +31,6 @@ Should you need to add an additional JAR dependency for PXF, for example a JDBC 
 $ ssh gpadmin@<gpmaster>
 gpadmin@gpmaster$ cp new_dependent_jar.jar $PXF_CONF/lib/
 gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster sync
-gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster stop
-gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster start
+gpadmin@gpmaster$ $GPHOME/pxf/bin/pxf cluster restart
 ```
 


### PR DESCRIPTION
pxf supports the `pxf cluster restart` command:
- update reference page
- update "restarting pxf" procedure
- misc doc updates replacing stop/start with restart
