### PR TITLE
[6X_STABLE] Bugfix: rows might be split into wrong partitions

### DIFF
--- a/contrib/pg_upgrade/test_gpdb_pre.sql
+++ b/contrib/pg_upgrade/test_gpdb_pre.sql
@@ -49,3 +49,4 @@ DROP TABLE IF EXISTS public.parttest_t;
 DROP TABLE IF EXISTS public.pt_dropped_col_distkey;
 DROP TABLE IF EXISTS partition_pruning.sales;
 DROP TABLE IF EXISTS public.partdisttest;
+DROP TABLE IF EXISTS public.users_test;

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -2840,3 +2840,59 @@ reset session authorization;
 DROP TABLE part_expr_test_range;
 DROP TABLE part_expr_test_list;
 DROP ROLE part_expr_role;
+--
+-- Test handling of dropped columns in SPLIT PARTITION. (PR #9386)
+--
+DROP TABLE IF EXISTS users_test;
+NOTICE:  table "users_test" does not exist, skipping
+CREATE TABLE users_test
+(
+  id          INT,
+  dd          TEXT,
+  user_name   VARCHAR(40),
+  user_email  VARCHAR(60),
+  born_time   TIMESTAMP,
+  create_time TIMESTAMP
+)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (create_time)
+(
+  PARTITION p2019 START ('2019-01-01'::TIMESTAMP) END ('2020-01-01'::TIMESTAMP),
+  DEFAULT PARTITION extra
+);
+NOTICE:  CREATE TABLE will create partition "users_test_1_prt_extra" for table "users_test"
+NOTICE:  CREATE TABLE will create partition "users_test_1_prt_p2019" for table "users_test"
+-- Drop useless column dd for some reason
+ALTER TABLE users_test DROP COLUMN dd;
+-- Assume we forgot/failed to split out new partitions beforehand
+INSERT INTO users_test VALUES(1, 'A', 'A@abc.com', '1970-01-01', '2019-01-01 12:00:00');
+INSERT INTO users_test VALUES(2, 'B', 'B@abc.com', '1980-01-01', '2020-01-01 12:00:00');
+INSERT INTO users_test VALUES(3, 'C', 'C@abc.com', '1990-01-01', '2021-01-01 12:00:00');
+-- New partition arrives late
+ALTER TABLE users_test SPLIT DEFAULT PARTITION START ('2020-01-01'::TIMESTAMP) END ('2021-01-01'::TIMESTAMP)
+ INTO (PARTITION p2020, DEFAULT PARTITION);
+NOTICE:  exchanged partition "extra" of relation "users_test" with relation "pg_temp_114588"
+NOTICE:  dropped partition "extra" for relation "users_test"
+NOTICE:  CREATE TABLE will create partition "users_test_1_prt_p2020" for table "users_test"
+NOTICE:  CREATE TABLE will create partition "users_test_1_prt_extra" for table "users_test"
+-- Expect A
+SELECT user_name FROM users_test_1_prt_p2019;
+ user_name 
+-----------
+ A
+(1 row)
+
+-- Expect B
+SELECT user_name FROM users_test_1_prt_p2020;
+ user_name 
+-----------
+ B
+(1 row)
+
+-- Expect C
+SELECT user_name FROM users_test_1_prt_extra;
+ user_name 
+-----------
+ C
+(1 row)
+

--- a/src/test/regress/sql/partition1.sql
+++ b/src/test/regress/sql/partition1.sql
@@ -1447,3 +1447,43 @@ reset session authorization;
 DROP TABLE part_expr_test_range;
 DROP TABLE part_expr_test_list;
 DROP ROLE part_expr_role;
+
+--
+-- Test handling of dropped columns in SPLIT PARTITION. (PR #9386)
+--
+DROP TABLE IF EXISTS users_test;
+
+CREATE TABLE users_test
+(
+  id          INT,
+  dd          TEXT,
+  user_name   VARCHAR(40),
+  user_email  VARCHAR(60),
+  born_time   TIMESTAMP,
+  create_time TIMESTAMP
+)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (create_time)
+(
+  PARTITION p2019 START ('2019-01-01'::TIMESTAMP) END ('2020-01-01'::TIMESTAMP),
+  DEFAULT PARTITION extra
+);
+
+-- Drop useless column dd for some reason
+ALTER TABLE users_test DROP COLUMN dd;
+
+-- Assume we forgot/failed to split out new partitions beforehand
+INSERT INTO users_test VALUES(1, 'A', 'A@abc.com', '1970-01-01', '2019-01-01 12:00:00');
+INSERT INTO users_test VALUES(2, 'B', 'B@abc.com', '1980-01-01', '2020-01-01 12:00:00');
+INSERT INTO users_test VALUES(3, 'C', 'C@abc.com', '1990-01-01', '2021-01-01 12:00:00');
+
+-- New partition arrives late
+ALTER TABLE users_test SPLIT DEFAULT PARTITION START ('2020-01-01'::TIMESTAMP) END ('2021-01-01'::TIMESTAMP)
+ INTO (PARTITION p2020, DEFAULT PARTITION);
+
+-- Expect A
+SELECT user_name FROM users_test_1_prt_p2019;
+-- Expect B
+SELECT user_name FROM users_test_1_prt_p2020;
+-- Expect C
+SELECT user_name FROM users_test_1_prt_extra;


### PR DESCRIPTION
split_rows() scans tuples from T and route them to new parts (A, B) based
on A's or B's constraints. If T has one or more dropped columns before its
partition key, T's partition key would have a different attribute number
from its new parts. In this case, the constraints choose a wrong column
which can cause bad behaviors.

To fix it, each tuple iteration should reconstruct the partition tuple
slot and assign it to econtext before ExecQual calls. The reconstruction
process can happen once or twice because we assume A, B might have two
different tupdescs.

One bad behavior, rows are split into wrong partitions. Reproduce:

```sql
DROP TABLE IF EXISTS users_test;

CREATE TABLE users_test
(
  id          INT,
  dd          TEXT,
  user_name   VARCHAR(40),
  user_email  VARCHAR(60),
  born_time   TIMESTAMP,
  create_time TIMESTAMP
)
DISTRIBUTED BY (id)
PARTITION BY RANGE (create_time)
(
  PARTITION p2019 START ('2019-01-01'::TIMESTAMP) END ('2020-01-01'::TIMESTAMP),
  DEFAULT PARTITION extra
);

/* Drop useless column dd for some reason */
ALTER TABLE users_test DROP COLUMN dd;

/* Forgot/Failed to split out new partitions beforehand */
INSERT INTO users_test VALUES(1, 'A', 'A@abc.com', '1970-01-01', '2020-01-01 12:00:00');
INSERT INTO users_test VALUES(2, 'B', 'B@abc.com', '1980-01-01', '2020-01-02 18:00:00');
INSERT INTO users_test VALUES(3, 'C', 'C@abc.com', '1990-01-01', '2020-01-03 08:00:00');

/* New partition arrives late */
ALTER TABLE users_test SPLIT DEFAULT PARTITION START ('2020-01-01'::TIMESTAMP) END ('2021-01-01'::TIMESTAMP)
 INTO (PARTITION p2020, DEFAULT PARTITION);

/*
 * - How many new users already in 2020?
 * - Wow, no one.
 */
SELECT count(1) FROM users_test_1_prt_p2020;
```

Reviewed-by: Georgios Kokolatos <gkokolatos@pivotal.io>
Reviewed-by: Heikki Linnakangas <hlinnakangas@pivotal.io>
(cherry picked from commit 101922f1540bc670ee1756e26612bfe0f4edb299)

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
