### PR TITLE
Refactor Memtuple functions

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -947,7 +947,7 @@ upgrade_tuple(AppendOnlyExecutorReadBlock *executorReadBlock,
 		/* get attribute values form mis-aligned tuple */
 		memtuple_deform_misaligned(mtup, pbind, values, isnull);
 		/* Form a new, properly-aligned, tuple */
-		newtuple = memtuple_form_to(pbind, values, isnull, NULL, NULL, true);
+		newtuple = memtuple_form_to(pbind, values, isnull, NULL, NULL, false);
 	}
 	else
 	{

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -947,7 +947,7 @@ upgrade_tuple(AppendOnlyExecutorReadBlock *executorReadBlock,
 		/* get attribute values form mis-aligned tuple */
 		memtuple_deform_misaligned(mtup, pbind, values, isnull);
 		/* Form a new, properly-aligned, tuple */
-		newtuple = memtuple_form_to(pbind, values, isnull, NULL, NULL, false);
+		newtuple = memtuple_form(pbind, values, isnull);
 	}
 	else
 	{

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -954,7 +954,7 @@ upgrade_tuple(AppendOnlyExecutorReadBlock *executorReadBlock,
 		/*
 		 * make a modifiable copy
 		 */
-		newtuple = memtuple_copy_to(mtup, NULL, NULL);
+		newtuple = memtuple_copy(mtup);
 	}
 
 	/*
@@ -2865,7 +2865,7 @@ appendonly_insert(AppendOnlyInsertDesc aoInsertDesc,
 		 * so performance of this case isn't important.
 		 */
 		if (tup == instup)
-			tup = memtuple_copy_to(instup, NULL, NULL);
+			tup = memtuple_copy(instup);
 
 		/*
 		 * If the object id of this tuple has already been assigned, trust the

--- a/src/backend/access/common/memtuple.c
+++ b/src/backend/access/common/memtuple.c
@@ -907,24 +907,18 @@ Datum memtuple_getattr(MemTuple mtup, MemTupleBinding *pbind, int attnum, bool *
 	return memtuple_getattr_by_alignment(mtup, pbind, attnum, isnull, true /* aligned */);
 }
 
-
-MemTuple memtuple_copy_to(MemTuple mtup, MemTuple dest, uint32 *destlen)
+/*
+ * Return a palloc'd copy of 'mtup'.
+ *
+ * This corresponds to heap_copytuple() for HeapTuples.
+ */
+MemTuple
+memtuple_copy(MemTuple mtup)
 {
-	uint32 len = memtuple_get_size(mtup);
+	MemTuple	dest;
+	uint32		len = memtuple_get_size(mtup);
 
-	if(!destlen)
-		dest = (MemTuple) palloc(len);
-	else
-	{
-		if(*destlen < len)
-		{
-			*destlen = len;
-			return NULL;
-		}
-
-		*destlen = len;
-	}
-
+	dest = (MemTuple) palloc(len);
 	memcpy((char *) dest, (char *) mtup, len);
 	return dest;
 }

--- a/src/backend/access/common/memtuple.c
+++ b/src/backend/access/common/memtuple.c
@@ -558,6 +558,17 @@ static inline unsigned char *memtuple_get_nullp(MemTuple mtup, MemTupleBinding *
 	return mtup->PRIVATE_mt_bits + (mtbind_has_oid(pbind) ? sizeof(Oid) : 0);
 }
 
+/*
+ * Form a memtuple from values and isnull. Returns a palloc'd tuple.
+ *
+ * This corresponds to heap_form_tuple() for HeapTuples.
+ */
+MemTuple
+memtuple_form(MemTupleBinding *pbind, Datum *values, bool *isnull)
+{
+	return memtuple_form_to(pbind, values, isnull, NULL, NULL, false);
+}
+
 /* form a memtuple from values and isnull, to a prespecified buffer */
 MemTuple memtuple_form_to(
 		MemTupleBinding *pbind,

--- a/src/backend/access/heap/tuptoaster.c
+++ b/src/backend/access/heap/tuptoaster.c
@@ -662,7 +662,7 @@ compute_dest_tuplen(TupleDesc tupdesc, MemTupleBinding *pbind, bool hasnull, Dat
 	if(pbind) 
 	{
 		uint32 nullsave_dummy;
-		return (int) compute_memtuple_size(pbind, d, isnull, hasnull, &nullsave_dummy);
+		return (int) compute_memtuple_size(pbind, d, isnull, &nullsave_dummy, &hasnull);
 	}
 
 	return heap_compute_data_size(tupdesc, d, isnull);

--- a/src/backend/access/heap/tuptoaster.c
+++ b/src/backend/access/heap/tuptoaster.c
@@ -1171,7 +1171,7 @@ toast_insert_or_update_generic(Relation rel, GenericTuple newtup, GenericTuple o
 	{
 		if(ismemtuple)
 		{
-			result_gtuple = (GenericTuple) memtuple_form_to(pbind, toast_values, toast_isnull, NULL, NULL, false);
+			result_gtuple = (GenericTuple) memtuple_form(pbind, toast_values, toast_isnull);
 			if (mtbind_has_oid(pbind))
 			{
 				Oid			oid;

--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -427,14 +427,17 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 		 * Send it as a MemTuple.
 		 */
 		MemTuple	tuple;
-		int			tupleSize;
+		uint32		tupleSize;
 		int			paddedSize;
+		uint32		null_save_len = 0;
+		bool		has_nulls = false;
 
 		if (slot->PRIVATE_tts_memtuple &&
 			!memtuple_get_hasext(slot->PRIVATE_tts_memtuple))
 		{
 			/* we can use the existing MemTuple as it is. */
 			tuple = slot->PRIVATE_tts_memtuple;
+			tupleSize = memtuple_get_size(tuple);
 		}
 		else
 		{
@@ -469,32 +472,38 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 				}
 			}
 
-			tuple = memtuple_form_to(slot->tts_mt_bind, values, isnull, NULL, NULL);
+			tupleSize = compute_memtuple_size(slot->tts_mt_bind, values, isnull,
+											  &null_save_len, &has_nulls);
+			tuple = palloc(tupleSize);
+			memtuple_form_to(slot->tts_mt_bind, values, isnull,
+							 tupleSize, null_save_len, has_nulls,
+							 tuple);
 			MemoryContextSwitchTo(oldContext);
 		}
 
-		if (CandidateForSerializeDirect(targetRoute, b))
+		/*
+		 * Here we first try to in-line serialize the tuple directly into
+		 * buffer.
+		 */
+		paddedSize = TYPEALIGN(TUPLE_CHUNK_ALIGN, tupleSize);
+		if (CandidateForSerializeDirect(targetRoute, b) &&
+			paddedSize + TUPLE_CHUNK_HEADER_SIZE <= b->prilen)
 		{
 			/*
-			 * Here we first try to in-line serialize the tuple directly into
-			 * buffer.
+			 * Will fit.
+			 *
+			 * XXX: We could almost point memtuple_form_to() directly at the
+			 * target buffer, instead of forming a palloc'd copy first, but alas,
+			 * memtuple_form_to() assumes that the target pointer is aligned.
 			 */
-			tupleSize = memtuple_get_size(tuple);
+			memcpy(b->pri + TUPLE_CHUNK_HEADER_SIZE, tuple, tupleSize);
+			memset(b->pri + TUPLE_CHUNK_HEADER_SIZE + tupleSize, 0, paddedSize - tupleSize);
 
-			paddedSize = TYPEALIGN(TUPLE_CHUNK_ALIGN, tupleSize);
+			dataSize += paddedSize;
 
-			if (paddedSize + TUPLE_CHUNK_HEADER_SIZE <= b->prilen)
-			{
-				/* will fit. */
-				memcpy(b->pri + TUPLE_CHUNK_HEADER_SIZE, tuple, tupleSize);
-				memset(b->pri + TUPLE_CHUNK_HEADER_SIZE + tupleSize, 0, paddedSize - tupleSize);
-
-				dataSize += paddedSize;
-
-				SetChunkType(b->pri, TC_WHOLE);
-				SetChunkDataSize(b->pri, dataSize - TUPLE_CHUNK_HEADER_SIZE);
-				return dataSize;
-			}
+			SetChunkType(b->pri, TC_WHOLE);
+			SetChunkDataSize(b->pri, dataSize - TUPLE_CHUNK_HEADER_SIZE);
+			return dataSize;
 		}
 
 		/*
@@ -508,8 +517,8 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 
 		AssertState(s_tupSerMemCtxt != NULL);
 
-		addByteStringToChunkList(tcList, (char *) tuple, memtuple_get_size(tuple), &pSerInfo->chunkCache);
-		addPadding(tcList, &pSerInfo->chunkCache, memtuple_get_size(tuple));
+		addByteStringToChunkList(tcList, (char *) tuple, tupleSize, &pSerInfo->chunkCache);
+		addPadding(tcList, &pSerInfo->chunkCache, tupleSize);
 
 		MemoryContextReset(s_tupSerMemCtxt);
 	}

--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -16,6 +16,8 @@
 #include "postgres.h"
 
 #include "access/htup.h"
+#include "access/memtup.h"
+#include "access/tuptoaster.h"
 #include "catalog/pg_type.h"
 #include "cdb/cdbmotion.h"
 #include "cdb/cdbsrlz.h"
@@ -30,8 +32,6 @@
 #include "utils/builtins.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
-
-#include "access/memtup.h"
 
 /*
  * Transient record types table is sent to upsteam via a specially constructed
@@ -438,11 +438,38 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 		}
 		else
 		{
+			Datum	   *values = slot_get_values(slot);
+			bool	   *isnull = slot_get_isnull(slot);
 			MemoryContext oldContext;
-			oldContext = MemoryContextSwitchTo(s_tupSerMemCtxt);
+
 			slot_getallattrs(slot);
-			tuple = memtuple_form_to(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot),
-									  NULL, NULL, true);
+
+			oldContext = MemoryContextSwitchTo(s_tupSerMemCtxt);
+
+			/*
+			 * If the tuple contains any toasted attributes, fetch them now,
+			 * because the receiver cannot fetch them.
+			 */
+			for (int i = 0; i < tupdesc->natts; i++)
+			{
+				Form_pg_attribute attr = tupdesc->attrs[i];
+
+				/* memtuple_form_to() treats dropped attibutes as null */
+				if (attr->attisdropped || isnull[i])
+					continue;
+
+				if (attr->attlen == -1 && VARATT_IS_EXTERNAL(DatumGetPointer(values[i])))
+				{
+					if (values == slot_get_values(slot))
+					{
+						values = (Datum *) palloc(tupdesc->natts * sizeof(Datum));
+						memcpy(values, slot_get_values(slot), tupdesc->natts * sizeof(Datum));
+					}
+					values[i] = PointerGetDatum(heap_tuple_fetch_attr((struct varlena *)DatumGetPointer(values[i])));
+				}
+			}
+
+			tuple = memtuple_form_to(slot->tts_mt_bind, values, isnull, NULL, NULL);
 			MemoryContextSwitchTo(oldContext);
 		}
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6661,10 +6661,7 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 					 * Form the new tuple. Note that we don't explicitly pfree it,
 					 * since the per-tuple memory context will be reset shortly.
 					 */
-					mtuple = memtuple_form_to(mt_bind,
-											  values, isnull,
-											  NULL, NULL, false);
-
+					mtuple = memtuple_form(mt_bind, values, isnull);
 
 					/* Preserve OID, if any */
 					if (newTupDesc->tdhasoid)

--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -336,7 +336,7 @@ makeHashAggEntryForInput(AggState *aggstate, TupleTableSlot *inputslot, uint32 h
 													 values,
 													 isnull,
 													 entry->tuple_and_aggs,
-													 &tup_len, false);
+													 &tup_len);
 	Assert(tup_len > 0 && entry->tuple_and_aggs == NULL);
 
 	if (GET_TOTAL_USED_SIZE(hashtable) + MAXALIGN(MAXALIGN(tup_len) + aggs_len) >=
@@ -356,7 +356,7 @@ makeHashAggEntryForInput(AggState *aggstate, TupleTableSlot *inputslot, uint32 h
 													 values,
 													 isnull,
 													 entry->tuple_and_aggs,
-													 &len, false);
+													 &len);
 	Assert(len == tup_len && entry->tuple_and_aggs != NULL);
 
 	MemoryContextSwitchTo(oldcxt);

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -662,12 +662,12 @@ ExecCopySlotMemTupleTo(TupleTableSlot *slot, MemoryContext pctxt, char *dest, un
 	}
 
 	slot_getallattrs(slot);
-	mtup = memtuple_form_to(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot), (MemTuple) dest, len, false);
+	mtup = memtuple_form_to(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot), (MemTuple) dest, len);
 
 	if(mtup || !pctxt)
 		return mtup;
 	mtup = (MemTuple) MemoryContextAlloc(pctxt, *len);
-	mtup = memtuple_form_to(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot), mtup, len, false);
+	mtup = memtuple_form_to(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot), mtup, len);
 
 	Assert(mtup);
 	return mtup;
@@ -737,7 +737,7 @@ ExecFetchSlotMemTuple(TupleTableSlot *slot)
 
 	tuplen = slot->PRIVATE_tts_mtup_buf_len;
 	newTuple = memtuple_form_to(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot),
-				(MemTuple) slot->PRIVATE_tts_mtup_buf, &tuplen, false);
+				(MemTuple) slot->PRIVATE_tts_mtup_buf, &tuplen);
 
 	if(!newTuple)
 	{
@@ -748,7 +748,7 @@ ExecFetchSlotMemTuple(TupleTableSlot *slot)
 		slot->PRIVATE_tts_mtup_buf_len = tuplen;
 
 		newTuple = memtuple_form_to(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot),
-			(MemTuple) slot->PRIVATE_tts_mtup_buf, &tuplen, false);
+			(MemTuple) slot->PRIVATE_tts_mtup_buf, &tuplen);
 	}
 
 	Assert(newTuple);

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -633,7 +633,7 @@ ExecCopySlotMemTuple(TupleTableSlot *slot)
 	/*
 	 * Otherwise we need to build a tuple from the Datum array.
 	 */
-	return memtuple_form_to(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot), NULL, 0, false);
+	return memtuple_form(slot->tts_mt_bind, slot_get_values(slot), slot_get_isnull(slot));
 }
 
 MemTuple

--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -4240,11 +4240,9 @@ copytup_heap(Tuplesortstate *state, SortTuple *stup, void *tup)
 	MemoryContext oldcontext = MemoryContextSwitchTo(state->tuplecontext);
 
 	slot_getallattrs(slot);
-	stup->tuple = memtuple_form_to(state->mt_bind, 
-			slot_get_values(slot),
-			slot_get_isnull(slot),
-			NULL, NULL, false
-			);
+	stup->tuple = memtuple_form(state->mt_bind,
+								slot_get_values(slot),
+								slot_get_isnull(slot));
 	USEMEM(state, GetMemoryChunkSpace(stup->tuple));
 
 	Assert(state->mt_bind);

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -2847,11 +2847,9 @@ copytup_heap(Tuplesortstate_mk *state, MKEntry *e, void *tup)
 	TupleTableSlot *slot = (TupleTableSlot *) tup;
 
 	slot_getallattrs(slot);
-	e->ptr = (void *) memtuple_form_to(state->mt_bind,
-									   slot_get_values(slot),
-									   slot_get_isnull(slot),
-									   NULL, NULL, false
-		);
+	e->ptr = (void *) memtuple_form(state->mt_bind,
+									slot_get_values(slot),
+									slot_get_isnull(slot));
 
 	state->totalTupleBytes += memtuple_get_size((MemTuple) e->ptr);
 

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -795,7 +795,7 @@ tuplestore_putvalues(Tuplestorestate *state, TupleDesc tdesc,
 		Assert(state->mt_bind);
 	}
 
-	MemTuple tuple = memtuple_form_to(state->mt_bind, values, isnull, NULL, NULL, false);
+	MemTuple tuple = memtuple_form(state->mt_bind, values, isnull);
 
 	USEMEM(state, GetMemoryChunkSpace(tuple));
 

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -1144,7 +1144,7 @@ tuplestore_gettupleslot(Tuplestorestate *state, bool forward,
 		if (copy && !should_free)
 		{
 			if (is_memtuple(tuple))
-				tuple = (GenericTuple) memtuple_copy_to((MemTuple) tuple, NULL, NULL);
+				tuple = (GenericTuple) memtuple_copy((MemTuple) tuple);
 			else
 				tuple = (GenericTuple) heap_copytuple((HeapTuple) tuple);
 			should_free = true;
@@ -1552,9 +1552,9 @@ static void *
 copytup_heap(Tuplestorestate *state, void *tup)
 {
 	if (!is_memtuple((GenericTuple) tup))
-		return heaptuple_copy_to((HeapTuple) tup, NULL, NULL);
+		return heap_copytuple((HeapTuple) tup);
 	else
-		return memtuple_copy_to((MemTuple) tup, NULL, NULL);
+		return memtuple_copy((MemTuple) tup);
 }
 
 static void

--- a/src/include/access/memtup.h
+++ b/src/include/access/memtup.h
@@ -145,7 +145,7 @@ extern MemTupleBinding* create_memtuple_binding(TupleDesc tupdesc);
 extern Datum memtuple_getattr(MemTuple mtup, MemTupleBinding *pbind, int attnum, bool *isnull);
 extern bool memtuple_attisnull(MemTuple mtup, MemTupleBinding *pbind, int attnum);
 
-extern uint32 compute_memtuple_size(MemTupleBinding *pbind, Datum *values, bool *isnull, bool hasnull, uint32 *nullsaves);
+extern uint32 compute_memtuple_size(MemTupleBinding *pbind, Datum *values, bool *isnull, uint32 *nullsaves, bool *has_nulls);
 
 extern MemTuple memtuple_copy_to(MemTuple mtup, MemTuple dest, uint32 *destlen);
 extern MemTuple memtuple_form(MemTupleBinding *pbind, Datum *values, bool *isnull);

--- a/src/include/access/memtup.h
+++ b/src/include/access/memtup.h
@@ -148,6 +148,7 @@ extern bool memtuple_attisnull(MemTuple mtup, MemTupleBinding *pbind, int attnum
 extern uint32 compute_memtuple_size(MemTupleBinding *pbind, Datum *values, bool *isnull, bool hasnull, uint32 *nullsaves);
 
 extern MemTuple memtuple_copy_to(MemTuple mtup, MemTuple dest, uint32 *destlen);
+extern MemTuple memtuple_form(MemTupleBinding *pbind, Datum *values, bool *isnull);
 extern MemTuple memtuple_form_to(MemTupleBinding *pbind, Datum *values, bool *isnull, MemTuple dest, uint32 *destlen, bool inline_toast);
 extern void memtuple_deform(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull);
 extern void memtuple_deform_misaligned(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull);

--- a/src/include/access/memtup.h
+++ b/src/include/access/memtup.h
@@ -149,7 +149,7 @@ extern uint32 compute_memtuple_size(MemTupleBinding *pbind, Datum *values, bool 
 
 extern MemTuple memtuple_copy_to(MemTuple mtup, MemTuple dest, uint32 *destlen);
 extern MemTuple memtuple_form(MemTupleBinding *pbind, Datum *values, bool *isnull);
-extern MemTuple memtuple_form_to(MemTupleBinding *pbind, Datum *values, bool *isnull, MemTuple dest, uint32 *destlen, bool inline_toast);
+extern MemTuple memtuple_form_to(MemTupleBinding *pbind, Datum *values, bool *isnull, MemTuple dest, uint32 *destlen);
 extern void memtuple_deform(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull);
 extern void memtuple_deform_misaligned(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull);
 

--- a/src/include/access/memtup.h
+++ b/src/include/access/memtup.h
@@ -149,7 +149,9 @@ extern uint32 compute_memtuple_size(MemTupleBinding *pbind, Datum *values, bool 
 
 extern MemTuple memtuple_copy_to(MemTuple mtup, MemTuple dest, uint32 *destlen);
 extern MemTuple memtuple_form(MemTupleBinding *pbind, Datum *values, bool *isnull);
-extern MemTuple memtuple_form_to(MemTupleBinding *pbind, Datum *values, bool *isnull, MemTuple dest, uint32 *destlen);
+extern void memtuple_form_to(MemTupleBinding *pbind, Datum *values, bool *isnull,
+							 uint32 len, uint32 null_save_len, bool hasnull,
+							 MemTuple mtup);
 extern void memtuple_deform(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull);
 extern void memtuple_deform_misaligned(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull);
 

--- a/src/include/access/memtup.h
+++ b/src/include/access/memtup.h
@@ -147,7 +147,7 @@ extern bool memtuple_attisnull(MemTuple mtup, MemTupleBinding *pbind, int attnum
 
 extern uint32 compute_memtuple_size(MemTupleBinding *pbind, Datum *values, bool *isnull, uint32 *nullsaves, bool *has_nulls);
 
-extern MemTuple memtuple_copy_to(MemTuple mtup, MemTuple dest, uint32 *destlen);
+extern MemTuple memtuple_copy(MemTuple mtup);
 extern MemTuple memtuple_form(MemTupleBinding *pbind, Datum *values, bool *isnull);
 extern void memtuple_form_to(MemTupleBinding *pbind, Datum *values, bool *isnull,
 							 uint32 len, uint32 null_save_len, bool hasnull,


### PR DESCRIPTION
Small refactoring that makes the memtuple functions nicer to use, and closer to the corresponding upstream heaptuple functions.