### PR TITLE
[6X backport]Fix inconsistent snapshot during concurrent update

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -22,7 +22,9 @@
 #include "catalog/pg_authid.h"
 #include "cdb/cdbtm.h"
 #include "libpq/libpq-be.h"
+#include "libpq/pqformat.h"
 #include "miscadmin.h"
+#include "storage/lmgr.h"
 #include "storage/s_lock.h"
 #include "storage/shmem.h"
 #include "storage/ipc.h"
@@ -125,6 +127,7 @@ static void setCurrentDtxState(DtxState state);
 static bool isDtxQueryDispatcher(void);
 static void performDtxProtocolCommitPrepared(const char *gid, bool raiseErrorIfNotFound);
 static void performDtxProtocolAbortPrepared(const char *gid, bool raiseErrorIfNotFound);
+static void sendWaitGxidsToQD(List *waitGxids);
 
 extern void CheckForResetSession(void);
 
@@ -268,6 +271,7 @@ currentDtxActivate(void)
 	MyTmGxact->distribTimeStamp = getDtxStartTime();
 	MyTmGxact->sessionId = gp_session_id;
 	setCurrentDtxState(DTX_STATE_ACTIVE_DISTRIBUTED);
+	GxactLockTableInsert(MyTmGxact->gxid);
 }
 
 static void
@@ -308,6 +312,8 @@ notifyCommittedDtxTransactionIsNeeded(void)
 void
 notifyCommittedDtxTransaction(void)
 {
+	ListCell   *l;
+
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 	Assert(DistributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE);
 	Assert(isCurrentDtxActivated());
@@ -324,6 +330,12 @@ notifyCommittedDtxTransaction(void)
 			ereport(ERROR,
 					(errmsg("Unexpected DTX state"),
 					 TM_ERRDETAIL));
+	}
+
+
+	foreach(l, MyTmGxactLocal->waitGxids)
+	{
+		GxactLockTableWait(lfirst_int(l));
 	}
 }
 
@@ -495,6 +507,7 @@ ClearTransactionState(TransactionId latestXid)
 	 * To fix this, transactions require two-phase commit should defer clear 
 	 * proc->xid here with ProcArryLock held.
 	 */
+	SIMPLE_FAULT_INJECTOR("before_xact_end_procarray");
 	LWLockAcquire(ProcArrayLock, LW_EXCLUSIVE);
 	ProcArrayEndTransaction(MyProc, latestXid, true);
 	ProcArrayEndGxact();
@@ -1163,6 +1176,17 @@ isMppTxOptions_ExplicitBegin(int txnOptions)
 /*=========================================================================
  * HELPER FUNCTIONS
  */
+static int
+compare_int(const void *va, const void *vb)
+{
+	int			a = *((const int *) va);
+	int			b = *((const int *) vb);
+
+	if (a == b)
+		return 0;
+	return (a > b) ? 1 : -1;
+}
+
 bool
 currentDtxDispatchProtocolCommand(DtxProtocolCommand dtxProtocolCommand, bool raiseError)
 {
@@ -1189,6 +1213,9 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 	char	   *dtxProtocolCommandStr = 0;
 
 	struct pg_result **results;
+	MemoryContext oldContext;
+	int *waitGxids = NULL;
+	int totalWaits = 0;
 
 	if (!dtxSegments)
 		return true;
@@ -1269,8 +1296,50 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 		}
 	}
 
+	/* gather all the waited gxids from segments and remove the duplicates */
 	for (i = 0; i < resultCount; i++)
-		PQclear(results[i]);
+		totalWaits += results[i]->nWaits;
+
+	if (totalWaits > 0)
+		waitGxids = palloc(sizeof(int) * totalWaits);
+
+	totalWaits = 0;
+	for (i = 0; i < resultCount; i++)
+	{
+		struct pg_result *result = results[i];
+
+		if (result->nWaits > 0)
+		{
+			memcpy(&waitGxids[totalWaits], result->waitGxids, sizeof(int) * result->nWaits);
+			totalWaits += result->nWaits;
+		}
+		PQclear(result);
+	}
+
+	if (totalWaits > 0)
+	{
+		int lastRepeat = -1;
+		if (MyTmGxactLocal->waitGxids)
+		{
+			pfree(MyTmGxactLocal->waitGxids);
+			MyTmGxactLocal->waitGxids = NULL;
+		}
+
+		qsort(waitGxids, totalWaits, sizeof(int), compare_int);
+
+		oldContext = MemoryContextSwitchTo(TopTransactionContext);
+		for (i = 0; i < totalWaits; i++)
+		{
+			if (waitGxids[i] == lastRepeat)
+				continue;
+			MyTmGxactLocal->waitGxids = lappend_int(MyTmGxactLocal->waitGxids, waitGxids[i]);
+			lastRepeat = waitGxids[i];
+		}
+		MemoryContextSwitchTo(oldContext);
+	}
+
+	if (waitGxids)
+		pfree(waitGxids);
 
 	if (results)
 		free(results);
@@ -1362,6 +1431,11 @@ resetGxact()
 	MyTmGxactLocal->dtxSegmentsMap = NULL;
 	MyTmGxactLocal->dtxSegments = NIL;
 	MyTmGxactLocal->isOnePhaseCommit = false;
+	if (MyTmGxactLocal->waitGxids != NULL)
+	{
+		pfree(MyTmGxactLocal->waitGxids);
+		MyTmGxactLocal->waitGxids = NULL;
+	}
 	setCurrentDtxState(DTX_STATE_NONE);
 }
 
@@ -1954,7 +2028,24 @@ performDtxProtocolPrepare(const char *gid)
 	setDistributedTransactionContext(DTX_CONTEXT_QE_PREPARED);
 }
 
+static void
+sendWaitGxidsToQD(List *waitGxids)
+{
+	ListCell *lc;
+	StringInfoData buf;
+	int len = list_length(waitGxids);
 
+	if (len == 0)
+		return;
+
+	pq_beginmessage(&buf, 'w');
+	pq_sendint(&buf, len, 4);
+	foreach(lc, waitGxids)
+	{
+		pq_sendint(&buf, lfirst_int(lc), 4);
+	}
+	pq_endmessage(&buf);
+}
 /**
  * On the QE, run the Commit one-phase operation.
  */
@@ -1963,6 +2054,8 @@ performDtxProtocolCommitOnePhase(const char *gid)
 {
 	DistributedTransactionTimeStamp distribTimeStamp;
 	DistributedTransactionId gxid;
+	List *waitGxids = list_copy(MyTmGxactLocal->waitGxids);
+
 	elog(DTM_DEBUG5,
 		 "performDtxProtocolCommitOnePhase going to call CommitTransaction for distributed transaction %s", gid);
 
@@ -1984,6 +2077,8 @@ performDtxProtocolCommitOnePhase(const char *gid)
 
 	finishDistributedTransactionContext("performDtxProtocolCommitOnePhase -- Commit onephase", false);
 	MyProc->localDistribXactData.state = LOCALDISTRIBXACT_STATE_NONE;
+
+	sendWaitGxidsToQD(waitGxids);
 }
 
 /**
@@ -1994,6 +2089,8 @@ performDtxProtocolCommitPrepared(const char *gid, bool raiseErrorIfNotFound)
 {
 	elog(DTM_DEBUG5,
 		 "performDtxProtocolCommitPrepared going to call FinishPreparedTransaction for distributed transaction %s", gid);
+
+	List *waitGxids = list_copy(MyTmGxactLocal->waitGxids);
 
 	StartTransactionCommand();
 
@@ -2016,6 +2113,8 @@ performDtxProtocolCommitPrepared(const char *gid, bool raiseErrorIfNotFound)
 	 * work to be performed.
 	 */
 	CommitTransactionCommand();
+
+	sendWaitGxidsToQD(waitGxids);
 
 	finishDistributedTransactionContext("performDtxProtocolCommitPrepared -- Commit Prepared", false);
 }

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -4832,6 +4832,7 @@ LocalXidGetDistributedXid(TransactionId xid)
 	DistributedTransactionId gxid = InvalidDistributedTransactionId;
 	ProcArrayStruct *arrayP = procArray;
 
+	SIMPLE_FAULT_INJECTOR("before_get_distributed_xid");
 	LWLockAcquire(ProcArrayLock, LW_SHARED);
 	for (index = 0; index < arrayP->numProcs; index++)
 	{

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -4824,6 +4824,39 @@ GetPidByGxid(DistributedTransactionId gxid)
 	return pid;
 }
 
+DistributedTransactionId
+LocalXidGetDistributedXid(TransactionId xid)
+{
+	int index;
+	DistributedTransactionTimeStamp tstamp;
+	DistributedTransactionId gxid = InvalidDistributedTransactionId;
+	ProcArrayStruct *arrayP = procArray;
+
+	LWLockAcquire(ProcArrayLock, LW_SHARED);
+	for (index = 0; index < arrayP->numProcs; index++)
+	{
+		int		 pgprocno = arrayP->pgprocnos[index];
+		volatile PGXACT *pgxact = &allPgXact[pgprocno];
+		volatile TMGXACT *gxact = &allTmGxact[pgprocno];
+		if (xid == pgxact->xid)
+		{
+			gxid = gxact->gxid;
+			break;
+		}
+	}
+	LWLockRelease(ProcArrayLock);
+
+	/* The transaction has already committed on segment */
+	if (gxid == InvalidDistributedTransactionId)
+	{
+		DistributedLog_GetDistributedXid(xid, &tstamp, &gxid);
+		AssertImply(gxid != InvalidDistributedTransactionId,
+					tstamp == MyTmGxact->distribTimeStamp);
+	}
+
+	return gxid;
+}
+
 /*
  * KnownAssignedXidsReset
  *		Resets KnownAssignedXids to be empty

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -24,8 +24,10 @@
 #include "miscadmin.h"
 #include "storage/lmgr.h"
 #include "storage/procarray.h"
+#include "storage/proc.h"
 #include "utils/inval.h"
 #include "utils/guc.h"
+#include "utils/memutils.h"
 
 #include "access/heapam.h"
 #include "catalog/namespace.h"
@@ -593,6 +595,29 @@ XactLockTableWait(TransactionId xid, Relation rel, ItemPointer ctid,
 	bool		first = true;
 
 	/*
+	 * Concurrent update and delete will wait on segment when GDD is enabled,
+	 * need to report the waited transactions to QD to make sure the they have
+	 * the same transaction order on the master.
+	 */
+	if (gp_enable_global_deadlock_detector && Gp_role == GP_ROLE_EXECUTE)
+	{
+		MemoryContext oldContext;
+		DistributedTransactionId gxid = LocalXidGetDistributedXid(xid);
+
+		if (gxid != InvalidDistributedTransactionId)
+		{
+			/*
+			 * allocate waitGxids in TopMemoryContext since it's used in
+			 * 'commit prepared' and the TopTransactionContext has been delete
+			 * after 'prepare'
+			 */
+			oldContext = MemoryContextSwitchTo(TopMemoryContext);
+			MyTmGxactLocal->waitGxids = lappend_int(MyTmGxactLocal->waitGxids, gxid);
+			MemoryContextSwitchTo(oldContext);
+		}
+	}
+
+	/*
 	 * If an operation is specified, set up our verbose error context
 	 * callback.
 	 */
@@ -648,6 +673,45 @@ XactLockTableWait(TransactionId xid, Relation rel, ItemPointer ctid,
 
 	if (oper != XLTW_None)
 		error_context_stack = callback.previous;
+}
+
+/*
+ *		GxactLockTableInsert
+ *
+ * CDB: a copy of XactLockTableInsert
+ * Insert a lock showing that the given distributed transaction ID is running
+ */
+void
+GxactLockTableInsert(DistributedTransactionId gxid)
+{
+	LOCKTAG		tag;
+
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+
+	SET_LOCKTAG_DISTRIB_TRANSACTION(tag, gxid);
+
+	(void) LockAcquire(&tag, ExclusiveLock, false, false);
+}
+
+/*
+ *		GxactLockTableWait
+ *
+ * CDB: a copy of XactLockTableWait, no need to take care of sub-transaction.
+ * Wait for the specified distributed transaction to commit or abort.
+ */
+void
+GxactLockTableWait(DistributedTransactionId gxid)
+{
+	LOCKTAG		tag;
+
+	Assert(gxid != InvalidDistributedTransactionId);
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+
+	SET_LOCKTAG_DISTRIB_TRANSACTION(tag, gxid);
+
+	(void) LockAcquire(&tag, ShareLock, false, false);
+
+	LockRelease(&tag, ShareLock, false);
 }
 
 /*
@@ -984,6 +1048,11 @@ DescribeLockTag(StringInfo buf, const LOCKTAG *tag)
 		case LOCKTAG_TRANSACTION:
 			appendStringInfo(buf,
 							 _("transaction %u"),
+							 tag->locktag_field1);
+			break;
+		case LOCKTAG_DISTRIB_TRANSACTION:
+			appendStringInfo(buf,
+							 _("distributed transaction %u"),
 							 tag->locktag_field1);
 			break;
 		case LOCKTAG_VIRTUALTRANSACTION:

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -35,6 +35,7 @@ static const char *const LockTagTypeNames[] = {
 	"append-only segment file",
 	"object",
 	"resource queue",
+	"distributed xid",
 	"userlock",
 	"advisory"
 };
@@ -391,6 +392,18 @@ pg_lock_status(PG_FUNCTION_ARGS)
 				nulls[9] = true;
 				break;
 			case LOCKTAG_TRANSACTION:
+				values[6] =
+					TransactionIdGetDatum(instance->locktag.locktag_field1);
+				nulls[1] = true;
+				nulls[2] = true;
+				nulls[3] = true;
+				nulls[4] = true;
+				nulls[5] = true;
+				nulls[7] = true;
+				nulls[8] = true;
+				nulls[9] = true;
+				break;
+			case LOCKTAG_DISTRIB_TRANSACTION:
 				values[6] =
 					TransactionIdGetDatum(instance->locktag.locktag_field1);
 				nulls[1] = true;

--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -82,5 +82,9 @@ extern void DistributedLog_InitOldestXmin(void);
 
 extern void DistributedLog_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
 extern void DistributedLog_desc(StringInfo buf, XLogRecord *record);
+extern void DistributedLog_GetDistributedXid(
+				TransactionId 						localXid,
+				DistributedTransactionTimeStamp		*distribTimeStamp,
+				DistributedTransactionId 			*distribXid);
 
 #endif							/* DISTRIBUTEDLOG_H */

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -237,6 +237,7 @@ typedef struct TMGXACTLOCAL
 
 	Bitmapset					*dtxSegmentsMap;
 	List						*dtxSegments;
+	List						*waitGxids;
 }	TMGXACTLOCAL;
 
 typedef struct TMGXACTSTATUS

--- a/src/include/storage/lmgr.h
+++ b/src/include/storage/lmgr.h
@@ -109,4 +109,6 @@ extern bool LockTagIsTemp(const LOCKTAG *tag);
 
 extern bool CondUpgradeRelLock(Oid relid, bool noWait);
 
+extern void GxactLockTableInsert(DistributedTransactionId xid);
+extern void GxactLockTableWait(DistributedTransactionId xid);
 #endif   /* LMGR_H */

--- a/src/include/storage/lock.h
+++ b/src/include/storage/lock.h
@@ -202,6 +202,7 @@ typedef enum LockTagType
 	 * Also, we use DB OID = 0 for shared objects such as tablespaces.
 	 */
 	LOCKTAG_RESOURCE_QUEUE,		/* ID info for resource queue is QUEUE ID */
+	LOCKTAG_DISTRIB_TRANSACTION,/* CDB: distributed transaction (for waiting for distributed xact done) */
 	LOCKTAG_USERLOCK,			/* reserved for old contrib/userlock code */
 	LOCKTAG_ADVISORY			/* advisory user locks */
 } LockTagType;
@@ -269,6 +270,14 @@ typedef struct LOCKTAG
 	 (locktag).locktag_field3 = 0, \
 	 (locktag).locktag_field4 = 0, \
 	 (locktag).locktag_type = LOCKTAG_TRANSACTION, \
+	 (locktag).locktag_lockmethodid = DEFAULT_LOCKMETHOD)
+
+#define SET_LOCKTAG_DISTRIB_TRANSACTION(locktag,gxid) \
+	((locktag).locktag_field1 = (gxid), \
+	 (locktag).locktag_field2 = 0, \
+	 (locktag).locktag_field3 = 0, \
+	 (locktag).locktag_field4 = 0, \
+	 (locktag).locktag_type = LOCKTAG_DISTRIB_TRANSACTION, \
 	 (locktag).locktag_lockmethodid = DEFAULT_LOCKMETHOD)
 
 #define SET_LOCKTAG_VIRTUALTRANSACTION(locktag,vxid) \

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -103,5 +103,6 @@ extern void ProcArraySetReplicationSlotXmin(TransactionId xmin,
 
 extern void ProcArrayGetReplicationSlotXmin(TransactionId *xmin,
 								TransactionId *catalog_xmin);
+extern DistributedTransactionId LocalXidGetDistributedXid(TransactionId xid);
 
 #endif   /* PROCARRAY_H */

--- a/src/interfaces/libpq/fe-exec.c
+++ b/src/interfaces/libpq/fe-exec.c
@@ -182,6 +182,8 @@ PQmakeEmptyPGresult(PGconn *conn, ExecStatusType status)
 	result->numCompleted = 0;
 	result->naotupcounts = 0;
 	result->aotupcounts = NULL;
+	result->nWaits = 0;
+	result->waitGxids = NULL;
 
 	if (conn)
 	{
@@ -738,6 +740,9 @@ PQclear(PGresult *res)
 		free(res->aotupcounts);
 	res->naotupcounts = 0;
 
+	if (res->waitGxids)
+		free(res->waitGxids);
+	res->nWaits = 0;
 	/* Free the PGresult structure itself */
 	free(res);
 }

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -85,6 +85,7 @@ pqParseInput3(PGconn *conn)
 	int			avail;
 #ifndef FRONTEND
 	int			numRejected  = 0;
+	int			i;
 	int64		numCompleted = 0;
 #endif
 
@@ -533,6 +534,33 @@ pqParseInput3(PGconn *conn)
 						return;
 					conn->asyncStatus = PGASYNC_READY;
 
+					break;
+
+				case 'w':
+					/*
+					 * 'commit prepared' and 'one-phase commit' reports a list of gxids
+					 * that the transaction has waited.
+					 */
+					if (conn->result == NULL)
+					{
+						conn->result = PQmakeEmptyPGresult(conn, PGRES_COMMAND_OK);
+						if (!conn->result)
+							return;
+					}
+
+					if (pqGetInt(&conn->result->nWaits, 4, conn))
+						return;
+
+					if (conn->result->nWaits > 0)
+					{
+						conn->result->waitGxids = malloc(sizeof(int) * conn->result->nWaits);
+						for (i = 0; i < conn->result->nWaits; i++)
+						{
+							int gxid;
+							pqGetInt(&gxid, 4, conn);
+							conn->result->waitGxids[i] = gxid;
+						}
+					}
 					break;
 #endif
 				default:

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -247,6 +247,8 @@ struct pg_result
 	/* GPDB: number of processed tuples for each AO partition */
 	int			naotupcounts;
 	PQaoRelTupCount *aotupcounts;
+	int		nWaits;
+	int		*waitGxids;
 };
 
 /* PGAsyncStatusType defines the state of the query-execution state machine */

--- a/src/test/isolation2/expected/concurrent_update.out
+++ b/src/test/isolation2/expected/concurrent_update.out
@@ -29,8 +29,6 @@ DROP TABLE t_concurrent_update;
 DROP
 
 
--- Test the concurrent update transaction order on the segment is reflected on master
--- enable gdd
 --start_ignore
 ! gpconfig -c gp_enable_global_deadlock_detector -v on;
 20200305:08:04:41:016395 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-c gp_enable_global_deadlock_detector -v on'
@@ -65,6 +63,8 @@ DROP
 
 --end_ignore
 
+-- Test the concurrent update transaction order on the segment is reflected on master
+-- enable gdd
 1: SHOW gp_enable_global_deadlock_detector;
  gp_enable_global_deadlock_detector 
 ------------------------------------
@@ -128,8 +128,57 @@ END
 ---+----
  1 | 21 
 (1 row)
-1: DROP TABLE t_concurrent_update;
+1q: ... <quitting>
+
+-- Same test as the above, except the first transaction commits before the
+-- second transaction check the wait gxid, it should get the gxid from
+-- pg_distributedlog instead of the procarray.
+4: BEGIN;
+BEGIN
+4: SET optimizer=off;
+SET
+4: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+UPDATE 1
+
+5: BEGIN;
+BEGIN
+5: SET optimizer=off;
+SET
+-- suspend before get 'wait gxid'
+5: SELECT gp_inject_fault('before_get_distributed_xid', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+5&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;  <waiting ...>
+
+6: SELECT gp_wait_until_triggered_fault('before_get_distributed_xid', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+4: END;
+END
+4: SELECT gp_inject_fault('before_get_distributed_xid', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+5<:  <... completed>
+UPDATE 1
+5: END;
+END
+6: SELECT * FROM t_concurrent_update;
+ a | b  
+---+----
+ 1 | 41 
+(1 row)
+6: DROP TABLE t_concurrent_update;
 DROP
+4q: ... <quitting>
+5q: ... <quitting>
+6q: ... <quitting>
 
 --start_ignore
 ! gpconfig -r gp_enable_global_deadlock_detector;
@@ -164,4 +213,3 @@ DROP
 20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Restarting System...
 
 --end_ignore
-1q: ... <quitting>

--- a/src/test/isolation2/expected/concurrent_update.out
+++ b/src/test/isolation2/expected/concurrent_update.out
@@ -22,6 +22,146 @@ UPDATE 1
 ---+----+--------------------------------------------------------------------------------------
  1 | 21 | test                                                                                 
 (1 row)
+1q: ... <quitting>
+2q: ... <quitting>
 
 DROP TABLE t_concurrent_update;
 DROP
+
+
+-- Test the concurrent update transaction order on the segment is reflected on master
+-- enable gdd
+--start_ignore
+! gpconfig -c gp_enable_global_deadlock_detector -v on;
+20200305:08:04:41:016395 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-c gp_enable_global_deadlock_detector -v on'
+
+! gpstop -rai;
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Gathering information and validating the environment...
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5622.g0cc5452d2bc build dev'
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb5/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb5/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Stopping master standby host 09c5497cf854 mode=immediate
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Successfully shutdown standby process on 09c5497cf854
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-0.00% of jobs completed
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-100.00% of jobs completed
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20200305:08:04:41:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-0.00% of jobs completed
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-100.00% of jobs completed
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-----------------------------------------------------
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-----------------------------------------------------
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Cleaning up leftover shared memory
+20200305:08:04:42:016472 gpstop:09c5497cf854:gpadmin-[INFO]:-Restarting System...
+
+--end_ignore
+
+1: SHOW gp_enable_global_deadlock_detector;
+ gp_enable_global_deadlock_detector 
+------------------------------------
+ on                                 
+(1 row)
+1: CREATE TABLE t_concurrent_update(a int, b int);
+CREATE
+1: INSERT INTO t_concurrent_update VALUES(1,1);
+INSERT 1
+
+2: BEGIN;
+BEGIN
+2: SET optimizer=off;
+SET
+2: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+UPDATE 1
+3: BEGIN;
+BEGIN
+3: SET optimizer=off;
+SET
+-- transaction 3 will wait transaction 1 on the segment
+3&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;  <waiting ...>
+
+-- transaction 2 suspend before commit, but it will wake up transaction 3 on segment
+2: select gp_inject_fault('before_xact_end_procarray', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2&: END;  <waiting ...>
+1: select gp_wait_until_triggered_fault('before_xact_end_procarray', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- transaction 3 should wait transaction 2 commit on master
+3<:  <... completed>
+UPDATE 1
+3&: END;  <waiting ...>
+1: select gp_inject_fault('before_xact_end_procarray', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- the query should not get the incorrect distributed snapshot: transaction 1 in-progress
+-- and transaction 2 finished
+1: SELECT * FROM t_concurrent_update;
+ a | b 
+---+---
+ 1 | 1 
+(1 row)
+2<:  <... completed>
+END
+3<:  <... completed>
+END
+2q: ... <quitting>
+3q: ... <quitting>
+
+1: SELECT * FROM t_concurrent_update;
+ a | b  
+---+----
+ 1 | 21 
+(1 row)
+1: DROP TABLE t_concurrent_update;
+DROP
+
+--start_ignore
+! gpconfig -r gp_enable_global_deadlock_detector;
+20200305:08:04:46:016977 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-r gp_enable_global_deadlock_detector'
+
+! gpstop -rai;
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Gathering information and validating the environment...
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5622.g0cc5452d2bc build dev'
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb5/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb5/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Stopping master standby host 09c5497cf854 mode=immediate
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Successfully shutdown standby process on 09c5497cf854
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-0.00% of jobs completed
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-100.00% of jobs completed
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20200305:08:04:47:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-0.00% of jobs completed
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-100.00% of jobs completed
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-----------------------------------------------------
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-----------------------------------------------------
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Cleaning up leftover shared memory
+20200305:08:04:48:017053 gpstop:09c5497cf854:gpadmin-[INFO]:-Restarting System...
+
+--end_ignore
+1q: ... <quitting>

--- a/src/test/isolation2/sql/concurrent_update.sql
+++ b/src/test/isolation2/sql/concurrent_update.sql
@@ -10,5 +10,52 @@ INSERT INTO t_concurrent_update VALUES(1,1,'test');
 1: END;
 2<:
 1: SELECT * FROM t_concurrent_update;
+1q:
+2q:
 
 DROP TABLE t_concurrent_update;
+
+
+-- Test the concurrent update transaction order on the segment is reflected on master
+-- enable gdd
+--start_ignore
+! gpconfig -c gp_enable_global_deadlock_detector -v on;
+! gpstop -rai;
+--end_ignore
+
+1: SHOW gp_enable_global_deadlock_detector;
+1: CREATE TABLE t_concurrent_update(a int, b int);
+1: INSERT INTO t_concurrent_update VALUES(1,1);
+
+2: BEGIN;
+2: SET optimizer=off;
+2: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+3: BEGIN;
+3: SET optimizer=off;
+-- transaction 3 will wait transaction 1 on the segment
+3&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;
+
+-- transaction 2 suspend before commit, but it will wake up transaction 3 on segment
+2: select gp_inject_fault('before_xact_end_procarray', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+2&: END;
+1: select gp_wait_until_triggered_fault('before_xact_end_procarray', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+-- transaction 3 should wait transaction 2 commit on master
+3<:
+3&: END;
+1: select gp_inject_fault('before_xact_end_procarray', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+-- the query should not get the incorrect distributed snapshot: transaction 1 in-progress
+-- and transaction 2 finished
+1: SELECT * FROM t_concurrent_update;
+2<:
+3<:
+2q:
+3q:
+
+1: SELECT * FROM t_concurrent_update;
+1: DROP TABLE t_concurrent_update;
+
+--start_ignore
+! gpconfig -r gp_enable_global_deadlock_detector;
+! gpstop -rai;
+--end_ignore 
+1q:


### PR DESCRIPTION
After enabling the global deadlock detector, we can support concurrent updates.
When updating one tuple at the same time, the conflict and wait are moved from
QD to QE. We need to make sure the implicated transaction order on the segments
is also considered on the master when taking the distributed snapshots.

This is reported: https://github.com/greenplum-db/gpdb/issues/9407

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
