### PR TITLE
WIP: ALter Table Alter Column Type AOCO table optimization

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3535,6 +3535,7 @@ _copyAlterTableCmd(const AlterTableCmd *from)
 	/* Need to copy AT workspace since process uses copy internally. */
 	COPY_NODE_FIELD(partoids);
 	COPY_SCALAR_FIELD(missing_ok);
+	COPY_SCALAR_FIELD(aoco_alter_type_norewrite);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3248,6 +3248,7 @@ _outAlterTableCmd(StringInfo str, const AlterTableCmd *node)
 	WRITE_BOOL_FIELD(part_expanded);
 	WRITE_NODE_FIELD(partoids);
 	WRITE_BOOL_FIELD(missing_ok);
+	WRITE_BOOL_FIELD(aoco_alter_type_norewrite);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -607,6 +607,7 @@ _readAlterTableCmd(void)
 	READ_BOOL_FIELD(part_expanded);
 	READ_NODE_FIELD(partoids);
 	READ_BOOL_FIELD(missing_ok);
+	READ_BOOL_FIELD(aoco_alter_type_norewrite);
 
 	READ_DONE();
 }

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1690,6 +1690,9 @@ typedef struct AlterTableCmd	/* one subcommand of an ALTER TABLE */
 	bool		part_expanded;	/* expands from another command, for partitioning */
 	List	   *partoids;		/* If applicable, OIDs of partition part tables */
 	bool		missing_ok;		/* skip error if missing? */
+
+	bool		aoco_alter_type_norewrite;		/* GPDB: do not re-write aoco table if possible */
+
 	/* addition info for partition table */
 	Bitmapset	*ps_none;
 	Bitmapset	*ps_root;

--- a/src/test/regress/expected/aoco_alter_opt.out
+++ b/src/test/regress/expected/aoco_alter_opt.out
@@ -1,0 +1,98 @@
+DROP TABLE IF EXISTS aoco_opt;
+CREATE TABLE aoco_opt (
+	a integer,
+	b integer default 3 NOT NULL encoding(compresstype=zlib,compresslevel=2),
+	c integer,
+	default column encoding (compresstype=RLE_TYPE)
+) WITH (
+	appendonly=true,
+	orientation=column
+) DISTRIBUTED BY (a);
+PREPARE attopts AS SELECT
+	attname,
+	atttypid,
+	pga.attnum,
+	attisdropped,
+	attislocal,
+	attstorage,
+	attinhcount,
+	pge.attoptions
+FROM
+	pg_attribute_encoding pge,
+	pg_attribute pga,
+	pg_class pgc
+WHERE
+	pga.attrelid = pgc.oid AND
+	pga.attnum = pge.attnum AND
+	pge.attrelid = pgc.oid AND
+	pgc.relname = 'aoco_opt'; 
+SELECT relfilenode AS origfilenode FROM pg_class WHERE relname = 'aoco_opt' \gset
+EXECUTE attopts;
+ attname | atttypid | attnum | attisdropped | attislocal | attstorage | attinhcount |                       attoptions                        
+---------+----------+--------+--------------+------------+------------+-------------+---------------------------------------------------------
+ a       |       23 |      1 | f            | t          | p          |           0 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ c       |       23 |      3 | f            | t          | p          |           0 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ b       |       23 |      2 | f            | t          | p          |           0 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+(3 rows)
+
+INSERT INTO aoco_opt SELECT a, a AS b, a AS c FROM generate_series(0, 9) a;
+BEGIN;
+ALTER TABLE aoco_opt ALTER COLUMN b SET DATA TYPE text;
+EXECUTE attopts;
+           attname            | atttypid | attnum | attisdropped | attislocal | attstorage | attinhcount |                       attoptions                        
+------------------------------+----------+--------+--------------+------------+------------+-------------+---------------------------------------------------------
+ a                            |       23 |      1 | f            | t          | p          |           0 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ c                            |       23 |      3 | f            | t          | p          |           0 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ........pg.dropped.2........ |        0 |      2 | t            | t          | p          |           0 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+ b                            |       25 |      4 | f            | t          | x          |           0 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+(4 rows)
+
+SELECT relname FROM pg_class WHERE relfilenode = :origfilenode;
+ relname  
+----------
+ aoco_opt
+(1 row)
+
+TABLE aoco_opt;
+ a | c | b 
+---+---+---
+ 5 | 5 | 5
+ 6 | 6 | 6
+ 9 | 9 | 9
+ 2 | 2 | 2
+ 3 | 3 | 3
+ 4 | 4 | 4
+ 7 | 7 | 7
+ 8 | 8 | 8
+ 0 | 0 | 0
+ 1 | 1 | 1
+(10 rows)
+
+-- This will fail due to silently dropped default
+INSERT INTO aoco_opt (a, c) VALUES (10, 10);
+ERROR:  null value in column "b" violates not-null constraint  (seg2 127.0.1.1:7004 pid=13130)
+DETAIL:  Failing row contains (10, 10, null).
+ROLLBACK;
+EXECUTE attopts;
+ attname | atttypid | attnum | attisdropped | attislocal | attstorage | attinhcount |                       attoptions                        
+---------+----------+--------+--------------+------------+------------+-------------+---------------------------------------------------------
+ a       |       23 |      1 | f            | t          | p          |           0 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ c       |       23 |      3 | f            | t          | p          |           0 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ b       |       23 |      2 | f            | t          | p          |           0 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+(3 rows)
+
+TABLE aoco_opt;
+ a | b | c 
+---+---+---
+ 5 | 5 | 5
+ 6 | 6 | 6
+ 9 | 9 | 9
+ 2 | 2 | 2
+ 3 | 3 | 3
+ 4 | 4 | 4
+ 7 | 7 | 7
+ 8 | 8 | 8
+ 0 | 0 | 0
+ 1 | 1 | 1
+(10 rows)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -121,7 +121,7 @@ test: db_size_functions
 # ERROR:  parameter "gp_interconnect_type" cannot be set after connection start
 
 ignore: gp_portal_error
-test: external_table external_table_create_privs column_compression eagerfree alter_table_aocs alter_table_aocs2 alter_distribution_policy aoco_privileges
+test: external_table external_table_create_privs column_compression eagerfree alter_table_aocs alter_table_aocs2 alter_distribution_policy aoco_privileges aoco_alter_opt
 test: alter_table_set alter_table_gp alter_table_ao subtransaction_visibility oid_consistency udf_exception_blocks
 # below test(s) inject faults so each of them need to be in a separate group
 test: aocs

--- a/src/test/regress/sql/aoco_alter_opt.sql
+++ b/src/test/regress/sql/aoco_alter_opt.sql
@@ -1,0 +1,48 @@
+DROP TABLE IF EXISTS aoco_opt;
+CREATE TABLE aoco_opt (
+	a integer,
+	b integer default 3 NOT NULL encoding(compresstype=zlib,compresslevel=2),
+	c integer,
+	default column encoding (compresstype=RLE_TYPE)
+) WITH (
+	appendonly=true,
+	orientation=column
+) DISTRIBUTED BY (a);
+
+PREPARE attopts AS SELECT
+	attname,
+	atttypid,
+	pga.attnum,
+	attisdropped,
+	attislocal,
+	attstorage,
+	attinhcount,
+	pge.attoptions
+FROM
+	pg_attribute_encoding pge,
+	pg_attribute pga,
+	pg_class pgc
+WHERE
+	pga.attrelid = pgc.oid AND
+	pga.attnum = pge.attnum AND
+	pge.attrelid = pgc.oid AND
+	pgc.relname = 'aoco_opt'; 
+
+SELECT relfilenode AS origfilenode FROM pg_class WHERE relname = 'aoco_opt' \gset
+
+EXECUTE attopts;
+
+INSERT INTO aoco_opt SELECT a, a AS b, a AS c FROM generate_series(0, 9) a;
+
+BEGIN;
+ALTER TABLE aoco_opt ALTER COLUMN b SET DATA TYPE text;
+EXECUTE attopts;
+SELECT relname FROM pg_class WHERE relfilenode = :origfilenode;
+TABLE aoco_opt;
+
+-- This will fail due to silently dropped default
+INSERT INTO aoco_opt (a, c) VALUES (10, 10);
+ROLLBACK;
+
+EXECUTE attopts;
+TABLE aoco_opt;


### PR DESCRIPTION
Append-optimised column oriented (AOCO) tables are organised as one file per
column at storage layer.  This layout is amenable to optimisation in case of
ALTER TABLE ALTER COLUMN command where rewriting the entire table being altered
can be avoided.  The ADD COLUMN subcommand of ALTER TABLE is already optimised
like this for AOCO tables.

There is a catch. The file names on disk are semantically significant.

Bypass this by converting the ALTER COLUMN subcommand into DROP COLUMN and ADD
COLUMN subcommands during preparation step of ALTER TABLE.  The altered column
gets a new attribute number in catalog, new entry in pg_aoseg table and a new
file on disk.

This works great because the magic of MVCC can allow two versions of the
relation to exist as long as there are open transactions referring to them.

The current implementaiton is trying to limit the diversion with upstream and
some operation might have been fitted better in a different layer, though they
are grouped together to limit the foot print.

A bug was found that DROP column does not remove segment files from dropped
columns. This should be fixed in a different PR.

There are a couple TODOs:
	* deal with default values / constraints when coercing to the type.
According to the postgres documentation: `PostgreSQL will attempt to convert the
column's default value (if any) to the new type, as well as any constraints that
involve the column. But these conversions might fail, or might produce
surprising results. It's often best to drop any constraints on the column before
altering its type, and then add back suitably modified constraints afterwards.`
Maybe emiting a message that defaults will be silently dropped or aborting the
optimization is also fine...
 	* deal with existing indexes. Now the indexes are silently dropped. Same as
 above.

Co-authored-by: Asim R P <apraveen@pivotal.io>