### PR TITLE
(6x backport)Fix plan when join lateral inner plan contains limit clause.

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -120,6 +120,7 @@ static void subquery_push_qual(Query *subquery,
 				   RangeTblEntry *rte, Index rti, Node *qual);
 static void recurse_push_qual(Node *setOp, Query *topquery,
 				  RangeTblEntry *rte, Index rti, Node *qual);
+static void bring_to_singleQE(PlannerInfo *root, RelOptInfo *rel);
 
 
 /*
@@ -369,6 +370,67 @@ set_rel_size(PlannerInfo *root, RelOptInfo *rel,
 }
 
 /*
+ * Decorate the Paths of 'rel' with Motions to bring the relation's
+ * result to SingleQE locus. The final plan will look something like
+ * this:
+ *
+ *   Result (with quals from 'outer_quals')
+ *           \
+ *            \_Material
+ *                   \
+ *                    \_ Gather
+ *                           \
+ *                            \_SeqScan (with quals from 'baserestrictinfo')
+ */
+static void
+bring_to_singleQE(PlannerInfo *root, RelOptInfo *rel)
+{
+	List	   *origpathlist;
+	ListCell   *lc;
+
+	origpathlist = rel->pathlist;
+	rel->cheapest_startup_path = NULL;
+	rel->cheapest_total_path = NULL;
+	rel->cheapest_unique_path = NULL;
+	rel->cheapest_parameterized_paths = NIL;
+	rel->pathlist = NIL;
+
+	foreach(lc, origpathlist)
+	{
+		Path	     *origpath = (Path *) lfirst(lc);
+		Path	     *path;
+		CdbPathLocus  target_locus;
+
+		if (CdbPathLocus_IsGeneral(origpath->locus) ||
+			CdbPathLocus_IsSingleQE(origpath->locus))
+			path = origpath;
+		else
+		{
+			/*
+			 * Cannot pass a param through motion, so if this is a parameterized
+			 * path, we can't use it.
+			 */
+			if (origpath->param_info)
+				continue;
+
+			CdbPathLocus_MakeSingleQE(&target_locus,
+									  origpath->locus.numsegments);
+
+			path = cdbpath_create_motion_path(root,
+											  origpath,
+											  NIL, // DESTROY pathkeys
+											  false,
+											  target_locus);
+
+			path = (Path *) create_material_path(root, rel, path);
+		}
+
+		add_path(rel, path);
+	}
+	set_cheapest(rel);
+}
+
+/*
  * set_rel_pathlist
  *	  Build access paths for a base relation
  */
@@ -422,6 +484,18 @@ set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel,
 				elog(ERROR, "unexpected rtekind: %d", (int) rel->rtekind);
 				break;
 		}
+	}
+
+	if (root->config->force_singleQE)
+	{
+		/*
+		 * CDB: we cannot pass parameters across motion,
+		 * if this is the inner plan of a lateral join and
+		 * it contains limit clause, we will reach here.
+		 * Planner will gather all the data into singleQE
+		 * and materialize it.
+		 */
+		bring_to_singleQE(root, rel);
 	}
 
 #ifdef OPTIMIZER_DEBUG
@@ -1371,6 +1445,16 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 		/* Generate the plan for the subquery */
 		config = CopyPlannerConfig(root->config);
 		config->honor_order_by = false;		/* partial order is enough */
+		/*
+		 * CDB: if this subquery is the inner plan of a lateral
+		 * join and if it contains a limit, we can only gather
+		 * it to singleQE and materialize the data because we
+		 * cannot pass params across motion.
+		 */
+		config->force_singleQE = false;
+		if ((!bms_is_empty(required_outer)) &&
+			(subquery->limitCount || subquery->limitOffset))
+			config->force_singleQE = true;
 
 		rel->subplan = subquery_planner(root->glob, subquery,
 									root,

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -793,6 +793,16 @@ create_join_plan(PlannerInfo *root, JoinPath *best_path)
 		best_path->outerjoinpath->motionHazard)
 		((Join *) plan)->prefetch_joinqual = true;
 
+	/* CDB: if the join's locus is bottleneck which means the
+	 * join gang only contains one process, so there is no
+	 * risk for motion deadlock.
+	 */
+	if (CdbPathLocus_IsBottleneck(best_path->path.locus))
+	{
+		((Join *) plan)->prefetch_inner = false;
+		((Join *) plan)->prefetch_joinqual = false;
+	}
+
 	plan->flow = cdbpathtoplan_create_flow(root,
 			best_path->path.locus,
 			best_path->path.parent ? best_path->path.parent->relids

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -378,6 +378,8 @@ PlannerConfig *DefaultPlannerConfig(void)
 
 	c1->is_under_subplan = false;
 
+	c1->force_singleQE = false;
+
 	return c1;
 }
 

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -48,6 +48,7 @@ typedef struct PlannerConfig
 
 	/* These ones are tricky */
 	//GpRoleValue	Gp_role; // TODO: this one is tricky
+	bool        force_singleQE; /* True means force gather base rel to singleQE  */
 } PlannerConfig;
 
 extern PlannerConfig *DefaultPlannerConfig(void);

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -966,3 +966,46 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 reset enable_hashjoin;
 reset enable_mergejoin;
 reset enable_nestloop;
+-- test lateral join inner plan contains limit
+-- we cannot pass params across motion so we
+-- can only generate a plan to gather all the
+-- data to singleQE. Here we create a compound
+-- data type as params to pass into inner plan.
+-- By doing so, if we fail to pass correct params
+-- into innerplan, it will throw error because
+-- of nullpointer reference. If we only use int
+-- type as params, the nullpointer reference error
+-- may not happen because we parse null to integer 0.
+create type mytype_for_lateral_test as (x int, y int);
+create table t1_lateral_limit(a int, b int, c mytype_for_lateral_test);
+create table t2_lateral_limit(a int, b int);
+insert into t1_lateral_limit values (1, 1, '(1,1)');
+insert into t1_lateral_limit values (1, 2, '(2,2)');
+insert into t2_lateral_limit values (2, 2);
+insert into t2_lateral_limit values (3, 3);
+explain select * from t1_lateral_limit as t1 cross join lateral
+(select ((c).x+t2.b) as n  from t2_lateral_limit as t2 order by n limit 1)s;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Nested Loop  (cost=10000000001.05..10000000002.11 rows=4 width=41)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=37)
+         ->  Seq Scan on t1_lateral_limit t1  (cost=0.00..1.01 rows=1 width=37)
+   ->  Materialize  (cost=1.05..1.07 rows=1 width=4)
+         ->  Limit  (cost=1.05..1.05 rows=1 width=4)
+               ->  Sort  (cost=1.05..1.05 rows=1 width=4)
+                     Sort Key: (((t1.c).x + t2.b))
+                     ->  Result  (cost=0.00..1.04 rows=1 width=4)
+                           ->  Materialize  (cost=0.00..1.03 rows=1 width=4)
+                                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+                                       ->  Seq Scan on t2_lateral_limit t2  (cost=0.00..1.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select * from t1_lateral_limit as t1 cross join lateral
+(select ((c).x+t2.b) as n  from t2_lateral_limit as t2 order by n limit 1)s;
+ a | b |   c   | n 
+---+---+-------+---
+ 1 | 1 | (1,1) | 3
+ 1 | 2 | (2,2) | 4
+(2 rows)
+

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -982,3 +982,46 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 reset enable_hashjoin;
 reset enable_mergejoin;
 reset enable_nestloop;
+-- test lateral join inner plan contains limit
+-- we cannot pass params across motion so we
+-- can only generate a plan to gather all the
+-- data to singleQE. Here we create a compound
+-- data type as params to pass into inner plan.
+-- By doing so, if we fail to pass correct params
+-- into innerplan, it will throw error because
+-- of nullpointer reference. If we only use int
+-- type as params, the nullpointer reference error
+-- may not happen because we parse null to integer 0.
+create type mytype_for_lateral_test as (x int, y int);
+create table t1_lateral_limit(a int, b int, c mytype_for_lateral_test);
+create table t2_lateral_limit(a int, b int);
+insert into t1_lateral_limit values (1, 1, '(1,1)');
+insert into t1_lateral_limit values (1, 2, '(2,2)');
+insert into t2_lateral_limit values (2, 2);
+insert into t2_lateral_limit values (3, 3);
+explain select * from t1_lateral_limit as t1 cross join lateral
+(select ((c).x+t2.b) as n  from t2_lateral_limit as t2 order by n limit 1)s;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Nested Loop  (cost=10000000001.05..10000000002.11 rows=4 width=41)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=37)
+         ->  Seq Scan on t1_lateral_limit t1  (cost=0.00..1.01 rows=1 width=37)
+   ->  Materialize  (cost=1.05..1.07 rows=1 width=4)
+         ->  Limit  (cost=1.05..1.05 rows=1 width=4)
+               ->  Sort  (cost=1.05..1.05 rows=1 width=4)
+                     Sort Key: (((t1.c).x + t2.b))
+                     ->  Result  (cost=0.00..1.04 rows=1 width=4)
+                           ->  Materialize  (cost=0.00..1.03 rows=1 width=4)
+                                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+                                       ->  Seq Scan on t2_lateral_limit t2  (cost=0.00..1.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select * from t1_lateral_limit as t1 cross join lateral
+(select ((c).x+t2.b) as n  from t2_lateral_limit as t2 order by n limit 1)s;
+ a | b |   c   | n 
+---+---+-------+---
+ 1 | 1 | (1,1) | 3
+ 1 | 2 | (2,2) | 4
+(2 rows)
+

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -471,3 +471,28 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 reset enable_hashjoin;
 reset enable_mergejoin;
 reset enable_nestloop;
+
+-- test lateral join inner plan contains limit
+-- we cannot pass params across motion so we
+-- can only generate a plan to gather all the
+-- data to singleQE. Here we create a compound
+-- data type as params to pass into inner plan.
+-- By doing so, if we fail to pass correct params
+-- into innerplan, it will throw error because
+-- of nullpointer reference. If we only use int
+-- type as params, the nullpointer reference error
+-- may not happen because we parse null to integer 0.
+
+create type mytype_for_lateral_test as (x int, y int);
+create table t1_lateral_limit(a int, b int, c mytype_for_lateral_test);
+create table t2_lateral_limit(a int, b int);
+insert into t1_lateral_limit values (1, 1, '(1,1)');
+insert into t1_lateral_limit values (1, 2, '(2,2)');
+insert into t2_lateral_limit values (2, 2);
+insert into t2_lateral_limit values (3, 3);
+
+explain select * from t1_lateral_limit as t1 cross join lateral
+(select ((c).x+t2.b) as n  from t2_lateral_limit as t2 order by n limit 1)s;
+
+select * from t1_lateral_limit as t1 cross join lateral
+(select ((c).x+t2.b) as n  from t2_lateral_limit as t2 order by n limit 1)s;


### PR DESCRIPTION
This is backport pr https://github.com/greenplum-db/gpdb/pull/9597 and https://github.com/greenplum-db/gpdb/pull/9623 from master to 6X.

The pr https://github.com/greenplum-db/gpdb/pull/9597 is already merged into master.

I will merge this pr after pr pipeline is green.

---------------

Previously, when join lateral inner plan contains limit
clause and the exec params are in targetlist of the query,
for the inner plan it may put a gather motion and then do
limit. This is not correct since it leads to passing params
across motion nodes. A typical case is shown below:

```
create table t1(a int, b int, c int) distributed by (a);
create table t2(a int, b int, c int) distributed by (a);
explain verbose select * from t1 join lateral
(select t1.b + t2.a from t2 limit 1)x on true;
                       QUERY PLAN
--------------------------------------------------------
 Nested Loop
   Output: t1.a, t1.b, t1.c, ((t1.b + t2.a))
   ->  Gather Motion 3:1
         Output: t1.a, t1.b, t1.c
         ->  Seq Scan on public.t1
               Output: t1.a, t1.b, t1.c
   ->  Materialize
         Output: ((t1.b + t2.a))
         ->  Limit
               Output: ((t1.b + t2.a))
               ->  Gather Motion 3:1
                     Output: ((t1.b + t2.a))
                     ->  Limit
                           Output: ((t1.b + t2.a))
                           ->  Seq Scan on public.t2
                                 Output: (t1.b + t2.a)
```

The above plan is invalid because NestLoop has to pass
params down to the scan of t2. Greenplum does not support
this yet.

This commit fixes the bug by gathering the table firstly.
When the subquery contains outer params and it has limit
clause, planner will try this. After this commit, the above
plan becomes:

```
explain verbose select * from t1 join lateral
(select t1.b + t2.a from t2 limit 1)x on true;
                      QUERY PLAN
------------------------------------------------------------
 Nested Loop
   Output: t1.a, t1.b, t1.c, ((t1.b + t2.a))
   ->  Materialize
         Output: t1.a, t1.b, t1.c
         ->  Gather Motion 3:1
               Output: t1.a, t1.b, t1.c
               ->  Seq Scan on public.t1
                     Output: t1.a, t1.b, t1.c
   ->  Materialize
         Output: ((t1.b + t2.a))
         ->  Limit
               Output: ((t1.b + t2.a))
               ->  Result
                     Output: (t1.b + t2.a)
                     ->  Materialize
                           Output: t2.a
                           ->  Gather Motion 3:1
                                 Output: t2.a
                                 ->  Seq Scan on public.t2
                                       Output: t2.a
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
