### PR TITLE
Update pg_aoseg entries for COPY FROM SEGMENT

### DIFF
--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1249,10 +1249,28 @@ DROP TABLE ext_dec17;
 COPY sales TO PROGRAM 'cat > /dev/null' IGNORE EXTERNAL PARTITIONS;
 COPY sales TO PROGRAM 'printf <SEGID> && cat > /dev/null' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
 DROP TABLE sales;
+
+-- Make sure COPY TO/FROM ON SEGMENT on an AO table works and that the
+-- corresponding aoseg tables get updated accordingly. We also check
+-- against an AO partition table since the dispatch result stores the
+-- individual leaf partition results in a special way compared to a
+-- single AO table and has its own result parsing logic.
 CREATE TABLE ao_copy(c int) WITH (appendonly=true);
+INSERT INTO ao_copy values (1);
 COPY ao_copy TO '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('ao_copy'::regclass);
 COPY ao_copy FROM '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('ao_copy'::regclass);
 DROP TABLE ao_copy;
+CREATE TABLE aopart_copy(c int, d int) WITH (appendonly=true) PARTITION BY RANGE(d) (START(0) END(2) EVERY(1));
+INSERT INTO aopart_copy values (1, 0), (2, 1);
+COPY aopart_copy TO '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_1'::regclass);
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_2'::regclass);
+COPY aopart_copy FROM '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_1'::regclass);
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_2'::regclass);
+DROP TABLE aopart_copy;
 
 -- "unknown" types can be dumped and restored: these attributes are
 -- NULL-terminated in memory (attlen == -2), so the COPY code needs to handle

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1516,10 +1516,57 @@ NOTICE:  COPY ignores external partition(s)
 COPY sales TO PROGRAM 'printf <SEGID> && cat > /dev/null' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
 NOTICE:  COPY ignores external partition(s)
 DROP TABLE sales;
+-- Make sure COPY TO/FROM ON SEGMENT on an AO table works and that the
+-- corresponding aoseg tables get updated accordingly. We also check
+-- against an AO partition table since the dispatch result stores the
+-- individual leaf partition results in a special way compared to a
+-- single AO table and has its own result parsing logic.
 CREATE TABLE ao_copy(c int) WITH (appendonly=true);
+INSERT INTO ao_copy values (1);
 COPY ao_copy TO '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('ao_copy'::regclass);
+ segno | modcount 
+-------+----------
+     1 |        1
+(1 row)
+
 COPY ao_copy FROM '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('ao_copy'::regclass);
+ segno | modcount 
+-------+----------
+     1 |        2
+(1 row)
+
 DROP TABLE ao_copy;
+CREATE TABLE aopart_copy(c int, d int) WITH (appendonly=true) PARTITION BY RANGE(d) (START(0) END(2) EVERY(1));
+INSERT INTO aopart_copy values (1, 0), (2, 1);
+COPY aopart_copy TO '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_1'::regclass);
+ segno | modcount 
+-------+----------
+     1 |        1
+(1 row)
+
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_2'::regclass);
+ segno | modcount 
+-------+----------
+     1 |        1
+(1 row)
+
+COPY aopart_copy FROM '/tmp/ao<SEGID>.txt' ON SEGMENT;
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_1'::regclass);
+ segno | modcount 
+-------+----------
+     1 |        2
+(1 row)
+
+SELECT segno, modcount FROM gp_toolkit.__gp_aoseg('aopart_copy_1_prt_2'::regclass);
+ segno | modcount 
+-------+----------
+     1 |        2
+(1 row)
+
+DROP TABLE aopart_copy;
 -- "unknown" types can be dumped and restored: these attributes are
 -- NULL-terminated in memory (attlen == -2), so the COPY code needs to handle
 -- them explicitly.


### PR DESCRIPTION
After running COPY FROM SEGMENT into an appendonly table, the pg_aoseg
entry on the master was not being updated as expected like regular
COPY. Add logic to update the pg_aoseg entries with the dispatch
results.

This was found while contemplating the usage of
`gp_update_ao_master_stats()` in PR #9258. Technically, users of COPY
FROM SEGMENT could just call `gp_update_ao_master_stats()` afterwards
but having the pg_aoseg entry updated at the end of COPY FROM SEGMENT
transaction seems more correct.

Question here is... should we fix COPY FROM SEGMENT by merging this PR or have external utilities just use the `gp_update_ao_master_stats()` function?