### PR TITLE
Always generate merge gather for select statement with locking clause…

### DIFF
--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -1898,28 +1898,28 @@ BEGIN
 ABORT
 
 -- 2.5 test order-by's plan
--- This doesn't actually return the rows in order, only in partial order.
--- That's because the LockRows node might need to fetch a new different value
--- in EvalPlanQual. PostgreSQL does the same, but it's worse in GPDB: we cannot
--- have a Gather Motion on top of the input, because the input isn't always
--- ordered, but that means that we definitely lose the ordering.
--- GPDB_96_MERGE_FIXME: Before 9.6, we used to create a sorted Gather Motion
--- plan anyway. That seems a bit bogus, but maybe we should keep doing that?
 1: begin;
 BEGIN
 1: explain select * from t_lockmods order by c for update;
  QUERY PLAN                                                                  
 -----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=3.11..3.17 rows=5 width=10) 
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.11..3.27 rows=5 width=10) 
+   Merge Key: c                                                              
    ->  LockRows  (cost=3.11..3.17 rows=2 width=10)                           
          ->  Sort  (cost=3.11..3.12 rows=2 width=10)                         
                Sort Key: c                                                   
                ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10) 
  Optimizer: Postgres query optimizer                                         
 (7 rows)
--- GPDB_96_MERGE_FIXME: this test had indeterministic row order differences,
--- because of the "LockRows loses sort order" issue.
---1: select * from t_lockmods order by c for update;
+1: select * from t_lockmods order by c for update;
+ c 
+---
+ 1 
+ 2 
+ 3 
+ 4 
+ 5 
+(5 rows)
 2: select * from show_locks_lockmodes;
  locktype | mode            | granted | relation   
 ----------+-----------------+---------+------------

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -559,18 +559,9 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 1: abort;
 
 -- 2.5 test order-by's plan
--- This doesn't actually return the rows in order, only in partial order.
--- That's because the LockRows node might need to fetch a new different value
--- in EvalPlanQual. PostgreSQL does the same, but it's worse in GPDB: we cannot
--- have a Gather Motion on top of the input, because the input isn't always
--- ordered, but that means that we definitely lose the ordering.
--- GPDB_96_MERGE_FIXME: Before 9.6, we used to create a sorted Gather Motion
--- plan anyway. That seems a bit bogus, but maybe we should keep doing that?
 1: begin;
 1: explain select * from t_lockmods order by c for update;
--- GPDB_96_MERGE_FIXME: this test had indeterministic row order differences,
--- because of the "LockRows loses sort order" issue.
---1: select * from t_lockmods order by c for update;
+1: select * from t_lockmods order by c for update;
 2: select * from show_locks_lockmodes;
 1: abort;
 


### PR DESCRIPTION
… and sort clause.

LockRowsPath will clear the pathkeys info since
when some other transactions concurrently update
the same relation then it cannot guarantee the order.
Postgres will not consider parallel path for the
select statement with locking clause (it sets parallel_safe
to false and parallel_workers to 0 in function
create_lockrows_path). However, Greenplum contains many
segments and is innately parallel. If we simply clear
the pathkey then if later we need a gather, we will
not choose merge gather so even if there is no concurrent
transaction, the data is not in order. See Github issue:
https://github.com/greenplum-db/gpdb/issues/9724.
So just before the finaly gather, we save the pathkeys
and then invoke create_lockrows_path. In the following
gather, if we found saved_pathkeys is not NIL, we just
create a merge gather.

Another need to mention here is that, the condition that
code can reach create_lockrows_path is very rigour: the
query has to be a toplevel select statement and the range
table has to be a normal heap table and there is only one
table invole the query and many other conditions (please
refer `checkCanOptSelectLockingClause` for details. As the
above analysis, if the code reaches here and the path->pathkeys
is not NIL, the following gather has to be the final gather.
This is very important because if it is not the final gather,
it might be used by others as subpath, and its pathkeys is
not NIL which breaks the rules for lockrows path. We need
to keep the pathkeys in the final gather here.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
