### PR TITLE
Always use the <,<=,>,>= for the comparison of gxid

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -242,9 +242,12 @@ DistributedLog_AdvanceOldestXmin(TransactionId oldestLocalXmin,
 		 * advance past it. Otherwise stop here. (Local-only transactions will
 		 * have zeros in distribXid and distribTimeStamp; this test will also
 		 * skip over those.)
+		 *
+		 * And the distributed xid is just a plain counter, so we just use the `>=` for
+		 * the comparison of gxid
 		 */
 		if (ptr->distribTimeStamp == distribTransactionTimeStamp &&
-				!TransactionIdPrecedes(ptr->distribXid, xminAllDistributedSnapshots))
+				ptr->distribXid >= xminAllDistributedSnapshots)
 			break;
 
 		TransactionIdAdvance(oldestXmin);

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -382,9 +382,13 @@ ProcArrayRemove(PGPROC *proc, TransactionId latestXid)
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
+		/*
+		 * Remeber that the distributed xid is just a plain counter, so we just use the `<` for
+		 * the comparison of gxid
+		 */
 		DistributedTransactionId gxid = allTmGxact[proc->pgprocno].gxid;
 		if (InvalidDistributedTransactionId != gxid &&
-			TransactionIdPrecedes(ShmemVariableCache->latestCompletedDxid, gxid))
+			ShmemVariableCache->latestCompletedDxid < gxid)
 			ShmemVariableCache->latestCompletedDxid = gxid;
 	}
 
@@ -422,8 +426,12 @@ ProcArrayEndGxact(TMGXACT *gxact)
 	gxact->includeInCkpt = false;
 	gxact->sessionId = 0;
 
+	/*
+	 * Remeber that the distributed xid is just a plain counter, so we just use the `<` for
+	 * the comparison of gxid
+	 */
 	if (InvalidDistributedTransactionId != gxid &&
-		TransactionIdPrecedes(ShmemVariableCache->latestCompletedDxid, gxid))
+		ShmemVariableCache->latestCompletedDxid < gxid)
 		ShmemVariableCache->latestCompletedDxid = gxid;
 }
 


### PR DESCRIPTION
the distributed xid is just a plain counter, there is no WRAPAROUND in it.

