### PR TITLE
Do not impose EXEC_FLAG_REWIND on outer child of NestLoop

### DIFF
--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -440,6 +440,7 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
 	 * Until we find a better way to handle the dependency of ShareInputScan on 
 	 * execution order, this is pretty much what we have to deal with.
 	 */
+	int original_eflags = eflags;
 	if (node->nestParams == NIL)
 		eflags |= EXEC_FLAG_REWIND;
 	else
@@ -448,12 +449,12 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
 	{
 		innerPlanState(nlstate) = ExecInitNode(innerPlan(node), estate, eflags);
 		if (!node->shared_outer)
-			outerPlanState(nlstate) = ExecInitNode(outerPlan(node), estate, eflags);
+			outerPlanState(nlstate) = ExecInitNode(outerPlan(node), estate, original_eflags);
 	}
 	else
 	{
 		if (!node->shared_outer)
-			outerPlanState(nlstate) = ExecInitNode(outerPlan(node), estate, eflags);
+			outerPlanState(nlstate) = ExecInitNode(outerPlan(node), estate, original_eflags);
 		innerPlanState(nlstate) = ExecInitNode(innerPlan(node), estate, eflags);
 	}
 


### PR DESCRIPTION
A NestLoop's outer child mostly preserves the executor "flags" passed on to
the NestLoop. While adding EXEC_FLAG_REWIND is harmless, it's illogical:
NestLoop only goes through the left child in a single pass.

This is likely an oversight from the 9.0 merge.

Co-authored-by: Melanie Plageman <mplageman@pivotal.io>

===
Melanie and I found this while working on d3ccff0434e4d005aefcaa8c6b9f7b0f770718c2