### PR TITLE
[6X backport]Include dtx bits in HEAP2_XACT_MASK

### DIFF
--- a/src/include/access/htup_details.h
+++ b/src/include/access/htup_details.h
@@ -262,7 +262,10 @@ struct HeapTupleHeaderData
 #define HEAP_HOT_UPDATED		0x4000	/* tuple was HOT-updated */
 #define HEAP_ONLY_TUPLE			0x8000	/* this is heap-only tuple */
 
-#define HEAP2_XACT_MASK			0xE000	/* visibility-related bits */
+#define HEAP2_XACT_MASK			0xF800	/* visibility-related bits
+										 * GPDB: include HEAP_XMIN_DISTRIBUTED_SNAPSHOT_IGNORE
+										 * and HEAP_XMAX_DISTRIBUTED_SNAPSHOT_IGNORE
+										 */
 
 /*
  * HEAP_TUPLE_HAS_MATCH is a temporary flag used during hash joins.  It is


### PR DESCRIPTION
Truncate table command updates the pg_class entry and the new tuple is a copy
of the old one, we need to take care of the header infomation that introduced
by Greenplum.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
