### PR TITLE
6x backport: Backport prefetch and outParams ref fix to 6X stable

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -87,6 +87,7 @@ static bool index_recheck_constraint(Relation index, Oid *constr_procs,
 						 Datum *existing_values, bool *existing_isnull,
 						 Datum *new_values);
 static void ShutdownExprContext(ExprContext *econtext, bool isCommit);
+static List *flatten_logic_exprs(Node *node);
 
 
 /* ----------------------------------------------------------------
@@ -1683,6 +1684,49 @@ ExecGetShareNodeEntry(EState* estate, int shareidx, bool fCreate)
 }
 
 /*
+ * flatten_logic_exprs
+ * This function is only used by ExecPrefetchJoinQual.
+ * ExecPrefetchJoinQual need to prefetch subplan in join
+ * qual that contains motion to materialize it to avoid
+ * motion deadlock. This function is going to flatten
+ * the bool exprs to avoid shortcut of bool logic.
+ * An example is:
+ * (a and b or c) or (d or e and f or g) and (h and i or j)
+ * will be transformed to
+ * (a, b, c, d, e, f, g, h, i, j).
+ */
+static List *
+flatten_logic_exprs(Node *node)
+{
+	if (node == NULL)
+		return NIL;
+
+	if (IsA(node, BoolExprState))
+	{
+		BoolExprState *be = (BoolExprState *) node;
+		return flatten_logic_exprs((Node *) (be->args));
+	}
+
+	if (IsA(node, List))
+	{
+		List     *es = (List *) node;
+		List     *result = NIL;
+		ListCell *lc = NULL;
+
+		foreach(lc, es)
+		{
+			Node *n = (Node *) lfirst(lc);
+			result = list_concat(result,
+								 flatten_logic_exprs(n));
+		}
+
+		return result;
+	}
+
+	return list_make1(node);
+}
+
+/*
  * Prefetch JoinQual to prevent motion hazard.
  *
  * A motion hazard is a deadlock between motions, a classic motion hazard in a
@@ -1709,7 +1753,7 @@ ExecGetShareNodeEntry(EState* estate, int shareidx, bool fCreate)
  *
  * Return true if the JoinQual is prefetched.
  */
-bool
+void
 ExecPrefetchJoinQual(JoinState *node)
 {
 	EState	   *estate = node->ps.state;
@@ -1719,8 +1763,10 @@ ExecPrefetchJoinQual(JoinState *node)
 	List	   *joinqual = node->joinqual;
 	TupleTableSlot *innertuple = econtext->ecxt_innertuple;
 
-	if (!joinqual)
-		return false;
+	ListCell   *lc = NULL;
+	List       *quals = NIL;
+
+	Assert(joinqual);
 
 	/* Outer tuples should not be fetched before us */
 	Assert(econtext->ecxt_outertuple == NULL);
@@ -1731,36 +1777,22 @@ ExecPrefetchJoinQual(JoinState *node)
 	econtext->ecxt_outertuple = ExecInitNullTupleSlot(estate,
 													  ExecGetResultType(outer));
 
+	quals = flatten_logic_exprs((Node *) joinqual);
+
 	/* Fetch subplan with the fake inner & outer tuples */
-	ExecQual(joinqual, econtext, false);
+	foreach(lc, quals)
+	{
+		/*
+		 * Force every joinqual is prefech because
+		 * our target is to materialize motion node.
+		 */
+		ExprState  *clause = (ExprState *) lfirst(lc);
+		(void) ExecQual(list_make1(clause), econtext, false);
+	}
 
 	/* Restore previous state */
 	econtext->ecxt_innertuple = innertuple;
 	econtext->ecxt_outertuple = NULL;
-
-	return true;
-}
-
-/*
- * Decide if should prefetch joinqual.
- *
- * Joinqual should be prefetched when both outer and joinqual contain motions.
- * In create_*join_plan() functions we set prefetch_joinqual according to the
- * outer motions, now we detect for joinqual motions to make the final
- * decision.
- *
- * See ExecPrefetchJoinQual() for details.
- *
- * This function should be called in ExecInit*Join() functions.
- *
- * Return true if JoinQual should be prefetched.
- */
-bool
-ShouldPrefetchJoinQual(EState *estate, Join *join)
-{
-	return (join->prefetch_joinqual &&
-			findSenderMotion(estate->es_plannedstmt,
-							 estate->currentSliceIdInPlan));
 }
 
 /* ----------------------------------------------------------------

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1727,6 +1727,52 @@ flatten_logic_exprs(Node *node)
 }
 
 /*
+ * fake_outer_params
+ *   helper function to fake the nestloop's nestParams
+ *   so that prefetch inner or prefetch joinqual will
+ *   not encounter NULL pointer reference issue. It is
+ *   only invoked in ExecNestLoop and ExecPrefetchJoinQual
+ *   when the join is a nestloop join.
+ */
+void
+fake_outer_params(JoinState *node)
+{
+	ExprContext    *econtext = node->ps.ps_ExprContext;
+	PlanState      *inner = innerPlanState(node);
+	TupleTableSlot *outerTupleSlot = econtext->ecxt_outertuple;
+	NestLoop       *nl = (NestLoop *) (node->ps.plan);
+	ListCell       *lc = NULL;
+
+	/* only nestloop contains nestParams */
+	Assert(IsA(node->ps.plan, NestLoop));
+
+	/* econtext->ecxt_outertuple must have been set fakely. */
+	Assert(outerTupleSlot != NULL);
+	/*
+	 * fetch the values of any outer Vars that must be passed to the
+	 * inner scan, and store them in the appropriate PARAM_EXEC slots.
+	 */
+	foreach(lc, nl->nestParams)
+	{
+		NestLoopParam *nlp = (NestLoopParam *) lfirst(lc);
+		int			paramno = nlp->paramno;
+		ParamExecData *prm;
+
+		prm = &(econtext->ecxt_param_exec_vals[paramno]);
+		/* Param value should be an OUTER_VAR var */
+		Assert(IsA(nlp->paramval, Var));
+		Assert(nlp->paramval->varno == OUTER_VAR);
+		Assert(nlp->paramval->varattno > 0);
+		prm->value = slot_getattr(outerTupleSlot,
+								  nlp->paramval->varattno,
+								  &(prm->isnull));
+		/* Flag parameter value as changed */
+		inner->chgParam = bms_add_member(inner->chgParam,
+										 paramno);
+	}
+}
+
+/*
  * Prefetch JoinQual to prevent motion hazard.
  *
  * A motion hazard is a deadlock between motions, a classic motion hazard in a
@@ -1776,6 +1822,13 @@ ExecPrefetchJoinQual(JoinState *node)
 													  ExecGetResultType(inner));
 	econtext->ecxt_outertuple = ExecInitNullTupleSlot(estate,
 													  ExecGetResultType(outer));
+
+	if (IsA(node->ps.plan, NestLoop))
+	{
+		NestLoop *nl = (NestLoop *) (node->ps.plan);
+		if (nl->nestParams)
+			fake_outer_params(node);
+	}
 
 	quals = flatten_logic_exprs((Node *) joinqual);
 

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -45,6 +45,8 @@
 /* Returns true if doing null-fill on inner relation */
 #define HJ_FILL_INNER(hjstate)	((hjstate)->hj_NullOuterTupleSlot != NULL)
 
+extern bool Test_print_prefetch_joinqual;
+
 static TupleTableSlot *ExecHashJoinOuterGetTuple(PlanState *outerNode,
 						  HashJoinState *hjstate,
 						  uint32 *hashvalue);
@@ -239,8 +241,11 @@ ExecHashJoin_guts(HashJoinState *node)
 				 *
 				 * See ExecPrefetchJoinQual() for details.
 				 */
-				if (node->prefetch_joinqual && ExecPrefetchJoinQual(&node->js))
+				if (node->prefetch_joinqual)
+				{
+					ExecPrefetchJoinQual(&node->js);
 					node->prefetch_joinqual = false;
+				}
 
 				/*
 				 * We just scanned the entire inner side and built the hashtable
@@ -600,7 +605,12 @@ ExecInitHashJoin(HashJoin *node, EState *estate, int eflags)
 	 * the fix to MPP-989)
 	 */
 	hjstate->prefetch_inner = node->join.prefetch_inner;
-	hjstate->prefetch_joinqual = ShouldPrefetchJoinQual(estate, &node->join);
+	hjstate->prefetch_joinqual = node->join.prefetch_joinqual;
+
+	if (Test_print_prefetch_joinqual && hjstate->prefetch_joinqual)
+		elog(NOTICE,
+			 "prefetch join qual in slice %d of plannode %d",
+			 currentSliceId, ((Plan *) node)->plan_node_id);
 
 	/*
 	 * initialize child nodes

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -160,6 +160,7 @@ typedef enum
 #define MarkInnerTuple(innerTupleSlot, mergestate) \
 	ExecCopySlot((mergestate)->mj_MarkedTupleSlot, (innerTupleSlot))
 
+extern bool Test_print_prefetch_joinqual;
 
 /*
  * MJExamineQuals
@@ -685,8 +686,11 @@ ExecMergeJoin_guts(MergeJoinState *node)
 	 *
 	 * See ExecPrefetchJoinQual() for details.
 	 */
-	if (node->prefetch_joinqual && ExecPrefetchJoinQual(&node->js))
+	if (node->prefetch_joinqual)
+	{
+		ExecPrefetchJoinQual(&node->js);
 		node->prefetch_joinqual = false;
+	}
 
 	/*
 	 * ok, everything is setup.. let's go to work
@@ -1572,7 +1576,13 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 	mergestate->mj_ConstFalseJoin = false;
 
 	mergestate->prefetch_inner = node->join.prefetch_inner;
-	mergestate->prefetch_joinqual = ShouldPrefetchJoinQual(estate, &node->join);
+	mergestate->prefetch_joinqual = node->join.prefetch_joinqual;
+
+	if (Test_print_prefetch_joinqual && mergestate->prefetch_joinqual)
+		elog(NOTICE,
+			 "prefetch join qual in slice %d of plannode %d",
+			 currentSliceId, ((Plan *) node)->plan_node_id);
+
 	/* Prepare inner operators for rewind after the prefetch */
 	rewindflag = mergestate->prefetch_inner ? EXEC_FLAG_REWIND : 0;
 

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -23,11 +23,14 @@
 
 #include "postgres.h"
 
+#include "cdb/cdbvars.h"
 #include "executor/execdebug.h"
 #include "executor/nodeNestloop.h"
 #include "optimizer/clauses.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
+
+extern bool Test_print_prefetch_joinqual;
 
 static void splitJoinQualExpr(NestLoopState *nlstate);
 static void extractFuncExprArgs(FuncExprState *fstate, List **lclauses, List **rclauses);
@@ -147,8 +150,11 @@ ExecNestLoop_guts(NestLoopState *node)
 	 *
 	 * See ExecPrefetchJoinQual() for details.
 	 */
-	if (node->prefetch_joinqual && ExecPrefetchJoinQual(&node->js))
+	if (node->prefetch_joinqual)
+	{
+		ExecPrefetchJoinQual(&node->js);
 		node->prefetch_joinqual = false;
+	}
 
 	/*
 	 * Ok, everything is setup for the join so now loop until we return a
@@ -390,8 +396,13 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
 	nlstate->shared_outer = node->shared_outer;
 
 	nlstate->prefetch_inner = node->join.prefetch_inner;
-	nlstate->prefetch_joinqual = ShouldPrefetchJoinQual(estate, &node->join);
-	
+	nlstate->prefetch_joinqual = node->join.prefetch_joinqual;
+
+	if (Test_print_prefetch_joinqual && nlstate->prefetch_joinqual)
+		elog(NOTICE,
+			 "prefetch join qual in slice %d of plannode %d",
+			 currentSliceId, ((Plan *) node)->plan_node_id);
+
 	/*CDB-OLAP*/
 	nlstate->reset_inner = false;
 	nlstate->require_inner_reset = !node->singleton_outer;

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -64,6 +64,14 @@
 #include "cdb/cdbsreh.h"
 #include "cdb/cdbvars.h"
 
+typedef struct
+{
+	plan_tree_base_prefix base; /* Required prefix for
+								 * plan_tree_walker/mutator */
+	Bitmapset            *seen_subplans;
+	bool                  result;
+} contain_motion_walk_context;
+
 static Plan *create_subplan(PlannerInfo *root, Path *best_path);		/* CDB */
 static Plan *create_scan_plan(PlannerInfo *root, Path *best_path);
 static List *build_path_tlist(PlannerInfo *root, Path *path);
@@ -188,6 +196,8 @@ static Motion *cdbpathtoplan_create_motion_plan(PlannerInfo *root,
 								 CdbMotionPath *path,
 								 Plan *subplan);
 static void append_initplan_for_function_scan(PlannerInfo *root, Path *best_path, Plan *plan);
+static bool contain_motion(PlannerInfo *root, Node *node);
+static bool contain_motion_walk(Node *node, contain_motion_walk_context *ctx);
 
 /*
  * GPDB_92_MERGE_FIXME: The following functions have been removed in PG 9.2
@@ -790,18 +800,6 @@ create_join_plan(PlannerInfo *root, JoinPath *best_path)
 	if (partition_selector_created)
 		((Join *) plan)->prefetch_inner = true;
 
-	/*
-	 * A motion deadlock can also happen when outer and joinqual both contain
-	 * motions.  It is not easy to check for joinqual here, so we set the
-	 * prefetch_joinqual mark only according to outer motion, and check for
-	 * joinqual later in the executor.
-	 *
-	 * See ExecPrefetchJoinQual() for details.
-	 */
-	if (best_path->outerjoinpath &&
-		best_path->outerjoinpath->motionHazard)
-		((Join *) plan)->prefetch_joinqual = true;
-
 	/* CDB: if the join's locus is bottleneck which means the
 	 * join gang only contains one process, so there is no
 	 * risk for motion deadlock.
@@ -825,6 +823,20 @@ create_join_plan(PlannerInfo *root, JoinPath *best_path)
 	if (plan->flow && plan->flow->hashExprs)
 	{
 		plan->targetlist = add_to_flat_tlist_junk(plan->targetlist, plan->flow->hashExprs, true /* resjunk */ );
+	}
+
+	/*
+	 * We may set prefetch_joinqual to true if there is
+	 * potential risk when create_xxxjoin_plan. Here, we
+	 * have all the information at hand, this is the final
+	 * logic to set prefetch_joinqual.
+	 */
+	if (((Join *) plan)->prefetch_joinqual)
+	{
+		List *joinqual = ((Join *) plan)->joinqual;
+
+		((Join *) plan)->prefetch_joinqual = contain_motion(root,
+															(Node *) joinqual);
 	}
 
 	/*
@@ -3330,7 +3342,8 @@ create_nestloop_plan(PlannerInfo *root,
 	 * See ExecPrefetchJoinQual() for details.
 	 */
 	if (best_path->outerjoinpath &&
-		best_path->outerjoinpath->motionHazard)
+		best_path->outerjoinpath->motionHazard &&
+		join_plan->join.joinqual != NIL)
 		join_plan->join.prefetch_joinqual = true;
 
 	return join_plan;
@@ -3667,14 +3680,16 @@ create_mergejoin_plan(PlannerInfo *root,
 	 * See ExecPrefetchJoinQual() for details.
 	 */
 	if (best_path->jpath.outerjoinpath &&
-		best_path->jpath.outerjoinpath->motionHazard)
+		best_path->jpath.outerjoinpath->motionHazard &&
+		join_plan->join.joinqual != NIL)
 		join_plan->join.prefetch_joinqual = true;
 	/*
 	 * If inner motion is not under a Material or Sort node then there could
 	 * also be motion deadlock between inner and joinqual in mergejoin.
 	 */
 	if (best_path->jpath.innerjoinpath &&
-		best_path->jpath.innerjoinpath->motionHazard)
+		best_path->jpath.innerjoinpath->motionHazard &&
+		join_plan->join.joinqual != NIL)
 		join_plan->join.prefetch_joinqual = true;
 
 	/* Costs of sort and material steps are included in path cost already */
@@ -3840,7 +3855,8 @@ create_hashjoin_plan(PlannerInfo *root,
 	 * See ExecPrefetchJoinQual() for details.
 	 */
 	if (best_path->jpath.outerjoinpath &&
-		best_path->jpath.outerjoinpath->motionHazard)
+		best_path->jpath.outerjoinpath->motionHazard &&
+		join_plan->join.joinqual != NIL)
 		join_plan->join.prefetch_joinqual = true;
 
 	copy_path_costsize(root, &join_plan->join.plan, &best_path->jpath.path);
@@ -7320,4 +7336,58 @@ append_initplan_for_function_scan(PlannerInfo *root, Path *best_path, Plan *plan
 														 best_path->parent ? best_path->parent->relids
 														 : NULL,
 														 &initplan->scan.plan);
+}
+
+/*
+ * contain_motion
+ * This function walks the joinqual list to  see there is
+ * any motion node in it. The only case a qual contains motion
+ * is that it is a SubPlan and the SubPlan contains motion.
+ * XXX: an over kill method is used here, for details please
+ * refer to the following function `contain_motion_walk`.
+ */
+static bool
+contain_motion(PlannerInfo *root, Node *node)
+{
+	contain_motion_walk_context ctx;
+	planner_init_plan_tree_base(&ctx.base, root);
+	ctx.result = false;
+	ctx.seen_subplans = NULL;
+
+	(void) contain_motion_walk(node, &ctx);
+
+	return ctx.result;
+}
+
+static bool
+contain_motion_walk(Node *node, contain_motion_walk_context *ctx)
+{
+	if (ctx->result)
+		return true;
+
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, SubPlan))
+	{
+		/*
+		 * In 6X we add motions for SubPlan after we have gotten
+		 * the plan. So at the time of this function calling,
+		 * we do not know if the SubPlan contains motion. We might
+		 * walk the plannedstmt to accurately determine this, but
+		 * that makes the code not that clean. So, we adopt an over
+		 * kill method here: any SubPlan contains motion. At least,
+		 * this can avoid motion deadlock.
+		 */
+		ctx->result = true;
+		return true;
+	}
+
+	if (IsA(node, Motion))
+	{
+		ctx->result = true;
+		return true;
+	}
+
+	return plan_tree_walker((Node *) node, contain_motion_walk, ctx);
 }

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -132,6 +132,7 @@ bool		Debug_appendonly_print_compaction = false;
 bool		Debug_resource_group = false;
 bool		Debug_bitmap_print_insert = false;
 bool		Test_print_direct_dispatch_info = false;
+bool        Test_print_prefetch_joinqual = false;
 bool		Test_copy_qd_qe_split = false;
 bool		gp_permit_relation_node_change = false;
 int			gp_max_local_distributed_cache = 1024;
@@ -1543,6 +1544,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&Test_print_direct_dispatch_info,
+		false,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"test_print_prefetch_joinqual", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("For testing purposes, print information about if we prefetch join qual."),
+			NULL,
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&Test_print_prefetch_joinqual,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -470,6 +470,7 @@ extern void UnregisterExprContextCallback(ExprContext *econtext,
 /* Share input utilities defined in execUtils.c */
 extern ShareNodeEntry * ExecGetShareNodeEntry(EState *estate, int shareid, bool fCreate);
 
+extern void fake_outer_params(JoinState *node);
 extern void ExecPrefetchJoinQual(JoinState *node);
 
 /* ResultRelInfo and Append Only segment assignment */

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -470,8 +470,7 @@ extern void UnregisterExprContextCallback(ExprContext *econtext,
 /* Share input utilities defined in execUtils.c */
 extern ShareNodeEntry * ExecGetShareNodeEntry(EState *estate, int shareid, bool fCreate);
 
-extern bool ExecPrefetchJoinQual(JoinState *node);
-extern bool ShouldPrefetchJoinQual(EState *estate, Join *join);
+extern void ExecPrefetchJoinQual(JoinState *node);
 
 /* ResultRelInfo and Append Only segment assignment */
 void ResultRelInfoSetSegno(ResultRelInfo *resultRelInfo, List *mapping);

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -104,6 +104,7 @@
 		"statement_timeout",
 		"temp_buffers",
 		"test_copy_qd_qe_split",
+		"test_print_prefetch_joinqual",
 		"TimeZone",
 		"verify_gpfdists_cert",
 		"vmem_process_interrupt",

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3310,6 +3310,38 @@ select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
  1 | 1 | 2 | 2
 (1 row)
 
+-- The above plan will prefetch inner plan and the inner plan refers
+-- outerParams. Previously, we do not handle this case correct and forgot
+-- to set the Params for nestloop in econtext. The outer Param is a compound
+-- data type instead of simple integer, it will lead to PANIC.
+-- See Github Issue: https://github.com/greenplum-db/gpdb/issues/9679
+-- for details.
+create type mytype_prefetch_params as (x int, y int);
+alter table b add column mt_col mytype_prefetch_params;
+explain select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.19..765906.72 rows=24 width=16)
+   ->  Nested Loop  (cost=0.19..765906.26 rows=8 width=16)
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.05 rows=1 width=36)
+               ->  Seq Scan on b  (cost=0.00..1.01 rows=1 width=36)
+         ->  Materialize  (cost=0.19..255301.72 rows=2 width=12)
+               ->  Nested Loop  (cost=0.19..255301.70 rows=2 width=12)
+                     Join Filter: (((b.mt_col).x > a.i) OR (b.i = a.i))
+                     ->  Materialize  (cost=0.00..1.06 rows=1 width=4)
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.05 rows=1 width=4)
+                                 ->  Seq Scan on a  (cost=0.00..1.01 rows=1 width=4)
+                     ->  Index Only Scan using c_i_j_idx on c  (cost=0.19..85100.20 rows=1 width=8)
+                           Index Cond: (j = (a.i + b.i))
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
+ i | i | i | j 
+---+---+---+---
+ 1 | 1 | 2 | 2
+(1 row)
+
 reset enable_hashjoin;
 reset enable_mergejoin;
 reset enable_nestloop;

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3307,6 +3307,38 @@ select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
  1 | 1 | 2 | 2
 (1 row)
 
+-- The above plan will prefetch inner plan and the inner plan refers
+-- outerParams. Previously, we do not handle this case correct and forgot
+-- to set the Params for nestloop in econtext. The outer Param is a compound
+-- data type instead of simple integer, it will lead to PANIC.
+-- See Github Issue: https://github.com/greenplum-db/gpdb/issues/9679
+-- for details.
+create type mytype_prefetch_params as (x int, y int);
+alter table b add column mt_col mytype_prefetch_params;
+explain select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.19..765906.72 rows=24 width=16)
+   ->  Nested Loop  (cost=0.19..765906.26 rows=8 width=16)
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.05 rows=1 width=36)
+               ->  Seq Scan on b  (cost=0.00..1.01 rows=1 width=36)
+         ->  Materialize  (cost=0.19..255301.72 rows=2 width=12)
+               ->  Nested Loop  (cost=0.19..255301.70 rows=2 width=12)
+                     Join Filter: (((b.mt_col).x > a.i) OR (b.i = a.i))
+                     ->  Materialize  (cost=0.00..1.06 rows=1 width=4)
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.05 rows=1 width=4)
+                                 ->  Seq Scan on a  (cost=0.00..1.01 rows=1 width=4)
+                     ->  Index Only Scan using c_i_j_idx on c  (cost=0.19..85100.20 rows=1 width=8)
+                           Index Cond: (j = (a.i + b.i))
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
+ i | i | i | j 
+---+---+---+---
+ 1 | 1 | 2 | 2
+(1 row)
+
 reset enable_hashjoin;
 reset enable_mergejoin;
 reset enable_nestloop;

--- a/src/test/regress/expected/deadlock2.out
+++ b/src/test/regress/expected/deadlock2.out
@@ -89,8 +89,43 @@ insert into t_subplan select :x0, :x0 from generate_series(1,:scale) i;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;
+set Test_print_prefetch_joinqual = on;
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1);
+NOTICE:  prefetch join qual in slice 0 of plannode 4
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg0 slice5 127.0.1.1:6002 pid=27794)
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg1 slice5 127.0.1.1:6003 pid=27795)
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg2 slice5 127.0.1.1:6004 pid=27796)
+ count 
+-------
+ 10000
+(1 row)
+
+-- The logic of ExecPrefetchJoinQual is to use two null
+-- tuples to fake inner and outertuple and then to ExecQual.
+-- It may short cut if some previous qual is test null expr.
+-- So ExecPrefetchJoinQual has to force ExecQual for each
+-- qual expr in the joinqual list. See the Github issue
+-- https://github.com/greenplum-db/gpdb/issues/8677
+-- for details.
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+   and (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
+NOTICE:  prefetch join qual in slice 0 of plannode 4
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg0 slice5 127.0.1.1:6002 pid=27794)
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg1 slice5 127.0.1.1:6003 pid=27795)
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg2 slice5 127.0.1.1:6004 pid=27796)
+ count 
+-------
+ 10000
+(1 row)
+
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+   and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
+   and not exists (select 1 from t_subplan where t_subplan.c2=t_outer.c1);
+NOTICE:  prefetch join qual in slice 0 of plannode 4
+NOTICE:  prefetch join qual in slice 7 of plannode 4  (seg0 slice7 127.0.1.1:6002 pid=27794)
+NOTICE:  prefetch join qual in slice 7 of plannode 4  (seg1 slice7 127.0.1.1:6003 pid=27795)
+NOTICE:  prefetch join qual in slice 7 of plannode 4  (seg2 slice7 127.0.1.1:6004 pid=27796)
  count 
 -------
  10000

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1049,3 +1049,71 @@ on true;
     1 | Sun Jan 02 02:04:00 2000 PST | Sun Jan 02 03:04:00 2000 PST
 (2 rows)
 
+-- test prefetch join qual
+-- we do not handle this correct
+-- the only case we need to prefetch join qual is:
+--   1. outer plan contains motion
+--   2. the join qual contains subplan that contains motion
+reset client_min_messages;
+set Test_print_prefetch_joinqual = true;
+-- prefetch join qual is only set correct for planner
+set optimizer = off;
+create table t1_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- the following plan contains redistribute motion in both inner and outer plan
+-- the join qual is t1.c > t2.c, it contains no motion, should not prefetch
+explain (costs off) select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.c > t2.c;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t1.b = t2.b)
+         Join Filter: (t1.c > t2.c)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: t1.b
+               ->  Seq Scan on t1_test_pretch_join_qual t1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: t2.b
+                     ->  Seq Scan on t2_test_pretch_join_qual t2
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+create table t3_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- the following plan contains motion in both outer plan and join qual,
+-- so we should prefetch join qual
+explain (costs off) select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.a > any (select sum(b) from t3_test_pretch_join_qual t3 where c > t2.a);
+NOTICE:  prefetch join qual in slice 0 of plannode 2
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t1.b = t2.b)
+         Join Filter: (SubPlan 1)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: t1.b
+               ->  Seq Scan on t1_test_pretch_join_qual t1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: t2.b
+                     ->  Seq Scan on t2_test_pretch_join_qual t2
+         SubPlan 1  (slice4; segments: 3)
+           ->  Aggregate
+                 ->  Result
+                       Filter: (t3.c > t2.a)
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                   ->  Seq Scan on t3_test_pretch_join_qual t3
+ Optimizer: Postgres query optimizer
+(19 rows)
+
+reset Test_print_prefetch_joinqual;
+reset optimizer;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1065,3 +1065,71 @@ on true;
     1 | Sun Jan 02 02:04:00 2000 PST | Sun Jan 02 03:04:00 2000 PST
 (2 rows)
 
+-- test prefetch join qual
+-- we do not handle this correct
+-- the only case we need to prefetch join qual is:
+--   1. outer plan contains motion
+--   2. the join qual contains subplan that contains motion
+reset client_min_messages;
+set Test_print_prefetch_joinqual = true;
+-- prefetch join qual is only set correct for planner
+set optimizer = off;
+create table t1_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- the following plan contains redistribute motion in both inner and outer plan
+-- the join qual is t1.c > t2.c, it contains no motion, should not prefetch
+explain (costs off) select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.c > t2.c;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t1.b = t2.b)
+         Join Filter: (t1.c > t2.c)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: t1.b
+               ->  Seq Scan on t1_test_pretch_join_qual t1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: t2.b
+                     ->  Seq Scan on t2_test_pretch_join_qual t2
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+create table t3_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- the following plan contains motion in both outer plan and join qual,
+-- so we should prefetch join qual
+explain (costs off) select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.a > any (select sum(b) from t3_test_pretch_join_qual t3 where c > t2.a);
+NOTICE:  prefetch join qual in slice 0 of plannode 2
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t1.b = t2.b)
+         Join Filter: (SubPlan 1)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: t1.b
+               ->  Seq Scan on t1_test_pretch_join_qual t1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: t2.b
+                     ->  Seq Scan on t2_test_pretch_join_qual t2
+         SubPlan 1  (slice4; segments: 3)
+           ->  Aggregate
+                 ->  Result
+                       Filter: (t3.c > t2.a)
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                   ->  Seq Scan on t3_test_pretch_join_qual t3
+ Optimizer: Postgres query optimizer
+(19 rows)
+
+reset Test_print_prefetch_joinqual;
+reset optimizer;

--- a/src/test/regress/sql/deadlock2.sql
+++ b/src/test/regress/sql/deadlock2.sql
@@ -92,6 +92,21 @@ insert into t_subplan select :x0, :x0 from generate_series(1,:scale) i;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;
+set Test_print_prefetch_joinqual = on;
 
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1);
+
+-- The logic of ExecPrefetchJoinQual is to use two null
+-- tuples to fake inner and outertuple and then to ExecQual.
+-- It may short cut if some previous qual is test null expr.
+-- So ExecPrefetchJoinQual has to force ExecQual for each
+-- qual expr in the joinqual list. See the Github issue
+-- https://github.com/greenplum-db/gpdb/issues/8677
+-- for details.
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+   and (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
+
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+   and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
+   and not exists (select 1 from t_subplan where t_subplan.c2=t_outer.c1);

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -472,6 +472,7 @@ reset enable_hashjoin;
 reset enable_mergejoin;
 reset enable_nestloop;
 
+
 -- test lateral join inner plan contains limit
 -- we cannot pass params across motion so we
 -- can only generate a plan to gather all the
@@ -515,3 +516,31 @@ inner join lateral
 (select myid, log_date as next_date
  from t_mylog_issue_8860 where myid = ml1.myid and log_date > ml1.log_date order by log_date asc limit 1) ml2
 on true;
+
+-- test prefetch join qual
+-- we do not handle this correct
+-- the only case we need to prefetch join qual is:
+--   1. outer plan contains motion
+--   2. the join qual contains subplan that contains motion
+reset client_min_messages;
+set Test_print_prefetch_joinqual = true;
+-- prefetch join qual is only set correct for planner
+set optimizer = off;
+
+create table t1_test_pretch_join_qual(a int, b int, c int);
+create table t2_test_pretch_join_qual(a int, b int, c int);
+
+-- the following plan contains redistribute motion in both inner and outer plan
+-- the join qual is t1.c > t2.c, it contains no motion, should not prefetch
+explain (costs off) select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.c > t2.c;
+
+create table t3_test_pretch_join_qual(a int, b int, c int);
+
+-- the following plan contains motion in both outer plan and join qual,
+-- so we should prefetch join qual
+explain (costs off) select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.a > any (select sum(b) from t3_test_pretch_join_qual t3 where c > t2.a);
+
+reset Test_print_prefetch_joinqual;
+reset optimizer;


### PR DESCRIPTION
This PR contains two commits that backport some important fix on master branch

1. backport the pr: https://github.com/greenplum-db/gpdb/pull/9616 and https://github.com/greenplum-db/gpdb/pull/9678
2. backport the pr: https://github.com/greenplum-db/gpdb/pull/9680

All the above PRs have been merged into master. This PR contains all the related test cases in master branch.

One important thing has to be mentioned here:

```
In 6X we add motions for SubPlan
after we have gotten the plan. So at the time of this function calling,
we do not know if the SubPlan contains motion. We might walk the plannedstmt
to accurately determine this, but that makes the code not that clean.
So, we adopt an over kill method here: any SubPlan contains motion. At least,
this can avoid motion deadlock.
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
