### PR TITLE
pg_upgrade: reject multi-schema partitioned tables

### DIFF
--- a/contrib/pg_upgrade/greenplum/check_gp.c
+++ b/contrib/pg_upgrade/greenplum/check_gp.c
@@ -28,6 +28,7 @@ static void check_gphdfs_external_tables(void);
 static void check_gphdfs_user_roles(void);
 static void check_unique_primary_constraint(void);
 static void check_for_array_of_partition_table_types(ClusterInfo *cluster);
+static void check_partition_schemas(void);
 
 
 /*
@@ -51,6 +52,7 @@ check_greenplum(void)
 	check_gphdfs_user_roles();
 	check_unique_primary_constraint();
 	check_for_array_of_partition_table_types(&old_cluster);
+	check_partition_schemas();
 }
 
 /*
@@ -896,4 +898,81 @@ check_for_array_of_partition_table_types(ClusterInfo *cluster)
 	pfree(dependee_partition_report);
 
 	check_ok();
+}
+
+void
+check_partition_schemas(void)
+{
+	int				dbnum;
+	FILE		   *script = NULL;
+	bool			found = false;
+	char			output_path[MAXPGPATH];
+
+	prep_status("Checking schemas on partitioned tables");
+
+	snprintf(output_path, sizeof(output_path), "mismatched_partition_schemas.txt");
+
+	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
+	{
+		PGresult   *res;
+		bool		db_used = false;
+		int			ntups;
+		int			rowno;
+		int			i_root,
+					i_child;
+		DbInfo	   *active_db = &old_cluster.dbarr.dbs[dbnum];
+		PGconn	   *conn = connectToServer(&old_cluster, active_db->db_name);
+
+		res = executeQueryOrDie(conn,
+								"SELECT c1.oid::pg_catalog.regclass AS root, "
+								"       c2.oid::pg_catalog.regclass AS child "
+								"  FROM pg_catalog.pg_partition p "
+								"  JOIN pg_catalog.pg_partition_rule pr ON p.oid = pr.paroid "
+								"  JOIN pg_catalog.pg_class c1 ON p.parrelid = c1.oid "
+								"  JOIN pg_catalog.pg_class c2 ON pr.parchildrelid = c2.oid "
+								" WHERE c1.relnamespace != c2.relnamespace "
+								" ORDER BY c1.oid, c2.oid;");
+
+		ntups = PQntuples(res);
+		i_root = PQfnumber(res, "root");
+		i_child = PQfnumber(res, "child");
+
+		for (rowno = 0; rowno < ntups; rowno++)
+		{
+			found = true;
+			if (script == NULL && (script = fopen_priv(output_path, "w")) == NULL)
+				pg_fatal("Could not open file \"%s\": %s\n",
+						 output_path, getErrorText());
+
+			if (!db_used)
+			{
+				fprintf(script, "Database: %s\n", active_db->db_name);
+				db_used = true;
+			}
+
+			fprintf(script, "  %s contains child %s\n",
+					PQgetvalue(res, rowno, i_root),
+					PQgetvalue(res, rowno, i_child));
+		}
+
+		PQclear(res);
+		PQfinish(conn);
+	}
+
+	if (script)
+		fclose(script);
+
+	if (found)
+	{
+		pg_log(PG_REPORT, "fatal\n");
+		pg_fatal(
+			"Your installation contains partitioned tables where one or more\n"
+			"child partitions are not in the same schema as the root partition.\n"
+			"ALTER TABLE ... SET SCHEMA must be performed on the child partitions\n"
+			"to match them before upgrading. A list of problem tables is in the\n"
+			"file:\n"
+			"    %s\n\n", output_path);
+	}
+	else
+		check_ok();
 }

--- a/contrib/pg_upgrade/test/integration/.gitignore
+++ b/contrib/pg_upgrade/test/integration/.gitignore
@@ -36,6 +36,7 @@
 /expected/unsupported_dist_coltypes.out
 /expected/gphdfs.out
 /expected/mismatched_aopartition_indexes.out
+/expected/mismatched_partition_schemas.out
 /expected/unsupported_name_col.out
 /expected/unsupported_tsquery_col.out
 /expected/upgraded_ao_table_without_base_relfilenode.out
@@ -48,6 +49,7 @@
 /sql/unsupported_dist_coltypes.sql
 /sql/gphdfs.sql
 /sql/mismatched_aopartition_indexes.sql
+/sql/mismatched_partition_schemas.sql
 /sql/unsupported_name_col.sql
 /sql/unsupported_tsquery_col.sql
 /sql/upgraded_ao_table_without_base_relfilenode.sql

--- a/contrib/pg_upgrade/test/integration/gpdb5_schedule
+++ b/contrib/pg_upgrade/test/integration/gpdb5_schedule
@@ -9,3 +9,4 @@ test: unsupported_tsquery_col
 test: gphdfs
 test: mismatched_aopartition_indexes
 test: different_name_index_backed_constraint
+test: mismatched_partition_schemas

--- a/contrib/pg_upgrade/test/integration/input/mismatched_partition_schemas.source
+++ b/contrib/pg_upgrade/test/integration/input/mismatched_partition_schemas.source
@@ -1,0 +1,23 @@
+-- Partitioned tables that have their root and partitions in different schemas
+-- must be rejected by GPDB's pg_upgrade.
+CREATE SCHEMA other_schema;
+
+CREATE TABLE multischema_partition (a int)
+  PARTITION BY RANGE(a) (START(1) END(2) EVERY(1));
+ALTER TABLE multischema_partition_1_prt_1 SET SCHEMA other_schema;
+
+CREATE TABLE multischema_subpartition (a int, b int)
+  PARTITION BY RANGE(a)
+    SUBPARTITION BY RANGE(b)
+    SUBPARTITION TEMPLATE (START(1) END(3) EVERY(1), DEFAULT SUBPARTITION other)
+  (START(1) END(2) EVERY(1));
+ALTER TABLE multischema_subpartition_1_prt_1_2_prt_2 SET SCHEMA other_schema;
+ALTER TABLE multischema_subpartition_1_prt_1_2_prt_other SET SCHEMA other_schema;
+
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+! /bin/cat ./mismatched_partition_schemas.txt ;
+
+-- Users need to correct the problem by manually renamespacing the partitions.
+ALTER TABLE other_schema.multischema_partition_1_prt_1 SET SCHEMA public;
+ALTER TABLE other_schema.multischema_subpartition_1_prt_1_2_prt_2 SET SCHEMA public;
+ALTER TABLE other_schema.multischema_subpartition_1_prt_1_2_prt_other SET SCHEMA public;

--- a/contrib/pg_upgrade/test/integration/output/mismatched_partition_schemas.source
+++ b/contrib/pg_upgrade/test/integration/output/mismatched_partition_schemas.source
@@ -1,0 +1,46 @@
+-- Partitioned tables that have their root and partitions in different schemas
+-- must be rejected by GPDB's pg_upgrade.
+CREATE SCHEMA other_schema;
+CREATE
+
+CREATE TABLE multischema_partition (a int) PARTITION BY RANGE(a) (START(1) END(2) EVERY(1));
+CREATE
+ALTER TABLE multischema_partition_1_prt_1 SET SCHEMA other_schema;
+ALTER
+
+CREATE TABLE multischema_subpartition (a int, b int) PARTITION BY RANGE(a) SUBPARTITION BY RANGE(b) SUBPARTITION TEMPLATE (START(1) END(3) EVERY(1), DEFAULT SUBPARTITION other) (START(1) END(2) EVERY(1));
+CREATE
+ALTER TABLE multischema_subpartition_1_prt_1_2_prt_2 SET SCHEMA other_schema;
+ALTER
+ALTER TABLE multischema_subpartition_1_prt_1_2_prt_other SET SCHEMA other_schema;
+ALTER
+
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+Performing Consistency Checks on Old Live Server
+------------------------------------------------
+Creating a dump of all tablespace metadata.                 ok
+Checking schemas on partitioned tables                      fatal
+
+Your installation contains partitioned tables where one or more
+child partitions are not in the same schema as the root partition.
+ALTER TABLE ... SET SCHEMA must be performed on the child partitions
+to match them before upgrading. A list of problem tables is in the
+file:
+    mismatched_partition_schemas.txt
+
+Failure, exiting
+
+! /bin/cat ./mismatched_partition_schemas.txt ;
+Database: upgradetest
+  public.multischema_partition contains child other_schema.multischema_partition_1_prt_1
+  public.multischema_subpartition contains child other_schema.multischema_subpartition_1_prt_1_2_prt_other
+  public.multischema_subpartition contains child other_schema.multischema_subpartition_1_prt_1_2_prt_2
+
+
+-- Users need to correct the problem by manually renamespacing the partitions.
+ALTER TABLE other_schema.multischema_partition_1_prt_1 SET SCHEMA public;
+ALTER
+ALTER TABLE other_schema.multischema_subpartition_1_prt_1_2_prt_2 SET SCHEMA public;
+ALTER
+ALTER TABLE other_schema.multischema_subpartition_1_prt_1_2_prt_other SET SCHEMA public;
+ALTER


### PR DESCRIPTION
Without `ATTACH PARTITION`, it's very difficult to correctly dump and restore a table in which the child partitions have a different schema than the root partition. Disallow this case for now.

It would be especially helpful to have more eyes on the new query, to try to catch any corner cases I haven't thought of. Currently, partitions and subpartitions are covered in the tests.

[The output source](https://github.com/greenplum-db/gpdb/pull/9732/files#diff-91d7407ec4189dea6cbd0c912c33ee5b) contains an example of what a failure would look like.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] ~Document changes~
- [ ] ~Communicate in the mailing list if needed~
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
