### PR TITLE
6X: basebackup: optimize for large exclude list

### DIFF
--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -19,6 +19,7 @@
 
 #include "miscadmin.h"
 #include "access/genam.h"
+#include "access/hash.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"		/* for pg_start/stop_backup */
 #include "cdb/cdbvars.h"
@@ -61,12 +62,12 @@ typedef struct
 	bool		nowait;
 	bool		includewal;
 	uint32		maxrate;
-	List	   *exclude;
+	HTAB	   *exclude;
 } basebackup_options;
 
 
-static bool match_exclude_list(char *path, List *exclude);
-static int64 sendDir(char *path, int basepathlen, bool sizeonly, List *tablespaces, List *exclude);
+static bool match_exclude_list(char *path, HTAB *exclude);
+static int64 sendDir(char *path, int basepathlen, bool sizeonly, List *tablespaces, HTAB *exclude);
 static int64 sendTablespace(char *path, bool sizeonly);
 static bool sendFile(char *readfilename, char *tarfilename,
 		 struct stat * statbuf, bool missing_ok);
@@ -673,6 +674,35 @@ compareWalFileNames(const void *a, const void *b)
 	return strcmp(fna + 8, fnb + 8);
 }
 
+/* Hash entire string */
+static uint32
+key_string_hash(const void *key, Size keysize)
+{
+	Size		s_len = strlen((const char *) key);
+
+	Assert(keysize == sizeof(char *));
+	return DatumGetUInt32(hash_any((const unsigned char *) key, (int) s_len));
+}
+
+/* Compare entire string. */
+static int
+key_string_compare(const void *key1, const void *key2, Size keysize)
+{
+	Assert(keysize == sizeof(char *));
+
+	return strcmp(*((const char **) key1), key2);
+}
+
+/* Copy string by copying pointer. */
+static void *
+key_string_copy(void *dest, const void *src, Size keysize)
+{
+	Assert(keysize == sizeof(char *));
+
+	*((char **) dest) = (char *) src;	/* trust caller re allocation */
+	return NULL;				/* not used */
+}
+
 /*
  * Parse the base backup options passed down by the parser
  */
@@ -688,7 +718,14 @@ parse_basebackup_options(List *options, basebackup_options *opt)
 	bool		o_maxrate = false;
 
 	MemSet(opt, 0, sizeof(*opt));
-	opt->exclude = NIL;
+
+	/*
+	 * The exclude hash table is only created if EXCLUDE options are specified.
+	 * The matching function is optimized to run fast when the hash table is
+	 * NULL.
+	 */
+	opt->exclude = NULL;
+
 	foreach(lopt, options)
 	{
 		DefElem    *defel = (DefElem *) lfirst(lopt);
@@ -760,7 +797,39 @@ parse_basebackup_options(List *options, basebackup_options *opt)
 		else if (strcmp(defel->defname, "exclude") == 0)
 		{
 			/* EXCLUDE option can be specified multiple times */
-			opt->exclude = lappend(opt->exclude, defel->arg);
+			bool		found;
+
+			if (unlikely(opt->exclude == NULL))
+			{
+				HASHCTL		hashctl;
+
+				/*
+				 * The hash table stores the string keys in-place if the
+				 * `match` and `keycopy` functions are not explicitly
+				 * specified.  In our case MAXPGPATH bytes need to be reserved
+				 * for each key, which is too wasteful.
+				 *
+				 * By specifying the `match` and `keycopy` functions we could
+				 * allocate the strings separately and store only the string
+				 * pointers in the hash table.
+				 */
+				hashctl.hash = key_string_hash;
+				hashctl.match = key_string_compare;
+				hashctl.keycopy = key_string_copy;
+
+				/* The hash table is used as a set, only the keys are meaningful */
+				hashctl.keysize = sizeof(char *);
+				hashctl.entrysize = hashctl.keysize;
+
+				opt->exclude = hash_create("replication exclude",
+										   64 /* nelem */,
+										   &hashctl,
+										   HASH_ELEM | HASH_FUNCTION |
+										   HASH_COMPARE | HASH_KEYCOPY);
+			}
+
+			hash_search(opt->exclude, pstrdup(strVal(defel->arg)),
+						HASH_ENTER, &found);
 		}
 		else
 			elog(ERROR, "option \"%s\" not recognized",
@@ -768,6 +837,9 @@ parse_basebackup_options(List *options, basebackup_options *opt)
 	}
 	if (opt->label == NULL)
 		opt->label = "base backup";
+
+	if (opt->exclude)
+		hash_freeze(opt->exclude);
 
 	elogif(debug_basebackup, LOG,
 			"basebackup options -- "
@@ -1065,7 +1137,7 @@ sendTablespace(char *path, bool sizeonly)
 	size = 512;					/* Size of the header just added */
 
 	/* Send all the files in the tablespace version directory */
-	size += sendDir(pathbuf, strlen(path), sizeonly, NIL, NIL);
+	size += sendDir(pathbuf, strlen(path), sizeonly, NIL, NULL);
 
 	return size;
 }
@@ -1076,19 +1148,14 @@ sendTablespace(char *path, bool sizeonly)
  * "./pg_log" etc).
  */
 static bool
-match_exclude_list(char *path, List *exclude)
+match_exclude_list(char *path, HTAB *exclude)
 {
-	ListCell	   *l;
+	bool		found = false;
 
-	foreach (l, exclude)
-	{
-		char	   *val = strVal(lfirst(l));
+	if (unlikely(exclude))
+		hash_search(exclude, path, HASH_FIND, &found);
 
-		if (strcmp(val, path) == 0)
-			return true;
-	}
-
-	return false;
+	return found;
 }
 
 /*
@@ -1103,7 +1170,7 @@ match_exclude_list(char *path, List *exclude)
  */
 static int64
 sendDir(char *path, int basepathlen, bool sizeonly, List *tablespaces,
-		List *exclude)
+		HTAB *exclude)
 {
 	DIR		   *dir;
 	struct dirent *de;

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -74,6 +74,8 @@ static bool forceoverwrite = false;
 #define MAX_EXCLUDE 255
 static int	num_exclude = 0;
 static char *excludes[MAX_EXCLUDE];
+static int	num_exclude_from = 0;
+static char *excludefroms[MAX_EXCLUDE];
 static int target_gp_dbid = 0;
 
 /* Progress counters */
@@ -271,6 +273,8 @@ usage(void)
 	printf(_("  -w, --no-password      never prompt for password\n"));
 	printf(_("  -W, --password         force password prompt (should happen automatically)\n"));
 	printf(_("  -E, --exclude          exclude path names\n"));
+	printf(_("      --exclude-from=FILE\n"
+			 "                         get path names to exclude from FILE\n"));
 	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
 }
 
@@ -1681,31 +1685,69 @@ WriteRecoveryConf(void)
 	fclose(cf);
 }
 
+static void
+add_to_exclude_list(PQExpBufferData *buf, const char *exclude)
+{
+	char		quoted[MAXPGPATH];
+	int			error;
+	size_t		len;
+
+	error = 1;
+	len = PQescapeStringConn(conn, quoted, exclude, MAXPGPATH, &error);
+	if (len == 0 || error != 0)
+	{
+		fprintf(stderr, _("%s: could not process exclude \"%s\": %s\n"),
+				progname, exclude, PQerrorMessage(conn));
+		disconnect_and_exit(1);
+	}
+	appendPQExpBuffer(buf, " EXCLUDE '%s'", quoted);
+}
+
 static char *
-build_exclude_list(char **exclude_list, int num)
+build_exclude_list(void)
 {
 	PQExpBufferData	buf;
 	int				i;
-	char			quoted[MAXPGPATH];
-	int				error;
-	size_t			len;
 
-	if (num == 0)
+	if (num_exclude == 0 && num_exclude_from == 0)
 		return "";
 
 	initPQExpBuffer(&buf);
 
-	for (i = 0; i < num; i++)
+	for (i = 0; i < num_exclude; i++)
+		add_to_exclude_list(&buf, excludes[i]);
+
+	for (i = 0; i < num_exclude_from; i++)
 	{
-		error = 1;
-		len = PQescapeStringConn(conn, quoted, exclude_list[i], MAXPGPATH, &error);
-		if (len == 0 || error != 0)
+		const char *filename = excludefroms[i];
+		FILE	   *file = fopen(filename, "r");
+		char		str[MAXPGPATH];
+
+		if (file == NULL)
 		{
-			fprintf(stderr, _("%s: could not process exclude \"%s\": %s\n"),
-					progname, exclude_list[i], PQerrorMessage(conn));
+			fprintf(stderr, _("%s: could not open exclude-from file \"%s\": %m\n"),
+					progname, filename);
 			disconnect_and_exit(1);
 		}
-		appendPQExpBuffer(&buf, "EXCLUDE '%s'", quoted);
+
+		/*
+		 * Each line contains a pathname to exclude.
+		 *
+		 * We must use fgets() instead of fscanf("%s") to correctly handle the
+		 * spaces in the filenames.
+		 */
+		while (fgets(str, sizeof(str), file))
+		{
+			/* Remove all trailing \r and \n */
+			for (int len = strlen(str);
+				 len > 0 && (str[len - 1] == '\r' || str[len - 1] == '\n');
+				 len--)
+				str[len - 1] = '\0';
+
+			add_to_exclude_list(&buf, str);
+		}
+
+		fclose(file);
 	}
 
 	if (PQExpBufferDataBroken(buf))
@@ -1798,7 +1840,7 @@ BaseBackup(void)
 	if (maxrate > 0)
 		maxrate_clause = psprintf("MAX_RATE %u", maxrate);
 
-	exclude_list = build_exclude_list(excludes, num_exclude);
+	exclude_list = build_exclude_list();
 
 	if (verbose)
 		fprintf(stderr,
@@ -1818,7 +1860,7 @@ BaseBackup(void)
 				 maxrate_clause ? maxrate_clause : "",
 				 exclude_list);
 
-	if (num_exclude != 0)
+	if (exclude_list[0] != '\0')
 		free(exclude_list);
 
 	if (PQsendQuery(conn, basebkp) == 0)
@@ -2138,6 +2180,7 @@ main(int argc, char **argv)
 		{"progress", no_argument, NULL, 'P'},
 		{"xlogdir", required_argument, NULL, 1},
 		{"exclude", required_argument, NULL, 'E'},
+		{"exclude-from", required_argument, NULL, 2},
 		{"force-overwrite", no_argument, NULL, 128},
 		{"target-gp-dbid", required_argument, NULL, 129},
 		{NULL, 0, NULL, 0}
@@ -2165,6 +2208,7 @@ main(int argc, char **argv)
 	}
 
 	num_exclude = 0;
+	num_exclude_from = 0;
 	while ((c = getopt_long(argc, argv, "D:F:r:RT:xX:l:zZ:d:c:h:p:U:s:S:wWvPE:",
 							long_options, &option_index)) != -1)
 	{
@@ -2306,10 +2350,21 @@ main(int argc, char **argv)
 				{
 					fprintf(stderr, _("%s: too many elements in exclude list: max is %d"),
 							progname, MAX_EXCLUDE);
+					fprintf(stderr, _("hint: use --exclude-from to load a large exclude list from a file"));
 					exit(1);
 				}
 
 				excludes[num_exclude++] = pg_strdup(optarg);
+				break;
+			case 2:			/* --exclude-from=FILE */
+				if (num_exclude_from >= MAX_EXCLUDE)
+				{
+					fprintf(stderr, _("%s: too many elements in exclude-from list: max is %d"),
+							progname, MAX_EXCLUDE);
+					exit(1);
+				}
+
+				excludefroms[num_exclude_from++] = pg_strdup(optarg);
 				break;
 			case 128:
 				forceoverwrite = true;


### PR DESCRIPTION
This PR contains below two optimizations:

## pg_basebackup: new option to load exclude lists from files

The pg_basebackup command supports the --exclude option to exclude a
path name, it can be provided multiple times to exclude multiple path
names.  However it can be provided at most 255 times, the limit is
hard-coded in the source code because it is internall a fix-sized string
array.

To support excluding more path names, we could enlarge this number,
however there is still limits on the cmdline size or the argument count.

So we now provide a new option, --exclude-from=FILE, to get the path
names to exclude from a file.

## replication/basebackup: use hash table for the exclude list

The replication basebackup command supports excluding path names with
the EXCLUDE clause, the excluding list used to be stored internally as a
string list and be matched one by one, this can be very inefficient when
the excluding list is large.

Now we store the path names to exclude in a hash table for better
performance.

This is the 6X version of https://github.com/greenplum-db/gpdb/pull/9600

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
