### PR TITLE
Update pg_aoseg entries for COPY FROM SEGMENT

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -2173,17 +2173,21 @@ CopyDispatchOnSegment(CopyState cstate, const CopyStmt *stmt)
 	int			i;
 	uint64		processed = 0;
 	uint64		rejected = 0;
+	bool		partitioned;
+	HTAB	   *aopartcounts = NULL;
+
 	dispatchStmt = copyObject((Node *) stmt);
 
 	/* add in partitions for dispatch */
 	dispatchStmt->partitions = RelationBuildPartitionDesc(cstate->rel, false);
 
 	all_relids = list_make1_oid(RelationGetRelid(cstate->rel));
+	partitioned = rel_is_partitioned(RelationGetRelid(cstate->rel));
 
 	/* add in AO segno map for dispatch */
 	if (dispatchStmt->is_from)
 	{
-		if (rel_is_partitioned(RelationGetRelid(cstate->rel)))
+		if (partitioned)
 		{
 			PartitionNode *pn = RelationBuildPartitionDesc(cstate->rel, false);
 
@@ -2213,10 +2217,53 @@ CopyDispatchOnSegment(CopyState cstate, const CopyStmt *stmt)
 
 		processed += result->numCompleted;
 		rejected += result->numRejected;
+
+		if (partitioned)
+			aopartcounts = PQprocessAoTupCounts(aopartcounts,
+												(void *) result->aotupcounts,
+												result->naotupcounts);
 	}
 
 	if (rejected)
 		ReportSrehResults(NULL, rejected);
+
+	/*
+	 * Record new tuple counts and increment the modification count in
+	 * pg_aoseg entries if the relations we've copied into are append only.
+	 */
+	if (dispatchStmt->is_from)
+	{
+		if (aopartcounts)
+		{
+			ListCell *lc;
+			foreach(lc, dispatchStmt->ao_segnos)
+			{
+				SegfileMapNode *map = lfirst(lc);
+				struct {
+					Oid relid;
+					int64 tupcount;
+				} *entry;
+				bool found;
+
+				entry = hash_search(aopartcounts,
+									&(map->relid),
+									HASH_FIND,
+									&found);
+
+				if (found && entry->tupcount > 0)
+				{
+					Relation rel = heap_open(map->relid, AccessShareLock);
+					UpdateMasterAosegTotals(rel, map->segno, entry->tupcount, 1);
+					heap_close(rel, NoLock);
+				}
+			}
+		}
+		else if (RelationIsAppendOptimized(cstate->rel) && processed > 0)
+		{
+			SegfileMapNode *map = linitial(dispatchStmt->ao_segnos);
+			UpdateMasterAosegTotals(cstate->rel, map->segno, processed, 1);
+		}
+	}
 
 	cdbdisp_clearCdbPgResults(&pgresults);
 	return processed;

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1248,10 +1248,28 @@ DROP TABLE ext_dec17;
 COPY sales TO PROGRAM 'cat > /dev/null' IGNORE EXTERNAL PARTITIONS;
 COPY sales TO PROGRAM 'printf <SEGID> && cat > /dev/null' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
 DROP TABLE sales;
+
+-- Make sure COPY TO/FROM ON SEGMENT on an AO table works and that the
+-- corresponding aoseg tables get updated accordingly. We also check
+-- against an AO partition table since the dispatch result stores the
+-- individual leaf partition results in a special way compared to a
+-- single AO table and has its own result parsing logic.
 CREATE TABLE ao_copy(c int) WITH (appendonly=true);
+INSERT INTO ao_copy values (1);
 COPY ao_copy TO '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('ao_copy'::regclass);
 COPY ao_copy FROM '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('ao_copy'::regclass);
 DROP TABLE ao_copy;
+CREATE TABLE aopart_copy(c int, d int) WITH (appendonly=true) PARTITION BY RANGE(d) (START(0) END(2) EVERY(1));
+INSERT INTO aopart_copy values (1, 0), (2, 1);
+COPY aopart_copy TO '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_1'::regclass);
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_2'::regclass);
+COPY aopart_copy FROM '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_1'::regclass);
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_2'::regclass);
+DROP TABLE aopart_copy;
 
 -- "unknown" types can be dumped and restored: these attributes are
 -- NULL-terminated in memory (attlen == -2), so the COPY code needs to handle

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -693,7 +693,7 @@ COPY (SELECT * FROM segment_reject_limit_from) TO '/tmp/segment_reject_limit<SEG
 -- 'COPY (SELECT ...) TO' on utility mode
 CREATE EXTERNAL WEB TABLE copy_cmd_utility(a text, b int)
   EXECUTE E'PGOPTIONS="-c gp_session_role=utility" \\
-    psql -p $GP_MASTER_PORT $GP_DATABASE $GP_USER -c \\
+    psql -X -p $GP_MASTER_PORT $GP_DATABASE $GP_USER -c \\
       "COPY (SELECT * FROM pg_class) TO \'/dev/null\'"'
   ON MASTER FORMAT 'text' (DELIMITER ' ');
 SELECT a FROM copy_cmd_utility;
@@ -1240,8 +1240,8 @@ COPY sales (id, date, amt) FROM stdin;
 12	2017-12-01	20.00
 \.
 -- execute external psql here to get the message of COPY
-\! psql -c "COPY sales TO '/tmp/test_sales_<SEGID>' ON SEGMENT" regression
-\! psql -c "COPY sales FROM '/tmp/test_sales_<SEGID>' ON SEGMENT" regression
+\! psql -X -c "COPY sales TO '/tmp/test_sales_<SEGID>' ON SEGMENT" regression
+\! psql -X -c "COPY sales FROM '/tmp/test_sales_<SEGID>' ON SEGMENT" regression
 CREATE EXTERNAL WEB TABLE ext_dec17(LIKE sales_1_prt_dec17) EXECUTE 'printf "12\t2017-12-01\t20.00\n"' ON MASTER FORMAT 'text';
 ALTER TABLE sales ALTER PARTITION dec17 EXCHANGE PARTITION dec17 WITH TABLE ext_dec17 WITHOUT VALIDATION;
 DROP TABLE ext_dec17;

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1515,10 +1515,57 @@ NOTICE:  COPY ignores external partition(s)
 COPY sales TO PROGRAM 'printf <SEGID> && cat > /dev/null' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
 NOTICE:  COPY ignores external partition(s)
 DROP TABLE sales;
+-- Make sure COPY TO/FROM ON SEGMENT on an AO table works and that the
+-- corresponding aoseg tables get updated accordingly. We also check
+-- against an AO partition table since the dispatch result stores the
+-- individual leaf partition results in a special way compared to a
+-- single AO table and has its own result parsing logic.
 CREATE TABLE ao_copy(c int) WITH (appendonly=true);
+INSERT INTO ao_copy values (1);
 COPY ao_copy TO '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('ao_copy'::regclass);
+ segno | modcount 
+-------+----------
+     1 |        1
+(1 row)
+
 COPY ao_copy FROM '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('ao_copy'::regclass);
+ segno | modcount 
+-------+----------
+     1 |        2
+(1 row)
+
 DROP TABLE ao_copy;
+CREATE TABLE aopart_copy(c int, d int) WITH (appendonly=true) PARTITION BY RANGE(d) (START(0) END(2) EVERY(1));
+INSERT INTO aopart_copy values (1, 0), (2, 1);
+COPY aopart_copy TO '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_1'::regclass);
+ segno | modcount 
+-------+----------
+     1 |        1
+(1 row)
+
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_2'::regclass);
+ segno | modcount 
+-------+----------
+     1 |        1
+(1 row)
+
+COPY aopart_copy FROM '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_1'::regclass);
+ segno | modcount 
+-------+----------
+     1 |        2
+(1 row)
+
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_2'::regclass);
+ segno | modcount 
+-------+----------
+     1 |        2
+(1 row)
+
+DROP TABLE aopart_copy;
 -- "unknown" types can be dumped and restored: these attributes are
 -- NULL-terminated in memory (attlen == -2), so the COPY code needs to handle
 -- them explicitly.

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -729,7 +729,7 @@ COPY (SELECT * FROM segment_reject_limit_from) TO '/tmp/segment_reject_limit<SEG
 -- 'COPY (SELECT ...) TO' on utility mode
 CREATE EXTERNAL WEB TABLE copy_cmd_utility(a text, b int)
   EXECUTE E'PGOPTIONS="-c gp_session_role=utility" \\
-    psql -p $GP_MASTER_PORT $GP_DATABASE $GP_USER -c \\
+    psql -X -p $GP_MASTER_PORT $GP_DATABASE $GP_USER -c \\
       "COPY (SELECT * FROM pg_class) TO \'/dev/null\'"'
   ON MASTER FORMAT 'text' (DELIMITER ' ');
 SELECT a FROM copy_cmd_utility;
@@ -1502,9 +1502,9 @@ NOTICE:  CREATE TABLE will create partition "sales_1_prt_nov17" for table "sales
 NOTICE:  CREATE TABLE will create partition "sales_1_prt_dec17" for table "sales"
 COPY sales (id, date, amt) FROM stdin;
 -- execute external psql here to get the message of COPY
-\! psql -c "COPY sales TO '/tmp/test_sales_<SEGID>' ON SEGMENT" regression
+\! psql -X -c "COPY sales TO '/tmp/test_sales_<SEGID>' ON SEGMENT" regression
 COPY 26
-\! psql -c "COPY sales FROM '/tmp/test_sales_<SEGID>' ON SEGMENT" regression
+\! psql -X -c "COPY sales FROM '/tmp/test_sales_<SEGID>' ON SEGMENT" regression
 COPY 26
 CREATE EXTERNAL WEB TABLE ext_dec17(LIKE sales_1_prt_dec17) EXECUTE 'printf "12\t2017-12-01\t20.00\n"' ON MASTER FORMAT 'text';
 ALTER TABLE sales ALTER PARTITION dec17 EXCHANGE PARTITION dec17 WITH TABLE ext_dec17 WITHOUT VALIDATION;


### PR DESCRIPTION
After running COPY FROM SEGMENT into an appendonly table, the pg_aoseg
entry on the master was not being updated as expected like regular
COPY. Add logic to update the pg_aoseg entries with the dispatch
results.

This was found while contemplating the usage of
`gp_update_ao_master_stats()` in PR #9258. Technically, users of COPY
FROM SEGMENT could just call `gp_update_ao_master_stats()` afterwards
but having the pg_aoseg entry updated at the end of COPY FROM SEGMENT
transaction seems more correct.