### PR TITLE
5x backport: Refactor and correct prefetch joinqual

### DIFF
--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -28,6 +28,8 @@
 #include "cdb/cdbvars.h"
 #include "miscadmin.h"			/* work_mem */
 
+extern bool Test_print_prefetch_joinqual;
+
 static TupleTableSlot *ExecHashJoinOuterGetTuple(PlanState *outerNode,
 						  HashJoinState *hjstate,
 						  uint32 *hashvalue);
@@ -216,8 +218,11 @@ ExecHashJoin(HashJoinState *node)
 		 *
 		 * See ExecPrefetchJoinQual() for details.
 		 */
-		if (node->prefetch_joinqual && ExecPrefetchJoinQual(&node->js))
+		if (node->prefetch_joinqual)
+		{
+			ExecPrefetchJoinQual(&node->js);
 			node->prefetch_joinqual = false;
+		}
 
 		/*
 		 * We just scanned the entire inner side and built the hashtable
@@ -531,7 +536,12 @@ ExecInitHashJoin(HashJoin *node, EState *estate, int eflags)
 	 * the fix to MPP-989)
 	 */
 	hjstate->prefetch_inner = node->join.prefetch_inner;
-	hjstate->prefetch_joinqual = ShouldPrefetchJoinQual(estate, &node->join);
+	hjstate->prefetch_joinqual = node->join.prefetch_joinqual;
+
+	if (Test_print_prefetch_joinqual && hjstate->prefetch_joinqual)
+		elog(NOTICE,
+			 "prefetch join qual in slice %d of plannode %d",
+			 currentSliceId, ((Plan *) node)->plan_node_id);
 
 	/*
 	 * initialize child nodes

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -152,6 +152,7 @@ typedef enum
 #define MarkInnerTuple(innerTupleSlot, mergestate) \
 	ExecCopySlot((mergestate)->mj_MarkedTupleSlot, (innerTupleSlot))
 
+extern bool Test_print_prefetch_joinqual;
 
 /*
  * MJExamineQuals
@@ -676,8 +677,11 @@ ExecMergeJoin(MergeJoinState *node)
 	 *
 	 * See ExecPrefetchJoinQual() for details.
 	 */
-	if (node->prefetch_joinqual && ExecPrefetchJoinQual(&node->js))
+	if (node->prefetch_joinqual)
+	{
+		ExecPrefetchJoinQual(&node->js);
 		node->prefetch_joinqual = false;
+	}
 
 	/*
 	 * ok, everything is setup.. let's go to work
@@ -1593,8 +1597,14 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 					 (PlanState *) mergestate);
 
 	mergestate->prefetch_inner = node->join.prefetch_inner;
-	mergestate->prefetch_joinqual = ShouldPrefetchJoinQual(estate, &node->join);
 	mergestate->mj_squelchInner = true;
+	mergestate->prefetch_joinqual = node->join.prefetch_joinqual;
+
+	if (Test_print_prefetch_joinqual && mergestate->prefetch_joinqual)
+		elog(NOTICE,
+			 "prefetch join qual in slice %d of plannode %d",
+			 currentSliceId, ((Plan *) node)->plan_node_id);
+
 	/* Prepare inner operators for rewind after the prefetch */
 	rewindflag = mergestate->prefetch_inner ? EXEC_FLAG_REWIND : 0;
 

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -23,9 +23,12 @@
 
 #include "postgres.h"
 
+#include "cdb/cdbvars.h"
 #include "executor/execdebug.h"
 #include "executor/nodeNestloop.h"
 #include "utils/memutils.h"
+
+extern bool Test_print_prefetch_joinqual;
 
 static void splitJoinQualExpr(NestLoopState *nlstate);
 static void extractFuncExprArgs(FuncExprState *fstate, List **lclauses, List **rclauses);
@@ -164,8 +167,11 @@ ExecNestLoop(NestLoopState *node)
 	 *
 	 * See ExecPrefetchJoinQual() for details.
 	 */
-	if (node->prefetch_joinqual && ExecPrefetchJoinQual(&node->js))
+	if (node->prefetch_joinqual)
+	{
+		ExecPrefetchJoinQual(&node->js);
 		node->prefetch_joinqual = false;
+	}
 
 	/*
 	 * Ok, everything is setup for the join so now loop until we return a
@@ -390,8 +396,13 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
 	nlstate->shared_outer = node->shared_outer;
 
 	nlstate->prefetch_inner = node->join.prefetch_inner;
-	nlstate->prefetch_joinqual = ShouldPrefetchJoinQual(estate, &node->join);
-	
+	nlstate->prefetch_joinqual = node->join.prefetch_joinqual;
+
+	if (Test_print_prefetch_joinqual && nlstate->prefetch_joinqual)
+		elog(NOTICE,
+			 "prefetch join qual in slice %d of plannode %d",
+			 currentSliceId, ((Plan *) node)->plan_node_id);
+
 	/*CDB-OLAP*/
 	nlstate->reset_inner = false;
 	nlstate->require_inner_reset = !node->singleton_outer;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -171,6 +171,7 @@ bool		Test_appendonly_override = false;
 bool		Test_print_direct_dispatch_info = false;
 bool		gp_test_orientation_override = false;
 bool		gp_permit_persistent_metadata_update = false;
+bool        Test_print_prefetch_joinqual = false;
 bool		gp_permit_relation_node_change = false;
 int			Test_compresslevel_override = 0;
 int			Test_blocksize_override = 0;
@@ -1852,6 +1853,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_startup_integrity_checks,
 		true, NULL, NULL
+	},
+
+	{
+		{"test_print_prefetch_joinqual", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("For testing purposes, print information about if we prefetch join qual."),
+			NULL,
+			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&Test_print_prefetch_joinqual,
+		false,
+		NULL, NULL, NULL
 	},
 
 	{

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -479,8 +479,7 @@ extern void UnregisterExprContextCallback(ExprContext *econtext,
 /* Share input utilities defined in execUtils.c */
 extern ShareNodeEntry * ExecGetShareNodeEntry(EState *estate, int shareid, bool fCreate);
 
-extern bool ExecPrefetchJoinQual(JoinState *node);
-extern bool ShouldPrefetchJoinQual(EState *estate, Join *join);
+extern void ExecPrefetchJoinQual(JoinState *node);
 
 /* ResultRelInfo and Append Only segment assignment */
 void ResultRelInfoSetSegno(ResultRelInfo *resultRelInfo, List *mapping);

--- a/src/test/regress/expected/deadlock2.out
+++ b/src/test/regress/expected/deadlock2.out
@@ -89,8 +89,43 @@ insert into t_subplan select :x0, :x0 from generate_series(1,:scale) i;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;
+set Test_print_prefetch_joinqual = on;
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1);
+NOTICE:  prefetch join qual in slice 0 of plannode 4
+NOTICE:  prefetch join qual in slice 4 of plannode 4  (seg0 slice4 127.0.1.1:25432 pid=39408)
+NOTICE:  prefetch join qual in slice 4 of plannode 4  (seg1 slice4 127.0.1.1:25433 pid=39409)
+NOTICE:  prefetch join qual in slice 4 of plannode 4  (seg2 slice4 127.0.1.1:25434 pid=39410)
+ count 
+-------
+ 10000
+(1 row)
+
+-- The logic of ExecPrefetchJoinQual is to use two null
+-- tuples to fake inner and outertuple and then to ExecQual.
+-- It may short cut if some previous qual is test null expr.
+-- So ExecPrefetchJoinQual has to force ExecQual for each
+-- qual expr in the joinqual list. See the Github issue
+-- https://github.com/greenplum-db/gpdb/issues/8677
+-- for details.
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+   and (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
+NOTICE:  prefetch join qual in slice 0 of plannode 4
+NOTICE:  prefetch join qual in slice 4 of plannode 4  (seg0 slice4 127.0.1.1:25432 pid=39408)
+NOTICE:  prefetch join qual in slice 4 of plannode 4  (seg1 slice4 127.0.1.1:25433 pid=39409)
+NOTICE:  prefetch join qual in slice 4 of plannode 4  (seg2 slice4 127.0.1.1:25434 pid=39410)
+ count 
+-------
+ 10000
+(1 row)
+
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+   and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
+   and not exists (select 1 from t_subplan where t_subplan.c2=t_outer.c1);
+NOTICE:  prefetch join qual in slice 0 of plannode 4
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg0 slice5 127.0.1.1:25432 pid=39408)
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg1 slice5 127.0.1.1:25433 pid=39409)
+NOTICE:  prefetch join qual in slice 5 of plannode 4  (seg2 slice5 127.0.1.1:25434 pid=39410)
  count 
 -------
  10000

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -889,3 +889,73 @@ reset optimizer;
 reset enable_nestloop;
 reset enable_hashjoin;
 reset enable_mergejoin;
+-- test prefetch join qual
+-- we do not handle this correct
+-- the only case we need to prefetch join qual is:
+--   1. outer plan contains motion
+--   2. the join qual contains subplan that contains motion
+reset client_min_messages;
+set Test_print_prefetch_joinqual = true;
+-- prefetch join qual is only set correct for planner
+set optimizer = off;
+create table t1_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- the following plan contains redistribute motion in both inner and outer plan
+-- the join qual is t1.c > t2.c, it contains no motion, should not prefetch
+explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.c > t2.c;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=3410.75..56612.58 rows=2022804 width=24)
+   ->  Hash Join  (cost=3410.75..56612.58 rows=674268 width=24)
+         Hash Cond: t1.b = t2.b
+         Join Filter: t1.c > t2.c
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+               Hash Key: t1.b
+               ->  Seq Scan on t1_test_pretch_join_qual t1  (cost=0.00..879.00 rows=25967 width=12)
+         ->  Hash  (cost=2437.00..2437.00 rows=25967 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+                     Hash Key: t2.b
+                     ->  Seq Scan on t2_test_pretch_join_qual t2  (cost=0.00..879.00 rows=25967 width=12)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(13 rows)
+
+create table t3_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- the following plan contains motion in both outer plan and join qual,
+-- so we should prefetch join qual
+explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.a > any (select sum(b) from t3_test_pretch_join_qual t3 where c > t2.a);
+NOTICE:  prefetch join qual in slice 0 of plannode 2
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=3410.75..13213071198.52 rows=3034205 width=24)
+   ->  Hash Join  (cost=3410.75..13213071198.52 rows=1011402 width=24)
+         Hash Cond: t1.b = t2.b
+         Join Filter: (subplan)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+               Hash Key: t1.b
+               ->  Seq Scan on t1_test_pretch_join_qual t1  (cost=0.00..879.00 rows=25967 width=12)
+         ->  Hash  (cost=2437.00..2437.00 rows=25967 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+                     Hash Key: t2.b
+                     ->  Seq Scan on t2_test_pretch_join_qual t2  (cost=0.00..879.00 rows=25967 width=12)
+         SubPlan 1
+           ->  Aggregate  (cost=2177.34..2177.35 rows=1 width=8)
+                 ->  Result  (cost=1099.72..1359.38 rows=8656 width=4)
+                       Filter: t3.c > $0
+                       ->  Materialize  (cost=1099.72..1359.38 rows=8656 width=4)
+                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1073.75 rows=8656 width=4)
+                                   ->  Seq Scan on t3_test_pretch_join_qual t3  (cost=0.00..1073.75 rows=8656 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(20 rows)
+
+reset Test_print_prefetch_joinqual;
+reset optimizer;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -900,3 +900,73 @@ reset optimizer;
 reset enable_nestloop;
 reset enable_hashjoin;
 reset enable_mergejoin;
+-- test prefetch join qual
+-- we do not handle this correct
+-- the only case we need to prefetch join qual is:
+--   1. outer plan contains motion
+--   2. the join qual contains subplan that contains motion
+reset client_min_messages;
+set Test_print_prefetch_joinqual = true;
+-- prefetch join qual is only set correct for planner
+set optimizer = off;
+create table t1_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- the following plan contains redistribute motion in both inner and outer plan
+-- the join qual is t1.c > t2.c, it contains no motion, should not prefetch
+explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.c > t2.c;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=3410.75..56612.58 rows=2022804 width=24)
+   ->  Hash Join  (cost=3410.75..56612.58 rows=674268 width=24)
+         Hash Cond: t1.b = t2.b
+         Join Filter: t1.c > t2.c
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+               Hash Key: t1.b
+               ->  Seq Scan on t1_test_pretch_join_qual t1  (cost=0.00..879.00 rows=25967 width=12)
+         ->  Hash  (cost=2437.00..2437.00 rows=25967 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+                     Hash Key: t2.b
+                     ->  Seq Scan on t2_test_pretch_join_qual t2  (cost=0.00..879.00 rows=25967 width=12)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(13 rows)
+
+create table t3_test_pretch_join_qual(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- the following plan contains motion in both outer plan and join qual,
+-- so we should prefetch join qual
+explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.a > any (select sum(b) from t3_test_pretch_join_qual t3 where c > t2.a);
+NOTICE:  prefetch join qual in slice 0 of plannode 2
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=3410.75..13213071198.52 rows=3034205 width=24)
+   ->  Hash Join  (cost=3410.75..13213071198.52 rows=1011402 width=24)
+         Hash Cond: t1.b = t2.b
+         Join Filter: (subplan)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+               Hash Key: t1.b
+               ->  Seq Scan on t1_test_pretch_join_qual t1  (cost=0.00..879.00 rows=25967 width=12)
+         ->  Hash  (cost=2437.00..2437.00 rows=25967 width=12)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+                     Hash Key: t2.b
+                     ->  Seq Scan on t2_test_pretch_join_qual t2  (cost=0.00..879.00 rows=25967 width=12)
+         SubPlan 1
+           ->  Aggregate  (cost=2177.34..2177.35 rows=1 width=8)
+                 ->  Result  (cost=1099.72..1359.38 rows=8656 width=4)
+                       Filter: t3.c > $0
+                       ->  Materialize  (cost=1099.72..1359.38 rows=8656 width=4)
+                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1073.75 rows=8656 width=4)
+                                   ->  Seq Scan on t3_test_pretch_join_qual t3  (cost=0.00..1073.75 rows=8656 width=4)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(20 rows)
+
+reset Test_print_prefetch_joinqual;
+reset optimizer;

--- a/src/test/regress/output/query_info_hook_test.source
+++ b/src/test/regress/output/query_info_hook_test.source
@@ -116,9 +116,9 @@ WARNING:  Query submit
 WARNING:  Query start
 WARNING:  Plan node initializing
 WARNING:  Plan node executing node_type: NESTLOOP
-WARNING:  Plan node executing node_type: MATERIAL
 WARNING:  Plan node executing node_type: LIMIT
 WARNING:  Plan node executing node_type: SEQSCAN
+WARNING:  Plan node executing node_type: MATERIAL
 WARNING:  Plan node executing node_type: LIMIT
 WARNING:  Plan node executing node_type: SEQSCAN
 WARNING:  function inner query submit

--- a/src/test/regress/sql/deadlock2.sql
+++ b/src/test/regress/sql/deadlock2.sql
@@ -92,6 +92,21 @@ insert into t_subplan select :x0, :x0 from generate_series(1,:scale) i;
 set enable_hashjoin to on;
 set enable_mergejoin to off;
 set enable_nestloop to off;
+set Test_print_prefetch_joinqual = on;
 
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1);
+
+-- The logic of ExecPrefetchJoinQual is to use two null
+-- tuples to fake inner and outertuple and then to ExecQual.
+-- It may short cut if some previous qual is test null expr.
+-- So ExecPrefetchJoinQual has to force ExecQual for each
+-- qual expr in the joinqual list. See the Github issue
+-- https://github.com/greenplum-db/gpdb/issues/8677
+-- for details.
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+   and (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
+
+select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
+   and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
+   and not exists (select 1 from t_subplan where t_subplan.c2=t_outer.c1);

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -409,3 +409,31 @@ reset optimizer;
 reset enable_nestloop;
 reset enable_hashjoin;
 reset enable_mergejoin;
+
+-- test prefetch join qual
+-- we do not handle this correct
+-- the only case we need to prefetch join qual is:
+--   1. outer plan contains motion
+--   2. the join qual contains subplan that contains motion
+reset client_min_messages;
+set Test_print_prefetch_joinqual = true;
+-- prefetch join qual is only set correct for planner
+set optimizer = off;
+
+create table t1_test_pretch_join_qual(a int, b int, c int);
+create table t2_test_pretch_join_qual(a int, b int, c int);
+
+-- the following plan contains redistribute motion in both inner and outer plan
+-- the join qual is t1.c > t2.c, it contains no motion, should not prefetch
+explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.c > t2.c;
+
+create table t3_test_pretch_join_qual(a int, b int, c int);
+
+-- the following plan contains motion in both outer plan and join qual,
+-- so we should prefetch join qual
+explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
+on t1.b = t2.b and t1.a > any (select sum(b) from t3_test_pretch_join_qual t3 where c > t2.a);
+
+reset Test_print_prefetch_joinqual;
+reset optimizer;


### PR DESCRIPTION
This pr is backport 6x commit (https://github.com/greenplum-db/gpdb/commit/c74341463335fcb12d1eb3f2cb04094a1efc1ea7) to 5x.

It has already been reviewed and merged into 6X.

----------------

We introduces prefetch joinqual logic in commit fa762b and
later refactoed it in commit 36a93ba. But the logic before does
not handle things correct. Previously we finally check this until
ExecInitXXX and forgot to check if there is joinqual.

This commit fixes the issue for planner. It determines the bool
field `prefetch_joinqual` during planning stage.  The logic is
first set the field to show the risk in create_xxxjoin_plan, and then
in create_join_plan after we get the plan, if there is risk then we
loop each joinqual to see if there is motion in it (The only case
is the joinqual is a SubPlan). In 5X we add motions for SubPlan
after we have gotten the plan. So at the time of this function calling,
we do not know if the SubPlan contains motion. We might walk the plannedstmt
to accurately determine this, but that makes the code not that clean.
So, we adopt an over kill method here: any SubPlan contains motion. At least,
this can avoid motion deadlock.

Also this commit improves the logic of ExecPrefetchJoinQual to
solve the github issue:  https://github.com/greenplum-db/gpdb/issues/8677
It fixes this by flattening the bool expr of the joinqual and force each
of them to be Prefetched.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
