### PR TITLE
Fix xids on segments

### DIFF
--- a/contrib/pg_upgrade/greenplum/controldata_gp.c
+++ b/contrib/pg_upgrade/greenplum/controldata_gp.c
@@ -38,15 +38,16 @@ reset_system_identifier(void)
 
 /*
  * Greenplum upgrade involves copying the MASTER_DATA_DIRECTORY to
- * each primary segment. We need to freeze the master data *after* the master
- * schema has been restored to allow the data to be visible on the segments.
+ * each primary segment. We need to freeze the master and segments data
+ * *after* the master schema has been restored and pg_resetxlog has been run
+ * to set the control values. In postgres, autovacuum is supposed to take care
+ * of it.
  * All databases need to be frozen including those where datallowconn is false.
  *
- * Note: No further updates should occur after freezing the master data
- * directory.
+ * Note: No further updates should occur after freezing the data directory.
  */
 void
-freeze_master_data(void)
+freeze_database(void)
 {
        PGconn                  *conn;
        PGconn                  *conn_template1;

--- a/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -75,7 +75,7 @@ bool is_show_progress_mode(void);
 void validate_greenplum_options(void);
 
 /* pg_upgrade_greenplum.c */
-void freeze_master_data(void);
+void freeze_database(void);
 void reset_system_identifier(void);
 
 


### PR DESCRIPTION
Problem:
After upgrade of the database 5->6 or 6->6, when a create table is executed, it reports the below warning when you create a table.
```
WARNING:  database with OID 0 must be vacuumed within 147483647 transactions  (seg2 127.0.0.1:25434 pid=97928)
HINT:  To avoid a database shutdown, execute a database-wide VACUUM in that database.
```
If you further go to run VACUUM FREEZE, it reports the below error:
```
template1=# vacuum freeze;
ERROR:  found xmin 711 from before relfrozenxid 800  (seg0 127.0.0.1:50433 pid=39596)
template1=#
```
For upgrading gpdb database, first we upgrade the master and then the segments. The interesting ones related to the problem here are the below 


```
1. Create a new cluster
2. Upgrade the master of the new cluster
     2.a) Execute copy_clog_xlog_xid - Which executes pg_resetxlog to the set new control data files using the values based on the old master control data file.
     2.b) Execute set_frozenxids: Which updates the catalog with datfrozenxid, datminmxid. relfrozenxid, relminmxid based on the corresponding old master
     2.c) Restore the schema
     2.d) Vacuum Freeze - This updates the value of `checkpoint's oldestXID` and `checkpoint's 
oldestXID's DB` too.
5. Upgrade segment
  5.a) Copy master catalog to the segment
  5.b) Execute copy_clog_xlog_xid - Which executes pg_resetxlog to the set new control data files using the values based on the old master control data file.

```
If we see the error, it is coming from the segments. If you look the controldata files for the segment after upgrade, they have default values, But for the master, they have valid values. (SINCE on master, VACUUM FREEZE was run)
pg_controldata <path_of_segment_data_dir>
```
Latest checkpoint's oldestXID:        2294968074
Latest checkpoint's oldestXID's DB:   0
```
The above values are currently invalid. 
When pg_resetxlog is run to set the `Latest checkpoint's NextXID:`, it sets the value of the nextxid, and put default values for oldestXidDB and oldestXid with the assumption that autovacuum will take care of it. Autovacuum is disabled in greenplum, so these values are not updated, and the WARNING  `WARNING:  database with OID 0 must be vacuumed ` is observed.
```
	if (set_xid != 0)
	{
		ControlFile.checkPointCopy.nextXid = set_xid;

		/*
		 * For the moment, just set oldestXid to a value that will force
		 * immediate autovacuum-for-wraparound.  It's not clear whether adding
		 * user control of this is useful, so let's just do something that's
		 * reasonably safe.  The magic constant here corresponds to the
		 * maximum allowed value of autovacuum_freeze_max_age.
		 */
		ControlFile.checkPointCopy.oldestXid = set_xid - 2000000000;
		ControlFile.checkPointCopy.oldestXid = set_xid - 2000000000;
		if (ControlFile.checkPointCopy.oldestXid < FirstNormalTransactionId)
			ControlFile.checkPointCopy.oldestXid += FirstNormalTransactionId;
		ControlFile.checkPointCopy.oldestXidDB = InvalidOid;
	}
````

Further, even if you try to run VACUUM, it complains
```
ERROR:  found xmin 711 from before relfrozenxid 800  (seg0 127.0.0.1:50433 pid=39596)
```
During the upgrade of a segment, the following steps are performed
1. Copy the upgraded master catalog
2. Execute copy_clog_xlog_xid which executes pg_resetxlog to the set new control data files using the values based on the old master control data file.

So now the segment catalog tables has datfrozenxid, datminmxid. relfrozenxid, relminmxid same to that of upgraded master catalog, but since we execute pg_resetxlog to set the control values to correspond to the old segment (which is being upgraded). The relfrozenxid may be higher than the checkpoints NextXID and the error is seen.

In order to fix the issue, we should ensure that we run the `set_frozenxids` and `vacuum freeze` on the segments too.
Vacuum freeze updates the values of the `oldestXidDB`and `oldestXid` and set_frozenxids updates the segment catalog table to reflect proper `datfrozenxid, datminmxid. relfrozenxid, relminmxid ` corresponding to the source cluster.