### PR TITLE
Avoid ADD COLUMN full table rewrite for AOCO child partitions

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -5932,8 +5932,8 @@ ATRewriteTables(AlterTableStmt *parsetree, List **wqueue, LOCKMODE lockmode)
 }
 
 /*
- * Scan an existing column for varblock headers, write one new segfile
- * each for new columns.  newvals is a list of NewColumnValue items.
+ * A helper for ATAocsWriteNewColumns(). It scans an existing column for
+ * varblock headers. Write one new segfile each for new columns.
  */
 static void
 ATAocsWriteSegFileNewColumns(
@@ -6093,9 +6093,6 @@ column_to_scan(AOCSFileSegInfo **segInfos, int nseg, int natts, Relation aocsrel
 	return scancol;
 }
 
-/*
- * ATAocsNoRewrite: Leverage column orientation to avoid rewrite.
- */
 static void
 ATAocsWriteNewColumns(AlteredTableInfo *tab)
 {

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6116,25 +6116,6 @@ ATAocsWriteNewColumns(AlteredTableInfo *tab)
 	Snapshot snapshot;
 	int addcols;
 
-	if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		/*
-		 * We remove the hash entry for this relation even though
-		 * there is no rewrite because we may have dropped some
-		 * segfiles that were in AOSEG_STATE_AWAITING_DROP state in
-		 * column_to_scan(). The cost of recreating the entry later on
-		 * is cheap so this should be fine. If we don't remove the
-		 * hash entry and we had done any segfile drops, master will
-		 * continue to see those segfiles as unavailable for use.
-		 *
-		 * Note that ALTER already took an exclusive lock on the
-		 * relation so we are guaranteed to not drop the hash
-		 * entry from under any concurrent operation.
-		 */
-		AORelRemoveHashEntry(tab->relid);
-		return;
-	}
-
 	snapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 
 	estate = CreateExecutorState();

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -7801,8 +7801,13 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 		colDef->is_local = false;
 	}
 
-	/* This must be a root partition */
-	if (!recursing)
+	/*
+	 * Leave a flag on tables in the partition hierarchy that can benefit from the
+	 * optimization for columnar tables.
+	 * We have to do it while processing the root partition because that's the
+	 * only level where the `ADD COLUMN` subcommands are populated.
+	 */
+	if (!recursing && tab->relkind == RELKIND_RELATION)
 	{
 		bool	aocs_write_new_columns_only;
 		/*

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -7827,7 +7827,8 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 			 * We have acquired lockmode on the root and first-level partitions
 			 * already. This leaves the deeper subpartitions unlocked, but no
 			 * operations can drop (or alter) those relations without locking
-			 * through the root
+			 * through the root. Note that find_all_inheritors() also includes
+			 * the root partition in the returned list.
 			 */
 			List *all_inheritors = find_all_inheritors(tab->relid, NoLock, NULL);
 			ListCell *lc;

--- a/src/include/commands/event_trigger.h
+++ b/src/include/commands/event_trigger.h
@@ -32,6 +32,7 @@ typedef struct EventTriggerData
 #define AT_REWRITE_DEFAULT_VAL			0x02
 #define AT_REWRITE_COLUMN_REWRITE		0x04
 #define AT_REWRITE_ALTER_OID			0x08
+#define AT_REWRITE_OPTIMIZE_AOCS		0x10 /* set if AOCS and only the AT_PASS_ADD_COL subcmd is populated */
 
 /*
  * EventTriggerData is the node type that is passed as fmgr "context" info

--- a/src/include/commands/event_trigger.h
+++ b/src/include/commands/event_trigger.h
@@ -32,7 +32,8 @@ typedef struct EventTriggerData
 #define AT_REWRITE_DEFAULT_VAL			0x02
 #define AT_REWRITE_COLUMN_REWRITE		0x04
 #define AT_REWRITE_ALTER_OID			0x08
-#define AT_REWRITE_OPTIMIZE_AOCS		0x10 /* set if AOCS and only the AT_PASS_ADD_COL subcmd is populated */
+/* set if AOCS and only the AT_PASS_ADD_COL subcmd is populated */
+#define AT_REWRITE_NEW_COLUMNS_ONLY_AOCS	0x10
 
 /*
  * EventTriggerData is the node type that is passed as fmgr "context" info

--- a/src/test/regress/expected/alter_table_aocs2.out
+++ b/src/test/regress/expected/alter_table_aocs2.out
@@ -775,7 +775,7 @@ insert into nonbulk_rle_tab values (-1,-5);
 ANALYZE nonbulk_rle_tab; -- To avoid NOTICE about missing stats with ORCA.
 update nonbulk_rle_tab set b = b + 3 where a = -1;
 -- ADD COLUMN for AOCO partition children should not trigger full table rewrite
-CREATE OR REPLACE FUNCTION compare_relfilenodes(table_relfilenode oid, tablename text)
+CREATE OR REPLACE FUNCTION compare_relfilenodes(table_relfilenode oid, tablename regclass)
 RETURNS TEXT AS
 $$
 DECLARE
@@ -785,11 +785,11 @@ BEGIN
 		   WHEN relfilenode = table_relfilenode THEN 'optimized rewrite occurred'
 		   ELSE 'full table rewrite occurred'
 		   END INTO result
-	FROM gp_dist_random('pg_class') WHERE gp_segment_id = 0 AND relname = tablename;
+	FROM gp_dist_random('pg_class') WHERE gp_segment_id = 0 AND oid = tablename;
 RETURN result;
 END;
 $$
-LANGUAGE 'plpgsql' IMMUTABLE;
+LANGUAGE 'plpgsql' STABLE;
 -- Scenario 1: Parent is AOCO, 1 child is AO, 1 child is heap. Heap and AO children require full table rewrite
 CREATE TABLE rewrite_optimization_aoco_parent(a int, b int, c int)
 WITH (APPENDONLY = true, ORIENTATION = column)

--- a/src/test/regress/expected/alter_table_aocs2.out
+++ b/src/test/regress/expected/alter_table_aocs2.out
@@ -923,3 +923,103 @@ SELECT compare_relfilenodes(:'relfilenode_child_aoco', 'rewrite_optimization_hea
  full table rewrite occurred
 (1 row)
 
+-- Parent is heap, child is heap, grandchild is AOCO.
+CREATE TABLE subpartition_aoco_leaf(a int, b int, c int)
+DISTRIBUTED BY (a)
+  PARTITION BY RANGE(b) SUBPARTITION BY RANGE(c) 
+      (PARTITION intermediate START (0) END (2)
+        (SUBPARTITION leaf START (0) END(2) WITH (APPENDONLY = true, ORIENTATION = column))
+      );
+NOTICE:  CREATE TABLE will create partition "subpartition_aoco_leaf_1_prt_intermediate" for table "subpartition_aoco_leaf"
+NOTICE:  CREATE TABLE will create partition "subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf" for table "subpartition_aoco_leaf_1_prt_intermediate"
+INSERT INTO subpartition_aoco_leaf SELECT i, i % 2, i % 2 FROM generate_series(1,10)i;
+SELECT relfilenode AS relfilenode_root
+FROM gp_dist_random('pg_class')
+WHERE gp_segment_id = 0 AND relname = 'subpartition_aoco_leaf' \gset
+SELECT relfilenode AS relfilenode_intermediate
+FROM gp_dist_random('pg_class')
+WHERE gp_segment_id = 0 AND relname = 'subpartition_aoco_leaf_1_prt_intermediate' \gset
+SELECT relfilenode AS relfilenode_leaf
+FROM gp_dist_random('pg_class')
+WHERE gp_segment_id = 0 AND relname = 'subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf' \gset
+-- Scenario 1: ADD COLUMN for AOCO subpartitioned table should not trigger full
+-- table rewrite. AOCO leaf only writes new column
+ALTER TABLE subpartition_aoco_leaf ADD COLUMN new_col int DEFAULT 1;
+SELECT * FROM subpartition_aoco_leaf;
+ a  | b | c | new_col 
+----+---+---+---------
+  1 | 1 | 1 |       1
+  5 | 1 | 1 |       1
+  6 | 0 | 0 |       1
+  9 | 1 | 1 |       1
+ 10 | 0 | 0 |       1
+  2 | 0 | 0 |       1
+  3 | 1 | 1 |       1
+  4 | 0 | 0 |       1
+  7 | 1 | 1 |       1
+  8 | 0 | 0 |       1
+(10 rows)
+
+SELECT compare_relfilenodes(:'relfilenode_root', 'subpartition_aoco_leaf');
+    compare_relfilenodes     
+-----------------------------
+ full table rewrite occurred
+(1 row)
+
+SELECT compare_relfilenodes(:'relfilenode_intermediate', 'subpartition_aoco_leaf_1_prt_intermediate');
+    compare_relfilenodes     
+-----------------------------
+ full table rewrite occurred
+(1 row)
+
+SELECT compare_relfilenodes(:'relfilenode_leaf', 'subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf');
+    compare_relfilenodes    
+----------------------------
+ optimized rewrite occurred
+(1 row)
+
+SELECT relfilenode AS relfilenode_root
+FROM gp_dist_random('pg_class')
+WHERE gp_segment_id = 0 AND relname = 'subpartition_aoco_leaf' \gset
+SELECT relfilenode AS relfilenode_intermediate
+FROM gp_dist_random('pg_class')
+WHERE gp_segment_id = 0 AND relname = 'subpartition_aoco_leaf_1_prt_intermediate' \gset
+SELECT relfilenode AS relfilenode_leaf
+FROM gp_dist_random('pg_class')
+WHERE gp_segment_id = 0 AND relname = 'subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf' \gset
+-- Scenario 2: mixing ADD COLUMN with ALTER COLUMN TYPE should trigger full
+-- table rewrite for every level
+ALTER TABLE subpartition_aoco_leaf ADD COLUMN new_col2 int DEFAULT 1, ALTER COLUMN new_col TYPE bigint;
+SELECT * FROM subpartition_aoco_leaf;
+ a  | b | c | new_col | new_col2 
+----+---+---+---------+----------
+  1 | 1 | 1 |       1 |        1
+  2 | 0 | 0 |       1 |        1
+  3 | 1 | 1 |       1 |        1
+  4 | 0 | 0 |       1 |        1
+  7 | 1 | 1 |       1 |        1
+  8 | 0 | 0 |       1 |        1
+  5 | 1 | 1 |       1 |        1
+  6 | 0 | 0 |       1 |        1
+  9 | 1 | 1 |       1 |        1
+ 10 | 0 | 0 |       1 |        1
+(10 rows)
+
+SELECT compare_relfilenodes(:'relfilenode_root', 'subpartition_aoco_leaf') AS heap_parent;
+         heap_parent         
+-----------------------------
+ full table rewrite occurred
+(1 row)
+
+SELECT compare_relfilenodes(:'relfilenode_intermediate', 'subpartition_aoco_leaf_1_prt_intermediate') AS ao_child;
+          ao_child           
+-----------------------------
+ full table rewrite occurred
+(1 row)
+
+SELECT compare_relfilenodes(:'relfilenode_leaf', 'subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf');
+    compare_relfilenodes     
+-----------------------------
+ full table rewrite occurred
+(1 row)
+

--- a/src/test/regress/expected/alter_table_aocs2.out
+++ b/src/test/regress/expected/alter_table_aocs2.out
@@ -795,21 +795,22 @@ DISTRIBUTED BY (a)
 NOTICE:  CREATE TABLE will create partition "rewrite_optimization_aoco_parent_1_prt_1" for table "rewrite_optimization_aoco_parent"
 NOTICE:  CREATE TABLE will create partition "rewrite_optimization_aoco_parent_1_prt_2" for table "rewrite_optimization_aoco_parent"
 SELECT $$
-SELECT -1 AS segno, oid::regclass AS rel, relfilenode
+SELECT -1 AS segno, oid::regclass AS rel, relfilenode, relstorage
 FROM pg_class
 WHERE oid IN (SELECT descendant FROM descendants_of(:'ROOT_PARTITION_UNDER_TEST'))
 UNION ALL
-SELECT gp_segment_id, oid::regclass, relfilenode
+SELECT gp_segment_id, oid::regclass, relfilenode, relstorage
 FROM gp_dist_random('pg_class')
 WHERE oid IN (SELECT descendant FROM descendants_of(:'ROOT_PARTITION_UNDER_TEST'))
 $$ AS qry \gset
 SELECT $$
 SELECT t.segno,
        t.rel,
+       t.relstorage,
        CASE
            WHEN table_relfilenode.segno IS NULL THEN 'full table rewritten'
            ELSE 'ADD COLUMN optimized for columnar table' END AS aoco_add_col_optimized
-FROM (:qry) t(segno, rel, relfilenode)
+FROM (:qry) t
          LEFT JOIN table_relfilenode USING (segno, rel, relfilenode)
 WHERE t.segno IN (-1, 0)
 ORDER BY 1, 2;
@@ -839,14 +840,14 @@ SELECT * FROM rewrite_optimization_aoco_parent;
 (10 rows)
 
 :chk_co_opt_qry;
- segno |                   rel                    |         aoco_add_col_optimized          
--------+------------------------------------------+-----------------------------------------
-    -1 | rewrite_optimization_aoco_parent         | ADD COLUMN optimized for columnar table
-    -1 | rewrite_optimization_aoco_parent_1_prt_1 | full table rewritten
-    -1 | rewrite_optimization_aoco_parent_1_prt_2 | full table rewritten
-     0 | rewrite_optimization_aoco_parent         | ADD COLUMN optimized for columnar table
-     0 | rewrite_optimization_aoco_parent_1_prt_1 | full table rewritten
-     0 | rewrite_optimization_aoco_parent_1_prt_2 | full table rewritten
+ segno |                   rel                    | relstorage |         aoco_add_col_optimized          
+-------+------------------------------------------+------------+-----------------------------------------
+    -1 | rewrite_optimization_aoco_parent         | c          | ADD COLUMN optimized for columnar table
+    -1 | rewrite_optimization_aoco_parent_1_prt_1 | a          | full table rewritten
+    -1 | rewrite_optimization_aoco_parent_1_prt_2 | h          | full table rewritten
+     0 | rewrite_optimization_aoco_parent         | c          | ADD COLUMN optimized for columnar table
+     0 | rewrite_optimization_aoco_parent_1_prt_1 | a          | full table rewritten
+     0 | rewrite_optimization_aoco_parent_1_prt_2 | h          | full table rewritten
 (6 rows)
 
 -- ADD COLUMN for AOCO partition children should not trigger full table rewrite
@@ -883,14 +884,14 @@ SELECT * FROM rewrite_optimization_heap_parent;
 (10 rows)
 
 :chk_co_opt_qry;
- segno |                   rel                    |         aoco_add_col_optimized          
--------+------------------------------------------+-----------------------------------------
-    -1 | rewrite_optimization_heap_parent         | full table rewritten
-    -1 | rewrite_optimization_heap_parent_1_prt_1 | full table rewritten
-    -1 | rewrite_optimization_heap_parent_1_prt_2 | ADD COLUMN optimized for columnar table
-     0 | rewrite_optimization_heap_parent         | full table rewritten
-     0 | rewrite_optimization_heap_parent_1_prt_1 | full table rewritten
-     0 | rewrite_optimization_heap_parent_1_prt_2 | ADD COLUMN optimized for columnar table
+ segno |                   rel                    | relstorage |         aoco_add_col_optimized          
+-------+------------------------------------------+------------+-----------------------------------------
+    -1 | rewrite_optimization_heap_parent         | h          | full table rewritten
+    -1 | rewrite_optimization_heap_parent_1_prt_1 | a          | full table rewritten
+    -1 | rewrite_optimization_heap_parent_1_prt_2 | c          | ADD COLUMN optimized for columnar table
+     0 | rewrite_optimization_heap_parent         | h          | full table rewritten
+     0 | rewrite_optimization_heap_parent_1_prt_1 | a          | full table rewritten
+     0 | rewrite_optimization_heap_parent_1_prt_2 | c          | ADD COLUMN optimized for columnar table
 (6 rows)
 
 REFRESH MATERIALIZED VIEW table_relfilenode;
@@ -911,14 +912,14 @@ SELECT * FROM rewrite_optimization_heap_parent;
 (10 rows)
 
 :chk_co_opt_qry;
- segno |                   rel                    | aoco_add_col_optimized 
--------+------------------------------------------+------------------------
-    -1 | rewrite_optimization_heap_parent         | full table rewritten
-    -1 | rewrite_optimization_heap_parent_1_prt_1 | full table rewritten
-    -1 | rewrite_optimization_heap_parent_1_prt_2 | full table rewritten
-     0 | rewrite_optimization_heap_parent         | full table rewritten
-     0 | rewrite_optimization_heap_parent_1_prt_1 | full table rewritten
-     0 | rewrite_optimization_heap_parent_1_prt_2 | full table rewritten
+ segno |                   rel                    | relstorage | aoco_add_col_optimized 
+-------+------------------------------------------+------------+------------------------
+    -1 | rewrite_optimization_heap_parent         | h          | full table rewritten
+    -1 | rewrite_optimization_heap_parent_1_prt_1 | a          | full table rewritten
+    -1 | rewrite_optimization_heap_parent_1_prt_2 | c          | full table rewritten
+     0 | rewrite_optimization_heap_parent         | h          | full table rewritten
+     0 | rewrite_optimization_heap_parent_1_prt_1 | a          | full table rewritten
+     0 | rewrite_optimization_heap_parent_1_prt_2 | c          | full table rewritten
 (6 rows)
 
 -- Parent is heap, child is heap, grandchild is AOCO.
@@ -958,14 +959,14 @@ SELECT * FROM subpartition_aoco_leaf;
 (10 rows)
 
 :chk_co_opt_qry;
- segno |                         rel                          |         aoco_add_col_optimized          
--------+------------------------------------------------------+-----------------------------------------
-    -1 | subpartition_aoco_leaf                               | full table rewritten
-    -1 | subpartition_aoco_leaf_1_prt_intermediate            | full table rewritten
-    -1 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | ADD COLUMN optimized for columnar table
-     0 | subpartition_aoco_leaf                               | full table rewritten
-     0 | subpartition_aoco_leaf_1_prt_intermediate            | full table rewritten
-     0 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | ADD COLUMN optimized for columnar table
+ segno |                         rel                          | relstorage |         aoco_add_col_optimized          
+-------+------------------------------------------------------+------------+-----------------------------------------
+    -1 | subpartition_aoco_leaf                               | h          | full table rewritten
+    -1 | subpartition_aoco_leaf_1_prt_intermediate            | h          | full table rewritten
+    -1 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | c          | ADD COLUMN optimized for columnar table
+     0 | subpartition_aoco_leaf                               | h          | full table rewritten
+     0 | subpartition_aoco_leaf_1_prt_intermediate            | h          | full table rewritten
+     0 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | c          | ADD COLUMN optimized for columnar table
 (6 rows)
 
 REFRESH MATERIALIZED VIEW table_relfilenode;
@@ -988,13 +989,13 @@ SELECT * FROM subpartition_aoco_leaf;
 (10 rows)
 
 :chk_co_opt_qry;
- segno |                         rel                          | aoco_add_col_optimized 
--------+------------------------------------------------------+------------------------
-    -1 | subpartition_aoco_leaf                               | full table rewritten
-    -1 | subpartition_aoco_leaf_1_prt_intermediate            | full table rewritten
-    -1 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | full table rewritten
-     0 | subpartition_aoco_leaf                               | full table rewritten
-     0 | subpartition_aoco_leaf_1_prt_intermediate            | full table rewritten
-     0 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | full table rewritten
+ segno |                         rel                          | relstorage | aoco_add_col_optimized 
+-------+------------------------------------------------------+------------+------------------------
+    -1 | subpartition_aoco_leaf                               | h          | full table rewritten
+    -1 | subpartition_aoco_leaf_1_prt_intermediate            | h          | full table rewritten
+    -1 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | c          | full table rewritten
+     0 | subpartition_aoco_leaf                               | h          | full table rewritten
+     0 | subpartition_aoco_leaf_1_prt_intermediate            | h          | full table rewritten
+     0 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | c          | full table rewritten
 (6 rows)
 

--- a/src/test/regress/expected/alter_table_aocs2.out
+++ b/src/test/regress/expected/alter_table_aocs2.out
@@ -774,3 +774,152 @@ alter table nonbulk_rle_tab add column b int default round(random()*100);
 insert into nonbulk_rle_tab values (-1,-5);
 ANALYZE nonbulk_rle_tab; -- To avoid NOTICE about missing stats with ORCA.
 update nonbulk_rle_tab set b = b + 3 where a = -1;
+-- ADD COLUMN for AOCO partition children should not trigger full table rewrite
+CREATE OR REPLACE FUNCTION compare_relfilenodes(table_relfilenode oid, tablename text)
+RETURNS TEXT AS
+$$
+DECLARE
+	result text;
+BEGIN
+	SELECT CASE
+		   WHEN relfilenode = table_relfilenode THEN 'optimized rewrite occurred'
+		   ELSE 'full table rewrite occurred'
+		   END INTO result
+	FROM gp_dist_random('pg_class') WHERE gp_segment_id = 0 AND relname = tablename;
+RETURN result;
+END;
+$$
+LANGUAGE 'plpgsql' IMMUTABLE;
+-- Scenario 1: Parent is AOCO, 1 child is AO, 1 child is heap. Heap and AO children require full table rewrite
+CREATE TABLE rewrite_optimization_aoco_parent(a int, b int, c int)
+WITH (APPENDONLY = true, ORIENTATION = column)
+DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (START (0) END (1) EVERY (1) WITH (APPENDONLY = true),
+        START (1) END (2) EVERY (1) WITH (APPENDONLY = false));
+NOTICE:  CREATE TABLE will create partition "rewrite_optimization_aoco_parent_1_prt_1" for table "rewrite_optimization_aoco_parent"
+NOTICE:  CREATE TABLE will create partition "rewrite_optimization_aoco_parent_1_prt_2" for table "rewrite_optimization_aoco_parent"
+INSERT INTO rewrite_optimization_aoco_parent SELECT i, i % 2, i FROM generate_series(1,10)i;
+SELECT relfilenode AS relfilenode_parent_aoco FROM gp_dist_random('pg_class') where gp_segment_id = 0 and relname = 'rewrite_optimization_aoco_parent'
+\gset
+SELECT relfilenode AS relfilenode_child_ao FROM gp_dist_random('pg_class') where gp_segment_id = 0 and relname = 'rewrite_optimization_aoco_parent_1_prt_1'
+\gset
+SELECT relfilenode AS relfilenode_child_heap FROM gp_dist_random('pg_class') where gp_segment_id = 0 and relname = 'rewrite_optimization_aoco_parent_1_prt_2'
+\gset
+ALTER TABLE rewrite_optimization_aoco_parent ADD COLUMN new_col int DEFAULT 1;
+SELECT * FROM rewrite_optimization_aoco_parent;
+ a  | b | c  | new_col 
+----+---+----+---------
+  1 | 1 |  1 |       1
+  6 | 0 |  6 |       1
+ 10 | 0 | 10 |       1
+  5 | 1 |  5 |       1
+  9 | 1 |  9 |       1
+  2 | 0 |  2 |       1
+  4 | 0 |  4 |       1
+  8 | 0 |  8 |       1
+  3 | 1 |  3 |       1
+  7 | 1 |  7 |       1
+(10 rows)
+
+SELECT compare_relfilenodes(:'relfilenode_parent_aoco', 'rewrite_optimization_aoco_parent') AS aoco_parent;
+        aoco_parent         
+----------------------------
+ optimized rewrite occurred
+(1 row)
+
+SELECT compare_relfilenodes(:'relfilenode_child_ao', 'rewrite_optimization_aoco_parent_1_prt_1') AS ao_child;
+          ao_child           
+-----------------------------
+ full table rewrite occurred
+(1 row)
+
+SELECT compare_relfilenodes(:'relfilenode_child_heap', 'rewrite_optimization_aoco_parent_1_prt_2') AS heap_child;
+         heap_child          
+-----------------------------
+ full table rewrite occurred
+(1 row)
+
+-- ADD COLUMN for AOCO partition children should not trigger full table rewrite
+-- Scenario 2: Parent is heap, 1 child is AO, 1 child is AOCO. AO child requires full table rewrite. AOCO child does not.
+CREATE TABLE rewrite_optimization_heap_parent(a int, b int, c int) DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (START (0) END (1) EVERY (1) WITH (APPENDONLY = true),
+        START (1) END (2) EVERY (1) WITH (APPENDONLY = true, ORIENTATION = column));
+NOTICE:  CREATE TABLE will create partition "rewrite_optimization_heap_parent_1_prt_1" for table "rewrite_optimization_heap_parent"
+NOTICE:  CREATE TABLE will create partition "rewrite_optimization_heap_parent_1_prt_2" for table "rewrite_optimization_heap_parent"
+INSERT INTO rewrite_optimization_heap_parent SELECT i, i % 2, i FROM generate_series(1,10)i;
+SELECT relfilenode AS relfilenode_parent_heap FROM gp_dist_random('pg_class') where gp_segment_id = 0 and relname = 'rewrite_optimization_heap_parent'
+\gset
+SELECT relfilenode AS relfilenode_child_ao FROM gp_dist_random('pg_class') where gp_segment_id = 0 and relname = 'rewrite_optimization_heap_parent_1_prt_1'
+\gset
+SELECT relfilenode AS relfilenode_child_aoco FROM gp_dist_random('pg_class') where gp_segment_id = 0 and relname = 'rewrite_optimization_heap_parent_1_prt_2'
+\gset
+ALTER TABLE rewrite_optimization_heap_parent ADD COLUMN new_col int DEFAULT 1;
+SELECT * FROM rewrite_optimization_heap_parent;
+ a  | b | c  | new_col 
+----+---+----+---------
+  6 | 0 |  6 |       1
+ 10 | 0 | 10 |       1
+  5 | 1 |  5 |       1
+  9 | 1 |  9 |       1
+  2 | 0 |  2 |       1
+  4 | 0 |  4 |       1
+  8 | 0 |  8 |       1
+  3 | 1 |  3 |       1
+  7 | 1 |  7 |       1
+  1 | 1 |  1 |       1
+(10 rows)
+
+SELECT compare_relfilenodes(:'relfilenode_parent_heap', 'rewrite_optimization_heap_parent') AS heap_parent;
+         heap_parent         
+-----------------------------
+ full table rewrite occurred
+(1 row)
+
+SELECT compare_relfilenodes(:'relfilenode_child_ao', 'rewrite_optimization_heap_parent_1_prt_1') AS ao_child;
+          ao_child           
+-----------------------------
+ full table rewrite occurred
+(1 row)
+
+SELECT compare_relfilenodes(:'relfilenode_child_aoco', 'rewrite_optimization_heap_parent_1_prt_2') AS aoco_child;
+         aoco_child         
+----------------------------
+ optimized rewrite occurred
+(1 row)
+
+ALTER TABLE rewrite_optimization_heap_parent ADD COLUMN new_col2 int DEFAULT 1, ALTER COLUMN c TYPE bigint;
+SELECT * FROM rewrite_optimization_heap_parent;
+ a  | b | c  | new_col | new_col2 
+----+---+----+---------+----------
+  1 | 1 |  1 |       1 |        1
+  6 | 0 |  6 |       1 |        1
+ 10 | 0 | 10 |       1 |        1
+  5 | 1 |  5 |       1 |        1
+  9 | 1 |  9 |       1 |        1
+  2 | 0 |  2 |       1 |        1
+  4 | 0 |  4 |       1 |        1
+  8 | 0 |  8 |       1 |        1
+  3 | 1 |  3 |       1 |        1
+  7 | 1 |  7 |       1 |        1
+(10 rows)
+
+SELECT compare_relfilenodes(:'relfilenode_parent_heap', 'rewrite_optimization_heap_parent') AS heap_parent;
+         heap_parent         
+-----------------------------
+ full table rewrite occurred
+(1 row)
+
+SELECT compare_relfilenodes(:'relfilenode_child_ao', 'rewrite_optimization_heap_parent_1_prt_1') AS ao_child;
+          ao_child           
+-----------------------------
+ full table rewrite occurred
+(1 row)
+
+SELECT compare_relfilenodes(:'relfilenode_child_aoco', 'rewrite_optimization_heap_parent_1_prt_2') AS aoco_child;
+         aoco_child          
+-----------------------------
+ full table rewrite occurred
+(1 row)
+

--- a/src/test/regress/expected/alter_table_aocs2.out
+++ b/src/test/regress/expected/alter_table_aocs2.out
@@ -774,22 +774,6 @@ alter table nonbulk_rle_tab add column b int default round(random()*100);
 insert into nonbulk_rle_tab values (-1,-5);
 ANALYZE nonbulk_rle_tab; -- To avoid NOTICE about missing stats with ORCA.
 update nonbulk_rle_tab set b = b + 3 where a = -1;
--- ADD COLUMN for AOCO partition children should not trigger full table rewrite
-CREATE OR REPLACE FUNCTION compare_relfilenodes(table_relfilenode oid, tablename regclass)
-RETURNS TEXT AS
-$$
-DECLARE
-	result text;
-BEGIN
-	SELECT CASE
-		   WHEN relfilenode = table_relfilenode THEN 'optimized rewrite occurred'
-		   ELSE 'full table rewrite occurred'
-		   END INTO result
-	FROM gp_dist_random('pg_class') WHERE gp_segment_id = 0 AND oid = tablename;
-RETURN result;
-END;
-$$
-LANGUAGE 'plpgsql' STABLE;
 CREATE FUNCTION descendants_of(rel regclass) RETURNS TABLE(descendant regclass)
 SET gp_recursive_cte=ON
 LANGUAGE SQL STABLE AS $fn$

--- a/src/test/regress/expected/alter_table_aocs2.out
+++ b/src/test/regress/expected/alter_table_aocs2.out
@@ -790,6 +790,17 @@ RETURN result;
 END;
 $$
 LANGUAGE 'plpgsql' STABLE;
+CREATE FUNCTION descendants_of(rel regclass) RETURNS TABLE(descendant regclass)
+SET gp_recursive_cte=ON
+LANGUAGE SQL STABLE AS $fn$
+WITH RECURSIVE w AS (
+  SELECT rel AS descendant
+  UNION ALL
+  SELECT inhrelid
+  FROM pg_inherits JOIN w ON inhparent = descendant
+)
+SELECT * FROM w;
+$fn$;
 -- Scenario 1: Parent is AOCO, 1 child is AO, 1 child is heap. Heap and AO children require full table rewrite
 CREATE TABLE rewrite_optimization_aoco_parent(a int, b int, c int)
 WITH (APPENDONLY = true, ORIENTATION = column)
@@ -799,13 +810,34 @@ DISTRIBUTED BY (a)
         START (1) END (2) EVERY (1) WITH (APPENDONLY = false));
 NOTICE:  CREATE TABLE will create partition "rewrite_optimization_aoco_parent_1_prt_1" for table "rewrite_optimization_aoco_parent"
 NOTICE:  CREATE TABLE will create partition "rewrite_optimization_aoco_parent_1_prt_2" for table "rewrite_optimization_aoco_parent"
+SELECT $$
+SELECT -1 AS segno, oid::regclass AS rel, relfilenode
+FROM pg_class
+WHERE oid IN (SELECT descendant FROM descendants_of(:'ROOT_PARTITION_UNDER_TEST'))
+UNION ALL
+SELECT gp_segment_id, oid::regclass, relfilenode
+FROM gp_dist_random('pg_class')
+WHERE oid IN (SELECT descendant FROM descendants_of(:'ROOT_PARTITION_UNDER_TEST'))
+$$ AS qry \gset
+SELECT $$
+SELECT t.segno,
+       t.rel,
+       CASE
+           WHEN table_relfilenode.segno IS NULL THEN 'full table rewritten'
+           ELSE 'ADD COLUMN optimized for columnar table' END AS aoco_add_col_optimized
+FROM (:qry) t(segno, rel, relfilenode)
+         LEFT JOIN table_relfilenode USING (segno, rel, relfilenode)
+WHERE t.segno IN (-1, 0)
+ORDER BY 1, 2;
+$$ AS chk_co_opt_qry \gset
+\set ROOT_PARTITION_UNDER_TEST rewrite_optimization_aoco_parent
+CREATE MATERIALIZED VIEW table_relfilenode (segno, rel, relfilenode)
+AS
+:qry
+;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segno' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO rewrite_optimization_aoco_parent SELECT i, i % 2, i FROM generate_series(1,10)i;
-SELECT relfilenode AS relfilenode_parent_aoco FROM gp_dist_random('pg_class') where gp_segment_id = 0 and relname = 'rewrite_optimization_aoco_parent'
-\gset
-SELECT relfilenode AS relfilenode_child_ao FROM gp_dist_random('pg_class') where gp_segment_id = 0 and relname = 'rewrite_optimization_aoco_parent_1_prt_1'
-\gset
-SELECT relfilenode AS relfilenode_child_heap FROM gp_dist_random('pg_class') where gp_segment_id = 0 and relname = 'rewrite_optimization_aoco_parent_1_prt_2'
-\gset
 ALTER TABLE rewrite_optimization_aoco_parent ADD COLUMN new_col int DEFAULT 1;
 SELECT * FROM rewrite_optimization_aoco_parent;
  a  | b | c  | new_col 
@@ -822,23 +854,16 @@ SELECT * FROM rewrite_optimization_aoco_parent;
   7 | 1 |  7 |       1
 (10 rows)
 
-SELECT compare_relfilenodes(:'relfilenode_parent_aoco', 'rewrite_optimization_aoco_parent') AS aoco_parent;
-        aoco_parent         
-----------------------------
- optimized rewrite occurred
-(1 row)
-
-SELECT compare_relfilenodes(:'relfilenode_child_ao', 'rewrite_optimization_aoco_parent_1_prt_1') AS ao_child;
-          ao_child           
------------------------------
- full table rewrite occurred
-(1 row)
-
-SELECT compare_relfilenodes(:'relfilenode_child_heap', 'rewrite_optimization_aoco_parent_1_prt_2') AS heap_child;
-         heap_child          
------------------------------
- full table rewrite occurred
-(1 row)
+:chk_co_opt_qry;
+ segno |                   rel                    |         aoco_add_col_optimized          
+-------+------------------------------------------+-----------------------------------------
+    -1 | rewrite_optimization_aoco_parent         | ADD COLUMN optimized for columnar table
+    -1 | rewrite_optimization_aoco_parent_1_prt_1 | full table rewritten
+    -1 | rewrite_optimization_aoco_parent_1_prt_2 | full table rewritten
+     0 | rewrite_optimization_aoco_parent         | ADD COLUMN optimized for columnar table
+     0 | rewrite_optimization_aoco_parent_1_prt_1 | full table rewritten
+     0 | rewrite_optimization_aoco_parent_1_prt_2 | full table rewritten
+(6 rows)
 
 -- ADD COLUMN for AOCO partition children should not trigger full table rewrite
 -- Scenario 2: Parent is heap, 1 child is AO, 1 child is AOCO. AO child requires full table rewrite. AOCO child does not.
@@ -848,13 +873,15 @@ CREATE TABLE rewrite_optimization_heap_parent(a int, b int, c int) DISTRIBUTED B
         START (1) END (2) EVERY (1) WITH (APPENDONLY = true, ORIENTATION = column));
 NOTICE:  CREATE TABLE will create partition "rewrite_optimization_heap_parent_1_prt_1" for table "rewrite_optimization_heap_parent"
 NOTICE:  CREATE TABLE will create partition "rewrite_optimization_heap_parent_1_prt_2" for table "rewrite_optimization_heap_parent"
+\set ROOT_PARTITION_UNDER_TEST rewrite_optimization_heap_parent
+DROP MATERIALIZED VIEW table_relfilenode;
+CREATE MATERIALIZED VIEW table_relfilenode (segno, rel, relfilenode)
+AS
+:qry
+;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segno' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO rewrite_optimization_heap_parent SELECT i, i % 2, i FROM generate_series(1,10)i;
-SELECT relfilenode AS relfilenode_parent_heap FROM gp_dist_random('pg_class') where gp_segment_id = 0 and relname = 'rewrite_optimization_heap_parent'
-\gset
-SELECT relfilenode AS relfilenode_child_ao FROM gp_dist_random('pg_class') where gp_segment_id = 0 and relname = 'rewrite_optimization_heap_parent_1_prt_1'
-\gset
-SELECT relfilenode AS relfilenode_child_aoco FROM gp_dist_random('pg_class') where gp_segment_id = 0 and relname = 'rewrite_optimization_heap_parent_1_prt_2'
-\gset
 ALTER TABLE rewrite_optimization_heap_parent ADD COLUMN new_col int DEFAULT 1;
 SELECT * FROM rewrite_optimization_heap_parent;
  a  | b | c  | new_col 
@@ -871,24 +898,18 @@ SELECT * FROM rewrite_optimization_heap_parent;
   1 | 1 |  1 |       1
 (10 rows)
 
-SELECT compare_relfilenodes(:'relfilenode_parent_heap', 'rewrite_optimization_heap_parent') AS heap_parent;
-         heap_parent         
------------------------------
- full table rewrite occurred
-(1 row)
+:chk_co_opt_qry;
+ segno |                   rel                    |         aoco_add_col_optimized          
+-------+------------------------------------------+-----------------------------------------
+    -1 | rewrite_optimization_heap_parent         | full table rewritten
+    -1 | rewrite_optimization_heap_parent_1_prt_1 | full table rewritten
+    -1 | rewrite_optimization_heap_parent_1_prt_2 | ADD COLUMN optimized for columnar table
+     0 | rewrite_optimization_heap_parent         | full table rewritten
+     0 | rewrite_optimization_heap_parent_1_prt_1 | full table rewritten
+     0 | rewrite_optimization_heap_parent_1_prt_2 | ADD COLUMN optimized for columnar table
+(6 rows)
 
-SELECT compare_relfilenodes(:'relfilenode_child_ao', 'rewrite_optimization_heap_parent_1_prt_1') AS ao_child;
-          ao_child           
------------------------------
- full table rewrite occurred
-(1 row)
-
-SELECT compare_relfilenodes(:'relfilenode_child_aoco', 'rewrite_optimization_heap_parent_1_prt_2') AS aoco_child;
-         aoco_child         
-----------------------------
- optimized rewrite occurred
-(1 row)
-
+REFRESH MATERIALIZED VIEW table_relfilenode;
 ALTER TABLE rewrite_optimization_heap_parent ADD COLUMN new_col2 int DEFAULT 1, ALTER COLUMN c TYPE bigint;
 SELECT * FROM rewrite_optimization_heap_parent;
  a  | b | c  | new_col | new_col2 
@@ -905,23 +926,16 @@ SELECT * FROM rewrite_optimization_heap_parent;
   7 | 1 |  7 |       1 |        1
 (10 rows)
 
-SELECT compare_relfilenodes(:'relfilenode_parent_heap', 'rewrite_optimization_heap_parent') AS heap_parent;
-         heap_parent         
------------------------------
- full table rewrite occurred
-(1 row)
-
-SELECT compare_relfilenodes(:'relfilenode_child_ao', 'rewrite_optimization_heap_parent_1_prt_1') AS ao_child;
-          ao_child           
------------------------------
- full table rewrite occurred
-(1 row)
-
-SELECT compare_relfilenodes(:'relfilenode_child_aoco', 'rewrite_optimization_heap_parent_1_prt_2') AS aoco_child;
-         aoco_child          
------------------------------
- full table rewrite occurred
-(1 row)
+:chk_co_opt_qry;
+ segno |                   rel                    | aoco_add_col_optimized 
+-------+------------------------------------------+------------------------
+    -1 | rewrite_optimization_heap_parent         | full table rewritten
+    -1 | rewrite_optimization_heap_parent_1_prt_1 | full table rewritten
+    -1 | rewrite_optimization_heap_parent_1_prt_2 | full table rewritten
+     0 | rewrite_optimization_heap_parent         | full table rewritten
+     0 | rewrite_optimization_heap_parent_1_prt_1 | full table rewritten
+     0 | rewrite_optimization_heap_parent_1_prt_2 | full table rewritten
+(6 rows)
 
 -- Parent is heap, child is heap, grandchild is AOCO.
 CREATE TABLE subpartition_aoco_leaf(a int, b int, c int)
@@ -933,15 +947,14 @@ DISTRIBUTED BY (a)
 NOTICE:  CREATE TABLE will create partition "subpartition_aoco_leaf_1_prt_intermediate" for table "subpartition_aoco_leaf"
 NOTICE:  CREATE TABLE will create partition "subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf" for table "subpartition_aoco_leaf_1_prt_intermediate"
 INSERT INTO subpartition_aoco_leaf SELECT i, i % 2, i % 2 FROM generate_series(1,10)i;
-SELECT relfilenode AS relfilenode_root
-FROM gp_dist_random('pg_class')
-WHERE gp_segment_id = 0 AND relname = 'subpartition_aoco_leaf' \gset
-SELECT relfilenode AS relfilenode_intermediate
-FROM gp_dist_random('pg_class')
-WHERE gp_segment_id = 0 AND relname = 'subpartition_aoco_leaf_1_prt_intermediate' \gset
-SELECT relfilenode AS relfilenode_leaf
-FROM gp_dist_random('pg_class')
-WHERE gp_segment_id = 0 AND relname = 'subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf' \gset
+\set ROOT_PARTITION_UNDER_TEST subpartition_aoco_leaf
+DROP MATERIALIZED VIEW table_relfilenode;
+CREATE MATERIALIZED VIEW table_relfilenode (segno, rel, relfilenode)
+AS
+:qry
+;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segno' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- Scenario 1: ADD COLUMN for AOCO subpartitioned table should not trigger full
 -- table rewrite. AOCO leaf only writes new column
 ALTER TABLE subpartition_aoco_leaf ADD COLUMN new_col int DEFAULT 1;
@@ -960,33 +973,18 @@ SELECT * FROM subpartition_aoco_leaf;
   8 | 0 | 0 |       1
 (10 rows)
 
-SELECT compare_relfilenodes(:'relfilenode_root', 'subpartition_aoco_leaf');
-    compare_relfilenodes     
------------------------------
- full table rewrite occurred
-(1 row)
+:chk_co_opt_qry;
+ segno |                         rel                          |         aoco_add_col_optimized          
+-------+------------------------------------------------------+-----------------------------------------
+    -1 | subpartition_aoco_leaf                               | full table rewritten
+    -1 | subpartition_aoco_leaf_1_prt_intermediate            | full table rewritten
+    -1 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | ADD COLUMN optimized for columnar table
+     0 | subpartition_aoco_leaf                               | full table rewritten
+     0 | subpartition_aoco_leaf_1_prt_intermediate            | full table rewritten
+     0 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | ADD COLUMN optimized for columnar table
+(6 rows)
 
-SELECT compare_relfilenodes(:'relfilenode_intermediate', 'subpartition_aoco_leaf_1_prt_intermediate');
-    compare_relfilenodes     
------------------------------
- full table rewrite occurred
-(1 row)
-
-SELECT compare_relfilenodes(:'relfilenode_leaf', 'subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf');
-    compare_relfilenodes    
-----------------------------
- optimized rewrite occurred
-(1 row)
-
-SELECT relfilenode AS relfilenode_root
-FROM gp_dist_random('pg_class')
-WHERE gp_segment_id = 0 AND relname = 'subpartition_aoco_leaf' \gset
-SELECT relfilenode AS relfilenode_intermediate
-FROM gp_dist_random('pg_class')
-WHERE gp_segment_id = 0 AND relname = 'subpartition_aoco_leaf_1_prt_intermediate' \gset
-SELECT relfilenode AS relfilenode_leaf
-FROM gp_dist_random('pg_class')
-WHERE gp_segment_id = 0 AND relname = 'subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf' \gset
+REFRESH MATERIALIZED VIEW table_relfilenode;
 -- Scenario 2: mixing ADD COLUMN with ALTER COLUMN TYPE should trigger full
 -- table rewrite for every level
 ALTER TABLE subpartition_aoco_leaf ADD COLUMN new_col2 int DEFAULT 1, ALTER COLUMN new_col TYPE bigint;
@@ -1005,21 +1003,14 @@ SELECT * FROM subpartition_aoco_leaf;
  10 | 0 | 0 |       1 |        1
 (10 rows)
 
-SELECT compare_relfilenodes(:'relfilenode_root', 'subpartition_aoco_leaf') AS heap_parent;
-         heap_parent         
------------------------------
- full table rewrite occurred
-(1 row)
-
-SELECT compare_relfilenodes(:'relfilenode_intermediate', 'subpartition_aoco_leaf_1_prt_intermediate') AS ao_child;
-          ao_child           
------------------------------
- full table rewrite occurred
-(1 row)
-
-SELECT compare_relfilenodes(:'relfilenode_leaf', 'subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf');
-    compare_relfilenodes     
------------------------------
- full table rewrite occurred
-(1 row)
+:chk_co_opt_qry;
+ segno |                         rel                          | aoco_add_col_optimized 
+-------+------------------------------------------------------+------------------------
+    -1 | subpartition_aoco_leaf                               | full table rewritten
+    -1 | subpartition_aoco_leaf_1_prt_intermediate            | full table rewritten
+    -1 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | full table rewritten
+     0 | subpartition_aoco_leaf                               | full table rewritten
+     0 | subpartition_aoco_leaf_1_prt_intermediate            | full table rewritten
+     0 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | full table rewritten
+(6 rows)
 

--- a/src/test/regress/sql/alter_table_aocs2.sql
+++ b/src/test/regress/sql/alter_table_aocs2.sql
@@ -492,24 +492,6 @@ ANALYZE nonbulk_rle_tab; -- To avoid NOTICE about missing stats with ORCA.
 update nonbulk_rle_tab set b = b + 3 where a = -1;
 
 
--- ADD COLUMN for AOCO partition children should not trigger full table rewrite
-
-CREATE OR REPLACE FUNCTION compare_relfilenodes(table_relfilenode oid, tablename regclass)
-RETURNS TEXT AS
-$$
-DECLARE
-	result text;
-BEGIN
-	SELECT CASE
-		   WHEN relfilenode = table_relfilenode THEN 'optimized rewrite occurred'
-		   ELSE 'full table rewrite occurred'
-		   END INTO result
-	FROM gp_dist_random('pg_class') WHERE gp_segment_id = 0 AND oid = tablename;
-RETURN result;
-END;
-$$
-LANGUAGE 'plpgsql' STABLE;
-
 CREATE FUNCTION descendants_of(rel regclass) RETURNS TABLE(descendant regclass)
 SET gp_recursive_cte=ON
 LANGUAGE SQL STABLE AS $fn$

--- a/src/test/regress/sql/alter_table_aocs2.sql
+++ b/src/test/regress/sql/alter_table_aocs2.sql
@@ -494,7 +494,7 @@ update nonbulk_rle_tab set b = b + 3 where a = -1;
 
 -- ADD COLUMN for AOCO partition children should not trigger full table rewrite
 
-CREATE OR REPLACE FUNCTION compare_relfilenodes(table_relfilenode oid, tablename text)
+CREATE OR REPLACE FUNCTION compare_relfilenodes(table_relfilenode oid, tablename regclass)
 RETURNS TEXT AS
 $$
 DECLARE
@@ -504,11 +504,11 @@ BEGIN
 		   WHEN relfilenode = table_relfilenode THEN 'optimized rewrite occurred'
 		   ELSE 'full table rewrite occurred'
 		   END INTO result
-	FROM gp_dist_random('pg_class') WHERE gp_segment_id = 0 AND relname = tablename;
+	FROM gp_dist_random('pg_class') WHERE gp_segment_id = 0 AND oid = tablename;
 RETURN result;
 END;
 $$
-LANGUAGE 'plpgsql' IMMUTABLE;
+LANGUAGE 'plpgsql' STABLE;
 
 -- Scenario 1: Parent is AOCO, 1 child is AO, 1 child is heap. Heap and AO children require full table rewrite
 CREATE TABLE rewrite_optimization_aoco_parent(a int, b int, c int)


### PR DESCRIPTION
ALTER TABLE ADD COLUMN to a child partition with storage type AOCO
should not trigger a full table rewrite. Instead, only data
corresponding to the new column should be written.

There was a regression caused by an implementation detail of the ALTER
TABLE machinery. 6c57239 in upstream Postgres (Postgres 9.1+ and
GPDB6+), changed ALTER TABLE ADD COLUMN.

Before 6c57239, ATPrepAddColumn() recursively processed child
partitions during the "prep" phase (phase 2), appending subcmds to the
AlteredTableInfo such that each partition table had a copy of all
AlterTableCmds. After 6c57239, ATExecAddColumn() recursively
processes children during the "exec" phase (phase 3), which happens
after subcmds are populated.

The AOCO ADD COLUMN code did a sanity check for the presence of
AlteredTableInfo->subcmds to determine if we can write only the new
column and avoid a full table rewrite. Child partitions were missing
these subcmds, so ALTER TABLE ADD COLUMN always did a full table
rewrite.

We initially considered moving the recursion back to the "prep" phase.
Other subcommand types (e.g. ALTER TABLE ALTER COLUMN TYPE) do recursion
during the "prep" phase. However, this would result in an unnecessary
and potentially incorrect diff from upstream Postgres.

Instead, we decoupled the logic for the table rewrite optimization from
the contents of the subcmd.  Based on the subcmds of the parent
partition, we determine if the optimization is *possible* then use the
storage type of the child partitions to make a final decision as to
whether or not the full table rewrite is required on a per-partition
basis.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>
Co-authored-by: Jesse Zhang <sbjesse@gmail.com>
Reviewed-by: Asim R P <apraveen@pivotal.io>
Reviewed-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>