### PR TITLE
[6X backport] Revert create pathkey in `convert_subquery_pathkeys`

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -1068,27 +1068,6 @@ convert_subquery_pathkeys(PlannerInfo *root, RelOptInfo *rel,
 																 tle);
 
 					/* See if we have a matching EC for that */
-					/*
-					 * In GPDB, we pass create_it = 'true', because even if the
-					 * sub-pathkey doesn't seem interesting to the parent, we
-					 * want to preserve the ordering if the result is gathered
-					 * to a single node later on. This case comes up, if you
-					 * e.g. create a view with an ORDER BY:
-					 *
-					 * CREATE VIEW v AS SELECT * FROM sourcetable ORDER BY vn;
-					 *
-					 * and query it:
-					 *
-					 * SELECT row_number() OVER(), vn FROM v_sourcetable;
-					 *
-					 * Although it's not required by the SQL standard, we try
-					 * to preserve the PostgreSQL behaviour, and honor the
-					 * ORDER BY. The parent query doesn't have an equivalence
-					 * class for the path key (vn), but if we don't pass it
-					 * up to the parent, it will not preserve the order when
-					 * it adds the Gather Motion to pull together the rows,
-					 * underneath the WindowAgg.
-					 */
 					outer_ec = get_eclass_for_sort_expr(root,
 														outer_expr,
 														NULL,
@@ -1097,7 +1076,7 @@ convert_subquery_pathkeys(PlannerInfo *root, RelOptInfo *rel,
 														sub_expr_coll,
 														0,
 														rel->relids,
-														true); /* create_it */
+														false); /* create_it */
 
 					/*
 					 * If we don't find a matching EC, this sub-pathkey isn't

--- a/src/test/regress/expected/gp_create_view.out
+++ b/src/test/regress/expected/gp_create_view.out
@@ -37,7 +37,7 @@ insert into sourcetable values
 -- Check that the rows come out in order, if there's an ORDER BY in
 -- the view definition.
 create view  v_sourcetable as select * from sourcetable order by vn;
-select row_number() over(), * from v_sourcetable;
+select row_number() over(), * from v_sourcetable order by vn;
  row_number | cn | vn | pn  |     dt     | qty  | prc  
 ------------+----+----+-----+------------+------+------
           1 |  1 | 10 | 200 | 03-01-1401 |   10 |    0
@@ -55,7 +55,7 @@ select row_number() over(), * from v_sourcetable;
 (12 rows)
 
 create view v_sourcetable1 as SELECT sourcetable.qty, vn, pn FROM sourcetable union select sourcetable.qty, sourcetable.vn, sourcetable.pn from sourcetable order by qty;
-select row_number() over(), * from v_sourcetable1;
+select row_number() over(), * from v_sourcetable1 order by qty;
  row_number | qty  | vn | pn  
 ------------+------+----+-----
           1 |    1 | 50 | 400

--- a/src/test/regress/expected/qp_union_intersect.out
+++ b/src/test/regress/expected/qp_union_intersect.out
@@ -1844,3 +1844,18 @@ order by 1,2;
  Execution time: 2.496 ms
 (23 rows)
 
+CREATE TABLE t1(c1 int, c2 int, c3 int);
+CREATE TABLE t2(c1 int, c2 int, c3 int);
+INSERT INTO t1 SELECT i, i ,i + 1 FROM generate_series(1,10) i;
+INSERT INTO t2 SELECT i, i ,i + 1 FROM generate_series(1,10) i;
+SET enable_hashagg = off;
+with tcte(c1, c2, c3) as (
+	SELECT c1, sum(c2) as c2, c3 FROM t1 WHERE c3 > 0 GROUP BY c1, c3
+	UNION ALL
+	SELECT c1, sum(c2) as c2, c3 FROM t2 WHERE c3 < 0 GROUP BY c1, c3
+)
+SELECT * FROM tcte WHERE c3 = 1;
+ c1 | c2 | c3 
+----+----+----
+(0 rows)
+

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -1869,3 +1869,18 @@ order by 1,2;
  Execution time: 3.142 ms
 (26 rows)
 
+CREATE TABLE t1(c1 int, c2 int, c3 int);
+CREATE TABLE t2(c1 int, c2 int, c3 int);
+INSERT INTO t1 SELECT i, i ,i + 1 FROM generate_series(1,10) i;
+INSERT INTO t2 SELECT i, i ,i + 1 FROM generate_series(1,10) i;
+SET enable_hashagg = off;
+with tcte(c1, c2, c3) as (
+	SELECT c1, sum(c2) as c2, c3 FROM t1 WHERE c3 > 0 GROUP BY c1, c3
+	UNION ALL
+	SELECT c1, sum(c2) as c2, c3 FROM t2 WHERE c3 < 0 GROUP BY c1, c3
+)
+SELECT * FROM tcte WHERE c3 = 1;
+ c1 | c2 | c3 
+----+----+----
+(0 rows)
+

--- a/src/test/regress/sql/gp_create_view.sql
+++ b/src/test/regress/sql/gp_create_view.sql
@@ -37,10 +37,10 @@ insert into sourcetable values
 -- Check that the rows come out in order, if there's an ORDER BY in
 -- the view definition.
 create view  v_sourcetable as select * from sourcetable order by vn;
-select row_number() over(), * from v_sourcetable;
+select row_number() over(), * from v_sourcetable order by vn;
 
 create view v_sourcetable1 as SELECT sourcetable.qty, vn, pn FROM sourcetable union select sourcetable.qty, sourcetable.vn, sourcetable.pn from sourcetable order by qty;
-select row_number() over(), * from v_sourcetable1;
+select row_number() over(), * from v_sourcetable1 order by qty;
 
 
 -- Check that the row-comparison operator is serialized and deserialized

--- a/src/test/regress/sql/qp_union_intersect.sql
+++ b/src/test/regress/sql/qp_union_intersect.sql
@@ -690,3 +690,16 @@ explain analyze select a, b, array_dims(array_agg(x)) from mergeappend_test r gr
 union all
 select null, null, array_dims(array_agg(x)) FROM mergeappend_test r
 order by 1,2;
+
+CREATE TABLE t1(c1 int, c2 int, c3 int);
+CREATE TABLE t2(c1 int, c2 int, c3 int);
+INSERT INTO t1 SELECT i, i ,i + 1 FROM generate_series(1,10) i;
+INSERT INTO t2 SELECT i, i ,i + 1 FROM generate_series(1,10) i;
+SET enable_hashagg = off;
+with tcte(c1, c2, c3) as (
+	SELECT c1, sum(c2) as c2, c3 FROM t1 WHERE c3 > 0 GROUP BY c1, c3
+	UNION ALL
+	SELECT c1, sum(c2) as c2, c3 FROM t2 WHERE c3 < 0 GROUP BY c1, c3
+)
+SELECT * FROM tcte WHERE c3 = 1;
+


### PR DESCRIPTION
In upstream, it does not create a new pathkey in convert_subquery_pathkeys function. It also
raises an issue in gpdb, so revert it.

cherry-pick from: 0138eed43680ea8c5c8d1529e29063bb17a4c63e

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
