### PR TITLE
Fix flatten logic expr in prefetch joinqual.

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1153,9 +1153,9 @@ flatten_logic_exprs(Node *node)
 	if (node == NULL)
 		return NIL;
 
-	if (IsA(node, BoolExpr))
+	if (IsA(node, BoolExprState))
 	{
-		BoolExpr *be = (BoolExpr *) node;
+		BoolExprState *be = (BoolExprState *) node;
 		return flatten_logic_exprs((Node *) (be->args));
 	}
 

--- a/src/test/regress/expected/deadlock2.out
+++ b/src/test/regress/expected/deadlock2.out
@@ -111,9 +111,21 @@ NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:700
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
 NOTICE:  prefetch join qual in slice 0 of plannode 3
-NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=25303)
-NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=25304)
-NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=25305)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=74425)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=74426)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=74427)
+ count 
+-------
+ 10000
+(1 row)
+
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+   and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
+   and not exists (select 1 from t_subplan where t_subplan.c2=t_outer.c1);
+NOTICE:  prefetch join qual in slice 0 of plannode 3
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=74425)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=74426)
+NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=74427)
  count 
 -------
  10000

--- a/src/test/regress/sql/deadlock2.sql
+++ b/src/test/regress/sql/deadlock2.sql
@@ -106,3 +106,7 @@ select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
 -- for details.
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
+
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+   and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
+   and not exists (select 1 from t_subplan where t_subplan.c2=t_outer.c1);


### PR DESCRIPTION
In executor, we should use BoolExprState instead
of BoolExpr.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
