### PR TITLE
Fix an assert failure in execMotionSortedReceiver().

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -2781,6 +2781,13 @@ ExecutePlan(EState *estate,
 	uint64		current_tuple_count;
 
 	/*
+	 * For holdable cursor, the plan is executed without rewinding on gpdb. We
+	 * need to quit if the executor has already emitted all tuples.
+	 */
+	if (estate->es_got_eos)
+		return;
+
+	/*
 	 * initialize local variables
 	 */
 	current_tuple_count = 0;

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -535,10 +535,11 @@ execMotionSortedReceiver(MotionState *node)
 			}
 #endif
 		}
-
-		/* At EOS, drop this sender from the priority queue. */
-		else if (!binaryheap_empty(hp))
+		else
+		{
+			/* At EOS, drop this sender from the priority queue. */
 			binaryheap_remove_first(hp);
+		}
 	}
 
 	/* Finished if all senders have returned EOS. */

--- a/src/test/regress/expected/portals.out
+++ b/src/test/regress/expected/portals.out
@@ -1202,3 +1202,43 @@ fetch all in c2;
 fetch backward all in c2;
 ERROR:  backward scan is not supported in this version of Greenplum Database
 rollback;
+-- gpdb: Test executor should return NULL directly during commit for holdable
+-- cursor if previously executor has emitted all tuples. We've seen two issues
+-- below.
+-- Assert failure:
+-- DETAIL:  FailedAssertion("!(!((heap)->bh_size == 0) && heap->bh_has_heap_property)", File: "binaryheap.c", Line: 161)
+CREATE TABLE foo1_tbl (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO foo1_tbl values(2);
+BEGIN;
+DECLARE foo1 CURSOR WITH HOLD FOR SELECT * FROM foo1_tbl ORDER BY a;
+FETCH ALL FROM foo1;
+ a 
+---
+ 2
+(1 row)
+
+COMMIT;
+FETCH ALL FROM foo1;
+ a 
+---
+(0 rows)
+
+CLOSE foo1;
+DROP TABLE foo1_tbl;
+-- ERROR:  cannot execute squelched plan node of type: 232 (execProcnode.c:887)
+BEGIN;
+DECLARE foo2 CURSOR WITH HOLD FOR SELECT relname, spcname FROM pg_catalog.pg_tablespace t, pg_catalog.pg_class c where c.reltablespace = t.oid AND c.relname = 'foo1_tbl';
+FETCH ALL FROM foo2;
+ relname | spcname 
+---------+---------
+(0 rows)
+
+COMMIT;
+FETCH ALL FROM foo2;
+ relname | spcname 
+---------+---------
+(0 rows)
+
+CLOSE foo2;

--- a/src/test/regress/sql/portals.sql
+++ b/src/test/regress/sql/portals.sql
@@ -524,3 +524,27 @@ declare c2 scroll cursor for select generate_series(1,3) as g;
 fetch all in c2;
 fetch backward all in c2;
 rollback;
+
+-- gpdb: Test executor should return NULL directly during commit for holdable
+-- cursor if previously executor has emitted all tuples. We've seen two issues
+-- below.
+
+-- Assert failure:
+-- DETAIL:  FailedAssertion("!(!((heap)->bh_size == 0) && heap->bh_has_heap_property)", File: "binaryheap.c", Line: 161)
+CREATE TABLE foo1_tbl (a int);
+INSERT INTO foo1_tbl values(2);
+BEGIN;
+DECLARE foo1 CURSOR WITH HOLD FOR SELECT * FROM foo1_tbl ORDER BY a;
+FETCH ALL FROM foo1;
+COMMIT;
+FETCH ALL FROM foo1;
+CLOSE foo1;
+DROP TABLE foo1_tbl;
+
+-- ERROR:  cannot execute squelched plan node of type: 232 (execProcnode.c:887)
+BEGIN;
+DECLARE foo2 CURSOR WITH HOLD FOR SELECT relname, spcname FROM pg_catalog.pg_tablespace t, pg_catalog.pg_class c where c.reltablespace = t.oid AND c.relname = 'foo1_tbl';
+FETCH ALL FROM foo2;
+COMMIT;
+FETCH ALL FROM foo2;
+CLOSE foo2;


### PR DESCRIPTION
The assert failure detail is:
FailedAssertion("!(!((heap)->bh_size == 0) && heap->bh_has_heap_property)", File: "binaryheap.c"

That happens when a holdable cursor re-execute the plan during commit, but the
plan has emitted all tuples previously. execMotionSortedReceiver() code is not
correctly handling this case so triggers an assert failure.

gpdb has a specific variable es_got_eos that could be used for fixing also.  In
ExecutePlan() we could check this value and then return NLLL without calling
executor code but this does not align with upstream code.