### PR TITLE
Fix PANIC if prefetch inner or joinqual that contains outerParams-ref.

### DIFF
--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -435,6 +435,7 @@ extern void check_exclusion_constraint(Relation heap, Relation index,
 /* Share input utilities defined in execUtils.c */
 extern ShareNodeEntry * ExecGetShareNodeEntry(EState *estate, int shareid, bool fCreate);
 
+extern void fake_outer_params(JoinState *node);
 extern void ExecPrefetchJoinQual(JoinState *node);
 
 /* ResultRelInfo and Append Only segment assignment */

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3310,6 +3310,38 @@ select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
  1 | 1 | 2 | 2
 (1 row)
 
+-- The above plan will prefetch inner plan and the inner plan refers
+-- outerParams. Previously, we do not handle this case correct and forgot
+-- to set the Params for nestloop in econtext. The outer Param is a compound
+-- data type instead of simple integer, it will lead to PANIC.
+-- See Github Issue: https://github.com/greenplum-db/gpdb/issues/9679
+-- for details.
+create type mytype_prefetch_params as (x int, y int);
+alter table b add column mt_col mytype_prefetch_params;
+explain select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.19..765906.72 rows=24 width=16)
+   ->  Nested Loop  (cost=0.19..765906.26 rows=8 width=16)
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.05 rows=1 width=36)
+               ->  Seq Scan on b  (cost=0.00..1.01 rows=1 width=36)
+         ->  Materialize  (cost=0.19..255301.72 rows=2 width=12)
+               ->  Nested Loop  (cost=0.19..255301.70 rows=2 width=12)
+                     Join Filter: (((b.mt_col).x > a.i) OR (b.i = a.i))
+                     ->  Materialize  (cost=0.00..1.06 rows=1 width=4)
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.05 rows=1 width=4)
+                                 ->  Seq Scan on a  (cost=0.00..1.01 rows=1 width=4)
+                     ->  Index Only Scan using c_i_j_idx on c  (cost=0.19..85100.20 rows=1 width=8)
+                           Index Cond: (j = (a.i + b.i))
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
+ i | i | i | j 
+---+---+---+---
+ 1 | 1 | 2 | 2
+(1 row)
+
 reset enable_hashjoin;
 reset enable_mergejoin;
 reset enable_nestloop;

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3303,6 +3303,38 @@ select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
  1 | 1 | 2 | 2
 (1 row)
 
+-- The above plan will prefetch inner plan and the inner plan refers
+-- outerParams. Previously, we do not handle this case correct and forgot
+-- to set the Params for nestloop in econtext. The outer Param is a compound
+-- data type instead of simple integer, it will lead to PANIC.
+-- See Github Issue: https://github.com/greenplum-db/gpdb/issues/9679
+-- for details.
+create type mytype_prefetch_params as (x int, y int);
+alter table b add column mt_col mytype_prefetch_params;
+explain select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.19..765906.72 rows=24 width=16)
+   ->  Nested Loop  (cost=0.19..765906.26 rows=8 width=16)
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.05 rows=1 width=36)
+               ->  Seq Scan on b  (cost=0.00..1.01 rows=1 width=36)
+         ->  Materialize  (cost=0.19..255301.72 rows=2 width=12)
+               ->  Nested Loop  (cost=0.19..255301.70 rows=2 width=12)
+                     Join Filter: (((b.mt_col).x > a.i) OR (b.i = a.i))
+                     ->  Materialize  (cost=0.00..1.06 rows=1 width=4)
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.05 rows=1 width=4)
+                                 ->  Seq Scan on a  (cost=0.00..1.01 rows=1 width=4)
+                     ->  Index Only Scan using c_i_j_idx on c  (cost=0.19..85100.20 rows=1 width=8)
+                           Index Cond: (j = (a.i + b.i))
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
+ i | i | i | j 
+---+---+---+---
+ 1 | 1 | 2 | 2
+(1 row)
+
 reset enable_hashjoin;
 reset enable_mergejoin;
 reset enable_nestloop;


### PR DESCRIPTION
To avoid motion deadlock, Greenplum may decide to prefetch
joinqual or inner plan. However, for NestLoop join, inner
plan or joinqual may depend on outerParams. Previously, we
do not handle outerParams correct in prefetch logic and thus
may lead to PANIC. See Github Issue https://github.com/greenplum-db/gpdb/issues/9679
for Details.

This commit fixes this by faking the outertuple to a null tuple
and then build the params in econtext for NestLoop join's prefetch
logic.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
