### PR TITLE
fix hang issue in interconnect

### DIFF
--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -656,9 +656,9 @@ processIncomingChunks(MotionLayerState *mlStates,
 	 * the chunk-sorter.
 	 */
 	if (srcRoute == ANY_ROUTE)
-		tcItem = transportStates->RecvTupleChunkFromAny(transportStates, motNodeID, &srcRoute);
+		tcItem = transportStates->RecvTupleChunkFromAny(transportStates, pMNEntry, motNodeID, &srcRoute);
 	else
-		tcItem = transportStates->RecvTupleChunkFrom(transportStates, motNodeID, srcRoute);
+		tcItem = transportStates->RecvTupleChunkFrom(transportStates, pMNEntry, motNodeID, srcRoute);
 
 	numChunks = 0;
 	chunkBytes = 0;

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -97,10 +97,12 @@ static void flushInterconnectListenerBacklog(void);
 static void waitOnOutbound(ChunkTransportStateEntry *pEntry);
 
 static TupleChunkListItem RecvTupleChunkFromAnyTCP(ChunkTransportState *transportStates,
+						 MotionNodeEntry *pMNEntry,
 						 int16 motNodeID,
 						 int16 *srcRoute);
 
 static TupleChunkListItem RecvTupleChunkFromTCP(ChunkTransportState *transportStates,
+					  MotionNodeEntry *pMNEntry,
 					  int16 motNodeID,
 					  int16 srcRoute);
 
@@ -2413,6 +2415,7 @@ doSendStopMessageTCP(ChunkTransportState *transportStates, int16 motNodeID)
 
 static TupleChunkListItem
 RecvTupleChunkFromTCP(ChunkTransportState *transportStates,
+					  MotionNodeEntry *pMNEntry,
 					  int16 motNodeID,
 					  int16 srcRoute)
 {
@@ -2434,6 +2437,7 @@ RecvTupleChunkFromTCP(ChunkTransportState *transportStates,
 
 static TupleChunkListItem
 RecvTupleChunkFromAnyTCP(ChunkTransportState *transportStates,
+						 MotionNodeEntry *pMNEntry,
 						 int16 motNodeID,
 						 int16 *srcRoute)
 {

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -521,8 +521,8 @@ typedef struct ChunkTransportState
 
 	/* Function pointers to our send/receive functions */
 	bool (*SendChunk)(struct ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntry, MotionConn *conn, TupleChunkListItem tcItem, int16 motionId);
-	TupleChunkListItem (*RecvTupleChunkFrom)(struct ChunkTransportState *transportStates, int16 motNodeID, int16 srcRoute);
-	TupleChunkListItem (*RecvTupleChunkFromAny)(struct ChunkTransportState *transportStates, int16 motNodeID, int16 *srcRoute);
+	TupleChunkListItem (*RecvTupleChunkFrom)(struct ChunkTransportState *transportStates, MotionNodeEntry *pMNEntry, int16 motNodeID, int16 srcRoute);
+	TupleChunkListItem (*RecvTupleChunkFromAny)(struct ChunkTransportState *transportStates, MotionNodeEntry *pMNEntry, int16 motNodeID, int16 *srcRoute);
 	void (*doSendStopMessage)(struct ChunkTransportState *transportStates, int16 motNodeID);
 	void (*SendEos)(struct ChunkTransportState *transportStates, int motNodeID, TupleChunkListItem tcItem);
 } ChunkTransportState;


### PR DESCRIPTION
When the upper node does not need the lower node to continue providing
tuples, the upper node executes the Squelch node. Squelch executes from
higher level to lower level in the plan tree. When motion is
encountered, a stop message is broadcast down. If we have a query for a
three-layer slice, the top node sends a stop message downwards, all QEs
in the third layer have received stop messages but some QEs in the
second layer have not received stop messages, then Deadlocks can occur
in receiver of motion.

When the executor finish running in QD, QD will send a signal to all QEs
to remind QE to end all work. After received the signal QE will make
'QueryFinishPending' false. So we will check 'QueryFinishPending' in
motion receiver function 'receiveChunksUDPIFC' and stop the receiver
when QueryFinishPending is true.

Because this problem cannot be reproduced sometimes, I haven't
add test cases.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
