### PR TITLE
Convert disable_cost to a guc

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4021,6 +4021,17 @@ struct config_int ConfigureNamesInt_gp[] =
 struct config_real ConfigureNamesReal_gp[] =
 {
 	{
+		{"disable_cost", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Sets the planner's cost of a disabled path."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&disable_cost,
+		1.0e10, 1.0e10, 1.0e30,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"gp_motion_cost_per_row", PGC_USERSET, QUERY_TUNING_COST,
 			gettext_noop("Sets the planner's estimate of the cost of "
 						 "moving a row between worker processes."),

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -104,6 +104,7 @@
 		"default_transaction_isolation",
 		"default_transaction_read_only",
 		"default_with_oids",
+		"disable_cost",
 		"dtx_phase2_retry_second",
 		"dynamic_library_path",
 		"dynamic_shared_memory_type",


### PR DESCRIPTION
There was a discussion about disable_cost being small sometimes on upstream,
https://www.postgresql.org/message-id/flat/CAO0i4_SSPV9TVxbbTRVLOnCyewopcc147fBZy%3Df2ABk15eHS%2Bg%40mail.gmail.com
but there is no conclusion there although many solutions are discussed there.
This issue seem to be more urgent for Greenplum since Greenplum is a
distributed system and can handle much more data than single node postgres.

Recently we encountered a user issue again that is quite relevant of this. In
the case merge join, instead of hashjoin is chosen. Admittedly in the case
there is a corner costing issue (might be uglily fixed though) in the hashjoin
code, but generally we are wondering if we should tune disable_cost to fix
given small disable_cost value has been known to be an issue sometimes also.

We know finally disable_cost might be gone on gpdb master, and we know we need
to work to make hashjoin costing more accurate (though sometimes it is hard),
but for now users are waiting for a solution on gpdb6, so we use the guc
solution temporarily but we are open to hear more suggestions (hardcode
disable_cost? fixing in pathing), etc.

Co-authored-by: Jinbao Chen <jinchen@pivotal.io>
