### PR TITLE
Backport plan_cache_mode GUC setting for PG12

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -3683,6 +3683,36 @@ SELECT * FROM parent WHERE key = 2400;
       </listitem>
      </varlistentry>
 
+     <varlistentry id="guc-plan-cache_mode" xreflabel="plan_cache_mode">
+      <term><varname>plan_cache_mode</varname> (<type>enum</type>)
+      <indexterm>
+       <primary><varname>plan_cache_mode</varname> configuration parameter</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+        Prepared statements (either explicitly prepared or implicitly
+        generated, for example in PL/pgSQL) can be executed using custom or
+        generic plans.  A custom plan is replanned for a new parameter value,
+        a generic plan is reused for repeated executions of the prepared
+        statement.  The choice between them is normally made automatically.
+        This setting overrides the default behavior and forces either a custom
+        or a generic plan.  This can be used to work around performance
+        problems in specific cases.  Note, however, that the plan cache
+        behavior is subject to change, so this setting, like all settings that
+        force the planner's hand, should be reevaluated regularly.
+       </para>
+
+       <para>
+        The allowed values are <literal>auto</literal>,
+        <literal>force_custom_plan</literal> and
+        <literal>force_generic_plan</literal>.  The default value is
+        <literal>auto</literal>.  The setting is applied when a cached plan is
+        to be executed, not when it is prepared.
+       </para>
+      </listitem>
+     </varlistentry>
+
      </variablelist>
     </sect2>
    </sect1>

--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -106,6 +106,8 @@ static void PlanCacheRelCallback(Datum arg, Oid relid);
 static void PlanCacheFuncCallback(Datum arg, int cacheid, uint32 hashvalue);
 static void PlanCacheSysCallback(Datum arg, int cacheid, uint32 hashvalue);
 
+/* GUC parameter */
+int	plan_cache_mode;
 
 /*
  * InitPlanCache: initialize module during InitPostgres.
@@ -1029,6 +1031,12 @@ choose_custom_plan(CachedPlanSource *plansource, ParamListInfo boundParams, Into
 	/* ... nor for transaction control statements */
 	if (IsTransactionStmtPlan(plansource))
 		return false;
+
+	/* Let settings force the decision */
+	if (plan_cache_mode == PLAN_CACHE_MODE_FORCE_GENERIC_PLAN)
+		return false;
+	if (plan_cache_mode == PLAN_CACHE_MODE_FORCE_CUSTOM_PLAN)
+		return true;
 
 	/* See if caller wants to force the decision */
 	if (plansource->cursor_options & CURSOR_OPT_GENERIC_PLAN)

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -406,6 +406,13 @@ static const struct config_enum_entry huge_pages_options[] = {
 	{NULL, 0, false}
 };
 
+static const struct config_enum_entry plan_cache_mode_options[] = {
+	{"auto", PLAN_CACHE_MODE_AUTO, false},
+	{"force_generic_plan", PLAN_CACHE_MODE_FORCE_GENERIC_PLAN, false},
+	{"force_custom_plan", PLAN_CACHE_MODE_FORCE_CUSTOM_PLAN, false},
+	{NULL, 0, false}
+};
+
 /*
  * Options for enum values stored in other modules
  */
@@ -3573,6 +3580,18 @@ static struct config_enum ConfigureNamesEnum[] =
 		},
 		&huge_pages,
 		HUGE_PAGES_TRY, huge_pages_options,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"plan_cache_mode", PGC_USERSET, QUERY_TUNING_OTHER,
+			gettext_noop("Controls the planner's selection of custom or generic plan."),
+			gettext_noop("Prepared statements can have custom and generic plans, and the planner "
+						 "will attempt to choose which is better.  This can be set to override "
+						 "the default behavior.")
+		},
+		&plan_cache_mode,
+		PLAN_CACHE_MODE_AUTO, plan_cache_mode_options,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -310,6 +310,7 @@ max_prepared_transactions = 250		# can be 0 or more
 #gp_segments_for_planner = 0     # if 0, actual number of segments is used
 
 #gp_enable_direct_dispatch = on
+#plan_cache_mode = auto
 
 optimizer_analyze_root_partition = on # stats collection on root partitions
 

--- a/src/include/utils/plancache.h
+++ b/src/include/utils/plancache.h
@@ -176,4 +176,15 @@ extern CachedPlan *GetCachedPlan(CachedPlanSource *plansource,
 			  IntoClause *intoClause);
 extern void ReleaseCachedPlan(CachedPlan *plan, bool useResOwner);
 
-#endif   /* PLANCACHE_H */
+/* possible values for plan_cache_mode */
+typedef enum
+{
+	PLAN_CACHE_MODE_AUTO,
+	PLAN_CACHE_MODE_FORCE_GENERIC_PLAN,
+	PLAN_CACHE_MODE_FORCE_CUSTOM_PLAN
+}			PlanCacheMode;
+
+/* GUC parameter */
+extern int plan_cache_mode;
+
+#endif							/* PLANCACHE_H */

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -423,6 +423,7 @@
 		"optimizer_use_gpdb_allocators",
 		"password_encryption",
 		"password_hash_algorithm",
+		"plan_cache_mode",
 		"pljava_classpath_insecure",
 		"pljava_debug",
 		"port",

--- a/src/test/regress/expected/plancache_optimizer.out
+++ b/src/test/regress/expected/plancache_optimizer.out
@@ -275,12 +275,11 @@ explain (costs off) execute test_mode_pp(2);
                         QUERY PLAN                        
 ----------------------------------------------------------
  Aggregate
-   ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Aggregate
-               ->  Index Only Scan using test_mode_a_idx on test_mode
-                     Index Cond: (a = 2)
- Optimizer: Postgres query optimizer
-(6 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Index Scan using test_mode_a_idx on test_mode
+               Index Cond: (a = 2)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+(5 rows)
 
 -- force generic plan
 set plan_cache_mode to force_generic_plan;
@@ -333,11 +332,10 @@ explain (costs off) execute test_mode_pp(2);
 -----------------------------
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Aggregate
-               ->  Seq Scan on test_mode
-                     Filter: (a = $1)
- Optimizer: Postgres query optimizer
-(6 rows)
+         ->  Index Scan using test_mode_a_idx on test_mode
+               Index Cond: (a = 2)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+(5 rows)
 
 -- but we can force a custom plan
 set plan_cache_mode to force_custom_plan;
@@ -345,11 +343,10 @@ explain (costs off) execute test_mode_pp(2);
                         QUERY PLAN                        
 ----------------------------------------------------------
  Aggregate
-   ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Aggregate
-               ->  Index Only Scan using test_mode_a_idx on test_mode
-                     Index Cond: (a = 2)
- Optimizer: Postgres query optimizer
-(6 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Index Scan using test_mode_a_idx on test_mode
+               Index Cond: (a = 2)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+(5 rows)
 
 drop table test_mode;

--- a/src/test/regress/sql/plancache.sql
+++ b/src/test/regress/sql/plancache.sql
@@ -162,3 +162,38 @@ end$$ language plpgsql;
 
 select cachebug();
 select cachebug();
+
+-- Test plan_cache_mode
+
+create table test_mode (a int);
+-- GPDB:setting the number of rows slightly higher to get a plan with
+-- Index Only Scan (similar to upstream)
+insert into test_mode select 1 from generate_series(1,15000) union all select 2;
+create index on test_mode (a);
+analyze test_mode;
+
+prepare test_mode_pp (int) as select count(*) from test_mode where a = $1;
+
+-- up to 5 executions, custom plan is used
+explain (costs off) execute test_mode_pp(2);
+
+-- force generic plan
+set plan_cache_mode to force_generic_plan;
+explain (costs off) execute test_mode_pp(2);
+
+-- get to generic plan by 5 executions
+set plan_cache_mode to auto;
+execute test_mode_pp(1); -- 1x
+execute test_mode_pp(1); -- 2x
+execute test_mode_pp(1); -- 3x
+execute test_mode_pp(1); -- 4x
+execute test_mode_pp(1); -- 5x
+
+-- we should now get a really bad plan
+explain (costs off) execute test_mode_pp(2);
+
+-- but we can force a custom plan
+set plan_cache_mode to force_custom_plan;
+explain (costs off) execute test_mode_pp(2);
+
+drop table test_mode;


### PR DESCRIPTION
This PR addresses github issue: https://github.com/greenplum-db/gpdb/issues/9671

Constant-folding of params passed in to PREPARE plans was ported from postgres, GPDB6 onwards. Now, when PREPARing the plan (by calling `plpy.prepare()`), GPDB tries to chooses a `custom plan` and constant folds the param. In [MADlib](https://github.com/apache/madlib), there are scenarios which involve passing in params to `plpy.prepare()` that can be as large as 600 MB. Due to the constant folding, these queries start to fail now. 
There is a GUC that was introduced in PG12([f7cb284](https://github.com/postgres/postgres/commit/f7cb2842bf47715133b40e4a503f35dbe60d1b72)), which allows user to control when to choose custom vs generic plan. This PR back-ports that commit to GPDB. 
GPDB master PR: https://github.com/greenplum-db/gpdb/pull/9675

## Here are some reminders before you submit the pull request
- [X] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [X] Pass `make installcheck`
- [ ] Review a PR in return to support the community
