### PR TITLE
Refactor and correct prefetch joinqual

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1135,6 +1135,18 @@ ExecGetShareNodeEntry(EState* estate, int shareidx, bool fCreate)
 	return (ShareNodeEntry *) list_nth(*estate->es_sharenode, shareidx);
 }
 
+/*
+ * flatten_logic_exprs
+ * This function is only used by ExecPrefetchJoinQual.
+ * ExecPrefetchJoinQual need to prefetch subplan in join
+ * qual that contains motion to materialize it to avoid
+ * motion deadlock. This function is going to flatten
+ * the bool exprs to avoid shortcut of bool logic.
+ * An example is:
+ * (a and b or c) or (d or e and f or g) and (h and i or j)
+ * will be transformed to
+ * (a, b, c, d, e, f, g, h, i, j).
+ */
 static List *
 flatten_logic_exprs(Node *node)
 {

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1193,36 +1193,6 @@ ExecPrefetchJoinQual(JoinState *node)
 	return true;
 }
 
-/*
- * Decide if should prefetch joinqual.
- *
- * Joinqual should be prefetched when both outer and joinqual contain motions.
- * In create_*join_plan() functions we set prefetch_joinqual according to the
- * outer motions, now we detect for joinqual motions to make the final
- * decision.
- *
- * See ExecPrefetchJoinQual() for details.
- *
- * This function should be called in ExecInit*Join() functions.
- *
- * Return true if JoinQual should be prefetched.
- */
-bool
-ShouldPrefetchJoinQual(EState *estate, Join *join)
-{
-	ExecSlice  *localSlice;
-
-	if (!join->prefetch_joinqual)
-		return false;
-
-	/* Is this slice the sender of a Motion? */
-	if (!estate->es_sliceTable)
-		return false;
-	localSlice = &estate->es_sliceTable->slices[estate->currentSliceId];
-
-	return (localSlice->parentIndex != -1);
-}
-
 /* ----------------------------------------------------------------
  *		CDB Slice Table utilities
  * ----------------------------------------------------------------

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -602,7 +602,7 @@ ExecInitHashJoin(HashJoin *node, EState *estate, int eflags)
 	 * the fix to MPP-989)
 	 */
 	hjstate->prefetch_inner = node->join.prefetch_inner;
-	hjstate->prefetch_joinqual = ShouldPrefetchJoinQual(estate, &node->join);
+	hjstate->prefetch_joinqual = node->join.prefetch_joinqual;
 
 	if (Test_print_prefech_joinqual && hjstate->prefetch_joinqual)
 		elog(NOTICE,

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -45,7 +45,7 @@
 /* Returns true if doing null-fill on inner relation */
 #define HJ_FILL_INNER(hjstate)	((hjstate)->hj_NullOuterTupleSlot != NULL)
 
-extern bool Test_print_prefech_joinqual;
+extern bool Test_print_prefetch_joinqual;
 
 static TupleTableSlot *ExecHashJoinOuterGetTuple(PlanState *outerNode,
 						  HashJoinState *hjstate,
@@ -241,8 +241,11 @@ ExecHashJoin_guts(HashJoinState *node)
 				 *
 				 * See ExecPrefetchJoinQual() for details.
 				 */
-				if (node->prefetch_joinqual && ExecPrefetchJoinQual(&node->js))
+				if (node->prefetch_joinqual)
+				{
+					ExecPrefetchJoinQual(&node->js);
 					node->prefetch_joinqual = false;
+				}
 
 				/*
 				 * We just scanned the entire inner side and built the hashtable
@@ -604,7 +607,7 @@ ExecInitHashJoin(HashJoin *node, EState *estate, int eflags)
 	hjstate->prefetch_inner = node->join.prefetch_inner;
 	hjstate->prefetch_joinqual = node->join.prefetch_joinqual;
 
-	if (Test_print_prefech_joinqual && hjstate->prefetch_joinqual)
+	if (Test_print_prefetch_joinqual && hjstate->prefetch_joinqual)
 		elog(NOTICE,
 			 "prefetch join qual in slice %d of plannode %d",
 			 currentSliceId, ((Plan *) node)->plan_node_id);

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -45,6 +45,8 @@
 /* Returns true if doing null-fill on inner relation */
 #define HJ_FILL_INNER(hjstate)	((hjstate)->hj_NullOuterTupleSlot != NULL)
 
+extern bool Test_print_prefech_joinqual;
+
 static TupleTableSlot *ExecHashJoinOuterGetTuple(PlanState *outerNode,
 						  HashJoinState *hjstate,
 						  uint32 *hashvalue);
@@ -601,6 +603,11 @@ ExecInitHashJoin(HashJoin *node, EState *estate, int eflags)
 	 */
 	hjstate->prefetch_inner = node->join.prefetch_inner;
 	hjstate->prefetch_joinqual = ShouldPrefetchJoinQual(estate, &node->join);
+
+	if (Test_print_prefech_joinqual && hjstate->prefetch_joinqual)
+		elog(NOTICE,
+			 "prefetch join qual in slice %d of plannode %d",
+			 currentSliceId, ((Plan *) node)->plan_node_id);
 
 	/*
 	 * initialize child nodes

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -160,6 +160,7 @@ typedef enum
 #define MarkInnerTuple(innerTupleSlot, mergestate) \
 	ExecCopySlot((mergestate)->mj_MarkedTupleSlot, (innerTupleSlot))
 
+extern bool Test_print_prefech_joinqual;
 
 /*
  * MJExamineQuals
@@ -1581,6 +1582,12 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 
 	mergestate->prefetch_inner = node->join.prefetch_inner;
 	mergestate->prefetch_joinqual = ShouldPrefetchJoinQual(estate, &node->join);
+
+	if (Test_print_prefech_joinqual && mergestate->prefetch_joinqual)
+		elog(NOTICE,
+			 "prefetch join qual in slice %d of plannode %d",
+			 currentSliceId, ((Plan *) node)->plan_node_id);
+
 	/* Prepare inner operators for rewind after the prefetch */
 	rewindflag = mergestate->prefetch_inner ? EXEC_FLAG_REWIND : 0;
 

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -160,7 +160,7 @@ typedef enum
 #define MarkInnerTuple(innerTupleSlot, mergestate) \
 	ExecCopySlot((mergestate)->mj_MarkedTupleSlot, (innerTupleSlot))
 
-extern bool Test_print_prefech_joinqual;
+extern bool Test_print_prefetch_joinqual;
 
 /*
  * MJExamineQuals
@@ -694,8 +694,11 @@ ExecMergeJoin_guts(MergeJoinState *node)
 	 *
 	 * See ExecPrefetchJoinQual() for details.
 	 */
-	if (node->prefetch_joinqual && ExecPrefetchJoinQual(&node->js))
+	if (node->prefetch_joinqual)
+	{
+		ExecPrefetchJoinQual(&node->js);
 		node->prefetch_joinqual = false;
+	}
 
 	/*
 	 * ok, everything is setup.. let's go to work
@@ -1583,7 +1586,7 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 	mergestate->prefetch_inner = node->join.prefetch_inner;
 	mergestate->prefetch_joinqual = node->join.prefetch_joinqual;
 
-	if (Test_print_prefech_joinqual && mergestate->prefetch_joinqual)
+	if (Test_print_prefetch_joinqual && mergestate->prefetch_joinqual)
 		elog(NOTICE,
 			 "prefetch join qual in slice %d of plannode %d",
 			 currentSliceId, ((Plan *) node)->plan_node_id);

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -1581,7 +1581,7 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 	mergestate->mj_ConstFalseJoin = false;
 
 	mergestate->prefetch_inner = node->join.prefetch_inner;
-	mergestate->prefetch_joinqual = ShouldPrefetchJoinQual(estate, &node->join);
+	mergestate->prefetch_joinqual = node->join.prefetch_joinqual;
 
 	if (Test_print_prefech_joinqual && mergestate->prefetch_joinqual)
 		elog(NOTICE,

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -30,7 +30,7 @@
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 
-extern bool Test_print_prefech_joinqual;
+extern bool Test_print_prefetch_joinqual;
 
 static void splitJoinQualExpr(NestLoopState *nlstate);
 static void extractFuncExprArgs(FuncExprState *fstate, List **lclauses, List **rclauses);
@@ -150,8 +150,11 @@ ExecNestLoop_guts(NestLoopState *node)
 	 *
 	 * See ExecPrefetchJoinQual() for details.
 	 */
-	if (node->prefetch_joinqual && ExecPrefetchJoinQual(&node->js))
+	if (node->prefetch_joinqual)
+	{
+		ExecPrefetchJoinQual(&node->js);
 		node->prefetch_joinqual = false;
+	}
 
 	/*
 	 * Ok, everything is setup for the join so now loop until we return a
@@ -395,7 +398,7 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
 	nlstate->prefetch_inner = node->join.prefetch_inner;
 	nlstate->prefetch_joinqual = node->join.prefetch_joinqual;
 
-	if (Test_print_prefech_joinqual && nlstate->prefetch_joinqual)
+	if (Test_print_prefetch_joinqual && nlstate->prefetch_joinqual)
 		elog(NOTICE,
 			 "prefetch join qual in slice %d of plannode %d",
 			 currentSliceId, ((Plan *) node)->plan_node_id);

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -393,7 +393,7 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
 	nlstate->shared_outer = node->shared_outer;
 
 	nlstate->prefetch_inner = node->join.prefetch_inner;
-	nlstate->prefetch_joinqual = ShouldPrefetchJoinQual(estate, &node->join);
+	nlstate->prefetch_joinqual = node->join.prefetch_joinqual;
 
 	if (Test_print_prefech_joinqual && nlstate->prefetch_joinqual)
 		elog(NOTICE,

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4255,7 +4255,8 @@ create_nestloop_plan(PlannerInfo *root,
 	 * See ExecPrefetchJoinQual() for details.
 	 */
 	if (best_path->outerjoinpath &&
-		best_path->outerjoinpath->motionHazard)
+		best_path->outerjoinpath->motionHazard &&
+		join_plan->join.joinqual != NIL)
 		join_plan->join.prefetch_joinqual = true;
 
 	return join_plan;
@@ -4594,14 +4595,16 @@ create_mergejoin_plan(PlannerInfo *root,
 	 * See ExecPrefetchJoinQual() for details.
 	 */
 	if (best_path->jpath.outerjoinpath &&
-		best_path->jpath.outerjoinpath->motionHazard)
+		best_path->jpath.outerjoinpath->motionHazard &&
+		join_plan->join.joinqual != NIL)
 		join_plan->join.prefetch_joinqual = true;
 	/*
 	 * If inner motion is not under a Material or Sort node then there could
 	 * also be motion deadlock between inner and joinqual in mergejoin.
 	 */
 	if (best_path->jpath.innerjoinpath &&
-		best_path->jpath.innerjoinpath->motionHazard)
+		best_path->jpath.innerjoinpath->motionHazard &&
+		join_plan->join.joinqual != NIL)
 		join_plan->join.prefetch_joinqual = true;
 
 	/* Costs of sort and material steps are included in path cost already */
@@ -4776,7 +4779,8 @@ create_hashjoin_plan(PlannerInfo *root,
 	 * See ExecPrefetchJoinQual() for details.
 	 */
 	if (best_path->jpath.outerjoinpath &&
-		best_path->jpath.outerjoinpath->motionHazard)
+		best_path->jpath.outerjoinpath->motionHazard &&
+		join_plan->join.joinqual != NIL)
 		join_plan->join.prefetch_joinqual = true;
 
 	copy_generic_path_info(&join_plan->join.plan, &best_path->jpath.path);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -1005,6 +1005,12 @@ create_join_plan(PlannerInfo *root, JoinPath *best_path)
 		((Join *) plan)->prefetch_joinqual = false;
 	}
 
+	/*
+	 * We may set prefetch_joinqual to true if there is
+	 * potential risk when create_xxxjoin_plan. Here, we
+	 * have all the information at hand, this is the final
+	 * logic to set prefetch_joinqual.
+	 */
 	if (((Join *) plan)->prefetch_joinqual)
 	{
 		List *joinqual = ((Join *) plan)->joinqual;
@@ -7654,6 +7660,12 @@ append_initplan_for_function_scan(PlannerInfo *root, Path *best_path, Plan *plan
 	initplan->scan.plan.flow = cdbpathtoplan_create_flow(root, best_path->locus);
 }
 
+/*
+ * contain_motion
+ * This function walks the joinqual list to  see there is
+ * any motion node in it. The only case a qual contains motion
+ * is that it is a SubPlan and the SubPlan contains motion.
+ */
 static bool
 contain_motion(PlannerInfo *root, Node *node)
 {

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -986,18 +986,6 @@ create_join_plan(PlannerInfo *root, JoinPath *best_path)
 	if (partition_selector_created)
 		((Join *) plan)->prefetch_inner = true;
 
-	/*
-	 * A motion deadlock can also happen when outer and joinqual both contain
-	 * motions.  It is not easy to check for joinqual here, so we set the
-	 * prefetch_joinqual mark only according to outer motion, and check for
-	 * joinqual later in the executor.
-	 *
-	 * See ExecPrefetchJoinQual() for details.
-	 */
-	if (best_path->outerjoinpath &&
-		best_path->outerjoinpath->motionHazard)
-		((Join *) plan)->prefetch_joinqual = true;
-
 	/* CDB: if the join's locus is bottleneck which means the
 	 * join gang only contains one process, so there is no
 	 * risk for motion deadlock.

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -131,6 +131,7 @@ bool		Debug_appendonly_print_compaction = false;
 bool		Debug_resource_group = false;
 bool		Debug_bitmap_print_insert = false;
 bool		Test_print_direct_dispatch_info = false;
+bool        Test_print_prefech_joinqual = false;
 bool		Test_copy_qd_qe_split = false;
 bool		gp_permit_relation_node_change = false;
 int			gp_max_local_distributed_cache = 1024;
@@ -1422,6 +1423,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Test_print_direct_dispatch_info,
+		false,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"test_print_prefetch_joinqual", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("For testing purposes, print information about if we prefetch join qual."),
+			NULL,
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&Test_print_prefech_joinqual,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -131,7 +131,7 @@ bool		Debug_appendonly_print_compaction = false;
 bool		Debug_resource_group = false;
 bool		Debug_bitmap_print_insert = false;
 bool		Test_print_direct_dispatch_info = false;
-bool        Test_print_prefech_joinqual = false;
+bool        Test_print_prefetch_joinqual = false;
 bool		Test_copy_qd_qe_split = false;
 bool		gp_permit_relation_node_change = false;
 int			gp_max_local_distributed_cache = 1024;
@@ -1433,7 +1433,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			NULL,
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
-		&Test_print_prefech_joinqual,
+		&Test_print_prefetch_joinqual,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -435,7 +435,7 @@ extern void check_exclusion_constraint(Relation heap, Relation index,
 /* Share input utilities defined in execUtils.c */
 extern ShareNodeEntry * ExecGetShareNodeEntry(EState *estate, int shareid, bool fCreate);
 
-extern bool ExecPrefetchJoinQual(JoinState *node);
+extern void ExecPrefetchJoinQual(JoinState *node);
 
 /* ResultRelInfo and Append Only segment assignment */
 void ResultRelInfoSetSegno(ResultRelInfo *resultRelInfo, List *mapping);

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -436,7 +436,6 @@ extern void check_exclusion_constraint(Relation heap, Relation index,
 extern ShareNodeEntry * ExecGetShareNodeEntry(EState *estate, int shareid, bool fCreate);
 
 extern bool ExecPrefetchJoinQual(JoinState *node);
-extern bool ShouldPrefetchJoinQual(EState *estate, Join *join);
 
 /* ResultRelInfo and Append Only segment assignment */
 void ResultRelInfoSetSegno(ResultRelInfo *resultRelInfo, List *mapping);

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -109,6 +109,7 @@
 		"statement_timeout",
 		"temp_buffers",
 		"test_copy_qd_qe_split",
+		"test_print_prefetch_joinqual",
 		"TimeZone",
 		"verify_gpfdists_cert",
 		"vmem_process_interrupt",

--- a/src/test/regress/expected/deadlock2.out
+++ b/src/test/regress/expected/deadlock2.out
@@ -89,8 +89,31 @@ insert into t_subplan select :x0, :x0 from generate_series(1,:scale) i;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;
+set Test_print_prefetch_joinqual = on;
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1);
+NOTICE:  prefetch join qual in slice 0 of plannode 3
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=25303)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=25304)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=25305)
+ count 
+-------
+ 10000
+(1 row)
+
+-- The logic of ExecPrefetchJoinQual is to use two null
+-- tuples to fake inner and outertuple and then to ExecQual.
+-- It may short cut if some previous qual is test null expr.
+-- So ExecPrefetchJoinQual has to force ExecQual for each
+-- qual expr in the joinqual list. See the Github issue
+-- https://github.com/greenplum-db/gpdb/issues/8677
+-- for details.
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+   and (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
+NOTICE:  prefetch join qual in slice 0 of plannode 3
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=25303)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=25304)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=25305)
  count 
 -------
  10000

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1169,7 +1169,6 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 (9 rows)
 
 drop table t_randomly_dist_table;
-<<<<<<< HEAD
 -- test lateral join inner plan contains limit
 -- we cannot pass params across motion so we
 -- can only generate a plan to gather all the
@@ -1210,7 +1209,6 @@ select * from t1_lateral_limit as t1 cross join lateral
  1 | 1 | (1,1) | 3
 (1 row)
 
-=======
 -- test prefetch join qual
 -- we do not handle this correct
 -- the only case we need to prefetch join qual is:
@@ -1277,10 +1275,5 @@ NOTICE:  prefetch join qual in slice 0 of plannode 1
  Optimizer: Postgres query optimizer
 (19 rows)
 
-<<<<<<< HEAD
-reset Test_print_prefetch_joinqual
->>>>>>> Add a guc to print prefetch join qual info.
-=======
 reset Test_print_prefetch_joinqual;
 reset optimizer;
->>>>>>> add prefetch logic

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1169,6 +1169,7 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 (9 rows)
 
 drop table t_randomly_dist_table;
+<<<<<<< HEAD
 -- test lateral join inner plan contains limit
 -- we cannot pass params across motion so we
 -- can only generate a plan to gather all the
@@ -1209,3 +1210,50 @@ select * from t1_lateral_limit as t1 cross join lateral
  1 | 1 | (1,1) | 3
 (1 row)
 
+=======
+-- test prefetch join qual
+-- we do not handle this correct
+-- the only case we need to prefetch join qual is:
+--   1. outer plan contains motion
+--   2. the join qual contains subplan that contains motion
+reset client_min_messages;
+set Test_print_prefetch_joinqual = true;
+create table t1_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.c > t2.c;
+NOTICE:  prefetch join qual in slice 0 of plannode 1
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3410.75..840448.88 rows=2022804 width=24)
+   ->  Hash Join  (cost=3410.75..799992.81 rows=674268 width=24)
+         Hash Cond: (t1.b = t2.b)
+         Join Filter: (t1.c > t2.c)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+               Hash Key: t1.b
+               ->  Seq Scan on t1_test_pretch_join_qual t1  (cost=0.00..879.00 rows=25967 width=12)
+         ->  Hash  (cost=2437.00..2437.00 rows=25967 width=12)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+                     Hash Key: t2.b
+                     ->  Seq Scan on t2_test_pretch_join_qual t2  (cost=0.00..879.00 rows=25967 width=12)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+-- the above plan contains redistribute motion in both inner and outer plan
+-- the join qual is t1.c > t2.c, it contains no motion, should not prefetch
+select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.c > t2.c;
+NOTICE:  prefetch join qual in slice 0 of plannode 1
+NOTICE:  prefetch join qual in slice 1 of plannode 1  (seg0 slice1 127.0.1.1:7002 pid=112898)
+NOTICE:  prefetch join qual in slice 1 of plannode 1  (seg1 slice1 127.0.1.1:7003 pid=112897)
+NOTICE:  prefetch join qual in slice 1 of plannode 1  (seg2 slice1 127.0.1.1:7004 pid=112899)
+ a | b | c | a | b | c 
+---+---+---+---+---+---
+(0 rows)
+
+reset Test_print_prefetch_joinqual
+>>>>>>> Add a guc to print prefetch join qual info.

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1218,42 +1218,69 @@ select * from t1_lateral_limit as t1 cross join lateral
 --   2. the join qual contains subplan that contains motion
 reset client_min_messages;
 set Test_print_prefetch_joinqual = true;
+-- prefetch join qual is only set correct for planner
+set optimizer = off;
 create table t1_test_pretch_join_qual(a int, b int, c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table t2_test_pretch_join_qual(a int, b int, c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+-- the following plan contains redistribute motion in both inner and outer plan
+-- the join qual is t1.c > t2.c, it contains no motion, should not prefetch
+explain (costs off) select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
 on t1.b = t2.b and t1.c > t2.c;
-NOTICE:  prefetch join qual in slice 0 of plannode 1
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=3410.75..840448.88 rows=2022804 width=24)
-   ->  Hash Join  (cost=3410.75..799992.81 rows=674268 width=24)
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
          Hash Cond: (t1.b = t2.b)
          Join Filter: (t1.c > t2.c)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: t1.b
-               ->  Seq Scan on t1_test_pretch_join_qual t1  (cost=0.00..879.00 rows=25967 width=12)
-         ->  Hash  (cost=2437.00..2437.00 rows=25967 width=12)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+               ->  Seq Scan on t1_test_pretch_join_qual t1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
                      Hash Key: t2.b
-                     ->  Seq Scan on t2_test_pretch_join_qual t2  (cost=0.00..879.00 rows=25967 width=12)
+                     ->  Seq Scan on t2_test_pretch_join_qual t2
  Optimizer: Postgres query optimizer
 (12 rows)
 
--- the above plan contains redistribute motion in both inner and outer plan
--- the join qual is t1.c > t2.c, it contains no motion, should not prefetch
-select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
-on t1.b = t2.b and t1.c > t2.c;
+create table t3_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- the following plan contains motion in both outer plan and join qual,
+-- so we should prefetch join qual
+explain (costs off) select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.a > any (select sum(b) from t3_test_pretch_join_qual t3 where c > t2.a);
 NOTICE:  prefetch join qual in slice 0 of plannode 1
-NOTICE:  prefetch join qual in slice 1 of plannode 1  (seg0 slice1 127.0.1.1:7002 pid=112898)
-NOTICE:  prefetch join qual in slice 1 of plannode 1  (seg1 slice1 127.0.1.1:7003 pid=112897)
-NOTICE:  prefetch join qual in slice 1 of plannode 1  (seg2 slice1 127.0.1.1:7004 pid=112899)
- a | b | c | a | b | c 
----+---+---+---+---+---
-(0 rows)
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t1.b = t2.b)
+         Join Filter: (SubPlan 1)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: t1.b
+               ->  Seq Scan on t1_test_pretch_join_qual t1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: t2.b
+                     ->  Seq Scan on t2_test_pretch_join_qual t2
+         SubPlan 1
+           ->  Aggregate
+                 ->  Result
+                       Filter: (t3.c > t2.a)
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                   ->  Seq Scan on t3_test_pretch_join_qual t3
+ Optimizer: Postgres query optimizer
+(19 rows)
 
+<<<<<<< HEAD
 reset Test_print_prefetch_joinqual
 >>>>>>> Add a guc to print prefetch join qual info.
+=======
+reset Test_print_prefetch_joinqual;
+reset optimizer;
+>>>>>>> add prefetch logic

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1216,34 +1216,69 @@ select * from t1_lateral_limit as t1 cross join lateral
 --   2. the join qual contains subplan that contains motion
 reset client_min_messages;
 set Test_print_prefetch_joinqual = true;
+-- prefetch join qual is only set correct for planner
+set optimizer = off;
 create table t1_test_pretch_join_qual(a int, b int, c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table t2_test_pretch_join_qual(a int, b int, c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
-on t1.b = t2.b and t1.c > t2.c;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=24)
-   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
-         Hash Cond: (t1_test_pretch_join_qual.b = t2_test_pretch_join_qual.b)
-         Join Filter: (t1_test_pretch_join_qual.c > t2_test_pretch_join_qual.c)
-         ->  Seq Scan on t1_test_pretch_join_qual  (cost=0.00..431.00 rows=1 width=12)
-         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
-                     ->  Seq Scan on t2_test_pretch_join_qual  (cost=0.00..431.00 rows=1 width=12)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.92.1
-(9 rows)
-
--- the above plan contains redistribute motion in both inner and outer plan
+-- the following plan contains redistribute motion in both inner and outer plan
 -- the join qual is t1.c > t2.c, it contains no motion, should not prefetch
-select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+explain (costs off) select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
 on t1.b = t2.b and t1.c > t2.c;
- a | b | c | a | b | c 
----+---+---+---+---+---
-(0 rows)
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t1.b = t2.b)
+         Join Filter: (t1.c > t2.c)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: t1.b
+               ->  Seq Scan on t1_test_pretch_join_qual t1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: t2.b
+                     ->  Seq Scan on t2_test_pretch_join_qual t2
+ Optimizer: Postgres query optimizer
+(12 rows)
 
+create table t3_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- the following plan contains motion in both outer plan and join qual,
+-- so we should prefetch join qual
+explain (costs off) select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.a > any (select sum(b) from t3_test_pretch_join_qual t3 where c > t2.a);
+NOTICE:  prefetch join qual in slice 0 of plannode 1
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t1.b = t2.b)
+         Join Filter: (SubPlan 1)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: t1.b
+               ->  Seq Scan on t1_test_pretch_join_qual t1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: t2.b
+                     ->  Seq Scan on t2_test_pretch_join_qual t2
+         SubPlan 1
+           ->  Aggregate
+                 ->  Result
+                       Filter: (t3.c > t2.a)
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                   ->  Seq Scan on t3_test_pretch_join_qual t3
+ Optimizer: Postgres query optimizer
+(19 rows)
+
+<<<<<<< HEAD
 reset Test_print_prefetch_joinqual
 >>>>>>> Add a guc to print prefetch join qual info.
+=======
+reset Test_print_prefetch_joinqual;
+reset optimizer;
+>>>>>>> add prefetch logic

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1167,6 +1167,7 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 (13 rows)
 
 drop table t_randomly_dist_table;
+<<<<<<< HEAD
 -- test lateral join inner plan contains limit
 -- we cannot pass params across motion so we
 -- can only generate a plan to gather all the
@@ -1207,3 +1208,42 @@ select * from t1_lateral_limit as t1 cross join lateral
  1 | 1 | (1,1) | 3
 (1 row)
 
+=======
+-- test prefetch join qual
+-- we do not handle this correct
+-- the only case we need to prefetch join qual is:
+--   1. outer plan contains motion
+--   2. the join qual contains subplan that contains motion
+reset client_min_messages;
+set Test_print_prefetch_joinqual = true;
+create table t1_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.c > t2.c;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=24)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
+         Hash Cond: (t1_test_pretch_join_qual.b = t2_test_pretch_join_qual.b)
+         Join Filter: (t1_test_pretch_join_qual.c > t2_test_pretch_join_qual.c)
+         ->  Seq Scan on t1_test_pretch_join_qual  (cost=0.00..431.00 rows=1 width=12)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Seq Scan on t2_test_pretch_join_qual  (cost=0.00..431.00 rows=1 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.92.1
+(9 rows)
+
+-- the above plan contains redistribute motion in both inner and outer plan
+-- the join qual is t1.c > t2.c, it contains no motion, should not prefetch
+select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.c > t2.c;
+ a | b | c | a | b | c 
+---+---+---+---+---+---
+(0 rows)
+
+reset Test_print_prefetch_joinqual
+>>>>>>> Add a guc to print prefetch join qual info.

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1167,7 +1167,6 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 (13 rows)
 
 drop table t_randomly_dist_table;
-<<<<<<< HEAD
 -- test lateral join inner plan contains limit
 -- we cannot pass params across motion so we
 -- can only generate a plan to gather all the
@@ -1208,7 +1207,6 @@ select * from t1_lateral_limit as t1 cross join lateral
  1 | 1 | (1,1) | 3
 (1 row)
 
-=======
 -- test prefetch join qual
 -- we do not handle this correct
 -- the only case we need to prefetch join qual is:
@@ -1275,10 +1273,5 @@ NOTICE:  prefetch join qual in slice 0 of plannode 1
  Optimizer: Postgres query optimizer
 (19 rows)
 
-<<<<<<< HEAD
-reset Test_print_prefetch_joinqual
->>>>>>> Add a guc to print prefetch join qual info.
-=======
 reset Test_print_prefetch_joinqual;
 reset optimizer;
->>>>>>> add prefetch logic


### PR DESCRIPTION
This PR contains several commits. Please review it commit by commit.

The reason we need prefetch join qual is to avoid motion deadlock between outerplan and
joinqual if both contain motion node. For the details of this background and knowledge,
please refer `srt/test/regress/sql/deadlock2.sql` and the function `src/backend/cdb/cdbllize.c:motion_sanity_walker`.

Previous code does not handle prefetch  join qual correct, it will set prefetch joinqual to true
if the outerplan contains motion node no matter what the joinqual is. Please refer the first
commit's test case in this PR to see the bug behavior.

In this PR, we remove previous logic of setting prefetch. Set this field during planning.
When we got the join plan, check if outer plan and joinqual both contain motion nodes.
This PR uses plan_tree_walk to loop the joinqual to find motion nodes.

Also, this PR fix the issue: https://github.com/greenplum-db/gpdb/issues/8677
It fixes it by force each expr in joinqual list to be prefetched when needed.

-------------------

I found the prefetch_inner and prefetch_joinqual field is not set correctly by ORCA.
We may need more work for ORCA. This PR only makes things correct for planner.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
