### PR TITLE
[GP6]: Update greenplum_path.sh to support gpdb package upgrade

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -9,7 +9,7 @@ $(recurse)
 generate_greenplum_path_file:
 	mkdir -p $(DESTDIR)$(prefix)
 	unset LIBPATH; \
-	bin/generate-greenplum-path.sh $(prefix) > $(DESTDIR)$(prefix)/greenplum_path.sh
+	bin/generate-greenplum-path.sh > $(DESTDIR)$(prefix)/greenplum_path.sh
 
 install: generate_greenplum_path_file
 	mkdir -p $(DESTDIR)$(prefix)/lib/python

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -78,7 +78,7 @@ pygresql:
 	@echo "--- PyGreSQL"
 	if [ ! -f $(DESTDIR)$(prefix)/greenplum_path.sh ]; then \
 		unset LIBPATH; \
-		./generate-greenplum-path.sh $(prefix) > $(DESTDIR)$(prefix)/greenplum_path.sh ; \
+		./generate-greenplum-path.sh > $(DESTDIR)$(prefix)/greenplum_path.sh ; \
 	fi
 	. $(DESTDIR)$(prefix)/greenplum_path.sh && unset PYTHONHOME && \
 	if [ "$(BLD_ARCH)" = 'aix7_ppc_64' ]; then \

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -1,26 +1,14 @@
 #!/usr/bin/env bash
 
-if [ x$1 != x ] ; then
-    GPHOME_PATH=$1
-else
-    GPHOME_PATH="\`pwd\`"
-fi
+cat <<"EOF"
+#!/usr/bin/env bash
+GPHOME="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-if [ "$2" = "ISO" ] ; then
-	cat <<-EOF
-		if [ "\${BASH_SOURCE:0:1}" == "/" ]
-		then
-		    GPHOME=\`dirname "\$BASH_SOURCE"\`
-		else
-		    GPHOME=\`pwd\`/\`dirname "\$BASH_SOURCE"\`
-		fi
-	EOF
-else
-	cat <<-EOF
-		GPHOME=${GPHOME_PATH}
-	EOF
-fi
-
+PYTHONHOME="${GPHOME}/ext/python"
+PYTHONPATH="${GPHOME}/lib/python"
+PATH="${GPHOME}/bin:${PYTHONHOME}/bin:${PATH}"
+LD_LIBRARY_PATH="${GPHOME}/lib:${PYTHONHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+EOF
 
 PLAT=`uname -s`
 if [ $? -ne 0 ] ; then
@@ -28,78 +16,28 @@ if [ $? -ne 0 ] ; then
     exit 1
 fi
 
-cat << EOF
-
-# Replace with symlink path if it is present and correct
-if [ -h \${GPHOME}/../greenplum-db ]; then
-    GPHOME_BY_SYMLINK=\`(cd \${GPHOME}/../greenplum-db/ && pwd -P)\`
-    if [ x"\${GPHOME_BY_SYMLINK}" = x"\${GPHOME}" ]; then
-        GPHOME=\`(cd \${GPHOME}/../greenplum-db/ && pwd -L)\`/.
-    fi
-    unset GPHOME_BY_SYMLINK
-fi
-EOF
-
-cat <<EOF
-#setup PYTHONHOME
-if [ -x \$GPHOME/ext/python/bin/python ]; then
-    PYTHONHOME="\$GPHOME/ext/python"
-    export PYTHONHOME
-fi
-EOF
-
-#setup PYTHONPATH
-if [ "x${PYTHONPATH}" == "x" ]; then
-    PYTHONPATH="\$GPHOME/lib/python"
-else
-    PYTHONPATH="\$GPHOME/lib/python:${PYTHONPATH}"
-fi
-cat <<EOF
-PYTHONPATH=${PYTHONPATH}
-EOF
-
-GP_BIN_PATH=\$GPHOME/bin
-GP_LIB_PATH=\$GPHOME/lib
-
-if [ -n "$PYTHONHOME" ]; then
-    GP_BIN_PATH=${GP_BIN_PATH}:\$PYTHONHOME/bin
-    GP_LIB_PATH=${GP_LIB_PATH}:\$PYTHONHOME/lib
-fi
-cat <<EOF
-PATH=${GP_BIN_PATH}:\$PATH
-EOF
-
-cat <<EOF
-LD_LIBRARY_PATH=${GP_LIB_PATH}:\${LD_LIBRARY_PATH-}
-export LD_LIBRARY_PATH
-EOF
-
 # AIX uses yet another library path variable
 # Also, Python on AIX requires special copies of some libraries.  Hence, lib/pware.
 if [ "${PLAT}" = "AIX" ]; then
-cat <<EOF
-PYTHONPATH=\${GPHOME}/ext/python/lib/python2.7:\${PYTHONPATH}
-LIBPATH=\${GPHOME}/lib/pware:\${GPHOME}/lib:\${GPHOME}/ext/python/lib:/usr/lib/threads:\${LIBPATH}
+cat <<"EOF"
+PYTHONPATH="${GPHOME}/ext/python/lib/python2.7:${PYTHONPATH}"
+LIBPATH="${GPHOME}/lib/pware:${GPHOME}/lib:${GPHOME}/ext/python/lib:/usr/lib/threads:${LIBPATH}"
 export LIBPATH
-GP_LIBPATH_FOR_PYTHON=\${GPHOME}/lib/pware
+GP_LIBPATH_FOR_PYTHON="${GPHOME}/lib/pware"
 export GP_LIBPATH_FOR_PYTHON
 EOF
 fi
 
-# openssl configuration file path
-cat <<EOF
-if [ -e \$GPHOME/etc/openssl.cnf ]; then
-OPENSSL_CONF=\$GPHOME/etc/openssl.cnf
-export OPENSSL_CONF
-fi
-EOF
+cat <<"EOF"
 
-cat <<EOF
+if [ -e "$GPHOME/etc/openssl.cnf" ]; then
+	OPENSSL_CONF="$GPHOME/etc/openssl.cnf"
+fi
+
 export GPHOME
 export PATH
-EOF
-
-cat <<EOF
+export PYTHONHOME
 export PYTHONPATH
+export LD_LIBRARY_PATH
+export OPENSSL_CONF
 EOF
-


### PR DESCRIPTION
Follow [Greenplum Server RPM Packaging Specification](https://github.com/greenplum-db/greenplum-database-release/blob/master/Greenplum-Server-RPM-Packaging-Specification.md#detailed-package-behavior), we need to update greenplum_path.sh file, and ensure many environment variables set correct.

There are a few basic requirments:

Greenplum Path Layer

* greenplum-path.sh shall be installed to `${installation prefix}/greenplum-db-[package-version]/greenplum_path.sh`

* ${GPHOME} shall by default be set to `%{installation prefix}/greenplum-db-[version]`

    * If the installation prefix for a package is changed from the default by a user, then `%{installation prefix` shall be updated during installation to reflect the user's preference

* `${LD_LIBRARY_PATH}`shall be set to `${GPHOME}/lib:${PYTHONHOME}/lib:${LD_LIBRARY_PATH-}`
* `${PYTHONHOME}` shall be set to `${GPHOME}/ext/python`
    * Note: the existing test -x shall be removed. Refer to [this slack conversation](https://greenplum.slack.com/archives/CNKQUK6TA/p1583866401001100) for an explanation.
* `${PYTHONPATH}` shall be set to `${GPHOME}/lib/python`
* `${PATH}` shall be set to `${GPHOME}/bin:${PYTHONHOME}/bin:${PATH}`
*  If the file `${GPHOME}/etc/openssl.cnf` exists then `${OPENSSL_CONF}` shall be set to `${GPHOME}/etc/openssl.cnf`
*  [A portable bash shebang shall be set](https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang)
*  The greenplum_path.sh file shall pass [ShellCheck](https://github.com/koalaman/shellcheck)


[#171588764]

Authored-by: Tingfang Bao <bbao@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
