### PR TITLE
Avoid ifaddrs utility crash

### DIFF
--- a/gpMgmt/bin/ifaddrs/main.c
+++ b/gpMgmt/bin/ifaddrs/main.c
@@ -66,6 +66,9 @@ int main(int argc, char *argv[])
 			continue;
 		}
 
+		if (addr == NULL)
+			continue;
+
 		switch (addr->sa_family)
 		{
 			case AF_INET:


### PR DESCRIPTION
`ifa_addr` may be null for interface returned by `getifaddrs()`. Hence,
checking for the same should be perfomed, else ifaddrs crashes. As
side effect to this crashing, on my ubuntu laptop `gpinitstandby` always fails.

Interface for which `getifaddrs()` returned null for me is:
gpd0: flags=4240<POINTOPOINT,NOARP,MULTICAST>  mtu 1500
        unspec 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00  txqueuelen 500  (UNSPEC)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

(gdb) p *list
$5 = {ifa_next = 0x5555555586a8, ifa_name = 0x555555558694 "gpd0",
ifa_flags = 4240, ifa_addr = 0x0, ifa_netmask = 0x0, ifa_ifu =
{ifu_broadaddr = 0x0, ifu_dstaddr = 0x0}, ifa_data = 0x555555558bb8}

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
