### PR TITLE
docs - pxf [cluster] sync now supports a delete option

### DIFF
--- a/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
@@ -68,7 +68,7 @@ The `pxf cluster` utility command manages PXF on the master, standby master, and
 
 The `pxf cluster sync` command takes the following option:
 
-<dt>-d | &#8211;&#8211;delete </dt>
+<dt>&#8211;d | &#8211;&#8211;delete </dt>
 <dd>Delete any files in the PXF user configuration on the standby master and segment hosts that are not also present on the master host.</dd>
 
 ## <a id="topic1__section5"></a>Examples

--- a/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
@@ -79,7 +79,7 @@ Stop the PXF service instance on all segment hosts:
 $ $GPHOME/pxf/bin/pxf cluster stop
 ```
 
-Synchronize the PXF configuration to the standby and all segment hosts, deleting files that do not exist on the master:
+Synchronize the PXF configuration to the standby and all segment hosts, deleting files that do not exist on the master host:
 
 ``` shell
 $ $GPHOME/pxf/bin/pxf cluster sync --delete

--- a/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf-cluster.html.md.erb
@@ -7,7 +7,7 @@ Manage the PXF configuration and the PXF service instance on all Greenplum Datab
 ## <a id="topic1__section2"></a>Synopsis
 
 ``` pre
-pxf cluster <command>
+pxf cluster <command> [<option>]
 ```
 
 where `<command>` is:
@@ -61,7 +61,15 @@ The `pxf cluster` utility command manages PXF on the master, standby master, and
 <dd>Stop the PXF service instance on all segment hosts.</dd>
 
 <dt>sync  </dt>
-<dd>Synchronize the PXF configuration from the master to the standby master and to all Greenplum Database segment hosts. If you have updated the PXF user configuration or added JAR files, you must also restart PXF after you synchronize the PXF configuration.</dd>
+<dd>Synchronize the PXF configuration (`$PXF_CONF`) from the master to the standby master and to all Greenplum Database segment hosts. By default, this command updates files on and copies files to the remote. You can instruct PXF to also delete files during the synchronization; see [Options](#options).</dd>
+<dd>If you have updated the PXF user configuration or added JAR files, you must also restart PXF after you synchronize the PXF configuration.</dd>
+
+## <a id="options"></a>Options
+
+The `pxf cluster sync` command takes the following option:
+
+<dt>-d | &#8211;&#8211;delete </dt>
+<dd>Delete any files in the PXF user configuration on the standby master and segment hosts that are not also present on the master host.</dd>
 
 ## <a id="topic1__section5"></a>Examples
 
@@ -69,6 +77,12 @@ Stop the PXF service instance on all segment hosts:
 
 ``` shell
 $ $GPHOME/pxf/bin/pxf cluster stop
+```
+
+Synchronize the PXF configuration to the standby and all segment hosts, deleting files that do not exist on the master:
+
+``` shell
+$ $GPHOME/pxf/bin/pxf cluster sync --delete
 ```
 
 ## <a id="topic1__section6"></a>See Also

--- a/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
@@ -62,7 +62,7 @@ You can start, stop, or restart the PXF service instance on a specific segment h
 <dd>Stop the PXF service instance running on the segment host.</dd>
 
 <dt>sync  </dt>
-<dd>Synchronize the PXF configuration from the master to a specific Greenplum Database standby master or segment host. You must run `pxf sync` on the master host. See [Options](pxf.html#options).</dd>
+<dd>Synchronize the PXF configuration (`$PXF_CONF`) from the master to a specific Greenplum Database standby master or segment host. You must run `pxf sync` on the master host. By default, this command updates files on and copies files to the remote. You can instruct PXF to also delete files during the synchronization; see [Options](#options).</dd>
 
 <dt>version  </dt>
 <dd>Display the PXF version and then exit.</dd>
@@ -76,10 +76,13 @@ The `pxf init` command takes the following option:
 
 The `pxf reset` command takes the following option:
 
-<dt>-f | --force </dt>
+<dt>-f | &#8211;&#8211;force </dt>
 <dd>Do not prompt before resetting the PXF service instance; reset without user interaction.</dd>
 
-The `pxf sync` command, run on the Greenplum Database master host, takes the following option:
+The `pxf sync` command, which you must run on the Greenplum Database master host, takes the following options:
+
+<dt>-d | &#8211;&#8211;delete </dt>
+<dd>Delete any files in the PXF user configuration on `<gphost>` that are not also present on the master host. If you specify this option, you must provide it on the command line before `<gphost>`.</dd>
 
 <dt>\<gphost\> </dt>
 <dd>The Greenplum Database host to which to synchronize the PXF configuration. `<gphost>` must identify the standy master host or a segment host.</dd>

--- a/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
@@ -79,13 +79,13 @@ The `pxf reset` command takes the following option:
 <dt>-f | &#8211;&#8211;force </dt>
 <dd>Do not prompt before resetting the PXF service instance; reset without user interaction.</dd>
 
-The `pxf sync` command, which you must run on the Greenplum Database master host, takes the following options:
+The `pxf sync` command, which you must run on the Greenplum Database master host, takes the following option and argument:
 
 <dt>-d | &#8211;&#8211;delete </dt>
 <dd>Delete any files in the PXF user configuration on `<gphost>` that are not also present on the master host. If you specify this option, you must provide it on the command line before `<gphost>`.</dd>
 
 <dt>\<gphost\> </dt>
-<dd>The Greenplum Database host to which to synchronize the PXF configuration. `<gphost>` must identify the standy master host or a segment host.</dd>
+<dd>The Greenplum Database host to which to synchronize the PXF configuration. Required. `<gphost>` must identify the standy master host or a segment host.</dd>
 
 ## <a id="topic1__section5"></a>Examples
 

--- a/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/ref/pxf.html.md.erb
@@ -71,17 +71,17 @@ You can start, stop, or restart the PXF service instance on a specific segment h
 
 The `pxf init` command takes the following option:
 
-<dt>-y </dt>
+<dt>&#8211;y </dt>
 <dd>Do not prompt, use the default `$PXF_CONF` directory location if the environment variable is not set.</dd>
 
 The `pxf reset` command takes the following option:
 
-<dt>-f | &#8211;&#8211;force </dt>
+<dt>&#8211;f | &#8211;&#8211;force </dt>
 <dd>Do not prompt before resetting the PXF service instance; reset without user interaction.</dd>
 
 The `pxf sync` command, which you must run on the Greenplum Database master host, takes the following option and argument:
 
-<dt>-d | &#8211;&#8211;delete </dt>
+<dt>&#8211;d | &#8211;&#8211;delete </dt>
 <dd>Delete any files in the PXF user configuration on `<gphost>` that are not also present on the master host. If you specify this option, you must provide it on the command line before `<gphost>`.</dd>
 
 <dt>\<gphost\> </dt>


### PR DESCRIPTION
in this PR:   add the new option to the `pxf` and `pxf cluster` references pages (we don't currently have a dedicated topic for sync/reset)

questions:
1.  any reason an admin would want extra files in their standby/segment PXF user configs that aren't on the master?
2.  any upgrade implications - i.e. do we want to recommend that the user runs a sync with delete?

doc review site links:
- http://docs-lisa-pxf-syncdelete.cfapps.io/7-0/pxf/ref/pxf-cluster.html
- http://docs-lisa-pxf-syncdelete.cfapps.io/7-0/pxf/ref/pxf.html
