### PR TITLE
Change WARNING log to normal log on sending request to gpfdist

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -217,7 +217,7 @@ destroy_curlhandle(curlhandle_t *h)
 			CURLMcode e = curl_multi_remove_handle(multi_handle, h->handle);
 
 			if (CURLM_OK != e)
-				elog(WARNING, "internal error curl_multi_remove_handle (%d - %s)", e, curl_easy_strerror(e));
+				elog(LOG, "internal error curl_multi_remove_handle (%d - %s)", e, curl_easy_strerror(e));
 			h->in_multi_handle = false;
 		}
 
@@ -257,7 +257,7 @@ url_curl_abort_callback(ResourceReleasePhase phase,
 		if (curr->owner == CurrentResourceOwner)
 		{
 			if (isCommit)
-				elog(WARNING, "url_curl reference leak: %p still referenced", curr);
+				elog(LOG, "url_curl reference leak: %p still referenced", curr);
 
 			destroy_curlhandle(curr);
 		}
@@ -569,6 +569,7 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 		CURLcode e = curl_easy_perform(file->curl->handle);
 		if (CURLE_OK != e)
 		{
+			/* For curl timeout, retry 2 times before reporting error */
 			if (CURLE_OPERATION_TIMEDOUT == e)
 			{
 				timeout_count++;
@@ -584,7 +585,7 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 			}
 			else
 			{
-				elog(WARNING, "%s error (%d - %s)", file->curl_url, e, curl_easy_strerror(e));
+				elog(LOG, "%s error (%d - %s)", file->curl_url, e, curl_easy_strerror(e));
 			}
 		}
 		else
@@ -612,6 +613,10 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 			response_string = NULL;
 		}
 
+		/*
+		 * For FDIST_TIMEOUT and curl errors except CURLE_OPERATION_TIMEDOUT
+		 * Retry until MAX_TRY_WAIT_TIME
+		 */
 		if (wait_time > MAX_TRY_WAIT_TIME)
 		{
 			ereport(ERROR,
@@ -621,7 +626,7 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 		}
 		else
 		{
-			elog(WARNING, "failed to send request to gpfdist (%s), will retry after %d seconds", file->curl_url, wait_time);
+			elog(LOG, "failed to send request to gpfdist (%s), will retry after %d seconds", file->curl_url, wait_time);
 			unsigned int for_wait = 0;
 			while (for_wait++ < wait_time)
 			{


### PR DESCRIPTION
Warning log will print in client/frontend, and some ODBC API returns
"SQL success with info" value. It may be considered as exception in
some clients.
So we change it to normal log and report error if it really fails.
