### PR TITLE
(6x backport) Fix plan when join lateral inner plan contains limit clause.

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2392,6 +2392,7 @@ _copyRestrictInfo(const RestrictInfo *from)
 	COPY_SCALAR_FIELD(outerjoin_delayed);
 	COPY_SCALAR_FIELD(can_join);
 	COPY_SCALAR_FIELD(pseudoconstant);
+	COPY_SCALAR_FIELD(contain_outer_query_references);
 	COPY_BITMAPSET_FIELD(clause_relids);
 	COPY_BITMAPSET_FIELD(required_relids);
 	COPY_BITMAPSET_FIELD(outer_relids);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2205,6 +2205,19 @@ _outHashPath(StringInfo str, const HashPath *node)
 	WRITE_INT_FIELD(num_batches);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
+static void
+_outProjectionPath(StringInfo str, const ProjectionPath *node)
+{
+	WRITE_NODE_TYPE("PROJECTIONPATH");
+
+	_outPathInfo(str, (const Path *) node);
+
+	WRITE_NODE_FIELD(subpath);
+	WRITE_BOOL_FIELD(dummypp);
+}
+#endif /* COMPILING_BINARY_FUNCS */
+
 static void
 _outCdbMotionPath(StringInfo str, const CdbMotionPath *node)
 {
@@ -2436,6 +2449,7 @@ _outRestrictInfo(StringInfo str, const RestrictInfo *node)
 	WRITE_BOOL_FIELD(outerjoin_delayed);
 	WRITE_BOOL_FIELD(can_join);
 	WRITE_BOOL_FIELD(pseudoconstant);
+	WRITE_BOOL_FIELD(contain_outer_query_references);
 	WRITE_BITMAPSET_FIELD(clause_relids);
 	WRITE_BITMAPSET_FIELD(required_relids);
 	WRITE_BITMAPSET_FIELD(outer_relids);
@@ -5050,6 +5064,9 @@ _outNode(StringInfo str, const void *obj)
 				break;
 			case T_HashPath:
 				_outHashPath(str, obj);
+				break;
+			case T_ProjectionPath:
+				_outProjectionPath(str, obj);
 				break;
             case T_CdbMotionPath:
                 _outCdbMotionPath(str, obj);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -76,6 +76,7 @@ static Plan *create_merge_append_plan(PlannerInfo *root, MergeAppendPath *best_p
 static Result *create_result_plan(PlannerInfo *root, ResultPath *best_path);
 static Material *create_material_plan(PlannerInfo *root, MaterialPath *best_path);
 static Plan *create_unique_plan(PlannerInfo *root, UniquePath *best_path);
+static Plan *create_projection_plan(PlannerInfo *root, ProjectionPath *best_path);
 static Plan *create_motion_plan(PlannerInfo *root, CdbMotionPath *path);
 static SeqScan *create_seqscan_plan(PlannerInfo *root, Path *best_path,
 					List *tlist, List *scan_clauses);
@@ -309,8 +310,16 @@ create_plan_recurse(PlannerInfo *root, Path *best_path)
 											(MergeAppendPath *) best_path);
 			break;
 		case T_Result:
-			plan = (Plan *) create_result_plan(root,
-											   (ResultPath *) best_path);
+			if (IsA(best_path, ProjectionPath))
+			{
+				plan = create_projection_plan(root,
+											  (ProjectionPath *) best_path);
+			}
+			else
+			{
+				plan = (Plan *) create_result_plan(root,
+												   (ResultPath *) best_path);
+			}
 			break;
 		case T_Material:
 			plan = (Plan *) create_material_plan(root,
@@ -1244,6 +1253,92 @@ create_unique_plan(PlannerInfo *root, UniquePath *best_path)
 	return plan;
 }
 
+/*
+ * create_projection_plan
+ *
+ *	  Create a plan tree to do a projection step and (recursively) plans
+ *	  for its subpaths.  We may need a Result node for the projection,
+ *	  but sometimes we can just let the subplan do the work.
+ */
+static Plan *
+create_projection_plan(PlannerInfo *root, ProjectionPath *best_path)
+{
+	Plan	   *plan;
+	Plan	   *subplan;
+	List	   *tlist;
+
+	/* Since we intend to project, we don't need to constrain child tlist */
+	subplan = create_plan_recurse(root, best_path->subpath);
+
+	tlist = build_path_tlist(root, &best_path->path);
+
+	/*
+	 * We might not really need a Result node here, either because the subplan
+	 * can project or because it's returning the right list of expressions
+	 * anyway.  Usually create_projection_path will have detected that and set
+	 * dummypp if we don't need a Result; but its decision can't be final,
+	 * because some createplan.c routines change the tlists of their nodes.
+	 * (An example is that create_merge_append_plan might add resjunk sort
+	 * columns to a MergeAppend.)  So we have to recheck here.  If we do
+	 * arrive at a different answer than create_projection_path did, we'll
+	 * have made slightly wrong cost estimates; but label the plan with the
+	 * cost estimates we actually used, not "corrected" ones.  (XXX this could
+	 * be cleaned up if we moved more of the sortcolumn setup logic into Path
+	 * creation, but that would add expense to creating Paths we might end up
+	 * not using.)
+	 */
+	if (!best_path->cdb_restrict_clauses &&
+		(is_projection_capable_plan(subplan) ||
+		 tlist_same_exprs(tlist, subplan->targetlist)))
+	{
+		/* Don't need a separate Result, just assign tlist to subplan */
+		plan = subplan;
+		plan->targetlist = tlist;
+
+		/* Label plan with the estimated costs we actually used */
+		plan->startup_cost = best_path->path.startup_cost;
+		plan->total_cost = best_path->path.total_cost;
+		plan->plan_rows = best_path->path.rows;
+		plan->plan_width = subplan->plan_width;
+		/* ... but be careful not to munge subplan's parallel-aware flag */
+	}
+	else
+	{
+		List	   *scan_clauses = NIL;
+		List	   *pseudoconstants = NIL;
+
+		if (best_path->cdb_restrict_clauses)
+		{
+			List	   *all_clauses = best_path->cdb_restrict_clauses;
+
+			/* Replace any outer-relation variables with nestloop params */
+			if (best_path->path.param_info)
+			{
+				all_clauses = (List *)
+					replace_nestloop_params(root, (Node *) all_clauses);
+			}
+
+			/* Sort clauses into best execution order */
+			all_clauses = order_qual_clauses(root, all_clauses);
+
+			/* Reduce RestrictInfo list to bare expressions; ignore pseudoconstants */
+			scan_clauses = extract_actual_clauses(all_clauses, false);
+
+			/* but we actually also want the pseudoconstants */
+			pseudoconstants = extract_actual_clauses(all_clauses, true);
+		}
+
+		/* We need a Result node */
+		plan = (Plan *) make_result(root, tlist, (Node *) pseudoconstants, subplan);
+
+		plan->qual = scan_clauses;
+
+		copy_path_costsize(root, plan, (Path *) best_path);
+		plan->flow = pull_up_Flow(plan, subplan);
+	}
+
+	return plan;
+}
 
 /*
  * create_motion_plan

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -802,6 +802,16 @@ create_join_plan(PlannerInfo *root, JoinPath *best_path)
 		best_path->outerjoinpath->motionHazard)
 		((Join *) plan)->prefetch_joinqual = true;
 
+	/* CDB: if the join's locus is bottleneck which means the
+	 * join gang only contains one process, so there is no
+	 * risk for motion deadlock.
+	 */
+	if (CdbPathLocus_IsBottleneck(best_path->path.locus))
+	{
+		((Join *) plan)->prefetch_inner = false;
+		((Join *) plan)->prefetch_joinqual = false;
+	}
+
 	plan->flow = cdbpathtoplan_create_flow(root,
 			best_path->path.locus,
 			best_path->path.parent ? best_path->path.parent->relids
@@ -1334,7 +1344,10 @@ create_projection_plan(PlannerInfo *root, ProjectionPath *best_path)
 		plan->qual = scan_clauses;
 
 		copy_path_costsize(root, plan, (Path *) best_path);
-		plan->flow = pull_up_Flow(plan, subplan);
+		plan->flow = cdbpathtoplan_create_flow(root,
+											   best_path->path.locus,
+											   best_path->path.parent ? best_path->path.parent->relids : NULL,
+											   plan);
 	}
 
 	return plan;

--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -17,6 +17,7 @@
 #include "postgres.h"
 
 #include "catalog/pg_type.h"
+#include "cdb/cdbmutate.h"
 #include "nodes/nodeFuncs.h"
 #include "optimizer/clauses.h"
 #include "optimizer/joininfo.h"
@@ -174,8 +175,8 @@ build_base_rel_tlists(PlannerInfo *root, List *final_tlist)
  *	  be true before deconstruct_jointree begins, and false after that.)
  */
 void
-add_vars_to_targetlist(PlannerInfo *root, List *vars,
-					   Relids where_needed, bool create_new_ph)
+add_vars_to_targetlist_x(PlannerInfo *root, List *vars,
+						 Relids where_needed, bool create_new_ph, bool force)
 {
 	ListCell   *temp;
 
@@ -210,7 +211,7 @@ add_vars_to_targetlist(PlannerInfo *root, List *vars,
 			}
 
 			/* System-defined attribute, whole row, or user-defined attribute */
-			if (bms_is_subset(where_needed, rel->relids))
+			if (bms_is_subset(where_needed, rel->relids) && !force)
 				continue;
 			Assert(attno >= rel->min_attr && attno <= rel->max_attr);
 			attno -= rel->min_attr;
@@ -238,6 +239,12 @@ add_vars_to_targetlist(PlannerInfo *root, List *vars,
 	}
 }
 
+void
+add_vars_to_targetlist(PlannerInfo *root, List *vars, Bitmapset *where_needed,
+					   bool create_new_ph)
+{
+	add_vars_to_targetlist_x(root, vars, where_needed, create_new_ph, false);
+}
 
 /*****************************************************************************
  *
@@ -2032,6 +2039,43 @@ check_redundant_nullability_qual(PlannerInfo *root, Node *clause)
 	return false;
 }
 
+static bool
+rel_need_upper(PlannerInfo *root, RelOptInfo *rel)
+{
+	switch (rel->rtekind)
+	{
+		case RTE_RELATION:
+			return GpPolicyIsPartitioned(rel->cdbpolicy) ||
+				GpPolicyIsReplicated(rel->cdbpolicy);
+
+		case RTE_SUBQUERY:
+			/* play it safe */
+			return true;
+
+		case RTE_FUNCTION:
+			/* XXX: depends on EXECUTE ON directive */
+			return false;
+
+		case RTE_VALUES:
+			return false;
+
+		case RTE_TABLEFUNCTION:
+			/* no correlated subqueries are allowed in a tablefunctions. So not sure
+			 * if this can happen */
+			return true;
+
+		case RTE_CTE:
+			/* play it safe */
+			return true;
+
+		case RTE_VOID:
+		case RTE_JOIN:
+		default:
+			/* shouldn't happen */
+			elog(ERROR, "unexpected RTE kind %d", rel->rtekind);
+	}
+}
+
 /*
  * distribute_restrictinfo_to_rels
  *	  Push a completed RestrictInfo into the proper restriction or join
@@ -2048,6 +2092,9 @@ distribute_restrictinfo_to_rels(PlannerInfo *root,
 	Relids		relids = restrictinfo->required_relids;
 	RelOptInfo *rel;
 
+	if (contains_outer_params((Node *) restrictinfo->clause, root))
+		restrictinfo->contain_outer_query_references = true;
+
 	switch (bms_membership(relids))
 	{
 		case BMS_SINGLETON:
@@ -2059,8 +2106,24 @@ distribute_restrictinfo_to_rels(PlannerInfo *root,
 			rel = find_base_rel(root, bms_singleton_member(relids));
 
 			/* Add clause to rel's restriction list */
-			rel->baserestrictinfo = lappend(rel->baserestrictinfo,
-											restrictinfo);
+			if (restrictinfo->contain_outer_query_references &&
+				rel_need_upper(root, rel))
+			{
+				List	   *vars = pull_var_clause((Node *) restrictinfo->clause,
+												   PVC_RECURSE_AGGREGATES,
+												   PVC_RECURSE_PLACEHOLDERS);
+
+				add_vars_to_targetlist_x(root, vars, relids,
+										 false, /* create_new_ph */
+										 true /* force */);
+				list_free(vars);
+
+				rel->upperrestrictinfo = lappend(rel->upperrestrictinfo,
+												 restrictinfo);
+			}
+			else
+				rel->baserestrictinfo = lappend(rel->baserestrictinfo,
+												restrictinfo);
 			break;
 		case BMS_MULTIPLE:
 

--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -2107,7 +2107,8 @@ distribute_restrictinfo_to_rels(PlannerInfo *root,
 
 			/* Add clause to rel's restriction list */
 			if (restrictinfo->contain_outer_query_references &&
-				rel_need_upper(root, rel))
+				rel_need_upper(root, rel) &&
+				root->config->force_singleQE)
 			{
 				List	   *vars = pull_var_clause((Node *) restrictinfo->clause,
 												   PVC_RECURSE_AGGREGATES,

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -378,6 +378,8 @@ PlannerConfig *DefaultPlannerConfig(void)
 
 	c1->is_under_subplan = false;
 
+	c1->force_singleQE = false;
+
 	return c1;
 }
 

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3610,18 +3610,16 @@ reparameterize_path(PlannerInfo *root, Path *path,
 }
 
 /*
- * create_projection_path
- *	  Creates a pathnode that represents performing a projection.
+ * create_projection_path_with_quals
+ *	  Creates a pathnode that represents performing a projection and filter.
  *
  * 'rel' is the parent relation associated with the result
  * 'subpath' is the path representing the source of data
- * 'target' is the PathTarget to be computed
  */
 ProjectionPath *
 create_projection_path_with_quals(PlannerInfo *root,
 								  RelOptInfo *rel,
 								  Path *subpath,
-								  List *tlist,
 								  List *restrict_clauses)
 {
 	ProjectionPath *pathnode = makeNode(ProjectionPath);

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3608,3 +3608,82 @@ reparameterize_path(PlannerInfo *root, Path *path,
 	}
 	return NULL;
 }
+
+/*
+ * create_projection_path
+ *	  Creates a pathnode that represents performing a projection.
+ *
+ * 'rel' is the parent relation associated with the result
+ * 'subpath' is the path representing the source of data
+ * 'target' is the PathTarget to be computed
+ */
+ProjectionPath *
+create_projection_path_with_quals(PlannerInfo *root,
+								  RelOptInfo *rel,
+								  Path *subpath,
+								  List *tlist,
+								  List *restrict_clauses)
+{
+	ProjectionPath *pathnode = makeNode(ProjectionPath);
+
+	pathnode->path.pathtype = T_Result;
+	pathnode->path.parent = rel;
+	/* For now, assume we are above any joins, so no parameterization */
+	pathnode->path.param_info = NULL;
+	/* Projection does not change the sort order */
+	pathnode->path.pathkeys = subpath->pathkeys;
+
+	pathnode->subpath = subpath;
+
+	/*
+	 * We might not need a separate Result node.  If the input plan node type
+	 * can project, we can just tell it to project something else.  Or, if it
+	 * can't project but the desired target has the same expression list as
+	 * what the input will produce anyway, we can still give it the desired
+	 * tlist (possibly changing its ressortgroupref labels, but nothing else).
+	 * Note: in the latter case, create_projection_plan has to recheck our
+	 * conclusion; see comments therein.
+	 *
+	 * GPDB: The 'restrict_clauses' is a GPDB addition. If the subpath supports
+	 * Filters, we could push them down too. But currently this is only used on
+	 * top of Material paths, which don't support it, so it doesn't matter.
+	 *
+	 * GPDB_96_MERGE_FIXME: Until 9.6, this isn't used in any situation where
+	 * we wouldn't need a Result. And we don't have is_projection_capable_path()
+	 * yet.
+	 */
+#if 0
+	if (!restrict_clauses &&
+		(is_projection_capable_path(subpath) ||
+		 equal(oldtarget->exprs, target->exprs)))
+	{
+		/* No separate Result node needed */
+		pathnode->dummypp = true;
+
+		/*
+		 * Set cost of plan as subpath's cost, adjusted for tlist replacement.
+		 */
+		pathnode->path.rows = subpath->rows;
+		pathnode->path.startup_cost = subpath->startup_cost +
+			(target->cost.startup - oldtarget->cost.startup);
+		pathnode->path.total_cost = subpath->total_cost +
+			(target->cost.startup - oldtarget->cost.startup) +
+			(target->cost.per_tuple - oldtarget->cost.per_tuple) * subpath->rows;
+	}
+	else
+#endif
+	{
+		/* We really do need the Result node */
+		pathnode->dummypp = false;
+
+		pathnode->path.rows = subpath->rows;
+		pathnode->path.startup_cost = subpath->startup_cost;
+		pathnode->path.total_cost = subpath->total_cost;
+
+		pathnode->cdb_restrict_clauses = restrict_clauses;
+	}
+
+	pathnode->path.locus = subpath->locus;
+
+	return pathnode;
+}

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -65,6 +65,6 @@ extern void sri_optimize_for_result(PlannerInfo *root, Plan *plan, RangeTblEntry
 									GpPolicy **targetPolicy, List **hashExprs_p, List **hashOpclasses_p);
 extern SplitUpdate *make_splitupdate(PlannerInfo *root, ModifyTable *mt, Plan *subplan,
 									 RangeTblEntry *rte);
-
+extern bool contains_outer_params(Node *node, void *context);
 
 #endif   /* CDBMUTATE_H */

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -311,6 +311,7 @@ typedef enum NodeTag
 	T_ResultPath,
 	T_MaterialPath,
 	T_UniquePath,
+	T_ProjectionPath,
 	T_EquivalenceClass,
 	T_EquivalenceMember,
 	T_PathKey,

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -48,6 +48,7 @@ typedef struct PlannerConfig
 
 	/* These ones are tricky */
 	//GpRoleValue	Gp_role; // TODO: this one is tricky
+	bool        force_singleQE; /* True means force gather base rel to singleQE  */
 } PlannerConfig;
 
 extern PlannerConfig *DefaultPlannerConfig(void);

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -605,6 +605,15 @@ typedef struct RelOptInfo
 								 * involving this rel */
 	bool		has_eclass_joins;		/* T means joininfo is incomplete */
 
+	/*
+	 * In a subquery, if this base relation contains quals that must
+	 * be evaluated at "outerquery" locus, and the base relation has a
+	 * different locus, they are kept here in 'upperrestrictinfo', instead of
+	 * 'baserestrictinfo'.
+	 */
+	List	   *upperrestrictinfo;		/* RestrictInfo structures (if base
+										 * rel) */
+
 	/* used by foreign scan */
 	ForeignTable		*ftEntry;
 } RelOptInfo;
@@ -1354,6 +1363,29 @@ typedef struct HashPath
 } HashPath;
 
 /*
+ * ProjectionPath represents a projection (that is, targetlist computation)
+ *
+ * Nominally, this path node represents using a Result plan node to do a
+ * projection step.  However, if the input plan node supports projection,
+ * we can just modify its output targetlist to do the required calculations
+ * directly, and not need a Result.  In some places in the planner we can just
+ * jam the desired PathTarget into the input path node (and adjust its cost
+ * accordingly), so we don't need a ProjectionPath.  But in other places
+ * it's necessary to not modify the input path node, so we need a separate
+ * ProjectionPath node, which is marked dummy to indicate that we intend to
+ * assign the work to the input plan node.  The estimated cost for the
+ * ProjectionPath node will account for whether a Result will be used or not.
+ */
+typedef struct ProjectionPath
+{
+	Path		path;
+	Path	   *subpath;		/* path representing input source */
+	bool		dummypp;		/* true if no separate Result is needed */
+
+	List	   *cdb_restrict_clauses;
+} ProjectionPath;
+
+/*
  * Restriction clause info.
  *
  * We create one of these for each AND sub-clause of a restriction condition
@@ -1497,6 +1529,12 @@ typedef struct RestrictInfo
 	bool		can_join;		/* see comment above */
 
 	bool		pseudoconstant; /* see comment above */
+
+	/*
+	 * GPDB: does the clause refer to outer query levels? (Which implies that
+	 * it must be evaluted in the same slice as the parent query)
+	 */
+	bool		contain_outer_query_references;
 
 	/* The set of relids (varnos) actually referenced in the clause: */
 	Relids		clause_relids;

--- a/src/include/optimizer/pathnode.h
+++ b/src/include/optimizer/pathnode.h
@@ -161,6 +161,12 @@ extern Path *reparameterize_path(PlannerInfo *root, Path *path,
 					Relids required_outer,
 					double loop_count);
 
+extern ProjectionPath *create_projection_path_with_quals(PlannerInfo *root,
+								  RelOptInfo *rel,
+								  Path *subpath,
+								  List *tlist,
+								  List *restrict_clauses);
+
 /*
  * prototypes for relnode.c
  */

--- a/src/include/optimizer/pathnode.h
+++ b/src/include/optimizer/pathnode.h
@@ -164,7 +164,6 @@ extern Path *reparameterize_path(PlannerInfo *root, Path *path,
 extern ProjectionPath *create_projection_path_with_quals(PlannerInfo *root,
 								  RelOptInfo *rel,
 								  Path *subpath,
-								  List *tlist,
 								  List *restrict_clauses);
 
 /*

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -235,6 +235,8 @@ extern int	join_collapse_limit;
 
 extern void add_base_rels_to_query(PlannerInfo *root, Node *jtnode);
 extern void build_base_rel_tlists(PlannerInfo *root, List *final_tlist);
+extern void add_vars_to_targetlist_x(PlannerInfo *root, List *vars,
+						 Relids where_needed, bool create_new_ph, bool force);
 extern void add_vars_to_targetlist(PlannerInfo *root, List *vars,
 					   Relids where_needed, bool create_new_ph);
 extern void find_lateral_references(PlannerInfo *root);

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -966,3 +966,86 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 reset enable_hashjoin;
 reset enable_mergejoin;
 reset enable_nestloop;
+-- test lateral join inner plan contains limit
+-- we cannot pass params across motion so we
+-- can only generate a plan to gather all the
+-- data to singleQE. Here we create a compound
+-- data type as params to pass into inner plan.
+-- By doing so, if we fail to pass correct params
+-- into innerplan, it will throw error because
+-- of nullpointer reference. If we only use int
+-- type as params, the nullpointer reference error
+-- may not happen because we parse null to integer 0.
+create type mytype_for_lateral_test as (x int, y int);
+create table t1_lateral_limit(a int, b int, c mytype_for_lateral_test);
+create table t2_lateral_limit(a int, b int);
+insert into t1_lateral_limit values (1, 1, '(1,1)');
+insert into t1_lateral_limit values (1, 2, '(2,2)');
+insert into t2_lateral_limit values (2, 2);
+insert into t2_lateral_limit values (3, 3);
+explain select * from t1_lateral_limit as t1 cross join lateral
+(select ((c).x+t2.b) as n  from t2_lateral_limit as t2 order by n limit 1)s;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Nested Loop  (cost=10000000001.05..10000000002.11 rows=4 width=41)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=37)
+         ->  Seq Scan on t1_lateral_limit t1  (cost=0.00..1.01 rows=1 width=37)
+   ->  Materialize  (cost=1.05..1.07 rows=1 width=4)
+         ->  Limit  (cost=1.05..1.05 rows=1 width=4)
+               ->  Sort  (cost=1.05..1.05 rows=1 width=4)
+                     Sort Key: (((t1.c).x + t2.b))
+                     ->  Result  (cost=0.00..1.04 rows=1 width=4)
+                           ->  Materialize  (cost=0.00..1.03 rows=1 width=4)
+                                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+                                       ->  Seq Scan on t2_lateral_limit t2  (cost=0.00..1.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select * from t1_lateral_limit as t1 cross join lateral
+(select ((c).x+t2.b) as n  from t2_lateral_limit as t2 order by n limit 1)s;
+ a | b |   c   | n 
+---+---+-------+---
+ 1 | 1 | (1,1) | 3
+ 1 | 2 | (2,2) | 4
+(2 rows)
+
+-- The following case is from Github Issue
+-- https://github.com/greenplum-db/gpdb/issues/8860
+-- It is the same issue as the above test suite.
+create table t_mylog_issue_8860 (myid int, log_date timestamptz );
+insert into  t_mylog_issue_8860 values (1,timestamptz '2000-01-02 03:04'),(1,timestamptz '2000-01-02 03:04'-'1 hour'::interval);
+insert into  t_mylog_issue_8860 values (2,timestamptz '2000-01-02 03:04'),(2,timestamptz '2000-01-02 03:04'-'2 hour'::interval);
+explain select ml1.myid, log_date as first_date, ml2.next_date from t_mylog_issue_8860 ml1
+inner join lateral
+(select myid, log_date as next_date
+ from t_mylog_issue_8860 where myid = ml1.myid and log_date > ml1.log_date order by log_date asc limit 1) ml2
+on true;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop  (cost=10000000001.08..10000000002.18 rows=4 width=20)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.06 rows=2 width=12)
+         ->  Seq Scan on t_mylog_issue_8860 ml1  (cost=0.00..1.02 rows=1 width=12)
+   ->  Materialize  (cost=1.08..1.10 rows=1 width=8)
+         ->  Subquery Scan on ml2  (cost=1.08..1.09 rows=1 width=8)
+               ->  Limit  (cost=1.08..1.08 rows=1 width=12)
+                     ->  Sort  (cost=1.08..1.08 rows=2 width=12)
+                           Sort Key: t_mylog_issue_8860.log_date
+                           ->  Result  (cost=0.00..1.07 rows=2 width=12)
+                                 Filter: ((t_mylog_issue_8860.log_date > ml1.log_date) AND (t_mylog_issue_8860.myid = ml1.myid))
+                                 ->  Materialize  (cost=0.00..1.07 rows=1 width=12)
+                                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.06 rows=2 width=12)
+                                             ->  Seq Scan on t_mylog_issue_8860  (cost=0.00..1.02 rows=1 width=12)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select ml1.myid, log_date as first_date, ml2.next_date from t_mylog_issue_8860 ml1
+inner join lateral
+(select myid, log_date as next_date
+ from t_mylog_issue_8860 where myid = ml1.myid and log_date > ml1.log_date order by log_date asc limit 1) ml2
+on true;
+ myid |          first_date          |          next_date           
+------+------------------------------+------------------------------
+    2 | Sun Jan 02 01:04:00 2000 PST | Sun Jan 02 03:04:00 2000 PST
+    1 | Sun Jan 02 02:04:00 2000 PST | Sun Jan 02 03:04:00 2000 PST
+(2 rows)
+

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -982,3 +982,86 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
 reset enable_hashjoin;
 reset enable_mergejoin;
 reset enable_nestloop;
+-- test lateral join inner plan contains limit
+-- we cannot pass params across motion so we
+-- can only generate a plan to gather all the
+-- data to singleQE. Here we create a compound
+-- data type as params to pass into inner plan.
+-- By doing so, if we fail to pass correct params
+-- into innerplan, it will throw error because
+-- of nullpointer reference. If we only use int
+-- type as params, the nullpointer reference error
+-- may not happen because we parse null to integer 0.
+create type mytype_for_lateral_test as (x int, y int);
+create table t1_lateral_limit(a int, b int, c mytype_for_lateral_test);
+create table t2_lateral_limit(a int, b int);
+insert into t1_lateral_limit values (1, 1, '(1,1)');
+insert into t1_lateral_limit values (1, 2, '(2,2)');
+insert into t2_lateral_limit values (2, 2);
+insert into t2_lateral_limit values (3, 3);
+explain select * from t1_lateral_limit as t1 cross join lateral
+(select ((c).x+t2.b) as n  from t2_lateral_limit as t2 order by n limit 1)s;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Nested Loop  (cost=10000000001.05..10000000002.11 rows=4 width=41)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=37)
+         ->  Seq Scan on t1_lateral_limit t1  (cost=0.00..1.01 rows=1 width=37)
+   ->  Materialize  (cost=1.05..1.07 rows=1 width=4)
+         ->  Limit  (cost=1.05..1.05 rows=1 width=4)
+               ->  Sort  (cost=1.05..1.05 rows=1 width=4)
+                     Sort Key: (((t1.c).x + t2.b))
+                     ->  Result  (cost=0.00..1.04 rows=1 width=4)
+                           ->  Materialize  (cost=0.00..1.03 rows=1 width=4)
+                                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+                                       ->  Seq Scan on t2_lateral_limit t2  (cost=0.00..1.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select * from t1_lateral_limit as t1 cross join lateral
+(select ((c).x+t2.b) as n  from t2_lateral_limit as t2 order by n limit 1)s;
+ a | b |   c   | n 
+---+---+-------+---
+ 1 | 1 | (1,1) | 3
+ 1 | 2 | (2,2) | 4
+(2 rows)
+
+-- The following case is from Github Issue
+-- https://github.com/greenplum-db/gpdb/issues/8860
+-- It is the same issue as the above test suite.
+create table t_mylog_issue_8860 (myid int, log_date timestamptz );
+insert into  t_mylog_issue_8860 values (1,timestamptz '2000-01-02 03:04'),(1,timestamptz '2000-01-02 03:04'-'1 hour'::interval);
+insert into  t_mylog_issue_8860 values (2,timestamptz '2000-01-02 03:04'),(2,timestamptz '2000-01-02 03:04'-'2 hour'::interval);
+explain select ml1.myid, log_date as first_date, ml2.next_date from t_mylog_issue_8860 ml1
+inner join lateral
+(select myid, log_date as next_date
+ from t_mylog_issue_8860 where myid = ml1.myid and log_date > ml1.log_date order by log_date asc limit 1) ml2
+on true;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop  (cost=10000000001.08..10000000002.18 rows=4 width=20)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.06 rows=2 width=12)
+         ->  Seq Scan on t_mylog_issue_8860 ml1  (cost=0.00..1.02 rows=1 width=12)
+   ->  Materialize  (cost=1.08..1.10 rows=1 width=8)
+         ->  Subquery Scan on ml2  (cost=1.08..1.09 rows=1 width=8)
+               ->  Limit  (cost=1.08..1.08 rows=1 width=12)
+                     ->  Sort  (cost=1.08..1.08 rows=2 width=12)
+                           Sort Key: t_mylog_issue_8860.log_date
+                           ->  Result  (cost=0.00..1.07 rows=2 width=12)
+                                 Filter: ((t_mylog_issue_8860.log_date > ml1.log_date) AND (t_mylog_issue_8860.myid = ml1.myid))
+                                 ->  Materialize  (cost=0.00..1.07 rows=1 width=12)
+                                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.06 rows=2 width=12)
+                                             ->  Seq Scan on t_mylog_issue_8860  (cost=0.00..1.02 rows=1 width=12)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select ml1.myid, log_date as first_date, ml2.next_date from t_mylog_issue_8860 ml1
+inner join lateral
+(select myid, log_date as next_date
+ from t_mylog_issue_8860 where myid = ml1.myid and log_date > ml1.log_date order by log_date asc limit 1) ml2
+on true;
+ myid |          first_date          |          next_date           
+------+------------------------------+------------------------------
+    2 | Sun Jan 02 01:04:00 2000 PST | Sun Jan 02 03:04:00 2000 PST
+    1 | Sun Jan 02 02:04:00 2000 PST | Sun Jan 02 03:04:00 2000 PST
+(2 rows)
+


### PR DESCRIPTION
This PR is 6x version of the pr https://github.com/greenplum-db/gpdb/pull/9623 and https://github.com/greenplum-db/gpdb/pull/9597. Those two PR has been merged into master
branch.

This PR does more job than those two because it depends on some infrastructure
from commit 00e25af. The first commit of this PR partially backport some of those
infrastructure to handle the situation when qual contains outerParams and subquery
contains limit clause.

The dev pipeline is green.

-----------------------

    Fix plan when join lateral inner plan contains limit clause.

    Previously, when join lateral inner plan contains limit
    clause and the exec params are in targetlist of the query,
    for the inner plan it may put a gather motion and then do
    limit. This is not correct since it leads to passing params
    across motion nodes. A typical case is shown below:

    ```
    create table t1(a int, b int, c int) distributed by (a);
    create table t2(a int, b int, c int) distributed by (a);
    explain verbose select * from t1 join lateral
    (select t1.b + t2.a from t2 limit 1)x on true;
                           QUERY PLAN
    --------------------------------------------------------
     Nested Loop
       Output: t1.a, t1.b, t1.c, ((t1.b + t2.a))
       ->  Gather Motion 3:1
             Output: t1.a, t1.b, t1.c
             ->  Seq Scan on public.t1
                   Output: t1.a, t1.b, t1.c
       ->  Materialize
             Output: ((t1.b + t2.a))
             ->  Limit
                   Output: ((t1.b + t2.a))
                   ->  Gather Motion 3:1
                         Output: ((t1.b + t2.a))
                         ->  Limit
                               Output: ((t1.b + t2.a))
                               ->  Seq Scan on public.t2
                                     Output: (t1.b + t2.a)
    ```

    The above plan is invalid because NestLoop has to pass
    params down to the scan of t2. Greenplum does not support
    this yet.

    This commit fixes the bug by gathering the table firstly.
    When the subquery contains outer params and it has limit
    clause, planner will try this. After this commit, the above
    plan becomes:

    ```
    explain verbose select * from t1 join lateral
    (select t1.b + t2.a from t2 limit 1)x on true;
                          QUERY PLAN
    ------------------------------------------------------------
     Nested Loop
       Output: t1.a, t1.b, t1.c, ((t1.b + t2.a))
       ->  Materialize
             Output: t1.a, t1.b, t1.c
             ->  Gather Motion 3:1
                   Output: t1.a, t1.b, t1.c
                   ->  Seq Scan on public.t1
                         Output: t1.a, t1.b, t1.c
       ->  Materialize
             Output: ((t1.b + t2.a))
             ->  Limit
                   Output: ((t1.b + t2.a))
                   ->  Result
                         Output: (t1.b + t2.a)
                         ->  Materialize
                               Output: t2.a
                               ->  Gather Motion 3:1
                                     Output: t2.a
                                     ->  Seq Scan on public.t2
                                           Output: t2.a

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
