### PR TITLE
Fix wait policy for SELECT ... FOR ... NOWAIT

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -1281,7 +1281,7 @@ try_relation_open(Oid relationId, LOCKMODE lockmode, bool noWait)
  * for distributed tables.
  */
 Relation
-CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
+CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool *lockUpgraded)
 {
     LOCKMODE    lockmode = reqmode;
 	Relation    rel;
@@ -1303,7 +1303,7 @@ CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
 	if (lockmode == RowExclusiveLock)
 	{
 		if (Gp_role == GP_ROLE_DISPATCH &&
-			CondUpgradeRelLock(relid, noWait))
+			CondUpgradeRelLock(relid))
 		{
 			lockmode = ExclusiveLock;
 			if (lockUpgraded != NULL)
@@ -1311,7 +1311,7 @@ CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
 		}
     }
 
-	rel = try_heap_open(relid, lockmode, noWait);
+	rel = try_heap_open(relid, lockmode, false);
 	if (!RelationIsValid(rel))
 		return NULL;
 
@@ -1342,11 +1342,11 @@ CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
  * an error or a valid opened relation returned.
  */
 Relation
-CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
+CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool *lockUpgraded)
 {
 	Relation rel;
 
-	rel = CdbTryOpenRelation(relid, reqmode, noWait, lockUpgraded);
+	rel = CdbTryOpenRelation(relid, reqmode, lockUpgraded);
 
 	if (!RelationIsValid(rel))
 	{
@@ -1359,47 +1359,6 @@ CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
 	return rel;
 
 }                                       /* CdbOpenRelation */
-
-/*
- * CdbOpenRelationRv -- Opens a relation with a specified lock mode.
- *
- * CDB: Like CdbTryOpenRelation, except that it guarantees either
- * an error or a valid opened relation returned.
- */
-Relation
-CdbOpenRelationRv(const RangeVar *relation, LOCKMODE reqmode, bool noWait, 
-				  bool *lockUpgraded)
-{
-	Oid			relid;
-	Relation	rel;
-
-	/* Look up the appropriate relation using namespace search */
-	relid = RangeVarGetRelid(relation, NoLock, false);
-	rel = CdbTryOpenRelation(relid, reqmode, noWait, lockUpgraded);
-
-	if (!RelationIsValid(rel))
-	{
-		if (relation->schemaname)
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_TABLE),
-					 errmsg("relation \"%s.%s\" does not exist",
-							relation->schemaname, relation->relname)));
-		}
-		else
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_TABLE),
-					 errmsg("relation \"%s\" does not exist",
-							relation->relname)));
-		}
-	}
-
-	return rel;
-
-}                                       /* CdbOpenRelation */
-
-
 
 /* ----------------
  *		relation_openrv - open any relation specified by a RangeVar

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1621,10 +1621,7 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 				{
 					lockmode = NoLock;
 				}
-				resultRelation = CdbOpenRelation(resultRelationOid,
-													 lockmode,
-													 false, /* noWait */
-													 NULL); /* lockUpgraded */
+				resultRelation = CdbOpenRelation(resultRelationOid, lockmode, NULL); /* lockUpgraded */
 			}
 			else
 			{

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -301,9 +301,7 @@ setTargetTable(ParseState *pstate, RangeVar *relation,
 	}
 	else
 	{
-
-		pstate->p_target_relation = parserOpenTable(pstate, relation, RowExclusiveLock,
-													false, NULL);
+		pstate->p_target_relation = parserOpenTable(pstate, relation, RowExclusiveLock, NULL);
 	}
 
 	/*

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -216,7 +216,7 @@ AcquireRewriteLocks(Query *parsetree,
 				/* Take a lock either using CDB lock promotion or not */
 				if (needLockUpgrade)
 				{
-					rel = CdbOpenRelation(rte->relid, lockmode, false, NULL);
+					rel = CdbOpenRelation(rte->relid, lockmode, NULL);
 				}
 				else
 				{

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -1235,7 +1235,7 @@ LockTagIsTemp(const LOCKTAG *tag)
  * we have to keep upgrading locks for AO table.
  */
 bool
-CondUpgradeRelLock(Oid relid, bool noWait)
+CondUpgradeRelLock(Oid relid)
 {
 	Relation rel;
 	bool upgrade = false;
@@ -1247,7 +1247,7 @@ CondUpgradeRelLock(Oid relid, bool noWait)
 	 * try_relation_open will throw error if
 	 * the relation is invaliad
 	 */
-	rel = try_relation_open(relid, NoLock, noWait);
+	rel = try_relation_open(relid, NoLock, false);
 
 	if (!rel)
 		return false;

--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -1641,7 +1641,7 @@ AcquireExecutorLocks(List *stmt_list, bool acquire)
 				if ((plannedstmt->commandType == CMD_UPDATE ||
 					 plannedstmt->commandType == CMD_DELETE ||
 					 IsOnConflictUpdate(plannedstmt)) &&
-					CondUpgradeRelLock(rte->relid, false))
+					CondUpgradeRelLock(rte->relid))
 					lockmode = ExclusiveLock;
 				else
 					lockmode = RowExclusiveLock;
@@ -1748,7 +1748,7 @@ ScanQueryForLocks(Query *parsetree, bool acquire)
 						 parsetree->commandType == CMD_DELETE ||
 						 (parsetree->onConflict &&
 						  parsetree->onConflict->action == ONCONFLICT_UPDATE)) &&
-						CondUpgradeRelLock(rte->relid, false))
+						CondUpgradeRelLock(rte->relid))
 						lockmode = ExclusiveLock;
 					else
 						lockmode = RowExclusiveLock;

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -101,12 +101,8 @@ extern Relation heap_openrv_extended(const RangeVar *relation,
 #define heap_close(r,l)  relation_close(r,l)
 
 /* CDB */
-extern Relation CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, 
-								bool *lockUpgraded);
-extern Relation CdbTryOpenRelation(Oid relid, LOCKMODE reqmode,
-								   bool noWait, bool *lockUpgraded);
-extern Relation CdbOpenRelationRv(const RangeVar *relation, LOCKMODE reqmode, 
-								  bool noWait, bool *lockUpgraded);
+extern Relation CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool *lockUpgraded);
+extern Relation CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool *lockUpgraded);
 
 /* struct definitions appear in relscan.h */
 typedef struct HeapScanDescData *HeapScanDesc;

--- a/src/include/parser/parse_relation.h
+++ b/src/include/parser/parse_relation.h
@@ -62,7 +62,7 @@ extern Node *colNameToVar(ParseState *pstate, char *colname, bool localonly,
 extern void markVarForSelectPriv(ParseState *pstate, Var *var,
 					 RangeTblEntry *rte);
 extern Relation parserOpenTable(ParseState *pstate, const RangeVar *relation,
-								int lockmode, bool nowait, bool *lockUpgraded);
+								int lockmode, bool *lockUpgraded);
 extern RangeTblEntry *addRangeTableEntry(ParseState *pstate,
 				   RangeVar *relation,
 				   Alias *alias,

--- a/src/include/storage/lmgr.h
+++ b/src/include/storage/lmgr.h
@@ -113,7 +113,7 @@ extern const char *GetLockNameFromTagType(uint16 locktag_type);
 /* Knowledge about which locktags describe temp objects */
 extern bool LockTagIsTemp(const LOCKTAG *tag);
 
-extern bool CondUpgradeRelLock(Oid relid, bool noWait);
+extern bool CondUpgradeRelLock(Oid relid);
 
 extern void GxactLockTableInsert(DistributedTransactionId xid);
 extern void GxactLockTableWait(DistributedTransactionId xid);

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -955,43 +955,63 @@ BEGIN
 1: abort;
 ABORT
 
+-- 1.6 select for update NOWAIT/SKIP LOCKED
+-- NOWAIT/SKIP LOCKED should not affect the table-level lock
+1: begin;
+BEGIN
+1: select * from t_lockmods for share;
+ c 
+---
+ 1 
+ 2 
+ 3 
+ 4 
+ 5 
+(5 rows)
+2&: select * from t_lockmods for update nowait;  <waiting ...>
+1: abort;
+ABORT
+2<:  <... completed>
+ c 
+---
+ 1 
+ 2 
+ 3 
+ 4 
+ 5 
+(5 rows)
+
+1: begin;
+BEGIN
+1: select * from t_lockmods for share;
+ c 
+---
+ 1 
+ 2 
+ 3 
+ 4 
+ 5 
+(5 rows)
+2&: select * from t_lockmods for update skip locked;  <waiting ...>
+1: abort;
+ABORT
+2<:  <... completed>
+ c 
+---
+ 1 
+ 2 
+ 3 
+ 4 
+ 5 
+(5 rows)
+
 1q: ... <quitting>
 2q: ... <quitting>
 
 -- start_ignore
 ! gpconfig -c gp_enable_global_deadlock_detector -v on;
-20190515:15:53:44:050050 gpconfig:zlv:gpadmin-[INFO]:-completed successfully with parameters '-c gp_enable_global_deadlock_detector -v on'
 
 ! gpstop -rai;
-20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Starting gpstop with args: -rai
-20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Gathering information and validating the environment...
-20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Obtaining Segment details from master...
-20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.196.g0f8a703 build dev'
-20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-There are 1 connections to the database
-20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
-20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Master host=zlv
-20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
-20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
-20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20190515:15:53:44:050220 gpstop:zlv:gpadmin-[INFO]:-Stopping master standby host zlv mode=fast
-20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-Successfully shutdown standby process on zlv
-20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
-20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
-20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-0.00% of jobs completed
-20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-100.00% of jobs completed
-20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
-20190515:15:53:45:050220 gpstop:zlv:gpadmin-[INFO]:-0.00% of jobs completed
-20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-100.00% of jobs completed
-20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-----------------------------------------------------
-20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-   Segments stopped successfully      = 6
-20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-   Segments with errors during stop   = 0
-20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-----------------------------------------------------
-20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
-20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
-20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover shared memory
-20190515:15:53:46:050220 gpstop:zlv:gpadmin-[INFO]:-Restarting System...
 
 -- end_ignore
 
@@ -1929,43 +1949,51 @@ BEGIN
 1: abort;
 ABORT
 
+-- 2.6 select for update NOWAIT/SKIP LOCKED
+-- with GDD, select for update could be optimized to not upgrade lock.
+1: begin;
+BEGIN
+1: select * from t_lockmods where c<3 for share;
+ c 
+---
+ 2 
+ 1 
+(2 rows)
+2: select * from t_lockmods for share;
+ c 
+---
+ 2 
+ 5 
+ 3 
+ 1 
+ 4 
+(5 rows)
+2: select * from t_lockmods for update skip locked;
+ c 
+---
+ 3 
+ 5 
+ 4 
+(3 rows)
+2: select * from t_lockmods where c>=3 for update nowait;
+ c 
+---
+ 5 
+ 4 
+ 3 
+(3 rows)
+2: select * from t_lockmods for update nowait;
+ERROR:  could not obtain lock on row in relation "t_lockmods"  (seg1 slice1 10.140.0.3:7003 pid=15182)
+1: abort;
+ABORT
+
 1q: ... <quitting>
 2q: ... <quitting>
 
 -- start_ignore
 ! gpconfig -c gp_enable_global_deadlock_detector -v off;
-20190515:15:53:50:051138 gpconfig:zlv:gpadmin-[INFO]:-completed successfully with parameters '-c gp_enable_global_deadlock_detector -v off'
 
 ! gpstop -rai;
-20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Starting gpstop with args: -rai
-20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Gathering information and validating the environment...
-20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Obtaining Segment details from master...
-20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.196.g0f8a703 build dev'
-20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-There are 0 connections to the database
-20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
-20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Master host=zlv
-20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Commencing Master instance shutdown with mode=immediate
-20190515:15:53:50:051308 gpstop:zlv:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
-20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-Stopping master standby host zlv mode=fast
-20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-Successfully shutdown standby process on zlv
-20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
-20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
-20190515:15:53:51:051308 gpstop:zlv:gpadmin-[INFO]:-0.00% of jobs completed
-20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-100.00% of jobs completed
-20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
-20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-0.00% of jobs completed
-20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-100.00% of jobs completed
-20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-----------------------------------------------------
-20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-   Segments stopped successfully      = 6
-20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-   Segments with errors during stop   = 0
-20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-----------------------------------------------------
-20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
-20190515:15:53:52:051308 gpstop:zlv:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
-20190515:15:53:53:051308 gpstop:zlv:gpadmin-[INFO]:-Cleaning up leftover shared memory
-20190515:15:53:53:051308 gpstop:zlv:gpadmin-[INFO]:-Restarting System...
 
 -- end_ignore
 

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -289,6 +289,20 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 2: select * from show_locks_lockmodes;
 1: abort;
 
+-- 1.6 select for update NOWAIT/SKIP LOCKED
+-- NOWAIT/SKIP LOCKED should not affect the table-level lock
+1: begin;
+1: select * from t_lockmods for share;
+2&: select * from t_lockmods for update nowait;
+1: abort;
+2<:
+
+1: begin;
+1: select * from t_lockmods for share;
+2&: select * from t_lockmods for update skip locked;
+1: abort;
+2<:
+
 1q:
 2q:
 
@@ -572,6 +586,16 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 -- because of the "LockRows loses sort order" issue.
 --1: select * from t_lockmods order by c for update;
 2: select * from show_locks_lockmodes;
+1: abort;
+
+-- 2.6 select for update NOWAIT/SKIP LOCKED
+-- with GDD, select for update could be optimized to not upgrade lock.
+1: begin;
+1: select * from t_lockmods where c<3 for share;
+2: select * from t_lockmods for share;
+2: select * from t_lockmods for update skip locked;
+2: select * from t_lockmods where c>=3 for update nowait;
+2: select * from t_lockmods for update nowait;
 1: abort;
 
 1q:


### PR DESCRIPTION
This PR fixs the issue https://github.com/greenplum-db/gpdb/issues/8539

The wait policy, NOWAIT or SKIP LOCKED, only affects how SELECT locks
rows as they are obtained from the table. They are used by the execution.
The SELECT statement with locking clause may upgrade the lock mode.
This PR removes the nowait logic in opening the relation in the parser analyze
stage. So, the SELECT statement with locking clause will wait for the table
lock if it can't hold the table lock.

Co-authored-by: Zhenghua Lyu zlv@pivotal.io

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
