### PR TITLE
tuplestore: support backward scanning of spill files

### DIFF
--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -1056,9 +1056,6 @@ tuplestore_gettuple(Tuplestorestate *state, bool forward,
 			 * word. If seek fails, assume we are at start of file.
 			 */
 
-			ereport(ERROR, (errmsg("Backward scanning of tuplestores are not supported at this time")));
-			return NULL;
-#if 0
 			if (BufFileSeek(state->myfile, readptr->file, -(long) sizeof(unsigned int),
 							SEEK_CUR) != 0)
 			{
@@ -1114,7 +1111,6 @@ tuplestore_gettuple(Tuplestorestate *state, bool forward,
 				 errmsg("could not seek in tuplestore temporary file: %m")));
 			tup = READTUP(state, tuplen);
 			return tup;
-#endif
 		default:
 			elog(ERROR, "invalid tuplestore state");
 			return NULL;		/* keep compiler quiet */
@@ -1600,6 +1596,26 @@ readtup_heap(Tuplestorestate *state, unsigned int len)
 {
 	void	   *tup = NULL;
 	uint32		tuplen = 0;
+
+	/*
+	 * CDB: in backward mode the passed-in len is the trailing length, it does
+	 * not contain the leading bit as the leading length used in forward mode.
+	 * The leading bit is necessary to determine the tuple type, a memory tuple
+	 * or a heap tuple, so we must re-read the leading length to make this
+	 * decision.
+	 */
+	if (state->backward)
+	{
+		TSReadPointer *readptr = &state->readptrs[state->activeptr];
+
+		if (BufFileSeek(state->myfile, readptr->file,
+						-(long) sizeof(unsigned int), SEEK_CUR) != 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not seek in tuplestore temporary file: %m")));
+
+		len = getlen(state, false);
+	}
 
 	if (is_len_memtuplen(len))
 	{

--- a/src/test/regress/expected/misc_jiras.out
+++ b/src/test/regress/expected/misc_jiras.out
@@ -1,0 +1,36 @@
+drop schema if exists misc_jiras;
+create schema misc_jiras;
+--
+-- Test backward scanning of tuplestore spill files.
+--
+-- When tuplestore cannot store all the data in memory it will spill some of
+-- the data to temporary files.  In gpdb we used to disable the backward
+-- scanning from these spill files because we could not determine the tuple
+-- type, memtup or heaptup, correctly.  The issue is fixed, the backward
+-- scanning should be supported now.
+--
+create table misc_jiras.t1 (c1 int, c2 text, c3 smallint) distributed by (c1);
+insert into misc_jiras.t1 select i % 13, md5(i::text), i % 3
+  from generate_series(1, 20000) i;
+-- tuplestore uses work_mem to control the in-memory data size, set a small
+-- value to trigger the spilling.
+set work_mem to '64kB';
+WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+select sum(cc) from (
+    select c1
+         , c2
+         , case when count(c3) = 0 then -1.0
+                else cume_dist() over (partition by c1,
+                                       case when count(c3) > 0 then 1 else 0 end
+                                       order by count(c3), c2)
+           end as cc
+      from misc_jiras.t1
+     group by 1, 2
+) tt;
+   sum   
+---------
+ 10006.5
+(1 row)
+
+reset work_mem;
+WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -41,7 +41,7 @@ test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp li
 # below test(s) inject faults so each of them need to be in a separate group
 test: gpcopy
 
-test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format olap_plans
+test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format olap_plans misc_jiras
 # below test(s) inject faults so each of them need to be in a separate group
 test: guc_gp
 

--- a/src/test/regress/sql/misc_jiras.sql
+++ b/src/test/regress/sql/misc_jiras.sql
@@ -1,0 +1,34 @@
+drop schema if exists misc_jiras;
+create schema misc_jiras;
+
+--
+-- Test backward scanning of tuplestore spill files.
+--
+-- When tuplestore cannot store all the data in memory it will spill some of
+-- the data to temporary files.  In gpdb we used to disable the backward
+-- scanning from these spill files because we could not determine the tuple
+-- type, memtup or heaptup, correctly.  The issue is fixed, the backward
+-- scanning should be supported now.
+--
+
+create table misc_jiras.t1 (c1 int, c2 text, c3 smallint) distributed by (c1);
+insert into misc_jiras.t1 select i % 13, md5(i::text), i % 3
+  from generate_series(1, 20000) i;
+
+-- tuplestore uses work_mem to control the in-memory data size, set a small
+-- value to trigger the spilling.
+set work_mem to '64kB';
+
+select sum(cc) from (
+    select c1
+         , c2
+         , case when count(c3) = 0 then -1.0
+                else cume_dist() over (partition by c1,
+                                       case when count(c3) > 0 then 1 else 0 end
+                                       order by count(c3), c2)
+           end as cc
+      from misc_jiras.t1
+     group by 1, 2
+) tt;
+
+reset work_mem;


### PR DESCRIPTION
When tuplestore cannot store all the data in memory it will spill some
of the data to temporary files.  In gpdb we used to disable the backward
scanning from these spill files because we could not determine the tuple
type, memtup or heaptup, correctly.

The tuple type is stored in the tuple header in the tuple length field
as the leading bit.  After the tuple there is also a tuple length,
called trailing length, for backward scanning.  The problem is that the
trailing length was checked for the leading bit, which does not contain
this bit at all.

Fixed by reading the tuple length inside the tuple, so the tuple type
can be determined correctly.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
