### PR TITLE
Increase superuser reserved connections

### DIFF
--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -600,6 +600,7 @@ BaseInit(void)
 static void check_superuser_connection_limit()
 {
 	if (!am_ftshandler &&
+		!IS_QUERY_DISPATCHER() &&
 		!HaveNFreeProcs(RESERVED_FTS_CONNECTIONS))
 		ereport(FATAL,
 				(errcode(ERRCODE_TOO_MANY_CONNECTIONS),

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1890,7 +1890,7 @@ static struct config_int ConfigureNamesInt[] =
 			NULL
 		},
 		&ReservedBackends,
-		3, RESERVED_FTS_CONNECTIONS, MAX_BACKENDS,
+		10, RESERVED_FTS_CONNECTIONS, MAX_BACKENDS,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1886,7 +1886,7 @@ static struct config_int ConfigureNamesInt[] =
 	{
 		{"superuser_reserved_connections", PGC_POSTMASTER, CONN_AUTH_SETTINGS,
 			gettext_noop("Sets the number of connection slots reserved for "
-						"superusers (including reserved FTS connections)."),
+						"superusers (including reserved FTS connection for primaries)."),
 			NULL
 		},
 		&ReservedBackends,

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -23,8 +23,9 @@
 #define MAX_PRE_AUTH_DELAY (60)
 /*
  * One connection must be reserved for FTS to always able to probe
- * primary. So, this acts as lower limit on reserved superuser connections.
-*/
+ * primary. So, this acts as lower limit on reserved superuser connections on
+ * primaries.
+ */
 #define RESERVED_FTS_CONNECTIONS (1)
 
 


### PR DESCRIPTION
As requested from field, 3 superuser connections is not enough for gpdb when customers run superuser maintenance scripts. 10 is the same value as the resource group admin_group's concurrency default limit. Also only have the fts connection reserved for primaries.
