### PR TITLE
Nestloop join in a subquery should not squelch inner motion

### DIFF
--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -1787,6 +1787,13 @@ ExecReScanMergeJoin(MergeJoinState *node, ExprContext *exprCtxt)
 	node->mj_InnerTupleSlot = NULL;
 
 	/*
+	 * If the parameter is used in the filter of the outer table scan, the outer returns
+	 * NULL doesn't mean we can squelch the inner, because next parameter to the outer
+	 * may return a valid tuple. Same as ExecReScanNestLoop.
+	 */
+	node->mj_squelchInner = false;
+
+	/*
 	 * if chgParam of subnodes is not null then plans will be re-scanned by
 	 * first ExecProcNode.
 	 */

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -589,7 +589,13 @@ ExecReScanNestLoop(NestLoopState *node, ExprContext *exprCtxt)
 	node->nl_NeedNewOuter = true;
 	node->nl_MatchedOuter = false;
 	node->nl_innerSideScanned = false;
-	/* CDB: We intentionally leave node->nl_innerSquelchNeeded unchanged on ReScan */
+
+	/*
+	 * If the parameter is used in the filter of the outer table scan, the outer returns
+	 * NULL doesn't mean we can squelch the inner, because next parameter to the outer
+	 * may return a valid tuple.
+	 */
+	node->nl_innerSquelchNeeded = false;
 }
 
 void

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -793,3 +793,94 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 reset enable_hashjoin;
 reset enable_mergejoin;
 reset enable_nestloop;
+-- test the scenario that the nestloop/merge join is in a subquery and the
+-- parameter passed to the outer of the join. We should not squelch the inner
+-- if the outer doesn't return a qualified tuple, because squelch the inner
+-- would stop the motion and when the next parameter comes in, the inner rescan
+-- can't get the correct data.
+create table t_join_squelch_a (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_join_squelch_a values (2, 2);
+create table t_join_squelch_b (x int, y int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_join_squelch_b values (2, 2);
+create table t_join_squelch_c(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_join_squelch_c values (1), (2);
+analyze t_join_squelch_a;
+analyze t_join_squelch_b;
+analyze t_join_squelch_c;
+set enable_nestloop to on;
+set enable_hashjoin to off;
+set enable_mergejoin to off;
+explain select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.26 rows=2 width=4)
+   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.26 rows=1 width=4)
+         SubPlan 1
+           ->  Aggregate  (cost=2.11..2.12 rows=1 width=8)
+                 ->  Aggregate  (cost=2.05..2.06 rows=1 width=8)
+                       ->  Nested Loop  (cost=0.00..2.04 rows=2 width=0)
+                             Join Filter: a.a = b.x
+                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                                   Filter: a.b = $0
+                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                               ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
+                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                               ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  enable_hashjoin=off; enable_mergejoin=off; enable_nestloop=on
+ Optimizer status: legacy query optimizer
+(18 rows)
+
+select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
+ d 
+---
+ 0
+ 1
+(2 rows)
+
+set enable_nestloop to off;
+set enable_hashjoin to off;
+set enable_mergejoin to on;
+explain select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.33 rows=2 width=4)
+   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.33 rows=1 width=4)
+         SubPlan 1
+           ->  Aggregate  (cost=2.14..2.15 rows=1 width=8)
+                 ->  Aggregate  (cost=2.08..2.09 rows=1 width=8)
+                       ->  Merge Join  (cost=2.04..2.07 rows=2 width=0)
+                             Merge Cond: a.a = b.x
+                             ->  Sort  (cost=1.02..1.03 rows=1 width=4)
+                                   Sort Key: a.a
+                                   ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                                         Filter: a.b = $0
+                                         ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                                     ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
+                             ->  Sort  (cost=1.02..1.02 rows=1 width=4)
+                                   Sort Key: b.x
+                                   ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                                         ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                                     ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  enable_hashjoin=off; enable_mergejoin=on; enable_nestloop=off
+ Optimizer status: legacy query optimizer
+(22 rows)
+
+select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
+ d 
+---
+ 0
+ 1
+(2 rows)
+
+drop table t_join_squelch_a, t_join_squelch_b, t_join_squelch_c;

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -373,3 +373,34 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 reset enable_hashjoin;
 reset enable_mergejoin;
 reset enable_nestloop;
+
+-- test the scenario that the nestloop/merge join is in a subquery and the
+-- parameter passed to the outer of the join. We should not squelch the inner
+-- if the outer doesn't return a qualified tuple, because squelch the inner
+-- would stop the motion and when the next parameter comes in, the inner rescan
+-- can't get the correct data.
+
+create table t_join_squelch_a (a int, b int);
+insert into t_join_squelch_a values (2, 2);
+create table t_join_squelch_b (x int, y int);
+insert into t_join_squelch_b values (2, 2);
+create table t_join_squelch_c(i int);
+insert into t_join_squelch_c values (1), (2);
+analyze t_join_squelch_a;
+analyze t_join_squelch_b;
+analyze t_join_squelch_c;
+
+set enable_nestloop to on;
+set enable_hashjoin to off;
+set enable_mergejoin to off;
+
+explain select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
+select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
+
+set enable_nestloop to off;
+set enable_hashjoin to off;
+set enable_mergejoin to on;
+
+explain select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
+select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
+drop table t_join_squelch_a, t_join_squelch_b, t_join_squelch_c;


### PR DESCRIPTION
When a nestloop join is in a subquery and the parameter passed to the outer
node doesn't have a match, it will squelch the inner node, which will stop the
motion. In this case, rescan the nestloop join with a different parameter won't
be able to get the correct data from the inner.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
