### PR TITLE
Check for any segments not in preferred roles

### DIFF
--- a/contrib/pg_upgrade/greenplum/check_gp.c
+++ b/contrib/pg_upgrade/greenplum/check_gp.c
@@ -919,6 +919,12 @@ check_preferred_roles(void)
 	int 		content;
 	PGconn	   *conn;
 
+	/*
+	 * We only need to check the segment roles on master
+ 	 */
+	if (!is_greenplum_dispatcher_mode())
+		return;
+
 	prep_status("Checking for segments not in preferred role");
 
 	snprintf(output_path, sizeof(output_path), "segment_roles_switched.txt");

--- a/contrib/pg_upgrade/test/integration/configuration/gpdb5-env.sh
+++ b/contrib/pg_upgrade/test/integration/configuration/gpdb5-env.sh
@@ -3,3 +3,4 @@ export STANDBY_PORT=50001
 export PORT_BASE=50002
 export DATADIRS="$PWD/gpdb5-data"
 export PGPORT=50000
+export MASTER_DATA_DIRECTORY="$DATADIRS/qddir/demoDataDir-1"

--- a/contrib/pg_upgrade/test/integration/gpdb5_schedule
+++ b/contrib/pg_upgrade/test/integration/gpdb5_schedule
@@ -9,3 +9,4 @@ test: unsupported_tsquery_col
 test: gphdfs
 test: mismatched_aopartition_indexes
 test: different_name_index_backed_constraint
+test: preferred_roles

--- a/contrib/pg_upgrade/test/integration/input/preferred_roles.source
+++ b/contrib/pg_upgrade/test/integration/input/preferred_roles.source
@@ -1,0 +1,40 @@
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+
+
+-- stop a primary in order to trigger a mirror promotion
+create or replace function stop_segment(datadir text)
+returns text as $$
+    import subprocess
+    cmd = 'pg_ctl -l postmaster.log -D %s -w -m immediate stop' % datadir
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
+$$ language plpythonu;
+
+
+-- function to wait for a segment to take a role
+create or replace function wait_for_content0(target_mode char) /*in func*/ returns void as $$ /*in func*/ declare /*in func*/ iterations int := 0; /*in func*/ begin /*in func*/ while iterations < 120 loop /*in func*/ perform pg_sleep(1); /*in func*/ if exists (select * from gp_segment_configuration where content = 0 and mode = target_mode) then /*in func*/ return; /*in func*/ end if; /*in func*/ iterations := iterations + 1; /*in func*/ end loop; /*in func*/ end $$ /*in func*/ language plpgsql;
+
+
+checkpoint;
+-- the check should not return any failure
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+
+-- Stop content 0 primary and let the mirror take over
+select stop_segment(fselocation) from pg_filespace_entry fe, gp_segment_configuration c, pg_filespace f
+where fe.fsedbid = c.dbid and c.content=0 and c.role='p' and f.oid = fe.fsefsoid and f.fsname = 'pg_system';
+
+select wait_for_content0('c');
+
+-- one of the segment has switched role, the check should catch it
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+
+-- start_ignore
+! ./gpdb5/bin/gprecoverseg -a -d @upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1;
+
+select wait_for_content0('s');
+
+! ./gpdb5/bin/gprecoverseg -a -r -d @upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1;
+
+select wait_for_content0('s');
+-- end_ignore

--- a/contrib/pg_upgrade/test/integration/output/preferred_roles.source
+++ b/contrib/pg_upgrade/test/integration/output/preferred_roles.source
@@ -1,0 +1,66 @@
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+
+
+-- stop a primary in order to trigger a mirror promotion
+create or replace function stop_segment(datadir text) returns text as $$ import subprocess cmd = 'pg_ctl -l postmaster.log -D %s -w -m immediate stop' % datadir return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '') $$ language plpythonu;
+CREATE
+
+
+-- function to wait for a segment to take a role
+create or replace function wait_for_content0(target_mode char) /*in func*/ returns void as $$ /*in func*/ declare /*in func*/ iterations int := 0; /*in func*/ begin /*in func*/ while iterations < 120 loop /*in func*/ perform pg_sleep(1); /*in func*/ if exists (select * from gp_segment_configuration where content = 0 and mode = target_mode) then /*in func*/ return; /*in func*/ end if; /*in func*/ iterations := iterations + 1; /*in func*/ end loop; /*in func*/ end $$ /*in func*/ language plpgsql;
+CREATE
+
+
+checkpoint;
+CHECKPOINT
+-- the check should not return any failure
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+Performing Consistency Checks on Old Live Server
+------------------------------------------------
+Creating a dump of all tablespace metadata.                 ok
+
+*Clusters are compatible*
+
+
+-- Stop content 0 primary and let the mirror take over
+select stop_segment(fselocation) from pg_filespace_entry fe, gp_segment_configuration c, pg_filespace f where fe.fsedbid = c.dbid and c.content=0 and c.role='p' and f.oid = fe.fsefsoid and f.fsname = 'pg_system';
+ stop_segment                                         
+------------------------------------------------------
+ waiting for server to shut down done
+server stopped
+ 
+(1 row)
+
+select wait_for_content0('c');
+ wait_for_content0 
+-------------------
+                   
+(1 row)
+
+-- one of the segment has switched role, the check should catch it
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+Performing Consistency Checks on Old Live Server
+------------------------------------------------
+Creating a dump of all tablespace metadata.                 ok
+Checking for segments not in preferred roles                fatal
+
+| The segments should be in their preferred roles for upgrade.
+| Segments not operating in the preferred roles must be recovered 
+| and/or rebalanced using gprecoverseg. The list of such segments 
+| is in the file:
+	segment_roles_switched.txt
+
+Failure, exiting
+
+
+-- start_ignore
+! ./gpdb5/bin/gprecoverseg -a -d @upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1;
+
+select wait_for_content0('s');
+
+! ./gpdb5/bin/gprecoverseg -a -r -d @upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1;
+
+select wait_for_content0('s');
+-- end_ignore

--- a/contrib/pg_upgrade/test/integration/test.sh
+++ b/contrib/pg_upgrade/test/integration/test.sh
@@ -13,7 +13,7 @@ main() {
 	local new_port=60000
 
 	# need python for sql isolation test modules.
-	source gpdb6/greenplum_path.sh
+	source gpdb5/greenplum_path.sh
 
 	if [ $# -eq 0 ]
 	then
@@ -34,6 +34,9 @@ main() {
 						 --old-port=$old_port \
 						 $gpdb5_input
 	./scripts/gpdb5-cluster stop
+	# need python for sql isolation test modules.
+	source gpdb6/greenplum_path.sh
+
 	./scripts/upgrade-cluster
 	./scripts/gpdb6-cluster start
 	./pg_upgrade_regress --use-existing \


### PR DESCRIPTION
pg_upgrade check should identify (fail) if there are any segments
not in their preferred roles

The below error will be seen
```
Checking for segments not in preferred roles                fatal

| The segments should be in their preferred roles for upgrade.
| Segments not operating in the preferred roles must be recovered
| and/or rebalanced using gprecoverseg, the list of such segments
| is in the file:
	segment_roles_switched.txt

Failure, exiting
✘-1 ~/workspace/gpdb [add-role-check-upgrade L|…51⚑ 1]
12:38 $ cat segment_roles_switched.txt
dbid "3" with content id "1" has switched role: role: "m" preferred_role: "p"
dbid "6" with content id "1" has switched role: role: "p" preferred_role: "m"
✔ ~/workspace/gpdb [add-role-check-upgrade L|…51⚑ 1]
12:38 $
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
