### PR TITLE
Fix analyzedb with config file to work with partitioned tables

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -568,7 +568,7 @@ class AnalyzeDb(Operation):
                 included_cols = self._get_include_or_exclude_cols(toks, '-i')
                 excluded_cols = self._get_include_or_exclude_cols(toks, '-x')
                 self._parse_column(col_dict, orig_table, schema, table, included_cols, excluded_cols,
-                                   [table] in all_root_partitions)
+                                   [orig_table] in all_root_partitions)
 
         else:  # all user tables in database
             alltables = run_sql(self.conn, GET_ALL_DATA_TABLES_SQL)

--- a/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
+++ b/gpMgmt/test/behave/mgmt_utils/analyzedb.feature
@@ -1512,6 +1512,27 @@ Feature: Incrementally analyze the database
         And "public.sales_1_prt_4" should appear in the latest state files
         And "public.sales_1_prt_3" should appear in the latest state files
 
+    @analyzedb_core @analyzedb_partition_tables
+    Scenario: Partition table with root partition passed to config file for AO table
+        Given no state files exist for database "incr_analyze"
+        And the user runs command "printf 'public.sales' > config_file"
+        When the user runs "analyzedb -a -d incr_analyze -f config_file"
+        Then analyzedb should return a return code of 0
+        And output should contain both "-public.sales_1_prt_2" and "-public.sales_1_prt_2"
+        And "public.sales_1_prt_2" should appear in the latest state files
+        And "public.sales_1_prt_3" should appear in the latest state files
+        And "public.sales_1_prt_4" should appear in the latest state files
+
+    @analyzedb_core @analyzedb_partition_tables
+    Scenario: Partition table with root partition passed to config file for heap table
+        Given no state files exist for database "incr_analyze"
+        And the user runs "psql -d incr_analyze -c 'create table foo (a int, b int) partition by range (b) (start (1) end  (4) every (1))'"
+        And the user runs command "printf 'public.foo' > config_file"
+        When the user runs "analyzedb -a -d incr_analyze -f config_file"
+        Then analyzedb should return a return code of 0
+	And output should contain both "-public.foo_1_prt_1" and "-public.foo_1_prt_3"
+        And the user runs "psql -d incr_analyze -c 'drop table foo'"
+
     @analyzedb_core @analyzedb_root_and_partition_tables
     Scenario: Partition tables, (entries for all parts, no change, some parts, root parts)
         Given no state files exist for database "incr_analyze"


### PR DESCRIPTION
Previously, running analyzedb with a config file (`analyzedb -f <config_file>`) 
containing a root partition would fail as we did not
properly populate the list of leaf partitions. The logic in analyzedb
assumes that we enumerate leaf partitions of the root partition that
the user had input (either from the command line or from a config file).
While we did this properly when the table was passed in from the command
line, we looked for the table name rather than the schema-qualifed table
for config files.

This bug would cause partitioned heap tables to fail when writing the
report/status files and would cause analyzedb to not track
DML changes in partitioned AO tables. Now, we properly check for the
schema-qualified table name when a config file is passed in.