### PR TITLE
Make sure ECONNRESET is correct on windows for gpfdist

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -48,10 +48,8 @@
 #include <io.h>
 #define SHUT_WR SD_SEND
 #define socklen_t int
-#ifndef ECONNRESET
+#undef ECONNRESET
 #define ECONNRESET   WSAECONNRESET
-#endif
-
 #endif
 
 #include <postgres.h>


### PR DESCRIPTION
ECONNRESET is defined as POSIX errno(108) in some windows build environment.
Then gpfdist doesn't redefine it. But that is incorrect value on windows.

So we make sure ECONNRESET is defined as WSAECONNRESET in gpfdist.
