### PR TITLE
Fix memory leak in checkpointer process.

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -2418,9 +2418,8 @@ TwoPhaseAddPreparedTransaction(prepared_transaction_agg_state **ptas,
  * is empty.
  */
 XLogRecPtr *
-getTwoPhaseOldestPreparedTransactionXLogRecPtr(XLogRecData *rdata)
+getTwoPhaseOldestPreparedTransactionXLogRecPtr(prepared_transaction_agg_state *ptas)
 {
-	prepared_transaction_agg_state *ptas = (prepared_transaction_agg_state *)rdata->data;
 	int			map_count = ptas->count;
 	prpt_map   *m = ptas->maps;
 	XLogRecPtr *oldest = NULL;

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9098,6 +9098,10 @@ CreateCheckPoint(int flags)
 			break;
 		}
 	}
+	/*
+	 * Save the data pointers that need to be pfreed after XLogInsert.
+	 * This is essential because rdata[x].data may be changed in XLogInsert.
+	 */
 	void *dataptr[6];
 	for (i = 2; i < 6; i++)
 		dataptr[i] = (void*)rdata[i].data;
@@ -9168,7 +9172,7 @@ CreateCheckPoint(int flags)
 	 */
 	freeDtxCheckPointInfoAndUnlock(dtxCheckPointInfo, dtxCheckPointInfoSize, &recptr);
 	/*
-	 * pfree data starting from rdata[1].next to the end.
+	 * pfree data starting from rdata[2].data to the end.
 	 * if gp_before_filespace_setup is on, rdata[2], rdata[3], rdata[4] are empty,
 	 * otherwise, they are allocated by mmxlog_append_checkpoint_data()
 	 */

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9143,7 +9143,16 @@ CreateCheckPoint(int flags)
 			 XLogLastInsertDataLen());
 	}
 
+	/* free heap memory allocated by palloc, to prevent the long-live memory context */
+	/* rdata[0].data uses the stack buffer */
+	/* rdata[1] is dtxCheckPointInfo */
 	freeDtxCheckPointInfoAndUnlock(dtxCheckPointInfo, dtxCheckPointInfoSize, &recptr);
+	/* rdata[2], rdata[3], rdata[4] are allocated by mmxlog_append_checkpoint_data() */
+	pfree(rdata[2].data);
+	pfree(rdata[3].data);
+	pfree(rdata[4].data);
+	/* rdata[5] is allocated by getTwoPhasePreparedTransactionData() */
+	pfree(rdata[5].data);
 
 	XLogFlush(recptr);
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9098,6 +9098,9 @@ CreateCheckPoint(int flags)
 			break;
 		}
 	}
+	void *dataptr[6];
+	for (i = 2; i < 6; i++)
+		dataptr[i] = (void*)rdata[i].data;
 
 	if (Debug_persistent_recovery_print)
 	{
@@ -9170,9 +9173,9 @@ CreateCheckPoint(int flags)
 	 * otherwise, they are allocated by mmxlog_append_checkpoint_data()
 	 */
 	{
-		XLogRecData *prdata = rdata[1].next;
-		for(; prdata; prdata = prdata->next)
-			pfree(prdata->data);
+		for (i = 2; i < 6; i++)
+			if (dataptr[i])
+				pfree(dataptr[i]);
 		dtxCheckPointInfo = NULL;
 		p = NULL;
 	}

--- a/src/backend/access/transam/xlog_mm.c
+++ b/src/backend/access/transam/xlog_mm.c
@@ -1599,6 +1599,9 @@ mmxlog_append_checkpoint_data(XLogRecData rdata[6])
 
 			SUPPRESS_ERRCONTEXT_POP();
 
+			rdata[2].data = NULL;
+			rdata[3].data = NULL;
+			rdata[4].data = NULL;
 			rdata[2].len = 0;
 			rdata[3].len = 0;
 			rdata[4].len = 0;

--- a/src/backend/access/transam/xlog_mm.c
+++ b/src/backend/access/transam/xlog_mm.c
@@ -1570,21 +1570,12 @@ mmxlog_add_database(
  *
  * NOTE: You must hold the PersistentObjLock before calling this routine!
  */
-void
-mmxlog_append_checkpoint_data(XLogRecData rdata[6])
+XLogRecData **
+mmxlog_append_checkpoint_data(XLogRecData rdata[3], XLogRecData **pnext)
 {
 	fspc_agg_state *f;
 	tspc_agg_state *t;
 	dbdir_agg_state *d;
-
-	/*
-	 * We must make sure no one traverses the rdata chain into uninitialised
-	 * data if we exit early, below.
-	 */
-	rdata[1].next = NULL;
-	rdata[2].next = NULL;
-	rdata[3].next = NULL;
-	rdata[4].next = NULL;
 
 	if (gp_before_filespace_setup)
 	{
@@ -1598,15 +1589,9 @@ mmxlog_append_checkpoint_data(XLogRecData rdata[6])
 				 "mmxlog_append_checkpoint_data: no tablespace and filespace information for checkpoint because gp_before_filespace_setup GUC is true");
 
 			SUPPRESS_ERRCONTEXT_POP();
-
-			rdata[2].data = NULL;
-			rdata[3].data = NULL;
-			rdata[4].data = NULL;
-			rdata[2].len = 0;
-			rdata[3].len = 0;
-			rdata[4].len = 0;
+			memset(rdata, 0, sizeof(XLogRecData) * 3);
 		}
-		return;
+		return pnext;
 	}
 
 	if (IsStandbyMode())
@@ -1630,19 +1615,21 @@ mmxlog_append_checkpoint_data(XLogRecData rdata[6])
 		get_database_data(&d, "mmxlog_append_checkpoint_data");
 	}
 
-	rdata[2].data = (char*)f;
+	rdata[0].data = (char*)f;
+	rdata[0].buffer = InvalidBuffer;
+	rdata[0].len = FSPC_CHECKPOINT_BYTES(f->count);
+	rdata[1].data = (char*)t;
+	rdata[1].buffer = InvalidBuffer;
+	rdata[1].len = TSPC_CHECKPOINT_BYTES(t->count);
+	rdata[2].data = (char*)d;
 	rdata[2].buffer = InvalidBuffer;
-	rdata[2].len = FSPC_CHECKPOINT_BYTES(f->count);
-	rdata[3].data = (char*)t;
-	rdata[3].buffer = InvalidBuffer;
-	rdata[3].len = TSPC_CHECKPOINT_BYTES(t->count);
-	rdata[4].data = (char*)d;
-	rdata[4].buffer = InvalidBuffer;
-	rdata[4].len = DBDIR_CHECKPOINT_BYTES(d->count);
+	rdata[2].len = DBDIR_CHECKPOINT_BYTES(d->count);
 
+	*pnext = &(rdata[0]);
+	rdata[0].next = &(rdata[1]);
 	rdata[1].next = &(rdata[2]);
-	rdata[2].next = &(rdata[3]);
-	rdata[3].next = &(rdata[4]);
+	pnext = &rdata[2].next;
+	rdata[2].next = NULL;
 
 	if (Debug_persistent_recovery_print)
 	{
@@ -1658,6 +1645,7 @@ mmxlog_append_checkpoint_data(XLogRecData rdata[6])
 
 		SUPPRESS_ERRCONTEXT_POP();
 	}
+	return pnext;
 }
 
 /*

--- a/src/backend/access/transam/xlog_mm.c
+++ b/src/backend/access/transam/xlog_mm.c
@@ -1598,6 +1598,10 @@ mmxlog_append_checkpoint_data(XLogRecData rdata[6])
 				 "mmxlog_append_checkpoint_data: no tablespace and filespace information for checkpoint because gp_before_filespace_setup GUC is true");
 
 			SUPPRESS_ERRCONTEXT_POP();
+
+			rdata[2].len = 0;
+			rdata[3].len = 0;
+			rdata[4].len = 0;
 		}
 		return;
 	}

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -2865,10 +2865,8 @@ getDtxCheckPointInfoAndLock(char **result, int *result_size)
 }
 
 void
-freeDtxCheckPointInfoAndUnlock(char *info, int info_size  __attribute__((unused)) , XLogRecPtr *recptr)
+freeDtxCheckPointInfoAndUnlock(XLogRecPtr *recptr)
 {
-	pfree(info);
-
 	releaseTmLock();
 
 	elog(DTM_DEBUG5, "Checkpoint with DTM information written at %X/%X.",

--- a/src/include/access/twophase.h
+++ b/src/include/access/twophase.h
@@ -96,7 +96,7 @@ extern void TwoPhaseAddPreparedTransactionInit(
 					        prepared_transaction_agg_state **ptas
 					      , int                             *maxCount);
 
-extern XLogRecPtr * getTwoPhaseOldestPreparedTransactionXLogRecPtr(XLogRecData *rdata);
+extern XLogRecPtr * getTwoPhaseOldestPreparedTransactionXLogRecPtr(prepared_transaction_agg_state *ptas);
 
 extern void TwoPhaseAddPreparedTransaction(
                  prepared_transaction_agg_state **ptas

--- a/src/include/access/xlogmm.h
+++ b/src/include/access/xlogmm.h
@@ -141,7 +141,7 @@ extern void mmxlog_log_create_tablespace(Oid filespace, Oid tablespace);
 extern void mmxlog_log_create_database(Oid tablespace, Oid database);
 extern void mmxlog_log_create_relfilenode(Oid tablespace, Oid database,
 										  Oid relfilenode, uint32 segnum);
-extern void mmxlog_append_checkpoint_data(XLogRecData rdata[5]);
+extern XLogRecData ** mmxlog_append_checkpoint_data(XLogRecData rdata[3], XLogRecData **pnext);
 extern void mmxlog_read_checkpoint_data(MasterMirrorCheckpointInfo mmckptInfo,
 										XLogRecPtr *beginLoc);
 extern bool mmxlog_filespace_get_path(

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -316,7 +316,7 @@ extern int	tmShmemSize(void);
 extern void initTM(void);
 
 extern void getDtxCheckPointInfoAndLock(char **result, int *result_size);
-extern void freeDtxCheckPointInfoAndUnlock(char *info, int info_size, XLogRecPtr *recptr);
+extern void freeDtxCheckPointInfoAndUnlock(XLogRecPtr *recptr);
 
 extern void verify_shared_snapshot_ready(void);
 


### PR DESCRIPTION
Checkpointer process is a long-live and the current memory context for
the FOR loop is its own memory context. So any memory leak will lead to
the checkpointer process hold more and more memory until the memory
context is reset.
The `rdata` to build xlog record has 5 pointers that allocated by
palloc/palloc0 and only one pointer frees the memory. It's better to
free memory here rather than resetting the memory context in the for loop
of the checkpointer process.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
