### PR TITLE
Fix execution of functions with EXECUTE ON options in utility mode.

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -7588,6 +7588,13 @@ append_initplan_for_function_scan(PlannerInfo *root, Path *best_path, Plan *plan
 	RangeTblFunction	*rtfunc;
 	FuncExpr	*funcexpr;
 
+	/*
+	 * In utility mode (or when planning a local query in QE), ignore EXECUTE
+	 * ON markings and run the function the normal way.
+	 */
+	if (Gp_role != GP_ROLE_DISPATCH)
+		return;
+
 	/* Currently we limit function number to one */
 	if (list_length(fsplan->functions) != 1)
 		return;

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -106,6 +106,7 @@ query_planner(PlannerInfo *root, List *tlist,
 		root->canon_pathkeys = NIL;
 		(*qp_callback) (root, qp_extra);
 
+		if (Gp_role == GP_ROLE_DISPATCH)
 		{
 			char		exec_location;
 
@@ -117,6 +118,8 @@ query_planner(PlannerInfo *root, List *tlist,
 				CdbPathLocus_MakeStrewn(&result_path->locus,
 										getgpsegmentCount());
 		}
+		else
+			CdbPathLocus_MakeEntry(&result_path->locus);
 
 		return final_rel;
 	}

--- a/src/test/isolation2/expected/execute_on_utilitymode.out
+++ b/src/test/isolation2/expected/execute_on_utilitymode.out
@@ -1,0 +1,102 @@
+--
+-- Test using functions with EXECUTE ON options in utility mode.
+--
+
+-- First, create test functions with different EXECUTE ON options
+
+create function srf_on_master () returns setof text as $$ begin	/* in func */ return next 'foo ' || current_setting('gp_contentid');	/* in func */ return next 'bar ' || current_setting('gp_contentid');	/* in func */ end;	/* in func */ $$ language plpgsql EXECUTE ON MASTER;
+CREATE
+
+create function srf_on_all_segments () returns setof text as $$ begin	/* in func */ return next 'foo ' || current_setting('gp_contentid');	/* in func */ return next 'bar ' || current_setting('gp_contentid');	/* in func */ end;	/* in func */ $$ language plpgsql EXECUTE ON ALL SEGMENTS;
+CREATE
+
+create function srf_on_any () returns setof text as $$ begin	/* in func */ return next 'foo ' || current_setting('gp_contentid');	/* in func */ return next 'bar ' || current_setting('gp_contentid');	/* in func */ end;	/* in func */ $$ language plpgsql EXECUTE ON ANY IMMUTABLE;
+CREATE
+
+create function srf_on_initplan () returns setof text as $$ begin	/* in func */ return next 'foo ' || current_setting('gp_contentid');	/* in func */ return next 'bar ' || current_setting('gp_contentid');	/* in func */ end;	/* in func */ $$ language plpgsql EXECUTE ON INITPLAN;
+CREATE
+
+-- Now try executing them in utility mode, in the master node and on a
+-- segment. The expected behavior is that the function runs on the node
+-- we're connected to, ignoring the EXECUTE ON directives.
+--
+-- Join with a table, to give the planner something more exciting to do
+-- than just create the FunctionScan plan.
+create table fewrows (t text) distributed by (t);
+CREATE
+insert into fewrows select g from generate_series(1, 10) g;
+INSERT 10
+
+-1U: select * from srf_on_master()       as srf (x) left join fewrows on x = t;
+ x      | t 
+--------+---
+ foo -1 |   
+ bar -1 |   
+(2 rows)
+-1U: select * from srf_on_all_segments() as srf (x) left join fewrows on x = t;
+ x      | t 
+--------+---
+ foo -1 |   
+ bar -1 |   
+(2 rows)
+-1U: select * from srf_on_any()          as srf (x) left join fewrows on x = t;
+ x      | t 
+--------+---
+ foo -1 |   
+ bar -1 |   
+(2 rows)
+-1U: select * from srf_on_initplan()     as srf (x) left join fewrows on x = t;
+ x      | t 
+--------+---
+ foo -1 |   
+ bar -1 |   
+(2 rows)
+
+1U: select * from srf_on_master(),       fewrows;
+ srf_on_master | t 
+---------------+---
+ foo 1         | 2 
+ foo 1         | 3 
+ foo 1         | 4 
+ foo 1         | 7 
+ bar 1         | 2 
+ bar 1         | 3 
+ bar 1         | 4 
+ bar 1         | 7 
+(8 rows)
+1U: select * from srf_on_all_segments(), fewrows;
+ srf_on_all_segments | t 
+---------------------+---
+ foo 1               | 2 
+ foo 1               | 3 
+ foo 1               | 4 
+ foo 1               | 7 
+ bar 1               | 2 
+ bar 1               | 3 
+ bar 1               | 4 
+ bar 1               | 7 
+(8 rows)
+1U: select * from srf_on_any(),          fewrows;
+ srf_on_any | t 
+------------+---
+ foo 1      | 2 
+ foo 1      | 3 
+ foo 1      | 4 
+ foo 1      | 7 
+ bar 1      | 2 
+ bar 1      | 3 
+ bar 1      | 4 
+ bar 1      | 7 
+(8 rows)
+1U: select * from srf_on_initplan(),     fewrows;
+ srf_on_initplan | t 
+-----------------+---
+ foo 1           | 2 
+ foo 1           | 3 
+ foo 1           | 4 
+ foo 1           | 7 
+ bar 1           | 2 
+ bar 1           | 3 
+ bar 1           | 4 
+ bar 1           | 7 
+(8 rows)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -5,8 +5,7 @@ test: ao_partition_lock
 test: dml_on_root_locks_all_parts
 
 test: select_dropped_table
-# test update hash col under utility mode
-test: update_hash_col_utilitymode
+test: update_hash_col_utilitymode execute_on_utilitymode
 
 # Tests for crash recovery
 test: uao_crash_compaction_column

--- a/src/test/isolation2/sql/execute_on_utilitymode.sql
+++ b/src/test/isolation2/sql/execute_on_utilitymode.sql
@@ -1,0 +1,52 @@
+--
+-- Test using functions with EXECUTE ON options in utility mode.
+--
+
+-- First, create test functions with different EXECUTE ON options
+
+create function srf_on_master () returns setof text as $$
+begin	/* in func */
+  return next 'foo ' || current_setting('gp_contentid');	/* in func */
+  return next 'bar ' || current_setting('gp_contentid');	/* in func */
+end;	/* in func */
+$$ language plpgsql EXECUTE ON MASTER;
+
+create function srf_on_all_segments () returns setof text as $$
+begin	/* in func */
+  return next 'foo ' || current_setting('gp_contentid');	/* in func */
+  return next 'bar ' || current_setting('gp_contentid');	/* in func */
+end;	/* in func */
+$$ language plpgsql EXECUTE ON ALL SEGMENTS;
+
+create function srf_on_any () returns setof text as $$
+begin	/* in func */
+  return next 'foo ' || current_setting('gp_contentid');	/* in func */
+  return next 'bar ' || current_setting('gp_contentid');	/* in func */
+end;	/* in func */
+$$ language plpgsql EXECUTE ON ANY IMMUTABLE;
+
+create function srf_on_initplan () returns setof text as $$
+begin	/* in func */
+  return next 'foo ' || current_setting('gp_contentid');	/* in func */
+  return next 'bar ' || current_setting('gp_contentid');	/* in func */
+end;	/* in func */
+$$ language plpgsql EXECUTE ON INITPLAN;
+
+-- Now try executing them in utility mode, in the master node and on a
+-- segment. The expected behavior is that the function runs on the node
+-- we're connected to, ignoring the EXECUTE ON directives.
+--
+-- Join with a table, to give the planner something more exciting to do
+-- than just create the FunctionScan plan.
+create table fewrows (t text) distributed by (t);
+insert into fewrows select g from generate_series(1, 10) g;
+
+-1U: select * from srf_on_master()       as srf (x) left join fewrows on x = t;
+-1U: select * from srf_on_all_segments() as srf (x) left join fewrows on x = t;
+-1U: select * from srf_on_any()          as srf (x) left join fewrows on x = t;
+-1U: select * from srf_on_initplan()     as srf (x) left join fewrows on x = t;
+
+1U: select * from srf_on_master(),       fewrows;
+1U: select * from srf_on_all_segments(), fewrows;
+1U: select * from srf_on_any(),          fewrows;
+1U: select * from srf_on_initplan(),     fewrows;


### PR DESCRIPTION
It's not entirely clear what the behavior should be in utility mode.
With this commit, the EXECUTE ON options are effectively ignored in
utility mode, so the function is executed locally on the node you're
connected to. To achieve that, force Entry locus for the FunctionScan
path in the planner, when in utility mode. This is how other kinds
of scans are planned in utility mode, too.

Without this fix, the join queries added in the test case, with
EXECUTE ON SEGMENTS function, generated a plan with a Motion, even in
utility mode, which failed an assertion in the executor. EXECUTE ON
INITPLAN had similar issues, causing an error in the executor, when it
tried to open a non-existent tuplestore file.
