### PR TITLE
Using dynamic share memory for cursor required snapshot dump

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3160,6 +3160,8 @@ PrepareTransaction(void)
 						 RESOURCE_RELEASE_BEFORE_LOCKS,
 						 true, true);
 
+	/* detach combocid dsm */
+	AtEOXact_ComboCid_Dsm_Detach();
 	/* Check we've released all buffer pins */
 	AtEOXact_Buffers(true);
 

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2819,6 +2819,7 @@ CommitTransaction(void)
 					  : XACT_EVENT_COMMIT);
 	CallXactCallbacksOnce(XACT_EVENT_COMMIT);
 
+	AtEOXact_ComboCid_Dsm_Detach();
 	ResourceOwnerRelease(TopTransactionResourceOwner,
 						 RESOURCE_RELEASE_BEFORE_LOCKS,
 						 true, true);

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2819,10 +2819,12 @@ CommitTransaction(void)
 					  : XACT_EVENT_COMMIT);
 	CallXactCallbacksOnce(XACT_EVENT_COMMIT);
 
-	AtEOXact_ComboCid_Dsm_Detach();
 	ResourceOwnerRelease(TopTransactionResourceOwner,
 						 RESOURCE_RELEASE_BEFORE_LOCKS,
 						 true, true);
+
+	/* detach combocid dsm */
+	AtEOXact_ComboCid_Dsm_Detach();
 
 	/* Check we've released all buffer pins */
 	AtEOXact_Buffers(true);
@@ -3414,6 +3416,7 @@ AbortTransaction(void)
 		ResourceOwnerRelease(TopTransactionResourceOwner,
 							 RESOURCE_RELEASE_BEFORE_LOCKS,
 							 false, true);
+		AtEOXact_ComboCid_Dsm_Detach();
 		AtEOXact_Buffers(false);
 		AtEOXact_RelationCache(false);
 		AtEOXact_Inval(false);

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1619,8 +1619,6 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 						  Snapshot snapshot,
 						  char *debugCaller)
 {
-	int combocidSize;
-
 	Assert(SharedLocalSnapshotSlot != NULL);
 
 	Assert(snapshot != NULL);
@@ -1650,18 +1648,11 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 		memcpy(SharedLocalSnapshotSlot->snapshot.xip, snapshot->xip, snapshot->xcnt * sizeof(TransactionId));
 	}
 	
-	/* combocid stuff */
-	combocidSize = ((usedComboCids < MaxComboCids) ? usedComboCids : MaxComboCids );
-
-	SharedLocalSnapshotSlot->combocidcnt = combocidSize;
-	memcpy((void *)SharedLocalSnapshotSlot->combocids, comboCids,
-		   combocidSize * sizeof(ComboCidKeyData));
-
 	SharedLocalSnapshotSlot->snapshot.curcid = snapshot->curcid;
 
 	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-			(errmsg("updateSharedLocalSnapshot: combocidsize is now %d max %d segmateSync %d->%d",
-					combocidSize, MaxComboCids, SharedLocalSnapshotSlot->segmateSync, dtxContextInfo->segmateSync)));
+			(errmsg("updateSharedLocalSnapshot: segmateSync %d->%d",
+					SharedLocalSnapshotSlot->segmateSync, dtxContextInfo->segmateSync)));
 
 	SetSharedTransactionId_writer(distributedTransactionContext);
 	
@@ -1730,17 +1721,6 @@ copyLocalSnapshot(Snapshot snapshot)
 
 	snapshot->curcid = SharedLocalSnapshotSlot->snapshot.curcid;
 	snapshot->subxcnt = -1;
-
-	/* combocid */
-	usedComboCids = SharedLocalSnapshotSlot->combocidcnt;
-	Assert(usedComboCids <= MaxComboCids);
-	if (usedComboCids > 0)
-	{
-		if (comboCids == NULL)
-			comboCids = MemoryContextAlloc(TopTransactionContext, MaxComboCids * sizeof(ComboCidKeyData));
-
-		memcpy(comboCids, (char *)SharedLocalSnapshotSlot->combocids, usedComboCids * sizeof(ComboCidKeyData));
-	}
 
 	if (TransactionIdPrecedes(snapshot->xmin, TransactionXmin))
 		TransactionXmin = snapshot->xmin;
@@ -3197,8 +3177,6 @@ UpdateSerializableCommandId(CommandId curcid)
 		 SharedLocalSnapshotSlot != NULL &&
 		 FirstSnapshotSet)
 	{
-		int combocidSize;
-
 		LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_EXCLUSIVE);
 
 		if (SharedLocalSnapshotSlot->QDxid != QEDtxContextInfo.distributedXid)
@@ -3221,16 +3199,6 @@ UpdateSerializableCommandId(CommandId curcid)
 						SharedLocalSnapshotSlot->snapshot.curcid,
 						getDistributedTransactionId(),
 						DtxContextToString(DistributedTransactionContext))));
-
-		ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-				(errmsg("serializable writer updating combocid: used combocids %d shared %d",
-						usedComboCids, SharedLocalSnapshotSlot->combocidcnt)));
-
-		combocidSize = ((usedComboCids < MaxComboCids) ? usedComboCids : MaxComboCids );
-
-		SharedLocalSnapshotSlot->combocidcnt = combocidSize;	
-		memcpy((void *)SharedLocalSnapshotSlot->combocids, comboCids,
-			   combocidSize * sizeof(ComboCidKeyData));
 
 		SharedLocalSnapshotSlot->snapshot.curcid = curcid;
 		SharedLocalSnapshotSlot->segmateSync = QEDtxContextInfo.segmateSync;

--- a/src/backend/utils/time/test/sharedsnapshot_test.c
+++ b/src/backend/utils/time/test/sharedsnapshot_test.c
@@ -44,7 +44,6 @@ test_write_read_shared_snapshot_for_cursor(void **state)
 	slot.QDxid = 10;
 	slot.ready = true;
 	slot.segmateSync = 1;
-	slot.combocidcnt = 0;
 	slot.snapshot.xmin = 99;
 	slot.snapshot.xmax = 110;
 	slot.snapshot.xcnt = XCNT;
@@ -59,11 +58,11 @@ test_write_read_shared_snapshot_for_cursor(void **state)
 	expect_any(LWLockAcquire, mode);
 	will_be_called(LWLockAcquire);
 
-	expect_any_count(FaultInjector_InjectFaultIfSet, faultName, 11);
-	expect_any_count(FaultInjector_InjectFaultIfSet, ddlStatement, 11);
-	expect_any_count(FaultInjector_InjectFaultIfSet, databaseName, 11);
-	expect_any_count(FaultInjector_InjectFaultIfSet, tableName, 11);
-	will_be_called_count(FaultInjector_InjectFaultIfSet, 11);
+	expect_any_count(FaultInjector_InjectFaultIfSet, faultName, 9);
+	expect_any_count(FaultInjector_InjectFaultIfSet, ddlStatement, 9);
+	expect_any_count(FaultInjector_InjectFaultIfSet, databaseName, 9);
+	expect_any_count(FaultInjector_InjectFaultIfSet, tableName, 9);
+	will_be_called_count(FaultInjector_InjectFaultIfSet, 9);
 
 	expect_any(LWLockRelease, lock);
 	will_be_called(LWLockRelease);

--- a/src/backend/utils/time/test/sharedsnapshot_test.c
+++ b/src/backend/utils/time/test/sharedsnapshot_test.c
@@ -12,91 +12,6 @@
 
 #include "../sharedsnapshot.c"
 
-/*
- * Write shared snapshot to file using dumpSharedLocalSnapshot_forCursor()
- * first.  Then read the snapshot from file using
- * readSharedLocalSnapshot_forCursor().  Validate that the contents read from
- * the file match what was written.
- */
-static void
-test_write_read_shared_snapshot_for_cursor(void **state)
-{
-#define XCNT 5
-	TransactionId xip[XCNT] = {100, 101, 103, 105, 109};
-	xipEntryCount = XCNT;
-
-	PGPROC writer_proc;
-	writer_proc.pid = 1000;
-
-	TopTransactionResourceOwner = ResourceOwnerCreate(NULL, "unittest resource owner");
-	CurrentResourceOwner = TopTransactionResourceOwner;
-	TopTransactionContext = CurrentMemoryContext;
-
-	/* create a dummy shared and local snapshot with 5 in-progress transactions */
-	SharedSnapshotSlot slot;
-	SharedLocalSnapshotSlot = &slot;
-	slot.slotindex = 1;
-	slot.slotid = 1;
-	slot.writer_proc = &writer_proc;
-	slot.writer_xact = NULL;
-	slot.xid = 100;
-	slot.startTimestamp = 0;
-	slot.QDxid = 10;
-	slot.ready = true;
-	slot.segmateSync = 1;
-	slot.snapshot.xmin = 99;
-	slot.snapshot.xmax = 110;
-	slot.snapshot.xcnt = XCNT;
-	slot.snapshot.xip = xip;
-	slot.slotLock = NULL;
-
-	/* assume the role of a writer to write the snapshot */
-	Gp_role = GP_ROLE_EXECUTE;
-	Gp_is_writer = true;
-
-	expect_any(LWLockAcquire, lock);
-	expect_any(LWLockAcquire, mode);
-	will_be_called(LWLockAcquire);
-
-	expect_any_count(FaultInjector_InjectFaultIfSet, faultName, 9);
-	expect_any_count(FaultInjector_InjectFaultIfSet, ddlStatement, 9);
-	expect_any_count(FaultInjector_InjectFaultIfSet, databaseName, 9);
-	expect_any_count(FaultInjector_InjectFaultIfSet, tableName, 9);
-	will_be_called_count(FaultInjector_InjectFaultIfSet, 9);
-
-	expect_any(LWLockRelease, lock);
-	will_be_called(LWLockRelease);
-
-	MyProc = &writer_proc;
-	MyProc->pid = 1000;
-
-	/* write the snapshot to file */
-	dumpSharedLocalSnapshot_forCursor();
-
-	/* assume the role of a reader to read the snapshot */
-	PGPROC reader_proc;
-	MyProc = &reader_proc;
-	MyProc->pid = 1234;
-	lockHolderProcPtr = &writer_proc;
-	Gp_is_writer = false;
-
-	QEDtxContextInfo.segmateSync = slot.segmateSync;
-	QEDtxContextInfo.distributedXid = slot.QDxid;
-
-	SnapshotData snapshot;
-	snapshot.xip = palloc(XCNT * sizeof(TransactionId));
-#define SUBXCNT 1
-	snapshot.subxip = palloc(SUBXCNT * sizeof(TransactionId));
-
-	/* read snapshot from the same file */
-	readSharedLocalSnapshot_forCursor(&snapshot, DTX_CONTEXT_QE_READER);
-
-	assert_true(snapshot.xcnt == XCNT);
-	int i;
-	for (i=0; i<XCNT; i++)
-		assert_true(slot.snapshot.xip[i] == snapshot.xip[i]);
-}
-
 static void
 test_boundaries_of_CreateSharedSnapshotArray(void **state)
 {
@@ -108,6 +23,7 @@ test_boundaries_of_CreateSharedSnapshotArray(void **state)
 
 	SharedSnapshotStruct 	*fakeSharedSnapshotArray = NULL;
 	LWLockPadded 			*fakeLockBase = NULL;
+	HTAB                    *fakeHashTable = malloc(1);
 
 	expect_string(RequestNamedLWLockTranche, tranche_name, "SharedSnapshotLocks");
 	expect_value(RequestNamedLWLockTranche, num_lwlocks, NUM_SHARED_SNAPSHOT_SLOTS);
@@ -120,6 +36,13 @@ test_boundaries_of_CreateSharedSnapshotArray(void **state)
 	expect_any_count(ShmemInitStruct, name, 1);
 	expect_any_count(ShmemInitStruct, size, 1);
 	expect_any_count(ShmemInitStruct, foundPtr, 1);
+
+	will_return_count(ShmemInitHash, &fakeHashTable, -1);
+	expect_any_count(ShmemInitHash, name, -1);
+	expect_any_count(ShmemInitHash, init_size, -1);
+	expect_any_count(ShmemInitHash, max_size, -1);
+	expect_any_count(ShmemInitHash, infoP, -1);
+	expect_any_count(ShmemInitHash, hash_flags, -1);
 
 	expect_string(RequestNamedLWLockTranche, tranche_name, "SharedSnapshotLocks");
 	expect_value(RequestNamedLWLockTranche, num_lwlocks, NUM_SHARED_SNAPSHOT_SLOTS);
@@ -156,7 +79,6 @@ main(int argc, char* argv[])
 
 	const UnitTest tests[] = {
 		unit_test(test_boundaries_of_CreateSharedSnapshotArray),
-		unit_test(test_write_read_shared_snapshot_for_cursor)
 	};
 	MemoryContextInit();
 	InitFileAccess();

--- a/src/backend/utils/time/tqual.c
+++ b/src/backend/utils/time/tqual.c
@@ -1145,12 +1145,6 @@ HeapTupleSatisfiesMVCC(Relation relation, HeapTuple htup, Snapshot snapshot,
 				return true;
 			}
 
-			/*
-			 * MPP-8317: cursors can't always *tell* that this is the current transaction.
-			 */
-			Assert(QEDtxContextInfo.cursorContext ||
-				   TransactionIdIsCurrentTransactionId(HeapTupleHeaderGetRawXmax(tuple)));
-
 			if (HeapTupleHeaderGetCmax(tuple) >= snapshot->curcid)
 				return true;	/* deleted after scan started */
 			else

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -173,10 +173,10 @@ struct PGPROC
 	uint32		waitPortalId;	/* portal id we are waiting on */
 
 	/*
-	 * Information for our combocid-map (populated in writer/dispatcher backends only)
+	 * Handle for our shared comboCids array (populated in writer/dispatcher
+	 * backends only)
 	 */
-	uint32		combocid_map_count; /* how many entries in the map ? */
-	dsm_handle  combocid_map_handle;
+	dsm_handle  comboCidsHandle;
 
 	/*
 	 * Current command_id for the running query

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -27,6 +27,7 @@
 
 #include "cdb/cdblocaldistribxact.h"  /* LocalDistribXactData */
 #include "cdb/cdbtm.h"  /* TMGXACT */
+#include "dsm.h"
 
 /*
  * Each backend advertises up to PGPROC_MAX_CACHED_SUBXIDS TransactionIds
@@ -175,6 +176,7 @@ struct PGPROC
 	 * Information for our combocid-map (populated in writer/dispatcher backends only)
 	 */
 	uint32		combocid_map_count; /* how many entries in the map ? */
+	dsm_handle  combocid_map_handle;
 
 	/*
 	 * Current command_id for the running query

--- a/src/include/utils/combocid.h
+++ b/src/include/utils/combocid.h
@@ -19,34 +19,9 @@
  * are in access/htup.h, because that's where the macro definitions that
  * those functions replaced used to be.
  */
- 
-/* CDB TODO: This is the max number of combo cids that we copy into the Shared
- * snapshot to the reader gangs.  As a result, transactions that have more than
- * 128 update/delete statements within them can result in the reader gangs
- * reading a tuple whose visibility they cannot determine because of not having
- * the entire combocids table.  Those statements will result in the reader gangs
- * throwing an error.  Ultimately, we need to find another way of serializing
- * this information that can support the arbitrary size of the combocids 
- * datastructure.
- */
-#define MaxComboCids 256
 
-/* Key and entry structures for the hash table */
-typedef struct
-{
-	CommandId		cmin;
-	CommandId		cmax;
-	TransactionId	xmin;
-} ComboCidKeyData;
-
-typedef ComboCidKeyData *ComboCidKey;
-
-extern volatile ComboCidKey comboCids;
-extern volatile int usedComboCids;
-extern volatile int sizeComboCids;
-
-extern void AtEOXact_ComboCid_Dsm_Detach(void);
 extern void AtEOXact_ComboCid(void);
+extern void AtEOXact_ComboCid_Dsm_Detach(void);
 extern void RestoreComboCIDState(char *comboCIDstate);
 extern void SerializeComboCIDState(Size maxsize, char *start_address);
 extern Size EstimateComboCIDStateSpace(void);

--- a/src/include/utils/combocid.h
+++ b/src/include/utils/combocid.h
@@ -45,6 +45,7 @@ extern volatile ComboCidKey comboCids;
 extern volatile int usedComboCids;
 extern volatile int sizeComboCids;
 
+extern void AtEOXact_ComboCid_Dsm_Detach(void);
 extern void AtEOXact_ComboCid(void);
 extern void RestoreComboCIDState(char *comboCIDstate);
 extern void SerializeComboCIDState(Size maxsize, char *start_address);

--- a/src/include/utils/sharedsnapshot.h
+++ b/src/include/utils/sharedsnapshot.h
@@ -27,8 +27,6 @@ typedef struct SharedSnapshotSlot
 	volatile TransactionId   QDxid;
 	volatile bool			ready;
 	volatile uint32			segmateSync;
-	uint32			combocidcnt;
-	ComboCidKeyData combocids[MaxComboCids];
 	SnapshotData	snapshot;
 	LWLock		   *slotLock;
 

--- a/src/include/utils/sharedsnapshot.h
+++ b/src/include/utils/sharedsnapshot.h
@@ -16,6 +16,7 @@
 #include "storage/proc.h"
 #include "utils/combocid.h"
 #include "utils/tqual.h"
+#include "storage/dsm.h"
 
 /* MPP Shared Snapshot */
 typedef struct SharedSnapshotSlot
@@ -29,6 +30,7 @@ typedef struct SharedSnapshotSlot
 	volatile uint32			segmateSync;
 	SnapshotData	snapshot;
 	LWLock		   *slotLock;
+	HTAB           *cursor_dump_hash;
 
 	/* for debugging only */
 	TransactionId	xid;

--- a/src/test/regress/expected/cursor.out
+++ b/src/test/regress/expected/cursor.out
@@ -640,12 +640,6 @@ FETCH ABSOLUTE 1 IN CUR;
 (1 row)
 
 COMMIT;
---
--- Shared snapshot files for cursor should be gone after transaction commits.
---
-CREATE EXTERNAL WEB TABLE check_cursor_files(a int)
-EXECUTE 'find base | grep pgsql_tmp | grep _sync | wc -l'
-FORMAT 'TEXT';
 BEGIN;
 DECLARE c CURSOR FOR SELECT * FROM ctest ORDER BY id;
 FETCH 1 FROM c;
@@ -654,23 +648,9 @@ FETCH 1 FROM c;
   1 | Test1
 (1 row)
 
--- There should be a shared snapshot file on every segment.
-SELECT DISTINCT a FROM check_cursor_files;
- a 
----
- 1
-(1 row)
-
 -- holdable cursor should be ok
 DECLARE c_hold CURSOR WITH HOLD FOR SELECT * FROM ctest ORDER BY id;
 COMMIT;
--- After commit, the shared snapshot files should be deleted.
-SELECT DISTINCT a FROM check_cursor_files;
- a 
----
- 0
-(1 row)
-
 FETCH 1 FROM c_hold;
  id | name  
 ----+-------

--- a/src/test/regress/sql/cursor.sql
+++ b/src/test/regress/sql/cursor.sql
@@ -386,26 +386,13 @@ FETCH ABSOLUTE 1 IN CUR;
 COMMIT;
 
 
---
--- Shared snapshot files for cursor should be gone after transaction commits.
---
-CREATE EXTERNAL WEB TABLE check_cursor_files(a int)
-EXECUTE 'find base | grep pgsql_tmp | grep _sync | wc -l'
-FORMAT 'TEXT';
-
 BEGIN;
 DECLARE c CURSOR FOR SELECT * FROM ctest ORDER BY id;
 FETCH 1 FROM c;
 
--- There should be a shared snapshot file on every segment.
-SELECT DISTINCT a FROM check_cursor_files;
-
 -- holdable cursor should be ok
 DECLARE c_hold CURSOR WITH HOLD FOR SELECT * FROM ctest ORDER BY id;
 COMMIT;
-
--- After commit, the shared snapshot files should be deleted.
-SELECT DISTINCT a FROM check_cursor_files;
 
 FETCH 1 FROM c_hold;
 


### PR DESCRIPTION
At present, sharedsnapshot dump message by BufFile for cursor. However,
in v12 upstream merge process, BufFile API is changed. This is a
good point to change the dump message using dynamic share memory.

For the shared segment management, this PR only uses a traditional
hashtable for each snapshot slot. After the merge finish, we can replace
it to dshash_table.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
