### PR TITLE
Dump combocid message to dynamic shared memory instead of BufFile

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3160,6 +3160,8 @@ PrepareTransaction(void)
 						 RESOURCE_RELEASE_BEFORE_LOCKS,
 						 true, true);
 
+	/* detach combocid dsm */
+	AtEOXact_ComboCid_Dsm_Detach();
 	/* Check we've released all buffer pins */
 	AtEOXact_Buffers(true);
 

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2819,6 +2819,7 @@ CommitTransaction(void)
 					  : XACT_EVENT_COMMIT);
 	CallXactCallbacksOnce(XACT_EVENT_COMMIT);
 
+	AtEOXact_ComboCid_Dsm_Detach();
 	ResourceOwnerRelease(TopTransactionResourceOwner,
 						 RESOURCE_RELEASE_BEFORE_LOCKS,
 						 true, true);

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2819,10 +2819,12 @@ CommitTransaction(void)
 					  : XACT_EVENT_COMMIT);
 	CallXactCallbacksOnce(XACT_EVENT_COMMIT);
 
-	AtEOXact_ComboCid_Dsm_Detach();
 	ResourceOwnerRelease(TopTransactionResourceOwner,
 						 RESOURCE_RELEASE_BEFORE_LOCKS,
 						 true, true);
+
+	/* detach combocid dsm */
+	AtEOXact_ComboCid_Dsm_Detach();
 
 	/* Check we've released all buffer pins */
 	AtEOXact_Buffers(true);
@@ -3414,6 +3416,7 @@ AbortTransaction(void)
 		ResourceOwnerRelease(TopTransactionResourceOwner,
 							 RESOURCE_RELEASE_BEFORE_LOCKS,
 							 false, true);
+		AtEOXact_ComboCid_Dsm_Detach();
 		AtEOXact_Buffers(false);
 		AtEOXact_RelationCache(false);
 		AtEOXact_Inval(false);

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1619,8 +1619,6 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 						  Snapshot snapshot,
 						  char *debugCaller)
 {
-	int combocidSize;
-
 	Assert(SharedLocalSnapshotSlot != NULL);
 
 	Assert(snapshot != NULL);
@@ -1650,18 +1648,11 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 		memcpy(SharedLocalSnapshotSlot->snapshot.xip, snapshot->xip, snapshot->xcnt * sizeof(TransactionId));
 	}
 	
-	/* combocid stuff */
-	combocidSize = ((usedComboCids < MaxComboCids) ? usedComboCids : MaxComboCids );
-
-	SharedLocalSnapshotSlot->combocidcnt = combocidSize;
-	memcpy((void *)SharedLocalSnapshotSlot->combocids, comboCids,
-		   combocidSize * sizeof(ComboCidKeyData));
-
 	SharedLocalSnapshotSlot->snapshot.curcid = snapshot->curcid;
 
 	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-			(errmsg("updateSharedLocalSnapshot: combocidsize is now %d max %d segmateSync %d->%d",
-					combocidSize, MaxComboCids, SharedLocalSnapshotSlot->segmateSync, dtxContextInfo->segmateSync)));
+			(errmsg("updateSharedLocalSnapshot: segmateSync %d->%d",
+					SharedLocalSnapshotSlot->segmateSync, dtxContextInfo->segmateSync)));
 
 	SetSharedTransactionId_writer(distributedTransactionContext);
 	
@@ -1730,17 +1721,6 @@ copyLocalSnapshot(Snapshot snapshot)
 
 	snapshot->curcid = SharedLocalSnapshotSlot->snapshot.curcid;
 	snapshot->subxcnt = -1;
-
-	/* combocid */
-	usedComboCids = SharedLocalSnapshotSlot->combocidcnt;
-	Assert(usedComboCids <= MaxComboCids);
-	if (usedComboCids > 0)
-	{
-		if (comboCids == NULL)
-			comboCids = MemoryContextAlloc(TopTransactionContext, MaxComboCids * sizeof(ComboCidKeyData));
-
-		memcpy(comboCids, (char *)SharedLocalSnapshotSlot->combocids, usedComboCids * sizeof(ComboCidKeyData));
-	}
 
 	if (TransactionIdPrecedes(snapshot->xmin, TransactionXmin))
 		TransactionXmin = snapshot->xmin;
@@ -3197,8 +3177,6 @@ UpdateSerializableCommandId(CommandId curcid)
 		 SharedLocalSnapshotSlot != NULL &&
 		 FirstSnapshotSet)
 	{
-		int combocidSize;
-
 		LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_EXCLUSIVE);
 
 		if (SharedLocalSnapshotSlot->QDxid != QEDtxContextInfo.distributedXid)
@@ -3221,16 +3199,6 @@ UpdateSerializableCommandId(CommandId curcid)
 						SharedLocalSnapshotSlot->snapshot.curcid,
 						getDistributedTransactionId(),
 						DtxContextToString(DistributedTransactionContext))));
-
-		ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-				(errmsg("serializable writer updating combocid: used combocids %d shared %d",
-						usedComboCids, SharedLocalSnapshotSlot->combocidcnt)));
-
-		combocidSize = ((usedComboCids < MaxComboCids) ? usedComboCids : MaxComboCids );
-
-		SharedLocalSnapshotSlot->combocidcnt = combocidSize;	
-		memcpy((void *)SharedLocalSnapshotSlot->combocids, comboCids,
-			   combocidSize * sizeof(ComboCidKeyData));
 
 		SharedLocalSnapshotSlot->snapshot.curcid = curcid;
 		SharedLocalSnapshotSlot->segmateSync = QEDtxContextInfo.segmateSync;

--- a/src/backend/utils/time/combocid.c
+++ b/src/backend/utils/time/combocid.c
@@ -487,6 +487,15 @@ dumpSharedComboCommandIds(void)
 							sizeComboCids)));
 		shared_comboCids = newsegment;
 
+		/* update dsm size */
+		shared_sizeComboCids = sizeComboCids;
+
+		/* reset current usage amount */
+		shared_usedComboCids = 0;
+		shared_ptr = dsm_segment_address(shared_comboCids);
+		num_elements_ptr = (int *) shared_ptr;
+		*num_elements_ptr = 0;
+
 		CurrentResourceOwner = oldowner;
 	}
 
@@ -510,6 +519,7 @@ dumpSharedComboCommandIds(void)
 	 */
 	pg_write_barrier();
 	*num_elements_ptr = usedComboCids;
+	shared_usedComboCids = usedComboCids;
 
 	/*
 	 * If we had to allocate a new segment, we swap it in place and release the
@@ -619,6 +629,9 @@ AtEOXact_ComboCid_Dsm_Detach(void)
 		MyProc->comboCidsHandle = 0;
 		dsm_detach(shared_comboCids);
 		shared_comboCids = NULL;
+
+		shared_usedComboCids = 0;
+		shared_sizeComboCids = 0;
 	}
 
 }

--- a/src/backend/utils/time/test/sharedsnapshot_test.c
+++ b/src/backend/utils/time/test/sharedsnapshot_test.c
@@ -44,7 +44,6 @@ test_write_read_shared_snapshot_for_cursor(void **state)
 	slot.QDxid = 10;
 	slot.ready = true;
 	slot.segmateSync = 1;
-	slot.combocidcnt = 0;
 	slot.snapshot.xmin = 99;
 	slot.snapshot.xmax = 110;
 	slot.snapshot.xcnt = XCNT;
@@ -59,11 +58,11 @@ test_write_read_shared_snapshot_for_cursor(void **state)
 	expect_any(LWLockAcquire, mode);
 	will_be_called(LWLockAcquire);
 
-	expect_any_count(FaultInjector_InjectFaultIfSet, faultName, 11);
-	expect_any_count(FaultInjector_InjectFaultIfSet, ddlStatement, 11);
-	expect_any_count(FaultInjector_InjectFaultIfSet, databaseName, 11);
-	expect_any_count(FaultInjector_InjectFaultIfSet, tableName, 11);
-	will_be_called_count(FaultInjector_InjectFaultIfSet, 11);
+	expect_any_count(FaultInjector_InjectFaultIfSet, faultName, 9);
+	expect_any_count(FaultInjector_InjectFaultIfSet, ddlStatement, 9);
+	expect_any_count(FaultInjector_InjectFaultIfSet, databaseName, 9);
+	expect_any_count(FaultInjector_InjectFaultIfSet, tableName, 9);
+	will_be_called_count(FaultInjector_InjectFaultIfSet, 9);
 
 	expect_any(LWLockRelease, lock);
 	will_be_called(LWLockRelease);

--- a/src/backend/utils/time/tqual.c
+++ b/src/backend/utils/time/tqual.c
@@ -1145,12 +1145,6 @@ HeapTupleSatisfiesMVCC(Relation relation, HeapTuple htup, Snapshot snapshot,
 				return true;
 			}
 
-			/*
-			 * MPP-8317: cursors can't always *tell* that this is the current transaction.
-			 */
-			Assert(QEDtxContextInfo.cursorContext ||
-				   TransactionIdIsCurrentTransactionId(HeapTupleHeaderGetRawXmax(tuple)));
-
 			if (HeapTupleHeaderGetCmax(tuple) >= snapshot->curcid)
 				return true;	/* deleted after scan started */
 			else

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -173,10 +173,10 @@ struct PGPROC
 	uint32		waitPortalId;	/* portal id we are waiting on */
 
 	/*
-	 * Information for our combocid-map (populated in writer/dispatcher backends only)
+	 * Handle for our shared comboCids array (populated in writer/dispatcher
+	 * backends only)
 	 */
-	uint32		combocid_map_count; /* how many entries in the map ? */
-	dsm_handle  combocid_map_handle;
+	dsm_handle  comboCidsHandle;
 
 	/*
 	 * Current command_id for the running query

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -27,6 +27,7 @@
 
 #include "cdb/cdblocaldistribxact.h"  /* LocalDistribXactData */
 #include "cdb/cdbtm.h"  /* TMGXACT */
+#include "dsm.h"
 
 /*
  * Each backend advertises up to PGPROC_MAX_CACHED_SUBXIDS TransactionIds
@@ -175,6 +176,7 @@ struct PGPROC
 	 * Information for our combocid-map (populated in writer/dispatcher backends only)
 	 */
 	uint32		combocid_map_count; /* how many entries in the map ? */
+	dsm_handle  combocid_map_handle;
 
 	/*
 	 * Current command_id for the running query

--- a/src/include/utils/combocid.h
+++ b/src/include/utils/combocid.h
@@ -19,34 +19,9 @@
  * are in access/htup.h, because that's where the macro definitions that
  * those functions replaced used to be.
  */
- 
-/* CDB TODO: This is the max number of combo cids that we copy into the Shared
- * snapshot to the reader gangs.  As a result, transactions that have more than
- * 128 update/delete statements within them can result in the reader gangs
- * reading a tuple whose visibility they cannot determine because of not having
- * the entire combocids table.  Those statements will result in the reader gangs
- * throwing an error.  Ultimately, we need to find another way of serializing
- * this information that can support the arbitrary size of the combocids 
- * datastructure.
- */
-#define MaxComboCids 256
 
-/* Key and entry structures for the hash table */
-typedef struct
-{
-	CommandId		cmin;
-	CommandId		cmax;
-	TransactionId	xmin;
-} ComboCidKeyData;
-
-typedef ComboCidKeyData *ComboCidKey;
-
-extern volatile ComboCidKey comboCids;
-extern volatile int usedComboCids;
-extern volatile int sizeComboCids;
-
-extern void AtEOXact_ComboCid_Dsm_Detach(void);
 extern void AtEOXact_ComboCid(void);
+extern void AtEOXact_ComboCid_Dsm_Detach(void);
 extern void RestoreComboCIDState(char *comboCIDstate);
 extern void SerializeComboCIDState(Size maxsize, char *start_address);
 extern Size EstimateComboCIDStateSpace(void);

--- a/src/include/utils/combocid.h
+++ b/src/include/utils/combocid.h
@@ -45,6 +45,7 @@ extern volatile ComboCidKey comboCids;
 extern volatile int usedComboCids;
 extern volatile int sizeComboCids;
 
+extern void AtEOXact_ComboCid_Dsm_Detach(void);
 extern void AtEOXact_ComboCid(void);
 extern void RestoreComboCIDState(char *comboCIDstate);
 extern void SerializeComboCIDState(Size maxsize, char *start_address);

--- a/src/include/utils/sharedsnapshot.h
+++ b/src/include/utils/sharedsnapshot.h
@@ -27,8 +27,6 @@ typedef struct SharedSnapshotSlot
 	volatile TransactionId   QDxid;
 	volatile bool			ready;
 	volatile uint32			segmateSync;
-	uint32			combocidcnt;
-	ComboCidKeyData combocids[MaxComboCids];
 	SnapshotData	snapshot;
 	LWLock		   *slotLock;
 


### PR DESCRIPTION
For write-gang and read-gang combocid synchronization, I remove
BufFile code and replace it with dynamic shared memory.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
