### PR TITLE
docs - add description for jsonb data type

### DIFF
--- a/gpdb-doc/dita/ref_guide/data_types.xml
+++ b/gpdb-doc/dita/ref_guide/data_types.xml
@@ -188,9 +188,9 @@
             <row>
               <entry colname="col1">jsonb</entry>
               <entry colname="col2"/>
-              <entry colname="col3">???</entry>
-              <entry colname="col4">???</entry>
-              <entry colname="col5">???</entry>
+              <entry colname="col3">1 byte + binary string</entry>
+              <entry colname="col4">json of any length in a decomposed binary format</entry>
+              <entry colname="col5">variable unlimited length</entry>
             </row>
             <row>
               <entry colname="col1">lseg</entry>


### PR DESCRIPTION
description is based on a comment for the jsonb_recv function
that I found in gpdb/src/backend/utils/adt/jsonb.c

