### PR TITLE
6X: Fix data reorganization when gp_use_legacy_hashops is true

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1456,6 +1456,22 @@ gpdb::GetDefaultDistributionOpclassForType
 }
 
 Oid
+gpdb::GetColumnDefOpclassForType
+	(
+	List *opclassName,
+	Oid typid
+	)
+{
+	GP_WRAP_START;
+	{
+		/* catalog tables: pg_type, pg_opclass */
+		return cdb_get_opclass_for_column_def(opclassName, typid);
+	}
+	GP_WRAP_END;
+	return false;
+}
+
+Oid
 gpdb::GetHashProcInOpfamily
 	(
 	Oid opfamily,

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -421,8 +421,25 @@ CContextDXLToPlStmt::GetDistributionHashOpclassForType(Oid typid)
 			// added to the range table only later. If it uses
 			// legacy ops, we have already decided to use default
 			// ops here, and we fall back unnecessarily.
-			m_distribution_hashops = DistrUseDefaultHashOps;
-			opclass = gpdb::GetDefaultDistributionOpclassForType(typid);
+			//
+			// On the other hand, when the opclass is not specified in the
+			// distributed-by clause one should be decided according to the
+			// gp_use_legacy_hashops setting.
+			opclass = gpdb::GetColumnDefOpclassForType(NIL, typid);
+			// update m_distribution_hashops accordingly
+			if (opclass == gpdb::GetDefaultDistributionOpclassForType(typid))
+			{
+				m_distribution_hashops = DistrUseDefaultHashOps;
+			}
+			else if (opclass == gpdb::GetLegacyCdbHashOpclassForBaseType(typid))
+			{
+				m_distribution_hashops = DistrUseLegacyHashOps;
+			}
+			else
+			{
+				GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported,
+						   GPOS_WSZ_LIT("Unsupported distribution hashops policy"));
+			}
 			break;
 	}
 

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3766,7 +3766,8 @@ setQryDistributionPolicy(IntoClause *into, Query *qry)
 			tle = list_nth(qry->targetList, keyindex - 1);
 
 			keytype = exprType((Node *) tle->expr);
-			keyopclass = GetIndexOpClass(ielem->opclass, keytype, "hash", HASH_AM_OID);
+			keyopclass = cdb_get_opclass_for_column_def(ielem->opclass,
+														keytype);
 
 			policykeys = lappend_int(policykeys, keyindex);
 			policyopclasses = lappend_oid(policyopclasses, keyopclass);

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -329,6 +329,9 @@ namespace gpdb {
 	// get the default hash opclass for type
 	Oid GetDefaultDistributionOpclassForType(Oid typid);
 
+	// get the column-definition hash opclass for type
+	Oid GetColumnDefOpclassForType(List *opclassName, Oid typid);
+
 	// get the hash function in an opfamily for given datatype
 	Oid GetHashProcInOpfamily(Oid opfamily, Oid typid);
 

--- a/src/test/regress/expected/gpdist_legacy_opclasses.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses.out
@@ -1,6 +1,9 @@
 --
 -- Tests for legacy cdbhash opclasses
 --
+drop schema if exists gpdist_legacy_opclasses;
+create schema gpdist_legacy_opclasses;
+set search_path to gpdist_legacy_opclasses;
 -- Basic sanity check of all the legacy hash opclasses. Create a table that
 -- uses all of them in the distribution key, and insert a value.
 set gp_use_legacy_hashops=on;
@@ -286,4 +289,97 @@ select * from legacy_enum a inner join legacy_enum b on a.color = b.color;
  red   | red
  green | green
 (3 rows)
+
+--
+-- A regression issue that the data is reorganized incorrectly when
+-- gp_use_legacy_hashops has non-default value.
+--
+-- The ALTER TABLE command reorganizes the data by using a temporary table, if
+-- a "distributed by" clause is specified without the opclasses, the default
+-- opclasses will be chosen.  There was a bug that the non-legacy opclasses are
+-- always chosen, regarding the setting of gp_use_legacy_hashops.  However the
+-- table's new opclasses are determined with gp_use_legacy_hashops, so when
+-- gp_use_legacy_hashops is true the data will be incorrectly redistributed.
+--
+-- set the guc to the non-default value
+set gp_use_legacy_hashops to on;
+create table legacy_data_reorg (c1 int) distributed by (c1);
+insert into legacy_data_reorg select i from generate_series(1, 10) i;
+-- verify the opclass and data distribution
+select gp_segment_id, c1 from legacy_data_reorg order by 1, 2;
+ gp_segment_id | c1 
+---------------+----
+             0 |  1
+             0 |  2
+             1 |  3
+             1 |  4
+             1 |  5
+             1 |  6
+             1 |  7
+             2 |  8
+             2 |  9
+             2 | 10
+(10 rows)
+
+select dp.localoid::regclass::name as name, oc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass oc
+    on oc.oid::text = dp.distclass::text
+ where dp.localoid = 'legacy_data_reorg'::regclass::oid;
+       name        |     opcname      
+-------------------+------------------
+ legacy_data_reorg | cdbhash_int4_ops
+(1 row)
+
+-- when reorganizing the table we set the distributed-by without an explicit
+-- opclass, so the default one should be chosen according to
+-- gp_use_legacy_hashops.
+alter table legacy_data_reorg set with (reorganize) distributed by (c1);
+-- double-check the opclass and data distribution
+select gp_segment_id, c1 from legacy_data_reorg order by 1, 2;
+ gp_segment_id | c1 
+---------------+----
+             0 |  1
+             0 |  2
+             1 |  3
+             1 |  4
+             1 |  5
+             1 |  6
+             1 |  7
+             2 |  8
+             2 |  9
+             2 | 10
+(10 rows)
+
+select dp.localoid::regclass::name as name, oc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass oc
+    on oc.oid::text = dp.distclass::text
+ where dp.localoid = 'legacy_data_reorg'::regclass::oid;
+       name        |     opcname      
+-------------------+------------------
+ legacy_data_reorg | cdbhash_int4_ops
+(1 row)
+
+--
+-- A regression issue similar to previous one, with CTAS.
+--
+-- The default opclasses in CTAS should also be determined with
+-- gp_use_legacy_hashops.
+--
+set gp_use_legacy_hashops=off;
+create table ctastest_off as select 123 as col distributed by (col);
+set gp_use_legacy_hashops=on;
+create table ctastest_on as select 123 as col distributed by (col);
+select dp.localoid::regclass::name as name, oc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass oc
+    on oc.oid::text = dp.distclass::text
+ where dp.localoid in ('ctastest_on'::regclass::oid,
+                       'ctastest_off'::regclass::oid);
+     name     |     opcname      
+--------------+------------------
+ ctastest_off | int4_ops
+ ctastest_on  | cdbhash_int4_ops
+(2 rows)
 

--- a/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
@@ -1,6 +1,9 @@
 --
 -- Tests for legacy cdbhash opclasses
 --
+drop schema if exists gpdist_legacy_opclasses;
+create schema gpdist_legacy_opclasses;
+set search_path to gpdist_legacy_opclasses;
 -- Basic sanity check of all the legacy hash opclasses. Create a table that
 -- uses all of them in the distribution key, and insert a value.
 set gp_use_legacy_hashops=on;
@@ -285,4 +288,97 @@ select * from legacy_enum a inner join legacy_enum b on a.color = b.color;
  red   | red
  green | green
 (3 rows)
+
+--
+-- A regression issue that the data is reorganized incorrectly when
+-- gp_use_legacy_hashops has non-default value.
+--
+-- The ALTER TABLE command reorganizes the data by using a temporary table, if
+-- a "distributed by" clause is specified without the opclasses, the default
+-- opclasses will be chosen.  There was a bug that the non-legacy opclasses are
+-- always chosen, regarding the setting of gp_use_legacy_hashops.  However the
+-- table's new opclasses are determined with gp_use_legacy_hashops, so when
+-- gp_use_legacy_hashops is true the data will be incorrectly redistributed.
+--
+-- set the guc to the non-default value
+set gp_use_legacy_hashops to on;
+create table legacy_data_reorg (c1 int) distributed by (c1);
+insert into legacy_data_reorg select i from generate_series(1, 10) i;
+-- verify the opclass and data distribution
+select gp_segment_id, c1 from legacy_data_reorg order by 1, 2;
+ gp_segment_id | c1 
+---------------+----
+             0 |  1
+             0 |  2
+             1 |  3
+             1 |  4
+             1 |  5
+             1 |  6
+             1 |  7
+             2 |  8
+             2 |  9
+             2 | 10
+(10 rows)
+
+select dp.localoid::regclass::name as name, oc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass oc
+    on oc.oid::text = dp.distclass::text
+ where dp.localoid = 'legacy_data_reorg'::regclass::oid;
+       name        |     opcname      
+-------------------+------------------
+ legacy_data_reorg | cdbhash_int4_ops
+(1 row)
+
+-- when reorganizing the table we set the distributed-by without an explicit
+-- opclass, so the default one should be chosen according to
+-- gp_use_legacy_hashops.
+alter table legacy_data_reorg set with (reorganize) distributed by (c1);
+-- double-check the opclass and data distribution
+select gp_segment_id, c1 from legacy_data_reorg order by 1, 2;
+ gp_segment_id | c1 
+---------------+----
+             0 |  1
+             0 |  2
+             1 |  3
+             1 |  4
+             1 |  5
+             1 |  6
+             1 |  7
+             2 |  8
+             2 |  9
+             2 | 10
+(10 rows)
+
+select dp.localoid::regclass::name as name, oc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass oc
+    on oc.oid::text = dp.distclass::text
+ where dp.localoid = 'legacy_data_reorg'::regclass::oid;
+       name        |     opcname      
+-------------------+------------------
+ legacy_data_reorg | cdbhash_int4_ops
+(1 row)
+
+--
+-- A regression issue similar to previous one, with CTAS.
+--
+-- The default opclasses in CTAS should also be determined with
+-- gp_use_legacy_hashops.
+--
+set gp_use_legacy_hashops=off;
+create table ctastest_off as select 123 as col distributed by (col);
+set gp_use_legacy_hashops=on;
+create table ctastest_on as select 123 as col distributed by (col);
+select dp.localoid::regclass::name as name, oc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass oc
+    on oc.oid::text = dp.distclass::text
+ where dp.localoid in ('ctastest_on'::regclass::oid,
+                       'ctastest_off'::regclass::oid);
+     name     |     opcname      
+--------------+------------------
+ ctastest_off | int4_ops
+ ctastest_on  | cdbhash_int4_ops
+(2 rows)
 

--- a/src/test/regress/sql/gpdist_legacy_opclasses.sql
+++ b/src/test/regress/sql/gpdist_legacy_opclasses.sql
@@ -2,6 +2,10 @@
 -- Tests for legacy cdbhash opclasses
 --
 
+drop schema if exists gpdist_legacy_opclasses;
+create schema gpdist_legacy_opclasses;
+set search_path to gpdist_legacy_opclasses;
+
 -- Basic sanity check of all the legacy hash opclasses. Create a table that
 -- uses all of them in the distribution key, and insert a value.
 set gp_use_legacy_hashops=on;
@@ -169,3 +173,62 @@ insert into legacy_enum values ('red'), ('green'), ('blue');
 
 explain (costs off) select * from legacy_enum a inner join legacy_enum b on a.color = b.color;
 select * from legacy_enum a inner join legacy_enum b on a.color = b.color;
+
+--
+-- A regression issue that the data is reorganized incorrectly when
+-- gp_use_legacy_hashops has non-default value.
+--
+-- The ALTER TABLE command reorganizes the data by using a temporary table, if
+-- a "distributed by" clause is specified without the opclasses, the default
+-- opclasses will be chosen.  There was a bug that the non-legacy opclasses are
+-- always chosen, regarding the setting of gp_use_legacy_hashops.  However the
+-- table's new opclasses are determined with gp_use_legacy_hashops, so when
+-- gp_use_legacy_hashops is true the data will be incorrectly redistributed.
+--
+
+-- set the guc to the non-default value
+set gp_use_legacy_hashops to on;
+
+create table legacy_data_reorg (c1 int) distributed by (c1);
+insert into legacy_data_reorg select i from generate_series(1, 10) i;
+
+-- verify the opclass and data distribution
+select gp_segment_id, c1 from legacy_data_reorg order by 1, 2;
+select dp.localoid::regclass::name as name, oc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass oc
+    on oc.oid::text = dp.distclass::text
+ where dp.localoid = 'legacy_data_reorg'::regclass::oid;
+
+-- when reorganizing the table we set the distributed-by without an explicit
+-- opclass, so the default one should be chosen according to
+-- gp_use_legacy_hashops.
+alter table legacy_data_reorg set with (reorganize) distributed by (c1);
+
+-- double-check the opclass and data distribution
+select gp_segment_id, c1 from legacy_data_reorg order by 1, 2;
+select dp.localoid::regclass::name as name, oc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass oc
+    on oc.oid::text = dp.distclass::text
+ where dp.localoid = 'legacy_data_reorg'::regclass::oid;
+
+--
+-- A regression issue similar to previous one, with CTAS.
+--
+-- The default opclasses in CTAS should also be determined with
+-- gp_use_legacy_hashops.
+--
+
+set gp_use_legacy_hashops=off;
+create table ctastest_off as select 123 as col distributed by (col);
+
+set gp_use_legacy_hashops=on;
+create table ctastest_on as select 123 as col distributed by (col);
+
+select dp.localoid::regclass::name as name, oc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass oc
+    on oc.oid::text = dp.distclass::text
+ where dp.localoid in ('ctastest_on'::regclass::oid,
+                       'ctastest_off'::regclass::oid);


### PR DESCRIPTION
The ALTER TABLE command reorganizes the data by using a temporary table,
if a "distributed by" clause is specified without the opclasses, the
default opclasses will be chosen.  There was a bug that the non-legacy
opclasses are always chosen, regarding the setting of
gp_use_legacy_hashops.  However the table's new opclasses are determined
with gp_use_legacy_hashops, so when gp_use_legacy_hashops is true the
data will be incorrectly redistributed.

The issue also exists in CTAS.

Fixed by choosing the default opclasses for the temporary table
according to gp_use_legacy_hashops.

Reviewed-by: Heikki Linnakangas <hlinnakangas@pivotal.io>
Reviewed-by: Ashwin Agrawal <aagrawal@pivotal.io>
Reviewed-by: Shreedhar Hardikar <shardikar@pivotal.io>

(cherry picked from commit aa52bd5099b512c23e46746c9b9284bf70397116)

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
