### PR TITLE
6X: Revert function name of getDtxStartTime()

### DIFF
--- a/src/backend/cdb/cdbdtxcontextinfo.c
+++ b/src/backend/cdb/cdbdtxcontextinfo.c
@@ -49,7 +49,7 @@ DtxContextInfo_CreateOnMaster(DtxContextInfo *dtxContextInfo, bool inCursor,
 	dtxContextInfo->distributedXid = getDistributedTransactionId();
 	if (dtxContextInfo->distributedXid != InvalidDistributedTransactionId)
 	{
-		dtxContextInfo->distributedTimeStamp = getDtmStartTime();
+		dtxContextInfo->distributedTimeStamp = getDtxStartTime();
 
 		getDistributedTransactionIdentifier(dtxContextInfo->distributedId);
 		dtxContextInfo->curcid = curcid;

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -166,7 +166,7 @@ isDtxContext(void)
  */
 
 DistributedTransactionTimeStamp
-getDtmStartTime(void)
+getDtxStartTime(void)
 {
 	if (shmDistribTimeStamp != NULL)
 		return *shmDistribTimeStamp;
@@ -265,7 +265,7 @@ currentDtxActivate(void)
 				(errmsg("reached the limit of %u global transactions per start",
 						LastDistributedTransactionId)));
 
-	MyTmGxact->distribTimeStamp = getDtmStartTime();
+	MyTmGxact->distribTimeStamp = getDtxStartTime();
 	MyTmGxact->sessionId = gp_session_id;
 	setCurrentDtxState(DTX_STATE_ACTIVE_DISTRIBUTED);
 }

--- a/src/backend/utils/gpmon/gpmon.c
+++ b/src/backend/utils/gpmon/gpmon.c
@@ -164,7 +164,7 @@ void gpmon_gettmid(int32* tmid)
 		*tmid = (int32)QEDtxContextInfo.distributedSnapshot.distribTransactionTimeStamp;
 	else
 		/* On QD */
-		*tmid = (int32)getDtmStartTime();
+		*tmid = (int32)getDtxStartTime();
 } 
 
 

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -275,7 +275,7 @@ extern volatile int *shmNumCommittedGxacts;
 extern char *DtxStateToString(DtxState state);
 extern char *DtxProtocolCommandToString(DtxProtocolCommand command);
 extern char *DtxContextToString(DtxContext context);
-extern DistributedTransactionTimeStamp getDtmStartTime(void);
+extern DistributedTransactionTimeStamp getDtxStartTime(void);
 extern void dtxCrackOpenGid(const char	*gid,
 							DistributedTransactionTimeStamp	*distribTimeStamp,
 							DistributedTransactionId		*distribXid);


### PR DESCRIPTION
Commit d2f1b48d76483d473c968d65b319e6a7914567fb renamed the public
function getDtxStartTime() to getDtmStartTime(). The change breaks
ABI compatiblity of metrics_collector on 6X_STABLE.
There is no problem to keep that change on the master.