### PR TITLE
fix ResProcSleep doesn't trigger deadlock check

### DIFF
--- a/src/backend/postmaster/autostats.c
+++ b/src/backend/postmaster/autostats.c
@@ -31,6 +31,7 @@
 #include "postmaster/autostats.h"
 #include "postmaster/autovacuum.h"
 #include "utils/acl.h"
+#include "utils/faultinjector.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
@@ -314,6 +315,8 @@ auto_stats(AutoStatsCmdType cmdType, Oid relationOid, uint64 ntuples, bool inFun
 
 	Assert(cmdType >= 0 && cmdType <= AUTOSTATS_CMDTYPE_SENTINEL);		/* it is a valid command
 																		 * as per auto-stats */
+
+	SIMPLE_FAULT_INJECTOR("before_auto_stats");
 
 	GpAutoStatsModeValue actual_gp_autostats_mode;
 

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -2102,6 +2102,7 @@ ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet)
 	LOCK	   *lock = locallock->lock;
 	PROCLOCK   *proclock = locallock->proclock;
 	PROC_QUEUE	*waitQueue = &(lock->waitProcs);
+	int			myWaitStatus;
 	PGPROC		*proc;
 	uint32		hashcode = locallock->hashcode;
 	LWLockId	partitionLock = LockHashPartitionLock(hashcode);
@@ -2124,7 +2125,7 @@ ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet)
 	MyProc->waitProcLock = (PROCLOCK *) proclock;
 	MyProc->waitLockMode = lockmode;
 
-	MyProc->waitStatus = STATUS_ERROR;	/* initialize result for error */
+	MyProc->waitStatus = STATUS_WAITING;	/* initialize result for error */
 
 	/* Now check the status of the self lock footgun. */
 	selflock = ResCheckSelfDeadLock(lock, proclock, incrementSet);
@@ -2148,6 +2149,10 @@ ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet)
 	if (ResourceCleanupIdleGangs)
 		cdbcomponent_cleanupIdleQEs(false);
 
+	/* Reset deadlock_state before enabling the timeout handler */
+	deadlock_state = DS_NOT_YET_CHECKED;
+	got_deadlock_timeout = false;
+
 	if (LockTimeout > 0)
 	{
 		EnableTimeoutParams timeouts[2];
@@ -2163,10 +2168,177 @@ ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet)
 	else
 		enable_timeout_after(DEADLOCK_TIMEOUT, DeadlockTimeout);
 
-	/*
-	 * Sleep on the semaphore.
-	 */
-	PGSemaphoreLock(MyProc->sem);
+	do
+	{
+		(void) WaitLatch(MyLatch, WL_LATCH_SET | WL_EXIT_ON_PM_DEATH, 0,
+					PG_WAIT_RESOURCE_QUEUE);
+		ResetLatch(MyLatch);
+		/* check for deadlocks first, as that's probably log-worthy */
+		if (got_deadlock_timeout)
+		{
+			CheckDeadLock();
+			got_deadlock_timeout = false;
+		}
+		CHECK_FOR_INTERRUPTS();
+
+		/*
+		 * waitStatus could change from STATUS_WAITING to something else
+		 * asynchronously.  Read it just once per loop to prevent surprising
+		 * behavior (such as missing log messages).
+		 */
+		myWaitStatus = *((volatile int *) &MyProc->waitStatus);
+
+		/*
+		 * If awoken after the deadlock check interrupt has run, and
+		 * log_lock_waits is on, then report about the wait.
+		 */
+		if (log_lock_waits && deadlock_state != DS_NOT_YET_CHECKED)
+		{
+			StringInfoData buf,
+						lock_waiters_sbuf,
+						lock_holders_sbuf;
+			const char	*modename;
+			long		secs;
+			int			usecs;
+			long		msecs;
+			SHM_QUEUE	*procLocks;
+			PROCLOCK	*proclock;
+			bool		first_holder = true,
+						first_waiter = true;
+			int			lockHoldersNum = 0;
+
+			initStringInfo(&buf);
+			initStringInfo(&lock_waiters_sbuf);
+			initStringInfo(&lock_holders_sbuf);
+
+			DescribeLockTag(&buf, &locallock->tag.lock);
+			modename = GetLockmodeName(locallock->tag.lock.locktag_lockmethodid,
+									   lockmode);
+			TimestampDifference(get_timeout_start_time(DEADLOCK_TIMEOUT),
+								GetCurrentTimestamp(),
+								&secs, &usecs);
+			msecs = secs * 1000 + usecs / 1000;
+			usecs = usecs % 1000;
+
+			/*
+			 * we loop over the lock's procLocks to gather a list of all
+			 * holders and waiters. Thus we will be able to provide more
+			 * detailed information for lock debugging purposes.
+			 *
+			 * lock->procLocks contains all processes which hold or wait for
+			 * this lock.
+			 */
+			LWLockAcquire(partitionLock, LW_SHARED);
+
+			procLocks = &(lock->procLocks);
+			proclock = (PROCLOCK *) SHMQueueNext(procLocks, procLocks,
+												 offsetof(PROCLOCK, lockLink));
+
+			while (proclock)
+			{
+				/*
+				 * we are a waiter if myProc->waitProcLock == proclock; we are
+				 * a holder if it is NULL or something different
+				 */
+				if (proclock->tag.myProc->waitProcLock == proclock)
+				{
+					if (first_waiter)
+					{
+						appendStringInfo(&lock_waiters_sbuf, "%d",
+									proclock->tag.myProc->pid);
+						first_waiter = false;
+					}
+					else
+						appendStringInfo(&lock_waiters_sbuf, ", %d",
+										 proclock->tag.myProc->pid);
+				}
+				else
+				{
+					if (first_holder)
+					{
+						appendStringInfo(&lock_holders_sbuf, "%d",
+										 proclock->tag.myProc->pid);
+						first_holder = false;
+					}
+					else
+						appendStringInfo(&lock_holders_sbuf, ", %d",
+										 proclock->tag.myProc->pid);
+					lockHoldersNum++;
+				}
+
+				proclock = (PROCLOCK *) SHMQueueNext(procLocks, &proclock->lockLink,
+												offsetof(PROCLOCK, lockLink));
+			}
+
+			LWLockRelease(partitionLock);
+
+			if (deadlock_state == DS_SOFT_DEADLOCK)
+				ereport(LOG,
+						(errmsg("process %d avoided deadlock for %s on %s by rearranging queue order after %ld.%03d ms",
+								MyProcPid, modename, buf.data, msecs, usecs),
+						 (errdetail_log_plural("Process holding the lock: %s. Wait queue: %s.",
+							"Processes holding the lock: %s. Wait queue: %s.",
+												lockHoldersNum, lock_holders_sbuf.data, lock_waiters_sbuf.data))));
+			else if (deadlock_state == DS_HARD_DEADLOCK)
+			{
+				/*
+				 * This message is a bit redundant with the error that will be
+				 * reported subsequently, but in some cases the error report
+				 * might not make it to the log (eg, if it's caught by an
+				 * exception handler), and we want to ensure all long-wait
+				 * events get logged.
+				 */
+				ereport(LOG,
+						(errmsg("process %d detected deadlock while waiting for %s on %s after %ld.%03d ms",
+								MyProcPid, modename, buf.data, msecs, usecs),
+						 (errdetail_log_plural("Process holding the lock: %s. Wait queue: %s.",
+						   "Processes holding the lock: %s. Wait queue: %s.",
+												lockHoldersNum, lock_holders_sbuf.data, lock_waiters_sbuf.data))));
+			}
+
+			if (myWaitStatus == STATUS_WAITING)
+				ereport(LOG,
+						(errmsg("process %d still waiting for %s on %s after %ld.%03d ms",
+								MyProcPid, modename, buf.data, msecs, usecs),
+						 (errdetail_log_plural("Process holding the lock: %s. Wait queue: %s.",
+						   "Processes holding the lock: %s. Wait queue: %s.",
+												lockHoldersNum, lock_holders_sbuf.data, lock_waiters_sbuf.data))));
+			else if (myWaitStatus == STATUS_OK)
+				ereport(LOG,
+					(errmsg("process %d acquired %s on %s after %ld.%03d ms",
+							MyProcPid, modename, buf.data, msecs, usecs)));
+			else
+			{
+				Assert(myWaitStatus == STATUS_ERROR);
+
+				/*
+				 * Currently, the deadlock checker always kicks its own
+				 * process, which means that we'll only see STATUS_ERROR when
+				 * deadlock_state == DS_HARD_DEADLOCK, and there's no need to
+				 * print redundant messages.  But for completeness and
+				 * future-proofing, print a message if it looks like someone
+				 * else kicked us off the lock.
+				 */
+				if (deadlock_state != DS_HARD_DEADLOCK)
+					ereport(LOG,
+							(errmsg("process %d failed to acquire %s on %s after %ld.%03d ms",
+								MyProcPid, modename, buf.data, msecs, usecs),
+							 (errdetail_log_plural("Process holding the lock: %s. Wait queue: %s.",
+							"Processes holding the lock: %s. Wait queue: %s.",
+													lockHoldersNum, lock_holders_sbuf.data, lock_waiters_sbuf.data))));
+			}
+
+			/*
+			 * At this point we might still need to wait for the lock. Reset
+			 * state so we don't print the above messages again.
+			 */
+			deadlock_state = DS_NO_DEADLOCK;
+
+			pfree(buf.data);
+			pfree(lock_holders_sbuf.data);
+			pfree(lock_waiters_sbuf.data);
+		}
+	} while (myWaitStatus == STATUS_WAITING);
 
 	if (LockTimeout > 0)
 	{
@@ -2203,44 +2375,60 @@ void
 ResLockWaitCancel(void)
 {
 	LWLockId	partitionLock;
+	DisableTimeoutParams timeouts[2];
 
-	if (lockAwaited != NULL)
+	HOLD_INTERRUPTS();
+
+	AbortStrongLockAcquire();
+
+	/* Nothing to do if we weren't waiting for a lock */
+	if (lockAwaited == NULL)
 	{
-		/* Unlink myself from the wait queue, if on it  */
-		partitionLock = LockHashPartitionLock(lockAwaited->hashcode);
-		LWLockAcquire(partitionLock, LW_EXCLUSIVE);
-
-		if (MyProc->links.next != NULL)
-		{
-			/* We could not have been granted the lock yet */
-			Assert(MyProc->waitStatus == STATUS_ERROR);
-
-			/* We should only be trying to cancel resource locks. */
-			Assert(LOCALLOCK_LOCKMETHOD(*lockAwaited) == RESOURCE_LOCKMETHOD);
-
-			ResRemoveFromWaitQueue(MyProc, lockAwaited->hashcode);
-			/*
-			 * lockAwaited's lock/proclock pointers are dangling after the call
-			 * to ResRemoveFromWaitQueue(). So clean up the locallock as well,
-			 * to avoid de-referencing them in the eventual ResLockRelease() in
-			 * ResLockPortal/ResLockUtilityPortal.
-			 */
-			RemoveLocalLock(lockAwaited);
-		}
-
-		lockAwaited = NULL;
-
-		LWLockRelease(partitionLock);
+		RESUME_INTERRUPTS();
+		return;
 	}
 
 	/*
-	 * Reset the proc wait semaphore to zero. This is necessary in the
-	 * scenario where someone else granted us the lock we wanted before we
-	 * were able to remove ourselves from the wait-list.
+	 * Turn off the deadlock and lock timeout timers, if they are still
+	 * running (see ResProcSleep).  Note we must preserve the LOCK_TIMEOUT
+	 * indicator flag, since this function is executed before
+	 * ProcessInterrupts when responding to SIGINT; else we'd lose the
+	 * knowledge that the SIGINT came from a lock timeout and not an external
+	 * source.
 	 */
-	PGSemaphoreReset(MyProc->sem);
+	timeouts[0].id = DEADLOCK_TIMEOUT;
+	timeouts[0].keep_indicator = false;
+	timeouts[1].id = LOCK_TIMEOUT;
+	timeouts[1].keep_indicator = true;
+	disable_timeouts(timeouts, 2);
 
-	return;
+	/* Unlink myself from the wait queue, if on it  */
+	partitionLock = LockHashPartitionLock(lockAwaited->hashcode);
+	LWLockAcquire(partitionLock, LW_EXCLUSIVE);
+
+	if (MyProc->links.next != NULL)
+	{
+		/* We could not have been granted the lock yet */
+		Assert(MyProc->waitStatus == STATUS_WAITING);
+
+		/* We should only be trying to cancel resource locks */
+		Assert(LOCALLOCK_LOCKMETHOD(*lockAwaited) == RESOURCE_LOCKMETHOD);
+
+		ResRemoveFromWaitQueue(MyProc, lockAwaited->hashcode);
+		/*
+		 * lockAwaited's lock/proclock pointers are dangling after the call
+		 * to ResRemoveFromWaitQueue(). So clean up the locallock as well,
+		 * to avoid de-referencing them in the eventual ResLockRelease() in
+		 * ResLockPortal/ResLockUtilityPortal.
+		 */
+		RemoveLocalLock(lockAwaited);
+	}
+
+	lockAwaited = NULL;
+
+	LWLockRelease(partitionLock);
+
+	RESUME_INTERRUPTS();
 }
 
 bool ProcCanSetMppSessionId(void)

--- a/src/test/isolation2/expected/resource_queue.out
+++ b/src/test/isolation2/expected/resource_queue.out
@@ -46,11 +46,11 @@ PREPARE
  ResourceQueue   | ResourceQueue 
  ResourceQueue   | ResourceQueue 
 (2 rows)
-0:SELECT granted, locktype, mode FROM pg_locks where locktype = 'resource queue';
+0:SELECT granted, locktype, mode FROM pg_locks where locktype = 'resource queue' and pid != pg_backend_pid();
  granted | locktype       | mode          
 ---------+----------------+---------------
- t       | resource queue | ExclusiveLock 
  f       | resource queue | ExclusiveLock 
+ t       | resource queue | ExclusiveLock 
  f       | resource queue | ExclusiveLock 
 (3 rows)
 

--- a/src/test/isolation2/expected/resource_queue_deadlock.out
+++ b/src/test/isolation2/expected/resource_queue_deadlock.out
@@ -1,0 +1,61 @@
+-- This test is used to test if waiting on a resource queue lock will
+-- trigger a local deadlock detection.
+
+0: CREATE RESOURCE QUEUE rq_deadlock_test WITH (active_statements = 1);
+CREATE
+0: CREATE role role_deadlock_test RESOURCE QUEUE rq_deadlock_test;
+CREATE
+
+0: SELECT gp_inject_fault_infinite('before_auto_stats', 'suspend', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+0&: SELECT gp_wait_until_triggered_fault('before_auto_stats', 1, dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';  <waiting ...>
+
+1: SET role role_deadlock_test;
+SET
+-- We need gp_autostats_mode to be ON_NO_STATS in this test.
+1: SET gp_autostats_mode = ON_NO_STATS;
+SET
+1: SHOW gp_autostats_mode;
+ gp_autostats_mode 
+-------------------
+ on_no_stats       
+(1 row)
+1: CREATE TABLE t_deadlock_test(c1 int);
+CREATE
+1&: INSERT INTO t_deadlock_test VALUES (1);  <waiting ...>
+2: SET role role_deadlock_test;
+SET
+2: BEGIN;
+BEGIN
+2: analyze t_deadlock_test;
+ANALYZE
+0<:  <... completed>
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+0: select gp_inject_fault_infinite('before_auto_stats', 'reset', dbid) from gp_segment_configuration where content = -1 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: SELECT * FROM t_deadlock_test;
+ERROR:  deadlock detected
+DETAIL:  Process 1618 waits for ExclusiveLock on resource queue 16520; blocked by process 1606.
+Process 1606 waits for ShareUpdateExclusiveLock on relation 16522 of database 16478; blocked by process 1618.
+HINT:  See server log for query details.
+2: ROLLBACK;
+ROLLBACK
+1<:  <... completed>
+INSERT 1
+
+-- Clean up the test
+0: DROP TABLE t_deadlock_test;
+DROP
+0: DROP ROLE role_deadlock_test;
+DROP
+0: DROP RESOURCE QUEUE rq_deadlock_test;
+DROP

--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -38,8 +38,16 @@ s/requested \d+ bytes//
 m/^DETAIL:  Process \d+ waits for ShareLock on transaction \d+; blocked by process \d+./
 s/^DETAIL:  Process \d+ waits for ShareLock on transaction \d+; blocked by process \d+./DETAIL:  Process PID waits for ShareLock on transaction XID; blocked by process PID./
 
+# For resource queue deadlock
+m/^DETAIL:  Process \d+ waits for ExclusiveLock on resource queue \d+; blocked by process \d+./
+s/^DETAIL:  Process \d+ waits for ExclusiveLock on resource queue \d+; blocked by process \d+./DETAIL:  Process PID waits for ExclusiveLock on resource queue OID; blocked by process PID./
+
 m/^Process \d+ waits for ShareLock on transaction \d+; blocked by process \d+./
 s/^Process \d+ waits for ShareLock on transaction \d+; blocked by process \d+./Process PID waits for ShareLock on transaction XID; blocked by process PID./
+
+# For resource queue deadlock
+m/^Process \d+ waits for ShareUpdateExclusiveLock on relation \d+ of database \d+; blocked by process \d+./
+s/^Process \d+ waits for ShareUpdateExclusiveLock on relation \d+ of database \d+; blocked by process \d+./Process PID waits for ShareUpdateExclusiveLock on relation OID of database OID; blocked by process PID./
 
 m/available \d+ MB/
 s/available \d+ MB//

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -61,6 +61,9 @@ test: misc
 
 test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue bitmap_index_ao_sparse
 
+# Test deadlock situation when waiting on a resource queue lock
+test: resource_queue_deadlock
+
 # below test(s) inject faults so each of them need to be in a separate group
 test: pg_terminate_backend
 test: gp_terminate_mpp_backends

--- a/src/test/isolation2/sql/resource_queue.sql
+++ b/src/test/isolation2/sql/resource_queue.sql
@@ -24,7 +24,7 @@
 
 -- Check pg_stat_activity and pg_locks again.
 0:SELECT wait_event_type, wait_event from pg_stat_activity where query = 'EXECUTE fooplan;';
-0:SELECT granted, locktype, mode FROM pg_locks where locktype = 'resource queue';
+0:SELECT granted, locktype, mode FROM pg_locks where locktype = 'resource queue' and pid != pg_backend_pid();
 
 1:END;
 

--- a/src/test/isolation2/sql/resource_queue_deadlock.sql
+++ b/src/test/isolation2/sql/resource_queue_deadlock.sql
@@ -1,0 +1,28 @@
+-- This test is used to test if waiting on a resource queue lock will
+-- trigger a local deadlock detection.
+
+0: CREATE RESOURCE QUEUE rq_deadlock_test WITH (active_statements = 1);
+0: CREATE role role_deadlock_test RESOURCE QUEUE rq_deadlock_test;
+
+0: SELECT gp_inject_fault_infinite('before_auto_stats', 'suspend', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+0&: SELECT gp_wait_until_triggered_fault('before_auto_stats', 1, dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+
+1: SET role role_deadlock_test;
+-- We need gp_autostats_mode to be ON_NO_STATS in this test.
+1: SET gp_autostats_mode = ON_NO_STATS;
+1: SHOW gp_autostats_mode;
+1: CREATE TABLE t_deadlock_test(c1 int);
+1&: INSERT INTO t_deadlock_test VALUES (1);
+2: SET role role_deadlock_test;
+2: BEGIN;
+2: analyze t_deadlock_test;
+0<:
+0: select gp_inject_fault_infinite('before_auto_stats', 'reset', dbid) from gp_segment_configuration where content = -1 and role = 'p';
+2: SELECT * FROM t_deadlock_test;
+2: ROLLBACK;
+1<:
+
+-- Clean up the test
+0: DROP TABLE t_deadlock_test;
+0: DROP ROLE role_deadlock_test;
+0: DROP RESOURCE QUEUE rq_deadlock_test;


### PR DESCRIPTION
Fix waiting on resqueue regular lock doesn't trigger deadlock detection

Since PG9.6, deadlock timeout mechanism was changed greatly compared
to the version before. Because resqueue lock is based on regular lock,
we need modify the correspoding deadlock detection mechanism on resqueue
lock accordingly.

fix issue #9651

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
