### PR TITLE
5X: Add ORCA CI files that were previously in gpdb master branch

### DIFF
--- a/concourse/scripts/build_gpdb.py
+++ b/concourse/scripts/build_gpdb.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python2
 
+import glob
 import optparse
 import os
 import shutil
@@ -11,6 +12,8 @@ from builds.GpBuild import GpBuild
 
 INSTALL_DIR = "/usr/local/gpdb"
 DEPENDENCY_INSTALL_DIR = "/usr/local"
+SCRIPT_LOC=os.path.dirname(os.path.realpath(__file__))
+GPDB_SRC_DIR="{0}/../../".format(SCRIPT_LOC)
 
 
 def copy_installed(output_dir):
@@ -30,11 +33,22 @@ def print_compiler_version():
 
 
 def create_gpadmin_user():
-    status = subprocess.call("gpdb_src/concourse/scripts/setup_gpadmin_user.bash")
+    status = subprocess.call("{0}/concourse/scripts/setup_gpadmin_user.bash".format(GPDB_SRC_DIR))
     os.chmod('/bin/ping', os.stat('/bin/ping').st_mode | stat.S_ISUID)
     if status:
         return status
 
+def extract_explain_test_suite():
+    tarfiles = glob.glob('explain_test_suite/*.tar.gz')
+    if len(tarfiles) != 1:
+        print("Expected to find 1 tar file.")
+        return 1
+    status = subprocess.call(["tar", "xvf", tarfiles[0]])
+    return status
+
+def tar_explain_output():
+    status = subprocess.call(["tar", "czvf", "icg_output/explain_ouput.tar.gz", "out/"])
+    return status
 
 def copy_output():
     for dirpath, dirs, diff_files in os.walk('gpdb_src/'):
@@ -47,7 +61,6 @@ def copy_output():
                 print fin.read()
     shutil.copyfile("gpdb_src/src/test/regress/regression.diffs", "icg_output/regression.diffs")
     shutil.copyfile("gpdb_src/src/test/regress/regression.out", "icg_output/regression.out")
-
 
 def install_dependencies(ci_common, dependencies, install_dir):
     for dependency in dependencies:
@@ -73,9 +86,10 @@ def main():
     parser.add_option("--gcc-env-file", dest="gcc_env_file", help="GCC env file to be sourced")
     parser.add_option("--orca-in-gpdb-install-location", dest="orca_in_gpdb_install_location", action="store_true",
                       help="Install ORCA header and library files in GPDB install directory")
-    parser.add_option("--action", choices=['build', 'test'], dest="action", default='build',
+    parser.add_option("--action", choices=['build', 'test', 'test_explain_suite'], dest="action", default='build',
                       help="Build GPDB or Run Install Check")
     parser.add_option("--gpdb_name", dest="gpdb_name")
+    parser.add_option("--dbexists", dest="dbexists", action="store_true", default=False, help="create demo cluster or not")
     (options, args) = parser.parse_args()
 
     gpBuild = GpBuild(options.mode)
@@ -86,7 +100,7 @@ def main():
     gpBuild.set_gcc_env_file(options.gcc_env_file)
 
     install_dir = INSTALL_DIR if options.orca_in_gpdb_install_location else DEPENDENCY_INSTALL_DIR
-    if options.action == 'test':
+    if options.action.startswith('test'):
         # if required, install orca and xerces library & header
         # in the install directory of gpdb to avoid packaging from multiple directories
         status = gpBuild.install_dependency(options.gpdb_name, INSTALL_DIR)
@@ -115,10 +129,10 @@ def main():
         status = gpBuild.make()
         fail_on_error(status)
 
-        status = gpBuild.unittest()
+        status = gpBuild.make_install()
         fail_on_error(status)
 
-        status = gpBuild.make_install()
+        status = gpBuild.unittest()
         fail_on_error(status)
 
         status = copy_installed(options.output_dir)
@@ -134,6 +148,17 @@ def main():
         if status:
             copy_output()
         return status
+
+    elif options.action == 'test_explain_suite':
+        status = create_gpadmin_user()
+        fail_on_error(status)
+        status = extract_explain_test_suite()
+        fail_on_error(status)
+        status = gpBuild.run_explain_test_suite(options.dbexists)
+        fail_on_error(status)
+        status = tar_explain_output()
+        fail_on_error(status)
+        return 0
 
     return 0
 

--- a/concourse/scripts/builds/GpBuild.py
+++ b/concourse/scripts/builds/GpBuild.py
@@ -1,8 +1,13 @@
 import subprocess
+import os
 from GpdbBuildBase import GpdbBuildBase
 
 INSTALL_DIR="/usr/local/gpdb"
 
+def fail_on_error(status):
+    import sys
+    if status:
+        sys.exit(status)
 
 class GpBuild(GpdbBuildBase):
     def __init__(self, mode="orca"):
@@ -56,6 +61,52 @@ class GpBuild(GpdbBuildBase):
             "runuser gpadmin -c \"source {0}/greenplum_path.sh \
             && source gpAux/gpdemo/gpdemo-env.sh && PGOPTIONS='-c optimizer={1}' \
             {2} \"".format(INSTALL_DIR, self.mode, make_command)], cwd="gpdb_src", shell=True)
+
+    def _run_gpdb_command(self, command, stdout=None, stderr=None, source_env_cmd=''):
+        cmd = "source {0}/greenplum_path.sh && source gpdb_src/gpAux/gpdemo/gpdemo-env.sh".format(INSTALL_DIR)
+        if len(source_env_cmd) != 0:
+            #over ride the command if requested
+            cmd = source_env_cmd
+        runcmd = "runuser gpadmin -c \"{0} && {1} \"".format(cmd, command)
+        print "Executing {}".format(runcmd)
+        return subprocess.call([runcmd], shell=True, stdout=stdout, stderr=stderr)
+
+    def run_explain_test_suite(self, dbexists):
+        source_env_cmd = ''
+        if dbexists:
+            source_env_cmd='source {0}/greenplum_path.sh && source ~/.bash_profile '.format(INSTALL_DIR)
+        else:
+            status = self.create_demo_cluster()
+            fail_on_error(status)
+            status = self._run_gpdb_command("createdb")
+            fail_on_error(status)
+            status = self._run_gpdb_command("psql -f sql/schema.sql")
+            fail_on_error(status)
+
+            with open("load_stats.txt", "w") as f:
+                status = self._run_gpdb_command("psql -f sql/stats.sql", stdout=f)
+            if status:
+                with open("load_stats.txt", "r") as f:
+                    print f.read()
+                fail_on_error(status)
+
+        # Now run the queries !!
+        os.mkdir('out')
+        status = 0
+        sql_files = os.listdir("sql")
+        sql_files.sort()
+        for fsql in sql_files:
+            if fsql.endswith('.sql') and fsql not in ['stats.sql', 'schema.sql']:
+                output_fname = 'out/{}'.format(fsql.replace('.sql', '.out'))
+                # GUC name should match with name in gpdb 5X_STABLE branch
+                with open(output_fname, 'w') as fout:
+                    current_status = self._run_gpdb_command("env PGOPTIONS='-c optimizer_enable_full_join=on' psql -a -f sql/{}".format(fsql), stdout=fout, stderr=fout, source_env_cmd=source_env_cmd)
+                    print "status: {0}".format(current_status)
+                    status = status if status != 0 else current_status
+
+        return status
+
+
 
     def append_configure_options(self, configure_options):
         if configure_options:

--- a/concourse/scripts/diff_explain_results_with_baseline.bash
+++ b/concourse/scripts/diff_explain_results_with_baseline.bash
@@ -1,0 +1,48 @@
+#!/bin/bash -l
+
+function _main() {
+
+	mkdir results/
+	tar xf explain_output/*.tar.gz -C results/ out/ --strip-components 1
+
+	mkdir baseline/
+	tar xf explain_output_baseline/*.tar.gz -C baseline/ out/ --strip-components 1
+
+	SUBEXPR='s/cost=[^ ]* //g; s/rows=[^ ]* //g; s/Time:.*$//g; s/Optimizer status:.*//g'
+	ls results/* | while read fsql; do
+		f=$(basename "$fsql")
+		curdir=$(pwd)
+		sed -e "$SUBEXPR" "$curdir/baseline/$f" > "/tmp/$f.baseline"
+		sed -e "$SUBEXPR" "$curdir/results/$f"	> "/tmp/$f.results"
+		diff -U3 -w "/tmp/$f.baseline" "/tmp/$f.results" >> simple.diffs
+
+		echo "Filename: $f" >> results_combined.out
+		cat "$curdir/results/$f" >> results_combined.out
+
+		echo "Filename: $f" >> baseline_combined.out
+		cat "$curdir/baseline/$f" >> baseline_combined.out
+	done
+
+	tarball_name=explain_test_results.tar.gz
+	if [ ! -z "${prefix}" ]; then
+	    tarball_name="explain_test_${prefix}_results.tar.gz"
+	fi
+	tar czvf $tarball_name results_combined.out baseline_combined.out
+	cp $tarball_name diffs/
+	cp simple.diffs diffs/
+
+	echo "======================================================================"
+	echo "DIFF FILE: simple.diffs"
+	echo "======================================================================"
+	cat diffs/simple.diffs
+
+	echo
+	echo "======================================================================"
+	echo "SUMMARY"
+	echo "======================================================================"
+	gpdb_main_src/concourse/scripts/perfsummary.py --baseLog baseline_combined.out results_combined.out
+
+	return $([ ! -s simple.diffs ]);
+}
+
+_main "$@"

--- a/concourse/scripts/perfsummary.py
+++ b/concourse/scripts/perfsummary.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python
+#
+# Extracts summary info from a log file that compiles and executes test suite
+# queries. Creates a CSV (comma-separated values) summary.
+#
+# Usage:
+#
+# perfsummary.py [ <log-file-name> ] [ --baseLog <base-log-file-name> ]
+#
+# Log files must have queries that were executed with timing on.
+#
+# Log files with more than one query must be in the following format:
+#
+# Filename: XXXXXXXX
+#
+# Query Plan
+# XXXXXXXXXXXX
+#
+# Time: XXXX
+#
+# Filename: XXXX
+
+
+import sys
+import re
+import argparse
+import os
+
+# types of diffs in plans, by increasing severity
+NO_CHANGES   = 0
+COST_CHANGES = 1
+ROWS_CHANGES = 2
+PLAN_CHANGES = 3
+planDiffText = { NO_CHANGES: "", COST_CHANGES: "cost change found", ROWS_CHANGES: "row change found", PLAN_CHANGES: "plan change found" }
+
+# the state of multiple test suite queries executed in a log file
+class FileState:
+    def __init__(self):
+        self.reset_curr_query_state()
+        self.first_file_name_match = True
+        
+        # an ordered list of query ids, including secondary queries
+        # for queries that are split into multiple selects
+        self.query_id_list = []
+        
+        # explain/planning time for each query
+        self.query_explain_time_map = {}
+        
+        # the explain plan for each query (as a list of strings)
+        self.query_explain_plan_map = {}
+        
+        # execution time for each query
+        self.query_exe_time_map = {}
+        
+        # comments for each query
+        self.query_comment_map = {}
+
+    # reset the state relating to the current query
+    def reset_curr_query_state(self):
+        self.curr_query_id = ""
+        self.planning_time1 = -1
+        self.planning_time2 = -1
+        self.exe_time1 = -1
+        self.exe_time2 = -1
+        # current plan, as it is assembled from multiple lines
+        self.curr_plan = []
+        # list of plans, one for each explain done in a query section
+        self.plans = []
+        self.comment1 = ""
+        self.comment2 = ""
+        self.exe_phase = False
+        self.explain_phase = False
+        self.plan_phase = False
+        self.second_query = False
+
+    # record query id and measurements for a single query,
+    # called several times with different seq_nums for multi-part queries
+    def recordQuery(self, seq_num):
+        query_id = self.curr_query_id
+        if seq_num > 0:
+            query_id = query_id + "b"
+        self.query_id_list.append(query_id)
+        if seq_num == 0:
+            self.query_explain_time_map[query_id] = self.planning_time1
+        else:
+            self.query_explain_time_map[query_id] = self.planning_time2
+        if seq_num == 0:
+            self.query_exe_time_map[query_id] = self.exe_time1
+        else:
+            self.query_exe_time_map[query_id] = self.exe_time2
+        if seq_num == 0:
+            self.query_comment_map[query_id] = self.comment1
+        else:
+            self.query_comment_map[query_id] = self.comment2
+        if len(self.plans) > seq_num:
+            self.query_explain_plan_map[query_id] = self.plans[seq_num]
+        else:
+            self.query_explain_plan_map[query_id] = "error - no plan found"
+            self.query_comment_map[query_id] += "error - no plan found"
+
+    # process a single line of a log file
+    def processLogFileLine(self, line_lf):
+        line             = line_lf.rstrip('\r\n')
+        fileNameMatch    = re.match(r'Filename: ',         line)
+        explainMatch     = re.match(r'[ ]*QUERY PLAN[ ]*', line)
+        executionMatch   = re.match(r'EXECUTION:',         line)
+        timeMatch        = re.match(r'Time: ',             line)
+        optimizerMatch   = re.match(r' Optimizer[ a-z]*: ',line)
+        eofMatch         = re.match(r'EOF-MARKER$',        line)
+
+        if executionMatch:
+            self.exe_phase = True
+            self.explain_phase = False
+        elif explainMatch:
+            self.exe_phase = False
+            self.explain_phase = True
+            self.plan_phase = True
+        elif timeMatch:
+            time = re.sub(r'Time: ([0-9]+).*', r'\1', line)
+            if self.exe_phase:
+                if self.exe_time1 < 0:
+                    self.exe_time1 = time
+                else:
+                    self.exe_time2 = time
+                    self.second_query = True
+            elif self.explain_phase:
+                if self.planning_time1 < 0:
+                    self.planning_time1 = time
+                else:
+                    self.planning_time2 = time
+                    self.second_query = True
+            # finalize the explain plan for this query and store it
+            if self.plan_phase:
+                self.plan_phase = False
+                self.plans.append(self.curr_plan)
+                self.curr_plan = []
+        elif optimizerMatch:
+            # Since this script can be used on older explain logs, match both
+            # original and new ORCA names
+            if (not re.search(' PQO ', line) and not re.search(' Pivotal Optimizer ', line)):
+                if self.planning_time1 < 0:
+                    self.comment1 = self.comment1 + "Fallback "
+                else:
+                    self.comment2 = self.comment2 + "Fallback "
+
+        if self.plan_phase:
+            # this is a line of an explain plan, remember it
+            self.curr_plan.append(line_lf)
+            
+        if (fileNameMatch and not self.first_file_name_match) or eofMatch:
+            # end of a query
+            self.recordQuery(0)
+            if self.second_query:
+                self.recordQuery(1)
+
+        if fileNameMatch:
+            # beginning of a new query
+            self.reset_curr_query_state()
+            self.first_file_name_match = False
+            self.curr_query_id = re.sub(r'Filename: 1([0-9]+).*', r'\1', line)
+
+    # process an entire log file
+    def processLogFile(self, logFileLines):
+        for line in logFileLines:
+            self.processLogFileLine(line)
+        self.processLogFileLine('EOF-MARKER')
+
+    def comparePlans(self, base, queryId):
+        myPlan = self.query_explain_plan_map[queryId]
+        basePlan = base.query_explain_plan_map[queryId]
+        # return value (0 = same, 1 = cost change, 2 = cardinality change, 3 = other change)
+
+        plan_change_found = False
+        cost_change_found = False
+        rows_change_found = False
+
+        if len(myPlan) != len(basePlan):
+            # plans are different (different number of lines)
+            return PLAN_CHANGES
+
+        for l in range(len(myPlan)):
+            myLine = myPlan[l]
+            baseLine = basePlan[l]
+            if myLine != baseLine:
+                myLineNoCost = re.sub(r'cost=[0-9.]*', 'cost=xxx', myLine)
+                baseLineNoCost = re.sub(r'cost=[0-9.]*', 'cost=xxx', baseLine)
+                if myLineNoCost == baseLineNoCost:
+                    cost_change_found = True
+                else:
+                    myLineNoRows = re.sub(r'rows=[0-9]*', 'rows=xxx', myLineNoCost)
+                    baseLineNoRows = re.sub(r'rows=[0-9]*', 'rows=xxx', baseLineNoCost)
+                    if myLineNoRows == baseLineNoRows:
+                        rows_change_found = True
+                    else:
+                        myOptimizer = re.sub(r'Optimizer[ a-z]*:.*', 'Optimizer:xxx', myLine)
+                        baseOptimizer = re.sub(r'Optimizer[ a-z]*:.*', 'Optimizer:xxx', baseLine)
+                        if myOptimizer != baseOptimizer:
+                            # lines are different even with masked-out rows and cost
+                            plan_change_found = True
+
+        if plan_change_found:
+            return PLAN_CHANGES
+        elif rows_change_found:
+            return ROWS_CHANGES
+        elif cost_change_found:
+            return COST_CHANGES
+        return NO_CHANGES
+
+    # print header for CSV file
+    def printHeader(self, numFiles):
+        if (numFiles == 1):
+            print 'Query id, planning time, execution time, comment'
+        else:
+            print 'Query id, base planning time, planning time, base execution time, execution time, plan changes, base comment, comment'
+
+    # print result for all recorded queries in CSV format for a single log file
+    def printme(self):
+        for q in self.query_id_list:
+            print "%s, %s, %s, %s" % (q, self.query_explain_time_map[q], self.query_exe_time_map[q], self.query_comment_map[q])
+
+    # print a CSV file with a comparison between a base file and a test file
+    def printComparison(self, base, diffDir, diffThreshold, diffLevel):
+        for q in self.query_id_list:
+            planDiffs = self.comparePlans(base, q)
+            print "%s, %s, %s, %s, %s, %s, %s, %s" % (q, base.query_explain_time_map[q], self.query_explain_time_map[q], base.query_exe_time_map[q], self.query_exe_time_map[q], planDiffText[planDiffs], base.query_comment_map[q], self.query_comment_map[q])
+            if int(diffLevel) <= int(planDiffs):
+                baseTime = float(base.query_exe_time_map[q])
+                testTime = float(self.query_exe_time_map[q])
+                if testTime > baseTime * (1+float(diffThreshold)/100.0) or testTime < 0:
+                    baseFileName = diffDir + "/base/" + q + ".plan"
+                    testFileName = diffDir + "/test/" + q + ".plan"
+                    with open(baseFileName, 'w') as fb:
+                        for line in base.query_explain_plan_map[q]:
+                            fb.write(line)
+                        fb.write("Execution time: %s\n" % base.query_exe_time_map[q])
+                    with open(testFileName, 'w') as ft:
+                        for line in self.query_explain_plan_map[q]:
+                            ft.write(line)
+                        ft.write("Execution time: %s\n" % self.query_exe_time_map[q])
+            
+
+def main():
+    parser = argparse.ArgumentParser(description='Summarize the test suite execute and explain log')
+    parser.add_argument('log_file', nargs = '?', help='log file with explain/execute output')
+    parser.add_argument('--baseLog',
+                        help='specify a log file from a base version to compare to')
+    parser.add_argument('--diffDir',
+                        help='request diff files to be created and specify a directory to place diffs into')
+    parser.add_argument('--diffThreshold',
+                        help='specify a numerical threshold to record plan diffs with a performance regression of more than n percent')
+    parser.add_argument('--diffLevel',
+                        help='specify which diff files to generate: 1 = all diffs, 2 = ignore cost diffs, 3 = plan diffs only')
+
+    args = parser.parse_args()
+
+    inputfile = args.log_file
+    basefile = args.baseLog
+    makeDiffs = (args.diffDir is not None)
+    diffDir = ""
+    diffThreshold = -100
+    diffLevel = 4
+    if makeDiffs:
+        # remove trailing slash, if it exists
+        diffDir = re.sub(r'(.*)/$','\1', args.diffDir)
+        try:
+            os.mkdir(diffDir)
+            os.mkdir(diffDir + "/base")
+            os.mkdir(diffDir + "/test")
+        except:
+            print "Unable to create diff directory %s" % diffDir
+            exit(1)
+        if args.diffThreshold is not None:
+            diffThreshold = args.diffThreshold
+            if args.diffLevel is None:
+                # if only diffThreshold is specified, then default diffLevel to COST_CHANGES
+                args.diffLevel = COST_CHANGES
+        if args.diffLevel is not None:
+            diffLevel = args.diffLevel
+    else:
+        if (args.diffThreshold is not None or args.diffLevel is not None):
+            print "Please specify the --diffDir option with a directory name to request diff files\n"
+            exit(1)
+
+    if inputfile is None:
+        print "Expected the name of a log file with test suite queries\n"
+        exit(1)
+
+    if basefile is not None:
+        with open(basefile, "r") as fpb:
+            baseState = FileState()
+            baseState.processLogFile(fpb)
+
+    with open(inputfile, "r") as fp:
+        testState = FileState()
+        testState.processLogFile(fp)
+
+    if basefile is None:
+        testState.printHeader(1)
+        testState.printme()
+    else:
+        testState.printHeader(2)
+        testState.printComparison(baseState, diffDir, diffThreshold, diffLevel)
+
+if __name__== "__main__":
+    main()

--- a/concourse/scripts/setup_gpadmin_user.bash
+++ b/concourse/scripts/setup_gpadmin_user.bash
@@ -61,18 +61,30 @@ set_limits() {
   su gpadmin -c 'ulimit -a'
 }
 
+create_gpadmin_if_not_existing() {
+  gpadmin_exists=`id gpadmin > /dev/null 2>&1;echo $?`
+  if [ "0" -eq "$gpadmin_exists" ]; then
+      echo "gpadmin user already exists, skipping creating again."
+  else
+      eval "$*"
+  fi
+}
+
 setup_gpadmin_user() {
   groupadd supergroup
   case "$TEST_OS" in
     sles)
       groupadd gpadmin
-      /usr/sbin/useradd -G gpadmin,supergroup,tty gpadmin
+      user_add_cmd="/usr/sbin/useradd -G gpadmin,supergroup,tty gpadmin"
+      create_gpadmin_if_not_existing ${user_add_cmd}
       ;;
     centos)
-      /usr/sbin/useradd -G supergroup,tty gpadmin
+      user_add_cmd="/usr/sbin/useradd -G supergroup,tty gpadmin"
+      create_gpadmin_if_not_existing ${user_add_cmd}
       ;;
     ubuntu)
-      /usr/sbin/useradd -G supergroup,tty gpadmin -s /bin/bash
+      user_add_cmd="/usr/sbin/useradd -G supergroup,tty gpadmin -s /bin/bash"
+      create_gpadmin_if_not_existing ${user_add_cmd}
       ;;
     *) echo "Unknown OS: $TEST_OS"; exit 1 ;;
   esac

--- a/concourse/scripts/untar_and_build_gpdb.py
+++ b/concourse/scripts/untar_and_build_gpdb.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+import subprocess
+import sys
+import os
+
+action = os.environ['ACTION']
+mode = os.environ['MODE']
+configure_option=os.environ['CONFIGURE_OPTION']
+
+def exec_command(cmd):
+  print "Executing command: {0}".format(cmd)
+  retcode = subprocess.call(cmd, shell=True)
+  if retcode != 0:
+    sys.exit(retcode)
+
+def get_assert_mode():
+    with open('gporca-commits-to-test/gpdb_assert_mode.txt') as fp:
+        assert_mode = fp.read().strip()
+        return assert_mode 
+
+untar_gpdb_cmd = "mkdir -p gpdb_src && tar -xf gpdb_tarball/gpdb*_src.tar.gz -C gpdb_src --strip 1"
+exec_command(untar_gpdb_cmd)
+
+# Default build mode is to enable assert. If the user explicitly specifies
+# 'disable-assert' option, only then don't enable the assert build.
+assert_mode = get_assert_mode()
+if assert_mode == 'enable-cassert':
+    configure_option += ' --enable-cassert'
+elif assert_mode != 'disable-cassert':
+    raise Exception('Unknown build type: (%s). Possible options are \'enable-cassert\' or \'disable-cassert\'')
+
+print "Beginning to {0}".format(action)
+if action == 'build':
+    build_gpdb_cmd = "gpdb_main_src/concourse/scripts/build_gpdb.py --mode={0} --output_dir=gpdb_binary/install --action={1} --configure-option='{2}' --orca-in-gpdb-install-location bin_orca bin_xerces".format(mode, action, configure_option)
+    exec_command(build_gpdb_cmd)
+
+    package_tarball_cmd = "env src_root=gpdb_binary/install dst_tarball=package_tarball/bin_gpdb.tar.gz gpdb_main_src/concourse/scripts/package_tarball.bash"
+    exec_command(package_tarball_cmd)
+
+elif action.startswith('test'):
+    environment_variables = os.environ['BLDWRAP_POSTGRES_CONF_ADDONS']
+
+    test_gpdb_cmd = "env {0} gpdb_main_src/concourse/scripts/build_gpdb.py --mode={1} --gpdb_name=bin_gpdb --action={2} --configure-option='{3}'".format(environment_variables, mode, action, configure_option) 
+    exec_command(test_gpdb_cmd)
+

--- a/concourse/tasks/diff_explain_results_with_baseline.yml
+++ b/concourse/tasks/diff_explain_results_with_baseline.yml
@@ -1,0 +1,15 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: pivotaldata/qp-gpdbdev
+inputs:
+  - name: gpdb_main_src
+  - name: explain_output
+  - name: explain_output_baseline
+outputs:
+  - name: diffs
+params:
+  prefix:
+run:
+  path: gpdb_main_src/concourse/scripts/diff_explain_results_with_baseline.bash

--- a/concourse/tasks/test_icg.yml
+++ b/concourse/tasks/test_icg.yml
@@ -4,20 +4,21 @@ image_resource:
   source:
     repository: pivotaldata/qp-gpdbdev
 inputs:
+  - name: gpdb_src
   - name: bin_orca
   - name: bin_xerces
-  - name: gpdb_src
-outputs:
   - name: bin_gpdb
+outputs:
+  - name: icg_output
 params:
+  BLDWRAP_POSTGRES_CONF_ADDONS:
   MODE:
-  OUTPUTDIR:
   ACTION:
   CONFIGURE_OPTION:
-  OTHER_CONFIGS:
+  GPDB_BINARY:
 run:
   path: sh
   args:
   - -exc
   - |
-    gpdb_src/concourse/scripts/build_gpdb.py ${MODE} ${OUTPUTDIR} ${ACTION} ${CONFIGURE_OPTION} ${OTHER_CONFIGS}
+    gpdb_src/concourse/scripts/build_gpdb.py ${MODE} ${ACTION} ${CONFIGURE_OPTION} ${GPDB_BINARY}

--- a/concourse/tasks/untar_build_with_orca.yml
+++ b/concourse/tasks/untar_build_with_orca.yml
@@ -1,0 +1,26 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: pivotaldata/qp-gpdbdev
+inputs:
+  - name: gporca-commits-to-test
+  - name: bin_orca
+  - name: bin_xerces
+  - name: bin_gpdb
+    optional: true
+  - name: gpdb_main_src
+  - name: gpdb_tarball
+  - name: explain_test_suite
+    optional: true
+outputs:
+  - name: gpdb_binary
+  - name: package_tarball
+  - name: icg_output
+run:
+  path: gpdb_main_src/concourse/scripts/untar_and_build_gpdb.py
+params:
+  ACTION:
+  MODE:
+  CONFIGURE_OPTION:
+  BLDWRAP_POSTGRES_CONF_ADDONS: statement_mem=250MB


### PR DESCRIPTION
Previously, the ORCA CI scripts existed only in the gpdb master branch, but were used to test all versions of GPDB (or in some cases only 5X versions). Now with ORCA moving
into the gpdb repo, we need to diverge these scripts (they've been heavily simplified/removed in master) . We'll be pointing the ORCA pipelines that only work with 5X artifacts to
use the scripts in the 5X gpdb branch instead of the master gpdb branch.