### PR TITLE
docs - pxf JAVA_HOME simplifications

### DIFF
--- a/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/init_pxf.html.md.erb
@@ -21,7 +21,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-You must explicitly initialize the PXF service instance. This one-time initialization creates the PXF service web application and generates PXF configuration files and templates.
+The PXF server is a Java application. You must explicitly initialize the PXF Java service instance. This one-time initialization creates the PXF service web application and generates PXF configuration files and templates.
 
 PXF provides two management commands that you can use for initialization:
 
@@ -30,15 +30,33 @@ PXF provides two management commands that you can use for initialization:
 
 PXF also provides similar `reset` commands that you can use to reset your PXF configuration.
 
-## <a id="init_pxf"></a> PXF Configuration Properties
+## <a id="init_pxf"></a> Configuration Properties
 
-PXF supports both internal and user-customizable configuration properties. Initializing PXF generates PXF internal configuration files, setting default properties specific to your configuration. Initializing PXF also generates configuration file templates for user-customizable settings such as custom profiles and PXF runtime and logging settings.
+PXF supports both internal and user-customizable configuration properties.
 
-PXF internal configuration files are located in your Greenplum Database installation in the `$GPHOME/pxf/conf` directory. You identify the PXF user configuration directory at PXF initialization time via an environment variable named `$PXF_CONF`. If you do not set `$PXF_CONF` prior to initializing PXF, PXF may prompt you to accept or decline the default user configuration directory, `$HOME/pxf`, during the initialization process.
+PXF internal configuration files are located in your Greenplum Database installation in the `$GPHOME/pxf/conf` directory.
+
+You identify the PXF user configuration directory at PXF initialization time via an environment variable named `$PXF_CONF`. If you do not set `$PXF_CONF` prior to initializing PXF, PXF may prompt you to accept or decline the default user configuration directory, `$HOME/pxf`, during the initialization process.
 
 **Note**: Choose a `$PXF_CONF` directory location that you can back up, and ensure that it resides outside of your Greenplum Database installation directory.
 
-During initialization, PXF creates the `$PXF_CONF` directory if necessary, and then populates it with subdirectories and template files. Refer to [PXF User Configuration Directories](about_pxf_dir.html#usercfg) for a list of these directories and their contents.
+Refer to [PXF User Configuration Directories](about_pxf_dir.html#usercfg) for a list of `$PXF_CONF` subdirectories and their contents.
+
+
+## <a id="init_descript"></a> Initialization Overview
+
+The PXF server runs on Java 8 or 11. You identify the PXF `$JAVA_HOME` and `$PXF_CONF` settings at PXF initialization time.
+
+Initializing PXF creates the PXF Java web application, and generates PXF internal configuration files, setting default properties specific to your configuration.
+
+Initializing PXF also creates the `$PXF_CONF` user configuration directory if it does not already exist, and then populates `conf` and `templates` subdirectories with the following:
+
+- `conf/` -  user-customizable files for PXF runtime and logging configuration settings
+- `templates/` - template configuration files
+
+If the `$PXF_CONF` directory you specify during initialization already exists, PXF updates only the `templates` subdirectory.
+
+**Note**: PXF remembers the `JAVA_HOME` setting that you specified during initialization by updating the property of the same name in the `$PXF_CONF/conf/pxf-env.sh` user configuration file. PXF sources this environment file on startup, allowing PXF to run with a Java installation that is different than the system default Java.
 
 
 ## <a id="init-pxf-prereq"></a>Prerequisites
@@ -47,6 +65,7 @@ Before initializing PXF in your Greenplum Database cluster, ensure that:
 
 - Your Greenplum Database cluster is up and running.
 - You have identified the PXF user configuration directory filesystem location, `$PXF_CONF`, and that the `gpadmin` user has the necessary permissions to create, or write to, this directory.
+- You can identify the Java 8 or 11 `$JAVA_HOME` setting for PXF.
  
 ## <a id="init-pxf-steps"></a>Procedure
 
@@ -58,13 +77,17 @@ Perform the following procedure to initialize PXF on each segment host in your G
     $ ssh gpadmin@<gpmaster>
     ```
 
+2. Export the PXF `JAVA_HOME` setting in your shell. For example:
+
+    ``` shell
+    gpadmin@gpmaster$ export JAVA_HOME=/usr/lib/jvm/jre
+    ```
+
 4. Run the `pxf cluster init` command to initialize the PXF service on the master, standby master, and on each segment host. For example, the following command specifies `/usr/local/greenplum-pxf` as the PXF user configuration directory for initialization:
 
     ``` shell
     gpadmin@gpmaster$ PXF_CONF=/usr/local/greenplum-pxf $GPHOME/pxf/bin/pxf cluster init
     ```
-
-    The `init` command creates the PXF web application and initializes the internal PXF configuration. The `init` command also creates the `$PXF_CONF` user configuration directory if it does not exist, and populates the `conf` and `templates` directories with user-customizable configuration templates. If `$PXF_CONF` exists, PXF updates only the `templates` directory.
 
     **Note**: The PXF service runs only on the segment hosts. However,`pxf cluster init` also sets up the PXF user configuration directories on the Greenplum Database master and standby master hosts.
 

--- a/gpdb-doc/markdown/pxf/install_java.html.md.erb
+++ b/gpdb-doc/markdown/pxf/install_java.html.md.erb
@@ -4,8 +4,6 @@ title: Installing Java for PXF
 
 PXF is a Java service. It requires a Java 8 or Java 11 installation on each Greenplum Database host.
 
-*If an appropriate version of Java is already installed on each Greenplum Database host, you need not perform the procedure in this topic.*
-
 
 ## <a id="prereq"></a>Prerequisites
 
@@ -21,31 +19,48 @@ Perform the following procedure to install Java on the master, standby master, a
     $ ssh gpadmin@<gpmaster>
     ```
 
-2. Create a text file that lists your Greenplum Database standby master host and segment hosts, one host name per line. For example, a file named `gphostfile` may include:
+2. Determine the version(s) of Java installed on the system:
 
     ``` pre
-    mstandby
-    seghost1
-    seghost2
-    seghost3
+    gpadmin@gpmaster$ rpm -qa | grep java
     ```
 
-3. Install Java on the master, standby master, and on each Greenplum Database segment host, and then set up the Java environment on each host.
+3. If the system does not include a Java version 8 or 11 installation, install one of these Java versions on the master, standby master, and on each Greenplum Database segment host.
 
-    1. Install the Java package. For example, to install Java version 8:
+    1. Create a text file that lists your Greenplum Database standby master host and segment hosts, one host name per line. For example, a file named `gphostfile` may include:
+
+        ``` pre
+        mstandby
+        seghost1
+        seghost2
+        seghost3
+        ```
+    2. Install the Java package on each host. For example, to install Java version 8:
 
         ``` shell
         gpadmin@gpmaster$ sudo yum -y install java-1.8.0-openjdk-1.8.0*
         gpadmin@gpmaster$ gpssh -e -v -f gphostfile sudo yum -y install java-1.8.0-openjdk-1.8.0*
         ```
 
-    2. Identify the Java base install directory. Update the `gpadmin` user's `.bashrc` file on each host to include this `$JAVA_HOME` setting if it is not already present. For example, if you installed Java 8:
+4. Identify the Java 8 or 11 `$JAVA_HOME` setting for PXF. For example:
 
-        ``` shell
-        gpadmin@gpmaster$ echo 'export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.x86_64/jre' >> /home/gpadmin/.bashrc
-        gpadmin@gpmaster$ gpssh -e -v -f gphostfile "echo 'export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.x86_64/jre' >> /home/gpadmin/.bashrc"
-        ```
+    If you installed Java 8:
 
-        If you installed Java 11, `JAVA_HOME` may be `/usr/lib/jvm/java-11-openjdk-11.0.4.11-0.el7_6.x86_64`.
+    ``` shell
+    JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.x86_64/jre
+    ```
 
-**Note**: If the superuser selected the newly-installed Java alternative as the system default, `JAVA_HOME=/usr/lib/jvm/jre`.
+    If you installed Java 11:
+    
+    ``` shell
+    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-11.0.4.11-0.el7_6.x86_64
+    ```
+
+    If the superuser configures the newly-installed Java alternative as the system default:
+
+    ``` shell
+    JAVA_HOME=/usr/lib/jvm/jre
+    ```
+
+5. Note the `$JAVA_HOME` setting; you provide this value when you initialize PXF.
+


### PR DESCRIPTION
no longer required to add JAVA_HOME to .bashrc on master and segment hosts.  should now specify JAVA_HOME in shell environment or on command line when initializing pxf.

in this PR:
- java install topic:  reword the install procedure, update installing java page, remove steps for setting JAVA_HOME in .bashrc, add step to note JAVA_HOME setting
- initializing pxf topic:  add "Initialization Overview" topic, rearrange some text, identify how/when to set JAVA_HOME and what PXF does with the setting

doc review sites link:
- installing java - http://docs-lisa-pxf-javahome.cfapps.io/7-0/pxf/install_java.html
- initializing pxf - http://docs-lisa-pxf-javahome.cfapps.io/7-0/pxf/init_pxf.html
