### PR TITLE
Free memory of CdbPgResults.pg_results afer use.

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1200,7 +1200,7 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 		PQclear(results[i]);
 
 	if (results)
-		free(results);
+		pfree(results);
 
 	return (numOfFailed == 0);
 }

--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -799,13 +799,7 @@ cdbdisp_returnResults(CdbDispatchResults *primaryResults, CdbPgResults *cdb_pgre
 	for (i = 0; i < primaryResults->resultCount; ++i)
 		nslots += cdbdisp_numPGresult(&primaryResults->resultArray[i]);
 
-
-	cdb_pgresults->pg_results = (struct pg_result **) calloc(nslots, sizeof(struct pg_result *));
-
-	if (!cdb_pgresults->pg_results)
-		ereport(ERROR, (errcode(ERRCODE_OUT_OF_MEMORY),
-						errmsg
-						("cdbdisp_returnResults failed: out of memory")));
+	cdb_pgresults->pg_results = (struct pg_result **) palloc0(nslots * sizeof(struct pg_result *));
 
 	/*
 	 * Collect results from primary gang.
@@ -900,6 +894,12 @@ cdbdisp_clearCdbPgResults(CdbPgResults *cdb_pgresults)
 
 	for (i = 0; i < cdb_pgresults->numResults; i++)
 		PQclear(cdb_pgresults->pg_results[i]);
+
+	if (cdb_pgresults->pg_results)
+	{
+		pfree(cdb_pgresults->pg_results);
+		cdb_pgresults->pg_results = NULL;
+	}
 
 	cdb_pgresults->numResults = 0;
 }

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -663,7 +663,7 @@ pg_lock_status(PG_FUNCTION_ARGS)
 		for (i = 0; i < mystatus->numsegresults; i++)
 			PQclear(mystatus->segresults[i]);
 
-		free(mystatus->segresults);
+		pfree(mystatus->segresults);
 	}
 
 	SRF_RETURN_DONE(funcctx);


### PR DESCRIPTION
The CdbPgResults.pg_results array that is returned from various dispatch functions
is allocated by cdbdisp_returnResults() via calloc(), so it should be free()-ed
after use. To this end, cdbdisp_clearCdbPgResults() is modified to take one
additional parameter 'free_results', and free the pg_results array if this
parameter is set to true.
