### PR TITLE
Remove code to add SubPlans used in Motions to subplan's target list.

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -7422,23 +7422,6 @@ cdbpathtoplan_create_motion_plan(PlannerInfo *root,
 			hashOpfamilies = lappend_oid(hashOpfamilies, opfamily);
 		}
 
-		/**
-		 * If there are subplans in the hashExpr, push it down to lower level.
-		 */
-		if (contain_subplans((Node *) hashExprs))
-		{
-			/* make a Result node to do the projection if necessary */
-			if (!is_projection_capable_plan(subplan))
-			{
-				List	   *tlist = copyObject(subplan->targetlist);
-
-				subplan = (Plan *) make_result(tlist, NULL, subplan);
-			}
-			subplan->targetlist = add_to_flat_tlist_junk(subplan->targetlist,
-														 hashExprs,
-														 true /* resjunk */);
-		}
-
 		motion = make_hashed_motion(subplan,
 									hashExprs,
 									hashOpfamilies,
@@ -7525,22 +7508,6 @@ cdbpathtoplan_create_motion_plan(PlannerInfo *root,
 		if (!hashExprs)
 			elog(ERROR, "could not find hash distribution key expressions in target list");
 
-		/**
-         * If there are subplans in the hashExpr, push it down to lower level.
-         */
-		if (contain_subplans((Node *) hashExprs))
-		{
-			/* make a Result node to do the projection if necessary */
-			if (!is_projection_capable_plan(subplan))
-			{
-				List	   *tlist = copyObject(subplan->targetlist);
-
-				subplan = (Plan *) make_result(tlist, NULL, subplan);
-			}
-			subplan->targetlist = add_to_flat_tlist_junk(subplan->targetlist,
-														 hashExprs,
-														 true /* resjunk */);
-        }
         motion = make_hashed_motion(subplan,
 									hashExprs,
 									hashOpfamilies,

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1357,6 +1357,8 @@ where exists (select 1 from CT where CT.a = foo.a);
 ---+---
 (0 rows)
 
+drop table foo;
+drop table bar;
 --
 -- Multiple SUBPLAN nodes referring to the same plan_id
 --
@@ -2189,3 +2191,119 @@ select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_s
 (0 rows)
 
 drop table if exists simplify_sub;
+--
+-- Test a couple of cases where a SubPlan is used in a Motion's hash key.
+--
+create table foo (i int4, j int4) distributed by (i);
+create table bar (i int4, j int4) distributed by (i);
+create table baz (i int4, j int4) distributed by (i);
+insert into foo select g, g from generate_series(1, 10) g;
+insert into bar values (1, 1);
+insert into baz select g, g from generate_series(5, 100) g;
+explain (verbose, costs off)
+select * from foo left outer join baz on (select bar.i from bar where bar.i = foo.i) + 1  = baz.j;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: foo.i, foo.j, baz.i, baz.j
+   ->  Hash Right Join
+         Output: foo.i, foo.j, baz.i, baz.j
+         Hash Cond: (baz.j = (((SubPlan 1)) + 1))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: baz.i, baz.j
+               Hash Key: baz.j
+               ->  Seq Scan on subselect_gp.baz
+                     Output: baz.i, baz.j
+         ->  Hash
+               Output: foo.i, foo.j, ((SubPlan 1))
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Output: foo.i, foo.j, ((SubPlan 1))
+                     Hash Key: (((SubPlan 1)) + 1)
+                     ->  Seq Scan on subselect_gp.foo
+                           Output: foo.i, foo.j, (SubPlan 1)
+                           SubPlan 1
+                             ->  Result
+                                   Output: bar.i
+                                   Filter: (bar.i = foo.i)
+                                   ->  Materialize
+                                         Output: bar.i
+                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                               Output: bar.i
+                                               ->  Seq Scan on subselect_gp.bar
+                                                     Output: bar.i
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(29 rows)
+
+select * from foo left outer join baz on (select bar.i from bar where bar.i = foo.i) + 1  = baz.j;
+ i  | j  | i | j 
+----+----+---+---
+ 10 | 10 |   |  
+  9 |  9 |   |  
+  6 |  6 |   |  
+  5 |  5 |   |  
+  8 |  8 |   |  
+  7 |  7 |   |  
+  4 |  4 |   |  
+  3 |  3 |   |  
+  2 |  2 |   |  
+  1 |  1 |   |  
+(10 rows)
+
+-- This is a variant of a query in the upstream 'subselect' test, with the
+-- twist that baz.i is the distribution key for the table. In the plan, the
+-- CASE WHEN construct with SubPlan is used as Hash Key in the Redistribute
+-- Motion. It is a planned as a hashed SubPlan. (We had a bug at one point,
+-- where the hashed SubPlan was added to the target list twice, which
+-- caused an error at runtime when the executor tried to build the hash
+-- table twice, because the Motion in the SubPlan couldn't be rescanned.)
+explain (verbose, costs off)
+select * from foo where
+  (case when foo.i in (select a.i from baz a) then foo.i else null end) in
+  (select b.i from baz b);
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: foo.i, foo.j
+   ->  Result
+         Output: foo.i, foo.j
+         ->  HashAggregate
+               Output: foo.i, foo.j, foo.ctid, foo.gp_segment_id
+               Group Key: foo.ctid, foo.gp_segment_id
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: foo.i, foo.j, foo.ctid, foo.gp_segment_id
+                     Hash Key: foo.ctid
+                     ->  Hash Join
+                           Output: foo.i, foo.j, foo.ctid, foo.gp_segment_id
+                           Hash Cond: (b.i = CASE WHEN ((hashed SubPlan 1)) THEN foo.i ELSE NULL::integer END)
+                           ->  Seq Scan on subselect_gp.baz b
+                                 Output: b.i, b.j
+                           ->  Hash
+                                 Output: foo.i, foo.j, ((hashed SubPlan 1)), foo.ctid, foo.gp_segment_id
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                       Output: foo.i, foo.j, ((hashed SubPlan 1)), foo.ctid, foo.gp_segment_id
+                                       Hash Key: CASE WHEN ((hashed SubPlan 1)) THEN foo.i ELSE NULL::integer END
+                                       ->  Seq Scan on subselect_gp.foo
+                                             Output: foo.i, foo.j, (hashed SubPlan 1), foo.ctid, foo.gp_segment_id
+                                             SubPlan 1
+                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                     Output: a.i
+                                                     ->  Seq Scan on subselect_gp.baz a
+                                                           Output: a.i
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(29 rows)
+
+select * from foo where
+  (case when foo.i in (select a.i from baz a) then foo.i else null end) in
+  (select b.i from baz b);
+ i  | j  
+----+----
+  6 |  6
+  7 |  7
+ 10 | 10
+  5 |  5
+  8 |  8
+  9 |  9
+(6 rows)
+

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1378,6 +1378,8 @@ where exists (select 1 from CT where CT.a = foo.a);
 ---+---
 (0 rows)
 
+drop table foo;
+drop table bar;
 --
 -- Multiple SUBPLAN nodes referring to the same plan_id
 --
@@ -2344,3 +2346,115 @@ select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_s
 (0 rows)
 
 drop table if exists simplify_sub;
+--
+-- Test a couple of cases where a SubPlan is used in a Motion's hash key.
+--
+create table foo (i int4, j int4) distributed by (i);
+create table bar (i int4, j int4) distributed by (i);
+create table baz (i int4, j int4) distributed by (i);
+insert into foo select g, g from generate_series(1, 10) g;
+insert into bar values (1, 1);
+insert into baz select g, g from generate_series(5, 100) g;
+explain (verbose, costs off)
+select * from foo left outer join baz on (select bar.i from bar where bar.i = foo.i) + 1  = baz.j;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: foo.i, foo.j, baz.i, baz.j
+   ->  Hash Right Join
+         Output: foo.i, foo.j, baz.i, baz.j
+         Hash Cond: (baz.j = (((SubPlan 1)) + 1))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: baz.i, baz.j
+               Hash Key: baz.j
+               ->  Seq Scan on subselect_gp.baz
+                     Output: baz.i, baz.j
+         ->  Hash
+               Output: foo.i, foo.j, ((SubPlan 1))
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Output: foo.i, foo.j, ((SubPlan 1))
+                     Hash Key: (((SubPlan 1)) + 1)
+                     ->  Seq Scan on subselect_gp.foo
+                           Output: foo.i, foo.j, (SubPlan 1)
+                           SubPlan 1
+                             ->  Result
+                                   Output: bar.i
+                                   Filter: (bar.i = foo.i)
+                                   ->  Materialize
+                                         Output: bar.i
+                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                               Output: bar.i
+                                               ->  Seq Scan on subselect_gp.bar
+                                                     Output: bar.i
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=on
+(29 rows)
+
+select * from foo left outer join baz on (select bar.i from bar where bar.i = foo.i) + 1  = baz.j;
+ i  | j  | i | j 
+----+----+---+---
+ 10 | 10 |   |  
+  9 |  9 |   |  
+  6 |  6 |   |  
+  5 |  5 |   |  
+  8 |  8 |   |  
+  7 |  7 |   |  
+  4 |  4 |   |  
+  3 |  3 |   |  
+  2 |  2 |   |  
+  1 |  1 |   |  
+(10 rows)
+
+-- This is a variant of a query in the upstream 'subselect' test, with the
+-- twist that baz.i is the distribution key for the table. In the plan, the
+-- CASE WHEN construct with SubPlan is used as Hash Key in the Redistribute
+-- Motion. It is a planned as a hashed SubPlan. (We had a bug at one point,
+-- where the hashed SubPlan was added to the target list twice, which
+-- caused an error at runtime when the executor tried to build the hash
+-- table twice, because the Motion in the SubPlan couldn't be rescanned.)
+explain (verbose, costs off)
+select * from foo where
+  (case when foo.i in (select a.i from baz a) then foo.i else null end) in
+  (select b.i from baz b);
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Result
+   Output: foo.i, foo.j
+   Filter: (SubPlan 2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: foo.i, foo.j
+         ->  Seq Scan on subselect_gp.foo
+               Output: foo.i, foo.j
+   SubPlan 1
+     ->  Result
+           Output: baz.i
+           ->  Materialize
+                 Output: baz.i
+                 ->  Gather Motion 3:1  (slice2; segments: 3)
+                       Output: baz.i
+                       ->  Seq Scan on subselect_gp.baz
+                             Output: baz.i
+   SubPlan 2
+     ->  Materialize
+           Output: baz_1.i
+           ->  Gather Motion 3:1  (slice3; segments: 3)
+                 Output: baz_1.i
+                 ->  Seq Scan on subselect_gp.baz baz_1
+                       Output: baz_1.i
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+ Settings: optimizer=on
+(25 rows)
+
+select * from foo where
+  (case when foo.i in (select a.i from baz a) then foo.i else null end) in
+  (select b.i from baz b);
+ i  | j  
+----+----
+  6 |  6
+  7 |  7
+ 10 | 10
+  5 |  5
+  8 |  8
+  9 |  9
+(6 rows)
+


### PR DESCRIPTION
I did some digging, this code was added in 2011 in this commit:

```
commit 796dcb358dc9dd40f2674373a2f542fd7c796e6a
Date:   Fri Oct 21 16:56:58 2011 -0800

    Add entries to subplan's targetlist for fixing setrefs of flow nodes in motion selectively.

    [JIRA: MPP-15086, MPP-15073]

    [git-p4: depot-paths = "//cdb2/main/": change = 99193]
```

Those JIRAs were duplicates of the same issue, which was an error in
regression tests, in the 'DML_over_joins' test. 'DML_over_joins' has
changed a lot since those days, but FWIW, it's not failing now, with
this code removed. The error from the JIRA looked like this:

```
    select m.* from m,r,purchase_par where m.a = r.a and m.b = purchase_par.id + 1;
    ERROR:  attribute number 2 exceeds number of columns 1 (execQual.c:626)  (seg2 slice1 rh55-tst3:10100 pid=12142)
```

The code has changed a lot since, and I believe this isn't needed anymore.
If the planner chooses to redistribute based on an expression, that
expression is surely used somewhere above the Motion, and should therefore
be in the targetlist already.

This fixes an error in the second test query that this adds. Before this
commit, the hashed SubPlan appeared twice in the target list of the Seq
Scan below the Redistribute Motion:

```
explain (verbose, costs off)
select * from foo where
  (case when foo.i in (select a.i from baz a) then foo.i else null end) in
  (select b.i from baz b);
                                                                                    QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Output: foo.i, foo.j
   ->  Result
         Output: foo.i, foo.j
         ->  HashAggregate
               Output: foo.i, foo.j, foo.ctid, foo.gp_segment_id
               Group Key: foo.ctid, foo.gp_segment_id
               ->  Redistribute Motion 3:3  (slice2; segments: 3)
                     Output: foo.i, foo.j, foo.ctid, foo.gp_segment_id
                     Hash Key: foo.ctid
                     ->  Hash Join
                           Output: foo.i, foo.j, foo.ctid, foo.gp_segment_id
                           Hash Cond: (b.i = (CASE WHEN (hashed SubPlan 1) THEN foo.i ELSE NULL::integer END))
                           ->  Seq Scan on subselect_gp.baz b
                                 Output: b.i, b.j
                           ->  Hash
                                 Output: foo.i, foo.j, ((hashed SubPlan 1)), foo.ctid, foo.gp_segment_id, (CASE WHEN (hashed SubPlan 1) THEN foo.i ELSE NULL::integer END)
                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                       Output: foo.i, foo.j, ((hashed SubPlan 1)), foo.ctid, foo.gp_segment_id, (CASE WHEN (hashed SubPlan 1) THEN foo.i ELSE NULL::integer END)
                                       Hash Key: (CASE WHEN (hashed SubPlan 1) THEN foo.i ELSE NULL::integer END)
                                       ->  Seq Scan on subselect_gp.foo
                                             Output: foo.i, foo.j, (hashed SubPlan 1), foo.ctid, foo.gp_segment_id, CASE WHEN (hashed SubPlan 1) THEN foo.i ELSE NULL::integer END
                                             SubPlan 1
                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)
                                                     Output: a.i
                                                     ->  Seq Scan on subselect_gp.baz a
                                                           Output: a.i
 Optimizer: Postgres query optimizer
 Settings: optimizer=off
(29 rows)
```

That failed at runtime with:

```
ERROR:  illegal rescan of motion node: invalid plan (nodeMotion.c:1232)  (seg0 slice3 127.0.0.1:40000 pid=16712) (nodeMotion.c:1232)
HINT:  Likely caused by bad NL-join, try setting enable_nestloop to off
```

Fixes: https://github.com/greenplum-db/gpdb/issues/9701
