### PR TITLE
5X: Harden analyzedb when a table is dropped

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -847,19 +847,17 @@ def generate_timestamp():
     return timestamp.strftime("%Y%m%d%H%M%S")
 
 
-def construct_oid_regclass_str(schema_table):
-    schema = schema_table[0]
-    table = schema_table[1]
-
-    return "'" + pg.escape_string("%s.%s" % (escape_identifier(schema), escape_identifier(table))) + "'::regclass"
-
-
 # The argument is a list of (schema, table) tuples. The output is a string containing an
 # SQL expression like: 'schema.table'::regclass, that can be embedded safely in an SQL string.
 # The escaping is a bit tricky here: the schema and table name need to be double-quoted, and the
 # whole string needs to be in single quotes.
+# This creates a subquery that will return a list of oids. This is necessary to prevent errors
+# in the case a table is dropped while analyzedb is running
 def get_oid_str(table_list):
-    return ','.join(map((lambda x: regclass_schema_tbl(x[0], x[1])), table_list))
+    subquery_str = "(SELECT pg_class.oid FROM pg_class, pg_namespace WHERE pg_class.relnamespace = pg_namespace.oid AND ("
+    tables = " OR ".join(map((lambda x: "(nspname = '%s' AND relname = '%s')" % (pg.escape_string(x[0]), pg.escape_string(x[1]))), table_list))
+    subquery_str = subquery_str + tables + "))"
+    return subquery_str
 
 
 def regclass_schema_tbl(schema, tbl):


### PR DESCRIPTION
Previously, analyzedb would error out and fail if a table was dropped
during analyzedb. Now, we silently skip dropped tables when determining
the tables to analyze.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
