### PR TITLE
[6X] Remove guc debug_latch

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -171,9 +171,6 @@ bool		debug_basebackup = false;
 
 int rep_lag_avoidance_threshold = 0;
 
-/* Latch mechanism debug GUCs */
-bool		debug_latch = false;
-
 bool		gp_keep_all_xlog = false;
 
 #define DEBUG_DTM_ACTION_PRIMARY_DEFAULT true
@@ -1719,17 +1716,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&debug_basebackup,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"debug_latch", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Print debug messages for latch mechanism."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&debug_latch,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -300,9 +300,6 @@ extern bool debug_basebackup;
 
 extern int rep_lag_avoidance_threshold;
 
-/* Latch mechanism debug GUCs */
-extern bool debug_latch;
-
 extern bool gp_maintenance_mode;
 extern bool gp_maintenance_conn;
 extern bool allow_segment_DML;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -83,7 +83,6 @@
 		"debug_dtm_action_segment",
 		"debug_dtm_action_sql_command_tag",
 		"debug_dtm_action_target",
-		"debug_latch",
 		"debug_pretty_print",
 		"debug_print_full_dtm",
 		"debug_print_parse",


### PR DESCRIPTION
This is removed on master. On gpdb6 the code is buggy since we immediately run
into issue when running simple tests. In the below case, SetLatch() is called
in pthread, however it calls elog() which is apparently not thread friendly. I
do not think anyone is using that.  Let's remove it in gpdb6 to align with
upstream also.

......
39 0x0000000000adc4a0 in ExceptionalCondition (
    conditionName=0xe0e3a8 "!(!(((unsigned long) main_tid) != 0) || (((unsigned long) pthread_self()) == ((unsigned long) main_tid)))",
    errorType=0xe0e38e "AssertImply failed", fileName=0xe0d800 "elog.c", lineNumber=4188) at assert.c:46
40 0x0000000000ae578a in send_message_to_server_log (edata=0x11d4340) at elog.c:4188
41 0x0000000000ae1122 in EmitErrorReport () at elog.c:1853
42 0x0000000000addcee in errfinish (dummy=0) at elog.c:674
43 0x0000000000ae0d47 in elog_finish (elevel=15, fmt=0xdb0008 "latch set -- Latch for process (pid %u) is now set.") at elog.c:1749
44 0x00000000008ca638 in SetLatch (latch=0x11df7d0) at pg_latch.c:532
45 0x0000000000b8de15 in rxThreadFunc (arg=0x0) at ic_udpifc.c:6446
46 0x0000003398207a51 in start_thread () from /lib64/libpthread.so.0
47 0x0000003397ee896d in clone () from /lib64/libc.so.6