### PR TITLE
Refactor the way executor parameters are dispatched.

### DIFF
--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -1171,15 +1171,6 @@ ExecEvalConst(ExprState *exprstate, ExprContext *econtext,
  *		Returns the value of a PARAM_EXEC parameter.
  * ----------------------------------------------------------------
  */
-
-/*
- * Greenplum Database Changes:
- * In executor mode, a PARAM_EXEC parameter can not be evaluated by executing
- * the subplan.  The subplan was executed on the dispatcher prior to
- * launching the main query.  The value of the result is passed to the qExec
- * in the ParamInfo, with a kind of PARAM_EXEC_REMOTE.
- * So, this function was changed to just do a lookup in that case.
- */
 static Datum
 ExecEvalParamExec(ExprState *exprstate, ExprContext *econtext,
 				  bool *isNull, ExprDoneCond *isDone)

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1913,117 +1913,30 @@ getLocallyExecutableSubplans(PlannedStmt *plannedstmt, Plan *root_plan)
 	return ctx.bms_subplans;
 }
 
-typedef struct ParamExtractorContext
-{
-	plan_tree_base_prefix base; /* Required prefix for plan_tree_walker/mutator */
-	EState *estate;
-} ParamExtractorContext;
-
 /*
- * Given a subplan determine if it is an initPlan (subplan->is_initplan) then copy its params
- * from estate-> es_param_list_info to estate->es_param_exec_vals.
- */
-static void ExtractSubPlanParam(SubPlan *subplan, EState *estate)
-{
-	/*
-	 * If this plan is un-correlated or undirect correlated one and want to
-	 * set params for parent plan then mark parameters as needing evaluation.
-	 *
-	 * Note that in the case of un-correlated subqueries we don't care about
-	 * setting parent->chgParam here: indices take care about it, for others -
-	 * it doesn't matter...
-	 */
-	if (subplan->setParam != NIL)
-	{
-		ListCell   *lst;
-
-		foreach(lst, subplan->setParam)
-		{
-			int			paramid = lfirst_int(lst);
-			ParamExecData *prmExec = &(estate->es_param_exec_vals[paramid]);
-
-			/**
-			 * Has this parameter been already
-			 * evaluated as part of preprocess_initplan()? If so,
-			 * we shouldn't re-evaluate it. If it has been evaluated,
-			 * we will simply substitute the actual value from
-			 * the external parameters.
-			 */
-			if (subplan->is_initplan)
-			{
-				ParamListInfo paramInfo = estate->es_param_list_info;
-				ParamExternData *prmExt = NULL;
-				int extParamIndex = -1;
-
-				Assert(paramInfo);
-				Assert(paramInfo->numParams > 0);
-
-				/*
-				 * To locate the value of this pre-evaluated parameter, we need to find
-				 * its location in the external parameter list.
-				 */
-				extParamIndex = paramInfo->numParams - estate->es_plannedstmt->nParamExec + paramid;
-				prmExt = &paramInfo->params[extParamIndex];
-
-				/* Make sure the types are valid */
-				if (!OidIsValid(prmExt->ptype))
-				{
-					prmExec->execPlan = NULL;
-					prmExec->isnull = true;
-					prmExec->value = (Datum) 0;
-				}
-				else
-				{
-					/** Hurray! Copy value from external parameter and don't bother setting up execPlan. */
-					prmExec->execPlan = NULL;
-					prmExec->isnull = prmExt->isnull;
-					prmExec->value = prmExt->value;
-				}
-			}
-		}
-	}
-}
-
-/*
- * Walker to extract all the precomputer InitPlan params in a plan tree.
- */
-static bool
-ParamExtractorWalker(Plan *node,
-				  void *context)
-{
-	Assert(context);
-	ParamExtractorContext *ctx = (ParamExtractorContext *) context;
-
-	/* Assuming InitPlan always runs on the master */
-	if (node == NULL)
-	{
-		return false;	/* don't visit subtree */
-	}
-
-	if (IsA(node, SubPlan))
-	{
-		SubPlan *sub_plan = (SubPlan *) node;
-		ExtractSubPlanParam(sub_plan, ctx->estate);
-	}
-
-	/* Continue walking */
-	return plan_tree_walker((Node*)node, ParamExtractorWalker, ctx, true);
-}
-
-/*
- * Find and extract all the InitPlan setParams in a root node's subtree.
+ * Copy PARAM_EXEC parameter values that were received from the QD into
+ * our EState.
  */
 void
-ExtractParamsFromInitPlans(PlannedStmt *plannedstmt, Plan *root, EState *estate)
+InstallDispatchedExecParams(QueryDispatchDesc *ddesc, EState *estate)
 {
-	ParamExtractorContext ctx;
-
-	ctx.base.node = (Node *) plannedstmt;
-	ctx.estate = estate;
-
 	Assert(Gp_role == GP_ROLE_EXECUTE);
 
-	ParamExtractorWalker(root, &ctx);
+	if (ddesc->paramInfo == NULL)
+		return;
+
+	for (int i = 0; i < ddesc->paramInfo->nExecParams; i++)
+	{
+		SerializedParamExecData *sprm = &ddesc->paramInfo->execParams[i];
+		ParamExecData *prmExec = &estate->es_param_exec_vals[i];
+
+		if (!sprm->isvalid)
+			continue;	/* not dispatched */
+
+		prmExec->execPlan = NULL;
+		prmExec->value = sprm->value;
+		prmExec->isnull = sprm->isnull;
+	}
 }
 
 /**

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -203,6 +203,8 @@
 
 static void _outNode(StringInfo str, void *obj);
 
+#define outDatum(str, value, typlen, typbyval) _outDatum(str, value, typlen, typbyval)
+
 static void
 _outList(StringInfo str, List *node)
 {
@@ -1066,21 +1068,6 @@ _outTupleDescNode(StringInfo str, TupleDescNode *node)
 	WRITE_INT_FIELD(tuple->tdtypmod);
 	WRITE_BOOL_FIELD(tuple->tdhasoid);
 	WRITE_INT_FIELD(tuple->tdrefcount);
-}
-
-static void
-_outSerializedParamExternData(StringInfo str, SerializedParamExternData *node)
-{
-	WRITE_NODE_TYPE("SERIALIZEDPARAMEXTERNDATA");
-
-	WRITE_BOOL_FIELD(isnull);
-	WRITE_INT16_FIELD(pflags);
-	WRITE_OID_FIELD(ptype);
-	WRITE_INT16_FIELD(plen);
-	WRITE_BOOL_FIELD(pbyval);
-
-	if (!node->isnull)
-		_outDatum(str, node->value, node->plen, node->pbyval);
 }
 
 static void
@@ -2091,8 +2078,8 @@ _outNode(StringInfo str, void *obj)
 			case T_TupleDescNode:
 				_outTupleDescNode(str, obj);
 				break;
-			case T_SerializedParamExternData:
-				_outSerializedParamExternData(str, obj);
+			case T_SerializedParams:
+				_outSerializedParams(str, obj);
 				break;
 
 			case T_AlterTSConfigurationStmt:

--- a/src/include/cdb/cdbdisp_query.h
+++ b/src/include/cdb/cdbdisp_query.h
@@ -35,6 +35,7 @@
 #define DF_WITH_SNAPSHOT  0x4
 
 struct QueryDesc;
+struct SerializedParams;
 struct CdbDispatcherState;
 struct CdbPgResults;
 struct CdbCopy;
@@ -56,17 +57,16 @@ struct CdbCopy;
  * To wait for completion, check for errors, and clean up, it is
  * suggested that the caller use cdbdisp_finishCommand().
  */
-void
-CdbDispatchPlan(struct QueryDesc *queryDesc,
-					 bool planRequiresTxn,
-					 bool cancelOnError);
+extern void CdbDispatchPlan(struct QueryDesc *queryDesc,
+							ParamExecData *execParams,
+							bool planRequiresTxn,
+							bool cancelOnError);
 
 /*
  * Special for sending SET commands that change GUC variables, so they go to all
  * gangs, both reader and writer
  */
-void
-CdbDispatchSetCommand(const char *strCommand, bool cancelOnError);
+extern void CdbDispatchSetCommand(const char *strCommand, bool cancelOnError);
 
 /*
  * CdbDispatchCommand
@@ -79,16 +79,14 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError);
  * 	Is the combination of EUS_NEED_TWO_PHASE, EUS_WITH_SNAPSHOT,EUS_CANCEL_ON_ERROR
  *
  */
-void
-CdbDispatchCommand(const char* strCommand,
-                    int flags,
-                    struct CdbPgResults* cdb_pgresults);
+extern void CdbDispatchCommand(const char *strCommand,
+							   int flags,
+							   struct CdbPgResults *cdb_pgresults);
 
-void
-CdbDispatchCommandToSegments(const char* strCommand,
-							 int flags,
-							 List *segments,
-							 struct CdbPgResults* cdb_pgresults);
+extern void CdbDispatchCommandToSegments(const char *strCommand,
+										 int flags,
+										 List *segments,
+										 struct CdbPgResults *cdb_pgresults);
 
 /*
  * CdbDispatchUtilityStatement
@@ -106,15 +104,14 @@ CdbDispatchCommandToSegments(const char* strCommand,
  * If returnPgResults is true, caller need to call cdbdisp_freeCdbPgResults() to
  * clear pg_results.
  */
-void
-CdbDispatchUtilityStatement(struct Node *stmt,
-							int flags,
-							List *oid_assignments,
-							struct CdbPgResults* cdb_pgresults);
+extern void CdbDispatchUtilityStatement(struct Node *stmt,
+										int flags,
+										List *oid_assignments,
+										struct CdbPgResults* cdb_pgresults);
 
 extern void CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags);
 extern void CdbDispatchCopyEnd(struct CdbCopy *cdbCopy);
 
-extern ParamListInfo deserializeParamListInfo(const char *str, int slen);
+extern ParamListInfo deserializeExternParams(struct SerializedParams *sparams);
 
 #endif   /* CDBDISP_QUERY_H */

--- a/src/include/cdb/cdbsubplan.h
+++ b/src/include/cdb/cdbsubplan.h
@@ -22,6 +22,5 @@
 #include "nodes/plannodes.h"
 
 extern void preprocess_initplans(QueryDesc *queryDesc);
-extern ParamListInfo addRemoteExecParamsToParamList(PlannedStmt *stmt, ParamListInfo p, ParamExecData *prm);
 
 #endif   /* CDBSUBPLAN_H */

--- a/src/include/executor/execUtils.h
+++ b/src/include/executor/execUtils.h
@@ -29,7 +29,7 @@ extern void AssignGangs(struct CdbDispatcherState *ds, QueryDesc *queryDesc);
 
 extern Motion *findSenderMotion(PlannedStmt *plannedstmt, int sliceIndex);
 extern Bitmapset *getLocallyExecutableSubplans(PlannedStmt *plannedstmt, Plan *root);
-extern void ExtractParamsFromInitPlans(PlannedStmt *plannedstmt, Plan *root, EState *estate);
+extern void InstallDispatchedExecParams(QueryDispatchDesc *ddesc, EState *estate);
 
 #ifdef USE_ASSERT_CHECKING
 struct PlannedStmt;

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -172,10 +172,10 @@ typedef enum NodeTag
 
 	/*
 	 * TupleDesc and ParamListInfo are not Nodes as such, but you can wrap
-	 * them in TupleDescNode and SerializedParamExternData structs for serialization.
+	 * them in TupleDescNode and SerializedParams structs for serialization.
 	 */
 	T_TupleDescNode,
-	T_SerializedParamExternData,
+	T_SerializedParams,
 
 	/*
 	 * TAGS FOR PRIMITIVE NODES (primnodes.h)

--- a/src/include/nodes/params.h
+++ b/src/include/nodes/params.h
@@ -14,7 +14,6 @@
 #ifndef PARAMS_H
 #define PARAMS_H
 
-#include "nodes/nodes.h"
 /* Forward declarations, to avoid including other headers */
 struct Bitmapset;
 struct ParseState;
@@ -77,26 +76,6 @@ typedef struct ParamListInfoData
 	ParamExternData params[FLEXIBLE_ARRAY_MEMBER];
 }	ParamListInfoData;
 
-
-/*
- * Serialized form of ParamExternData. This is used when query parameters
- * are serialized, when dispatching a query from QD to QEs.
- */
-typedef struct SerializedParamExternData
-{
-	NodeTag		type;
-
-	/* Fields from ParamExternData */
-	Datum		value;			/* parameter value */
-	bool		isnull;			/* is it NULL? */
-	uint16		pflags;			/* flag bits, see above */
-	Oid			ptype;			/* parameter's datatype, or 0 */
-
-	/* Extra information about the type */
-	int16		plen;
-	bool		pbyval;
-
-} SerializedParamExternData;
 
 /* ----------------
  *	  ParamExecData

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -244,7 +244,6 @@ typedef enum ParamKind
 {
 	PARAM_EXTERN,
 	PARAM_EXEC,
-	PARAM_EXEC_REMOTE, /* MPP ???? */
 	PARAM_SUBLINK,
 	PARAM_MULTIEXPR
 } ParamKind;


### PR DESCRIPTION
We used to append the executor parameters to the array of external
parameters in the QD, before the query was dispatched, and copied them
back to the array of executor parameters in the QE. For clarity, refactor
that so that external query parameters are kept separate from executor
parameters at all times.

The old comments talked about parameters with type PARAM_EXEC_REMOTE.
There must have been some plan to use that with dispatched parameters, but
it had never actually been used.
