### PR TITLE
Improve Append plan when General children exist

### DIFF
--- a/src/test/regress/expected/qp_union_intersect.out
+++ b/src/test/regress/expected/qp_union_intersect.out
@@ -1720,15 +1720,17 @@ explain (costs off)
 select a from dml_union_r where a > 95
 union all
 select g from generate_series(1,2) g;
-                   QUERY PLAN                   
-------------------------------------------------
- Append
-   ->  Gather Motion 3:1  (slice1; segments: 3)
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
          ->  Seq Scan on dml_union_r
                Filter: (a > 95)
-   ->  Function Scan on generate_series g
+         ->  Result
+               One-Time Filter: (gp_execution_segment() = 0)
+               ->  Function Scan on generate_series g
  Optimizer: Postgres query optimizer
-(6 rows)
+(8 rows)
 
 select a from dml_union_r where a > 95
 union all
@@ -1743,6 +1745,118 @@ select g from generate_series(1,2) g;
    1
    2
 (7 rows)
+
+explain (costs off)
+select sum(a) from (
+    select a from dml_union_r where a > 95
+    union all
+    select g from generate_series(1,2) g
+) t;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Append
+                     ->  Seq Scan on dml_union_r
+                           Filter: (a > 95)
+                     ->  Result
+                           One-Time Filter: (gp_execution_segment() = 0)
+                           ->  Function Scan on generate_series g
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select sum(a) from (
+   select a from dml_union_r where a > 95
+   union all
+   select g from generate_series(1,2) g
+) t;
+ sum 
+-----
+ 493
+(1 row)
+
+--
+-- Continue to test appending General to distributed table.
+-- This time, the General is a dummy path, produced by pushing down condition.
+-- (Only for planner, orca does not create dummy path here)
+--
+create table t_test_append_hash(a int, b int, c int) distributed by (a);
+insert into t_test_append_hash select i, i+1, i+2 from generate_series(1, 5)i;
+explain (costs off)
+with t(a, b, s) as (
+    select a, b, sum(c) from t_test_append_hash where a > b group by a, b
+    union all
+    select a, b, sum(c) from t_test_append_hash where a < b group by a, b
+) select * from t where t.a < t.b;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Result
+               One-Time Filter: (gp_execution_segment() = 0)
+               ->  HashAggregate
+                     Group Key: a, b
+                     ->  Result
+                           One-Time Filter: false
+         ->  GroupAggregate
+               Group Key: t_test_append_hash.a, t_test_append_hash.b
+               ->  Sort
+                     Sort Key: t_test_append_hash.a, t_test_append_hash.b
+                     ->  Seq Scan on t_test_append_hash
+                           Filter: ((a < b) AND (a < b))
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+with t(a, b, s) as (
+    select a, b, sum(c) from t_test_append_hash where a > b group by a, b
+    union all
+    select a, b, sum(c) from t_test_append_hash where a < b group by a, b
+) select * from t where t.a < t.b;
+ a | b | s 
+---+---+---
+ 2 | 3 | 4
+ 3 | 4 | 5
+ 4 | 5 | 6
+ 1 | 2 | 3
+ 5 | 6 | 7
+(5 rows)
+
+-- Test mixing a SegmentGeneral with distributed table.
+create table t_test_append_rep(a int, b int, c int) distributed replicated;
+insert into t_test_append_rep select i, i+1, i+2 from generate_series(5, 10)i;
+explain (costs off)
+select * from t_test_append_rep
+union all
+select * from t_test_append_hash;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Result
+               One-Time Filter: (gp_execution_segment() = 0)
+               ->  Seq Scan on t_test_append_rep
+         ->  Seq Scan on t_test_append_hash
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from t_test_append_rep
+union all
+select * from t_test_append_hash;
+ a  | b  | c  
+----+----+----
+  5 |  6 |  7
+  1 |  2 |  3
+  5 |  6 |  7
+  6 |  7 |  8
+  7 |  8 |  9
+  8 |  9 | 10
+  9 | 10 | 11
+ 10 | 11 | 12
+  2 |  3 |  4
+  3 |  4 |  5
+  4 |  5 |  6
+(11 rows)
 
 --
 -- Test for creation of MergeAppend paths.

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -1764,6 +1764,117 @@ select g from generate_series(1,2) g;
   99
 (7 rows)
 
+explain (costs off)
+select sum(a) from (
+    select a from dml_union_r where a > 95
+    union all
+    select g from generate_series(1,2) g
+) t;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Append
+                     ->  Seq Scan on dml_union_r
+                           Filter: (a > 95)
+                     ->  Result
+                           One-Time Filter: (gp_execution_segment() = 2)
+                           ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+(10 rows)
+
+select sum(a) from (
+   select a from dml_union_r where a > 95
+   union all
+   select g from generate_series(1,2) g
+) t;
+ sum 
+-----
+ 493
+(1 row)
+
+--
+-- Continue to test appending General to distributed table.
+-- This time, the General is a dummy path, produced by pushing down condition.
+-- (Only for planner, orca does not create dummy path here)
+--
+create table t_test_append_hash(a int, b int, c int) distributed by (a);
+insert into t_test_append_hash select i, i+1, i+2 from generate_series(1, 5)i;
+explain (costs off)
+with t(a, b, s) as (
+    select a, b, sum(c) from t_test_append_hash where a > b group by a, b
+    union all
+    select a, b, sum(c) from t_test_append_hash where a < b group by a, b
+) select * from t where t.a < t.b;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  GroupAggregate
+               Group Key: t_test_append_hash.a, t_test_append_hash.b
+               ->  Sort
+                     Sort Key: t_test_append_hash.a, t_test_append_hash.b
+                     ->  Seq Scan on t_test_append_hash
+                           Filter: ((a > b) AND (a < b))
+         ->  GroupAggregate
+               Group Key: t_test_append_hash_1.a, t_test_append_hash_1.b
+               ->  Sort
+                     Sort Key: t_test_append_hash_1.a, t_test_append_hash_1.b
+                     ->  Seq Scan on t_test_append_hash t_test_append_hash_1
+                           Filter: ((a < b) AND (a < b))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+(15 rows)
+
+with t(a, b, s) as (
+    select a, b, sum(c) from t_test_append_hash where a > b group by a, b
+    union all
+    select a, b, sum(c) from t_test_append_hash where a < b group by a, b
+) select * from t where t.a < t.b;
+ a | b | s 
+---+---+---
+ 2 | 3 | 4
+ 3 | 4 | 5
+ 4 | 5 | 6
+ 5 | 6 | 7
+ 1 | 2 | 3
+(5 rows)
+
+-- Test mixing a SegmentGeneral with distributed table.
+create table t_test_append_rep(a int, b int, c int) distributed replicated;
+insert into t_test_append_rep select i, i+1, i+2 from generate_series(5, 10)i;
+explain (costs off)
+select * from t_test_append_rep
+union all
+select * from t_test_append_hash;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Append
+         ->  Seq Scan on t_test_append_rep
+         ->  Broadcast Motion 3:1  (slice2; segments: 3)
+               ->  Seq Scan on t_test_append_hash
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+(6 rows)
+
+select * from t_test_append_rep
+union all
+select * from t_test_append_hash;
+ a  | b  | c  
+----+----+----
+  5 |  6 |  7
+  6 |  7 |  8
+  7 |  8 |  9
+  8 |  9 | 10
+  9 | 10 | 11
+ 10 | 11 | 12
+  1 |  2 |  3
+  5 |  6 |  7
+  2 |  3 |  4
+  3 |  4 |  5
+  4 |  5 |  6
+(11 rows)
+
 --
 -- Test for creation of MergeAppend paths.
 --

--- a/src/test/regress/sql/qp_union_intersect.sql
+++ b/src/test/regress/sql/qp_union_intersect.sql
@@ -654,6 +654,53 @@ select a from dml_union_r where a > 95
 union all
 select g from generate_series(1,2) g;
 
+explain (costs off)
+select sum(a) from (
+    select a from dml_union_r where a > 95
+    union all
+    select g from generate_series(1,2) g
+) t;
+
+select sum(a) from (
+   select a from dml_union_r where a > 95
+   union all
+   select g from generate_series(1,2) g
+) t;
+
+--
+-- Continue to test appending General to distributed table.
+-- This time, the General is a dummy path, produced by pushing down condition.
+-- (Only for planner, orca does not create dummy path here)
+--
+create table t_test_append_hash(a int, b int, c int) distributed by (a);
+insert into t_test_append_hash select i, i+1, i+2 from generate_series(1, 5)i;
+
+explain (costs off)
+with t(a, b, s) as (
+    select a, b, sum(c) from t_test_append_hash where a > b group by a, b
+    union all
+    select a, b, sum(c) from t_test_append_hash where a < b group by a, b
+) select * from t where t.a < t.b;
+
+with t(a, b, s) as (
+    select a, b, sum(c) from t_test_append_hash where a > b group by a, b
+    union all
+    select a, b, sum(c) from t_test_append_hash where a < b group by a, b
+) select * from t where t.a < t.b;
+
+-- Test mixing a SegmentGeneral with distributed table.
+create table t_test_append_rep(a int, b int, c int) distributed replicated;
+insert into t_test_append_rep select i, i+1, i+2 from generate_series(5, 10)i;
+
+explain (costs off)
+select * from t_test_append_rep
+union all
+select * from t_test_append_hash;
+
+select * from t_test_append_rep
+union all
+select * from t_test_append_hash;
+
 --
 -- Test for creation of MergeAppend paths.
 --


### PR DESCRIPTION
When we append General and Partitioned children together, consider
General as Strewn (rather than SingleQE) to postpone gather motion.
Add a special projection path to General, so that only a single QE
will actually produce rows.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
