### PR TITLE
Remove TUPLE_CHUNK_ALIGN.

### DIFF
--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -195,7 +195,7 @@ RecvTupleChunk(MotionConn *conn, ChunkTransportState *transportStates)
 		tcItem->chunk_length = tcSize;
 		tcItem->inplace = (char *) (conn->msgPos + bytesProcessed);
 
-		bytesProcessed += TYPEALIGN(TUPLE_CHUNK_ALIGN, tcSize);
+		bytesProcessed += tcSize;
 
 		if (firstTcItem == NULL)
 		{

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -2748,7 +2748,7 @@ flushBuffer(ChunkTransportState *transportStates,
 static bool
 SendChunkTCP(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntry, MotionConn *conn, TupleChunkListItem tcItem, int16 motionId)
 {
-	int			length = TYPEALIGN(TUPLE_CHUNK_ALIGN, tcItem->chunk_length);
+	int			length = tcItem->chunk_length;
 
 	Assert(conn->msgSize > 0);
 

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -5405,7 +5405,7 @@ SendChunkUDPIFC(ChunkTransportState *transportStates,
 				int16 motionId)
 {
 
-	int			length = TYPEALIGN(TUPLE_CHUNK_ALIGN, tcItem->chunk_length);
+	int			length = tcItem->chunk_length;
 	int			retry = 0;
 	bool		doCheckExpiration = false;
 	bool		gotStops = false;

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -28,12 +28,6 @@
 
 #define WRITER_IS_MISSING_MSG "reader could not find writer proc entry"
 
-#ifdef sparc
-#define TUPLE_CHUNK_ALIGN	4
-#else
-#define TUPLE_CHUNK_ALIGN	1
-#endif
-
 #ifndef PRIO_MAX
 #define PRIO_MAX 20
 #endif


### PR DESCRIPTION
It was set to 1 on all supported platforms, and I'm almost certain it
would be broken if you tried to set it to anything else, because it hasn't
been tested for a long time.

As far as I can see, the alignment was only needed because in the
receiving side, we cast the buffer into a TupSerHeader pointer, and there
was otherwise no guarantee that the buffer was suitable aligned for
TupSerHeader. That's easy to fix by memcpy()ing the TupSerHeader into a
local variable that's properly aligned.
