### PR TITLE
Refactor sorted Motion's merge heap.

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -3022,9 +3022,11 @@ typedef struct MotionState
 								 * each source segindex */
 
 	/* For sorted Motion recv */
-	struct binaryheap *tupleheap;
-	struct CdbTupleHeapInfo *tupleheap_entries;
-	struct CdbMergeComparatorContext *tupleheap_cxt;
+	int			numSortCols;
+	SortSupport sortKeys;
+	TupleTableSlot **slots;
+	struct binaryheap *tupleheap; /* binary heap of slot indices */
+	int			lastSortColIdx;
 
 	/* The following can be used for debugging, usage stats, etc.  */
 	int			numTuplesFromChild;	/* Number of tuples received from child */
@@ -3047,7 +3049,7 @@ typedef struct MotionState
 	int			numInputSegs;	/* the number of segments on the sending slice */
 } MotionState;
 
-/*zx
+/*
  * ExecNode for PartitionSelector.
  * This operator contains a Plannode in PlanState.
  */


### PR DESCRIPTION
Instead of having CdbTupleHeapInfo structs to hold the tuples currently
in the heap, store each tuple in a TupleTableSlot. That's what similar
code in nodeMergeAppend.c does.

I did some quick testing of this on laptop, and didn't see much of
difference. But I think this is more clear, and in the long term, I'd
like to get rid of GenericTuples, and this is a step in that direction.

This inlines the CdbMergeComparatorContext struct directly into
MotionState. Having a separate struct made some sense when we still used
to have two implementations of the heap, but that was removed in commit
726fb52a13.
