### PR TITLE
Fix minor incorrectness in external tables docs

### DIFF
--- a/doc/src/sgml/ref/create_external_table.sgml
+++ b/doc/src/sgml/ref/create_external_table.sgml
@@ -44,6 +44,7 @@ CREATE [READABLE] EXTERNAL [TEMPORARY | TEMP] TABLE table_name
                [NEWLINE [ AS ] 'LF' | 'CR' | 'CRLF']
                [FILL MISSING FIELDS] )]
            | 'CUSTOM' (Formatter=<formatter specifications>)
+     [ OPTIONS ( key 'value' [, ...] ) ]
      [ ENCODING 'encoding' ]
      [ [LOG ERRORS] SEGMENT REJECT LIMIT count
        [ROWS | PERCENT] ]
@@ -72,6 +73,7 @@ CREATE [READABLE] EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
                [NEWLINE [ AS ] 'LF' | 'CR' | 'CRLF']
                [FILL MISSING FIELDS] )]
            | 'CUSTOM' (Formatter=<formatter specifications>)
+     [ OPTIONS ( key 'value' [, ...] ) ]
      [ ENCODING 'encoding' ]
      [ [LOG ERRORS] SEGMENT REJECT LIMIT count
        [ROWS | PERCENT] ]
@@ -91,6 +93,7 @@ CREATE WRITABLE EXTERNAL [TEMPORARY | TEMP] TABLE table_name
                [FORCE QUOTE column [, ...]] ]
                [ESCAPE [AS] 'escape'] )]
            | 'CUSTOM' (Formatter=<formatter specifications>)
+    [ OPTIONS ( key 'value' [, ...] ) ]
     [ ENCODING 'write_encoding' ]
     [ DISTRIBUTED BY (column [opclass], [ ... ] ) | DISTRIBUTED RANDOMLY ]
 CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
@@ -107,6 +110,7 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE table_name
                [FORCE QUOTE column [, ...]] ]
                [ESCAPE [AS] 'escape'] )]
            | 'CUSTOM' (Formatter=<formatter specifications>)
+    [ OPTIONS ( key 'value' [, ...] ) ]
     [ ENCODING 'write_encoding' ]
     [ DISTRIBUTED BY (column [opclass], [ ... ] ) | DISTRIBUTED RANDOMLY ]
 

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
@@ -34,6 +34,7 @@
               [NEWLINE [ AS ] 'LF' | 'CR' | 'CRLF']
               [FILL MISSING FIELDS] )]
           | 'CUSTOM' (Formatter=<varname>&lt;formatter_specifications&gt;</varname>)
+    [ OPTIONS ( <varname>key</varname> '<varname>value</varname>' [, ...] ) ]
     [ ENCODING '<varname>encoding</varname>' ]
       [ [LOG ERRORS] SEGMENT REJECT LIMIT <varname>count</varname>
       [ROWS | PERCENT] ]
@@ -63,6 +64,7 @@ CREATE [READABLE] EXTERNAL WEB [TEMPORARY | TEMP] TABLE <varname>table_name</var
                [NEWLINE [ AS ] 'LF' | 'CR' | 'CRLF']
                [FILL MISSING FIELDS] )]
            | 'CUSTOM' (Formatter=<varname>&lt;formatter specifications&gt;</varname>)
+     [ OPTIONS ( <varname>key</varname> '<varname>value</varname>' [, ...] ) ]
      [ ENCODING '<varname>encoding</varname>' ]
      [ [LOG ERRORS] SEGMENT REJECT LIMIT <varname>count</varname>
        [ROWS | PERCENT] ]
@@ -85,6 +87,7 @@ CREATE WRITABLE EXTERNAL [TEMPORARY | TEMP] TABLE <varname>table_name</varname>
                [ESCAPE [AS] '<varname>escape</varname>'] )]
 
            | 'CUSTOM' (Formatter=<varname>&lt;formatter specifications&gt;</varname>)
+    [ OPTIONS ( <varname>key</varname> '<varname>value</varname>' [, ...] ) ]
     [ ENCODING '<varname>write_encoding</varname>' ]
     [ DISTRIBUTED BY ({<varname>column</varname> [<varname>opclass</varname>]}, [ ... ] ) | DISTRIBUTED RANDOMLY ]
 
@@ -117,6 +120,7 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE <varname>table_name</varna
                [FORCE QUOTE <varname>column</varname> [, ...]] | * ]
                [ESCAPE [AS] '<varname>escape</varname>'] )]
            | 'CUSTOM' (Formatter=<varname>&lt;formatter specifications&gt;</varname>)
+    [ OPTIONS ( <varname>key</varname> '<varname>value</varname>' [, ...] ) ]
     [ ENCODING '<varname>write_encoding</varname>' ]
     [ DISTRIBUTED BY ({<varname>column</varname> [<varname>opclass</varname>]}, [ ... ] ) | DISTRIBUTED RANDOMLY ]</codeblock>
     </section>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_exttable.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_exttable.xml
@@ -79,7 +79,7 @@
             <entry colname="col2">char</entry>
             <entry colname="col3"/>
             <entry colname="col4">Type of reject limit threshold: <codeph>r</codeph> for number of
-              rows.</entry>
+              rows, or <codeph>p</codeph> for percent.</entry>
           </row>
           <row>
             <entry colname="col1"><codeph>logerrors</codeph></entry>

--- a/src/backend/access/external/exttable_fdw_shim.c
+++ b/src/backend/access/external/exttable_fdw_shim.c
@@ -121,7 +121,7 @@ make_externalscan_info(ExtTableEntry *extEntry)
 	{
 		/*
 		 * single row error handling is requested, make sure reject limit and
-		 * error table (if requested) are valid.
+		 * reject type are valid.
 		 *
 		 * NOTE: this should never happen unless somebody modified the catalog
 		 * manually. We are just being pedantic here.

--- a/src/backend/catalog/pg_exttable.c
+++ b/src/backend/catalog/pg_exttable.c
@@ -305,7 +305,7 @@ GetExtTableEntryIfExists(Oid relid)
 		if(locationNull)
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("got invalid pg_exttable tuple. location and command are both NULL")));
+					 errmsg("invalid pg_exttable tuple, location and command are both NULL")));
 
 		extentry->command = NULL;
 	}
@@ -343,7 +343,7 @@ GetExtTableEntryIfExists(Oid relid)
 
 	if (isNull)
 	{
-		/* options list is always populated (url or ON X) */
+		/* options array is always populated, {} if no options set */
 		elog(ERROR, "could not find options for external protocol");
 	}
 	else

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -402,7 +402,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 	createForeignTableStmt->servername = PG_EXTTABLE_SERVER_NAME;
 	createForeignTableStmt->options = NIL;
 	CreateForeignTable(createForeignTableStmt, reloid,
-					   true /* skip permission checks, we checked the ourselves */);
+					   true /* skip permission checks, we checked them ourselves */);
 
 	InsertExtTableEntry(reloid,
 						iswritable,
@@ -711,7 +711,7 @@ transformFormatType(char *formatname)
  *
  * The result is an array that includes the format string.
  *
- * This method is a backported FDW's function from upper stream .
+ * This method is a backported FDW's function from upstream .
  */
 static Datum
 optionsListToArray(List *options)


### PR DESCRIPTION
The OPTIONS syntax wasn't documented, but since we don't really want to promote the external tables syntax going forward this just adds OPTIONS to the reference docs to make them complete. Also fix some smaller bits and pieces in the documentation and code comments.