### PR TITLE
Refactor code to sort/redistribute input to Agg nodes.

### DIFF
--- a/src/include/cdb/cdbgroupingpaths.h
+++ b/src/include/cdb/cdbgroupingpaths.h
@@ -30,11 +30,21 @@ extern void cdb_create_twostage_grouping_paths(PlannerInfo *root,
 											   List *rollup_lists,
 											   List *rollup_groupclauses);
 
-extern CdbPathLocus cdb_choose_grouping_locus(PlannerInfo *root, Path *path,
-											  PathTarget *target,
-											  List *groupClause,
-											  List *rollup_lists,
-											  List *rollup_groupclauses,
-											  bool *need_redistribute_p);
+extern Path *cdb_prepare_path_for_sorted_agg(PlannerInfo *root,
+											 bool is_sorted,
+											 RelOptInfo *rel,
+											 Path *subpath,
+											 PathTarget *target,
+											 List *group_pathkeys,
+											 double limit_tuples,
+											 List *groupClause,
+											 List *rollup_lists,
+											 List *rollup_groupclauses);
+extern Path *cdb_prepare_path_for_hashed_agg(PlannerInfo *root,
+											 Path *subpath,
+											 PathTarget *target,
+											 List *groupClause,
+											 List *rollup_lists,
+											 List *rollup_groupclauses);
 
 #endif   /* CDBGROUPINGPATHS_H */

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1720,6 +1720,53 @@ SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y G
     |  500
 (16 rows)
 
+--
+-- Test GROUP BY with a constant
+--
+create temp table group_by_const (col1 int, col2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into group_by_const select i from generate_series(1, 1000) i;
+explain (costs off)
+select 1, sum(col1) from group_by_const group by 1;
+                   QUERY PLAN                   
+------------------------------------------------
+ Finalize GroupAggregate
+   Group Key: (1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial GroupAggregate
+               Group Key: 1
+               ->  Seq Scan on group_by_const
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select 1, sum(col1) from group_by_const group by 1;
+ ?column? |  sum   
+----------+--------
+        1 | 500500
+(1 row)
+
+-- Same, but using an aggregate that doesn't have a combine function, so
+-- that you get a one-phase aggregate plan.
+explain (costs off)
+select 1, median(col1) from group_by_const group by 1;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: (1)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: (1)
+               ->  Seq Scan on group_by_const
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select 1, median(col1) from group_by_const group by 1;
+ ?column? | median 
+----------+--------
+        1 |  500.5
+(1 row)
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1722,6 +1722,57 @@ SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y G
     |  500
 (16 rows)
 
+--
+-- Test GROUP BY with a constant
+--
+create temp table group_by_const (col1 int, col2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into group_by_const select i from generate_series(1, 1000) i;
+explain (costs off)
+select 1, sum(col1) from group_by_const group by 1;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Finalize GroupAggregate
+         Group Key: (1)
+         ->  Sort
+               Sort Key: (1)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (1)
+                     ->  Streaming Partial HashAggregate
+                           Group Key: 1
+                           ->  Seq Scan on group_by_const
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+(11 rows)
+
+select 1, sum(col1) from group_by_const group by 1;
+ ?column? |  sum   
+----------+--------
+        1 | 500500
+(1 row)
+
+-- Same, but using an aggregate that doesn't have a combine function, so
+-- that you get a one-phase aggregate plan.
+explain (costs off)
+select 1, median(col1) from group_by_const group by 1;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: (1)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: (1)
+               ->  Seq Scan on group_by_const
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select 1, median(col1) from group_by_const group by 1;
+ ?column? | median 
+----------+--------
+        1 |  500.5
+(1 row)
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -375,7 +375,7 @@ select count(distinct j), count(distinct k), count(distinct m) from (select j,k,
  GroupAggregate
    Group Key: multiagg_with_subquery.j
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         Merge Key: multiagg_with_subquery.j, multiagg_with_subquery.k, multiagg_with_subquery.m
+         Merge Key: multiagg_with_subquery.j
          ->  GroupAggregate
                Group Key: multiagg_with_subquery.j, multiagg_with_subquery.k, multiagg_with_subquery.m
                ->  Sort

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1433,6 +1433,21 @@ EXPLAIN (COSTS OFF)
 SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x ORDER BY 1 NULLS LAST;
 SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x ORDER BY 1 NULLS LAST;
 
+--
+-- Test GROUP BY with a constant
+--
+create temp table group_by_const (col1 int, col2 int);
+insert into group_by_const select i from generate_series(1, 1000) i;
+
+explain (costs off)
+select 1, sum(col1) from group_by_const group by 1;
+select 1, sum(col1) from group_by_const group by 1;
+
+-- Same, but using an aggregate that doesn't have a combine function, so
+-- that you get a one-phase aggregate plan.
+explain (costs off)
+select 1, median(col1) from group_by_const group by 1;
+select 1, median(col1) from group_by_const group by 1;
 
 -- CLEANUP
 set client_min_messages='warning';


### PR DESCRIPTION
This introduces two new functions cdb_prepare_path_for_sorted_agg() and
cdb_prepare_path_for_hashed_agg(), to sort and/or redistribute the input
to an Agg node, in single-phase aggregation. Previously, the logic was
in the callers in planner.c. This is in preparation for the PostgreSQL v12
merge, which will introduce more codepaths that create Agg nodes;
encapsulating the logic in functions reduces the duplication.

Parallel grouping is currently disabled alogether, but if it wasn't, we
should be using these functions when creating parallel grouping paths,
too.

There's one almost user-visible change here, which explains the change
in 'gp_aggregates' expected output. If a sorted Gather Motion is created,
we now use the path keys needed for the grouping (root->grouped_pathkeys),
rather than the pathkeys of the subpath (subpath->pathkeys), as the merge
key for the Gather Motion. The grouped_pathkeys must be a subset of the
subpath's keys, but the subpath might have extra keys that are not needed
for the Agg. Don't bother to preserve the order of those extra keys,
mostly because it's more convenient in the code to not bother with it, but
in principle it also saves some CPU cycles.
