### PR TITLE
Fix ACL error when creating partition table

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1503,8 +1503,10 @@ heap_create_with_catalog(const char *relname,
 
 	/*
 	 * Determine the relation's initial permissions.
+	 * If rel is partition child, leave it NULL here, Because CopyRelationAcls()
+	 * will copy relacl from parent later.
 	 */
-	if (use_user_acl)
+	if (use_user_acl && !is_part_child)
 	{
 		switch (relkind)
 		{

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -8433,3 +8433,49 @@ select * from employee_table where user_id = 2;
 --------+---------+------+-----
 (0 rows)
 
+-- Test partition table with ACL.
+-- We grant default SELECT permission to a new user, this new user should be
+-- able to SELECT from any partition table we create later.
+-- (https://github.com/greenplum-db/gpdb/issues/9524)
+DROP TABLE IF EXISTS public.t_part_acl;
+NOTICE:  table "t_part_acl" does not exist, skipping
+DROP ROLE IF EXISTS user_prt_acl;
+CREATE ROLE user_prt_acl;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO user_prt_acl;
+CREATE TABLE public.t_part_acl (dt date)
+PARTITION BY RANGE (dt)
+(
+    START (date '2019-12-01') INCLUSIVE
+    END (date '2020-02-01') EXCLUSIVE
+    EVERY (INTERVAL '1 month')
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'dt' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_1" for table "t_part_acl"
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_2" for table "t_part_acl"
+INSERT INTO public.t_part_acl VALUES (date '2019-12-01'), (date '2020-01-31');
+-- check if parent and child table have same relacl
+SELECT relname FROM pg_class
+WHERE relname LIKE 't_part_acl%'
+  AND relacl = (SELECT relacl FROM pg_class WHERE relname = 't_part_acl');
+      relname       
+--------------------
+ t_part_acl
+ t_part_acl_1_prt_1
+ t_part_acl_1_prt_2
+(3 rows)
+
+-- check if new user can SELECT all data
+SET ROLE user_prt_acl;
+SELECT * FROM public.t_part_acl;
+     dt     
+------------
+ 12-01-2019
+ 01-31-2020
+(2 rows)
+
+RESET ROLE;
+DROP TABLE public.t_part_acl;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT ON TABLES FROM user_prt_acl;
+DROP ROLE user_prt_acl;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -8440,3 +8440,49 @@ select * from employee_table where user_id = 2;
 --------+---------+------+-----
 (0 rows)
 
+-- Test partition table with ACL.
+-- We grant default SELECT permission to a new user, this new user should be
+-- able to SELECT from any partition table we create later.
+-- (https://github.com/greenplum-db/gpdb/issues/9524)
+DROP TABLE IF EXISTS public.t_part_acl;
+NOTICE:  table "t_part_acl" does not exist, skipping
+DROP ROLE IF EXISTS user_prt_acl;
+CREATE ROLE user_prt_acl;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO user_prt_acl;
+CREATE TABLE public.t_part_acl (dt date)
+PARTITION BY RANGE (dt)
+(
+    START (date '2019-12-01') INCLUSIVE
+    END (date '2020-02-01') EXCLUSIVE
+    EVERY (INTERVAL '1 month')
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'dt' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_1" for table "t_part_acl"
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_2" for table "t_part_acl"
+INSERT INTO public.t_part_acl VALUES (date '2019-12-01'), (date '2020-01-31');
+-- check if parent and child table have same relacl
+SELECT relname FROM pg_class
+WHERE relname LIKE 't_part_acl%'
+  AND relacl = (SELECT relacl FROM pg_class WHERE relname = 't_part_acl');
+      relname       
+--------------------
+ t_part_acl
+ t_part_acl_1_prt_1
+ t_part_acl_1_prt_2
+(3 rows)
+
+-- check if new user can SELECT all data
+SET ROLE user_prt_acl;
+SELECT * FROM public.t_part_acl;
+     dt     
+------------
+ 12-01-2019
+ 01-31-2020
+(2 rows)
+
+RESET ROLE;
+DROP TABLE public.t_part_acl;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT ON TABLES FROM user_prt_acl;
+DROP ROLE user_prt_acl;


### PR DESCRIPTION
Fix GitHub Issue: #9524
Cause of this bug: Both heap_create_with_catalog() and
CopyRelationAcls() tried to write ACL for partition child tables,
which is not allowed.

Instead, We leave ACL to be NULL when heap_create_with_catalog()
creates child relations. This should fix the issue.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
