### PR TITLE
Avoid function bodies check on QE

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5162,6 +5162,13 @@ PostgresMain(int argc, char *argv[],
 						ereport(ERROR,
 								(errcode(ERRCODE_PROTOCOL_VIOLATION),
 								 errmsg("MPP protocol messages are only supported in QD - QE connections")));
+					/*
+					 * QD performs the function body check, hence QE doesn't
+					 * need to do the check again. Turn off the check in QE
+					 * process as an optimization. Also, helps eliminate the
+					 * need for having this GUC in-sync between QD and QE.
+					 */
+					check_function_bodies=false;
 
 					/* Set statement_timestamp() */
  					SetCurrentStatementStartTimestamp();

--- a/src/test/fsync/expected/bgwriter_checkpoint.out
+++ b/src/test/fsync/expected/bgwriter_checkpoint.out
@@ -15,8 +15,8 @@
 -- the hit times of fsync_counter is undetermined, both 5, 6 or 7 are
 -- correct, so mark them out to make case stable.
 -- start_matchsubs
--- m/num times hit:\'[5-7]\'/
--- s/num times hit:\'[5-7]\'/num times hit:\'greater_than_two\'/
+-- m/num times hit:\'[4-7]\'/
+-- s/num times hit:\'[4-7]\'/num times hit:\'greater_than_two\'/
 -- end_matchsubs
 begin;
 create function num_dirty(relid oid) returns bigint as
@@ -57,6 +57,7 @@ create table fsync_test2(a int, b int) distributed by (a);
 insert into fsync_test1 select i, i from generate_series(1,100)i;
 insert into fsync_test2 select -i, i from generate_series(1,100)i;
 end;
+vacuum pg_proc;
 -- Reset all faults.
 -- 
 -- NOTICE: important.

--- a/src/test/fsync/sql/bgwriter_checkpoint.sql
+++ b/src/test/fsync/sql/bgwriter_checkpoint.sql
@@ -15,8 +15,8 @@
 -- the hit times of fsync_counter is undetermined, both 5, 6 or 7 are
 -- correct, so mark them out to make case stable.
 -- start_matchsubs
--- m/num times hit:\'[5-7]\'/
--- s/num times hit:\'[5-7]\'/num times hit:\'greater_than_two\'/
+-- m/num times hit:\'[4-7]\'/
+-- s/num times hit:\'[4-7]\'/num times hit:\'greater_than_two\'/
 -- end_matchsubs
 begin;
 create function num_dirty(relid oid) returns bigint as
@@ -60,6 +60,7 @@ insert into fsync_test1 select i, i from generate_series(1,100)i;
 insert into fsync_test2 select -i, i from generate_series(1,100)i;
 end;
 
+vacuum pg_proc;
 -- Reset all faults.
 -- 
 -- NOTICE: important.


### PR DESCRIPTION
If session to segment resets due to gp_vmem_idle_resource_timeout, the
value of the GUC check_function_bodies should not be lost for the
session. On new connection to segments the value for this GUC should
be restored. Hence, this GUC should be in `sync_guc_name.h` and not in
`unsync_guc_name.h`.

The same problem exists in GPDB5 (where `GUC_GPDB_ADDOPT` needs to set
for this GUC) and GPDB6 as well.

This was reported from field where below function was being created.
```
set check_function_bodies = false;
-- wait for gp_vmem_idle_resource_timeout time and then run
CREATE FUNCTION public.f1() RETURNS smallint AS $$ SELECT f2() $$ LANGUAGE sql;
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
