### PR TITLE
docs - new GUC plan_cache_mode

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -7439,7 +7439,7 @@
           <codeph>force_custom_plan</codeph> and <codeph>force_generic_plan</codeph>. This setting
         is considered when a cached plan is to be executed, not when it is prepared. For more
         information see <codeph><xref href="../sql_commands/PREPARE.xml"/></codeph>.</p>
-      <p>The parameter can be set for a database system, an individual database, or a session or
+      <p>The parameter can be set for a database system, an individual database, a session, or a
         query.</p>
       <table id="table_ekc_xrq_zkb">
         <tgroup cols="3">

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -459,6 +459,10 @@
               <xref href="#optimizer_use_gpdb_allocators" format="dita"
                 >optimizer_use_gpdb_allocators</xref></li>
             <li>
+              <p>
+                <xref href="#plan_cache_mode"/></p>
+            </li>
+            <li>
               <xref href="#password_encryption"/>
             </li>
             <li>
@@ -7412,6 +7416,47 @@
             <row>
               <entry colname="col1">Boolean</entry>
               <entry colname="col2">on</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="plan_cache_mode">
+    <title>plan_cache_mode</title>
+    <body>
+      <p>Prepared statements (either explicitly prepared or implicitly generated, for example by
+        PL/pgSQL) can be executed using <i>custom</i> or <i>generic</i> plans. Custom plans are
+        created for each execution using its specific set of parameter values, while generic plans
+        do not rely on the parameter values and can be re-used across executions. The use of a
+        generic plan saves planning time, but if the ideal plan depends strongly on the parameter
+        values, then a generic plan might be inefficient. The choice between these options is
+        normally made automatically, but it can be overridden by setting the
+          <codeph>plan_cache_mode</codeph> parameter. If the prepared statement has no parameters, a
+        generic plan is always used.</p>
+      <p>The allowed values are <codeph>auto</codeph> (the default),
+          <codeph>force_custom_plan</codeph> and <codeph>force_generic_plan</codeph>. This setting
+        is considered when a cached plan is to be executed, not when it is prepared. For more
+        information see <codeph><xref href="../sql_commands/PREPARE.xml"/></codeph>.</p>
+      <p>The parameter can be set for a database system, an individual database, or a session or
+        query.</p>
+      <table id="table_ekc_xrq_zkb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">auto<p>force_custom_plan</p><p>force_generic_plan</p></entry>
+              <entry colname="col2">auto</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -23,9 +23,6 @@
       <li id="kh158533">
         <xref href="#topic29" type="topic" format="dita"/>
       </li>
-      <li id="kh171207">
-        <xref href="#topic33" type="topic" format="dita"/>
-      </li>
       <li id="kh158545">
         <xref href="#topic37" type="topic" format="dita"/>
       </li>
@@ -660,6 +657,7 @@
           <strow>
             <stentry>
               <p><xref href="guc-list.xml#gp_max_slices">gp_max_slices</xref></p>
+              <p><xref href="guc-list.xml#plan_cache_mode">plan_cache_mode</xref></p>
             </stentry>
           </strow>
         </simpletable>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -11,7 +11,6 @@
             <topicref href="guc_category-list.xml#topic57"/>
             <topicref href="guc_category-list.xml#topic21"/>
             <topicref href="guc_category-list.xml#topic29"/>
-            <topicref href="guc_category-list.xml#topic33"/>
             <topicref href="guc_category-list.xml#topic37"/>
             <topicref href="guc_category-list.xml#topic38"/>
             <topicref href="guc_category-list.xml#topic39"/>
@@ -235,6 +234,7 @@
             <topicref href="guc-list.xml#optimizer_sort_factor"/>
             <topicref href="guc-list.xml#optimizer_use_gpdb_allocators"/>
             <topicref href="guc-list.xml#password_encryption"/>
+            <topicref href="guc-list.xml#plan_cache_mode"/>
             <topicref href="guc-list.xml#pljava_classpath"/>
             <topicref href="guc-list.xml#pljava_classpath_insecure"/>
             <topicref href="guc-list.xml#pljava_statement_cache_size"/>

--- a/gpdb-doc/dita/ref_guide/sql_commands/PREPARE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/PREPARE.xml
@@ -18,7 +18,7 @@
         the prepared statement is planned and executed. This division of labor avoids repetitive
         parse analysis work, while allowing the execution plan to depend on the specific parameter
         values supplied.</p>
-      <p>Prepared statements can take parameters: values that are substituted into the statement
+      <p>Prepared statements can take parameters, values that are substituted into the statement
         when it is executed. When creating the prepared statement, refer to parameters by position,
         using <codeph>$1</codeph>, <codeph>$2</codeph>, etc. A corresponding list of parameter data
         types can optionally be specified. When a parameter's data type is not specified or is
@@ -124,9 +124,8 @@ EXECUTE usrrptplan(1, current_date);</codeblock>
     </section>
     <section id="section7">
       <title>Compatibility</title>
-      <p>The SQL standard includes a <codeph>PREPARE</codeph> statement, but it is only for use in
-        embedded SQL. This version of the <codeph>PREPARE</codeph> statement also uses a somewhat
-        different syntax.</p>
+      <p>The SQL standard includes a <codeph>PREPARE</codeph> statement, but it can only be used in
+        embedded SQL, and it uses a different syntax.</p>
     </section>
     <section id="section8">
       <title>See Also</title>

--- a/gpdb-doc/dita/ref_guide/sql_commands/PREPARE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/PREPARE.xml
@@ -1,53 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
-<topic id="topic1"><title id="dx20941">PREPARE</title><body><p id="sql_command_desc">Prepare a statement for execution.</p><section id="section2"><title>Synopsis</title><codeblock id="sql_command_synopsis">PREPARE <varname>name</varname> [ (<varname>datatype</varname> [, ...] ) ] AS <varname>statement</varname></codeblock></section><section id="section3"><title>Description</title>
-  <p><codeph>PREPARE</codeph> creates a prepared statement. A prepared
-  statement is a server-side object that can be used to optimize
-  performance. When the <codeph>PREPARE</codeph> statement is
-  executed, the specified statement is parsed, analyzed, and rewritten.
-  When an <codeph>EXECUTE</codeph> command is subsequently
-  issued, the prepared statement is planned and executed. This division
-  of labor avoids repetitive parse analysis work, while allowing
-  the execution plan to depend on the specific parameter values supplied.</p>
-  <p>Prepared statements can take parameters: values that are substituted into the statement when it
-        is executed. When creating the prepared statement, refer to parameters by position, using
-          <codeph>$1</codeph>, <codeph>$2</codeph>, etc. A corresponding list of parameter data
+<topic id="topic1">
+  <title id="dx20941">PREPARE</title>
+  <body>
+    <p id="sql_command_desc">Prepare a statement for execution.</p>
+    <section id="section2">
+      <title>Synopsis</title>
+      <codeblock id="sql_command_synopsis">PREPARE <varname>name</varname> [ (<varname>datatype</varname> [, ...] ) ] AS <varname>statement</varname></codeblock>
+    </section>
+    <section id="section3">
+      <title>Description</title>
+      <p><codeph>PREPARE</codeph> creates a prepared statement. A prepared statement is a
+        server-side object that can be used to optimize performance. When the
+          <codeph>PREPARE</codeph> statement is executed, the specified statement is parsed,
+        analyzed, and rewritten. When an <codeph>EXECUTE</codeph> command is subsequently issued,
+        the prepared statement is planned and executed. This division of labor avoids repetitive
+        parse analysis work, while allowing the execution plan to depend on the specific parameter
+        values supplied.</p>
+      <p>Prepared statements can take parameters: values that are substituted into the statement
+        when it is executed. When creating the prepared statement, refer to parameters by position,
+        using <codeph>$1</codeph>, <codeph>$2</codeph>, etc. A corresponding list of parameter data
         types can optionally be specified. When a parameter's data type is not specified or is
         declared as unknown, the type is inferred from the context in which the parameter is first
         used (if possible). When executing the statement, specify the actual values for these
-        parameters in the <codeph>EXECUTE</codeph> statement.</p><p>Prepared statements only last for the duration of the current database session. When the session
-        ends, the prepared statement is forgotten, so it must be recreated before being used again.
-        This also means that a single prepared statement cannot be used by multiple simultaneous
-        database clients; however, each client can create their own prepared statement to use. 
-        Prepared statements can be manually cleaned up using the <codeph><xref
-            href="DEALLOCATE.xml#topic1" type="topic" format="dita"/></codeph> command. </p><p>Prepared statements have the largest performance advantage when a
-single session is being used to execute a large number of similar statements.
-The performance difference will be particularly significant if the statements
-are complex to plan or rewrite, for example, if the query involves a
-join of many tables or requires the application of several rules. If
-the statement is relatively simple to plan and rewrite but relatively
-expensive to execute, the performance advantage of prepared statements
-will be less noticeable.</p></section><section id="section4"><title>Parameters</title><parml><plentry><pt><varname>name</varname></pt><pd>An arbitrary name given to this particular prepared statement. It
-must be unique within a single session and is subsequently used to execute
-or deallocate a previously prepared statement.</pd></plentry><plentry><pt><varname>datatype</varname></pt><pd>The data type of a parameter to the prepared statement. If the data type of a particular
-            parameter is unspecified or is specified as unknown, it will be inferred from the
-            context in which the parameter is first used. To refer to the parameters in the prepared
-            statement itself, use <codeph>$1</codeph>, <codeph>$2</codeph>, etc. </pd></plentry><plentry><pt><varname>statement</varname></pt><pd>Any <codeph>SELECT</codeph>, <codeph>INSERT</codeph>, <codeph>UPDATE</codeph>,
-<codeph>DELETE</codeph>, or <codeph>VALUES</codeph> statement.</pd></plentry></parml></section><section id="section5"><title>Notes</title>
-      <p>If a prepared statement is executed enough times, the server may eventually decide to save
-        and re-use a generic plan rather than re-planning each time. This will occur immediately if
-        the prepared statement has no parameters; otherwise it occurs only if the generic plan
-        appears to be not much more expensive than a plan that depends on specific parameter values.
-        Typically, a generic plan will be selected only if the query's performance is estimated to
-        be fairly insensitive to the specific parameter values supplied.</p>
-      <p>To examine the query plan Greenplum Database is using for a prepared statement, use <xref
-          href="EXPLAIN.xml#topic1">EXPLAIN</xref>. If a generic plan is in use, it will contain
-        parameter symbols <codeph>$<varname>n</varname></codeph>, while a custom plan will have the
-        current actual parameter values substituted into it. </p>
-  <p>For more information on query planning and the statistics collected by Greenplum Database for
-        that purpose, see the <codeph>ANALYZE</codeph> documentation.</p>
-  <p>Although the main point of a prepared statement is to avoid repeated parse analysis and
+        parameters in the <codeph>EXECUTE</codeph> statement.</p>
+      <p>Prepared statements only last for the duration of the current database session. When the
+        session ends, the prepared statement is forgotten, so it must be recreated before being used
+        again. This also means that a single prepared statement cannot be used by multiple
+        simultaneous database clients; however, each client can create their own prepared statement
+        to use. Prepared statements can be manually cleaned up using the <codeph><xref
+            href="DEALLOCATE.xml#topic1" type="topic" format="dita"/></codeph> command. </p>
+      <p>Prepared statements have the largest performance advantage when a single session is being
+        used to execute a large number of similar statements. The performance difference will be
+        particularly significant if the statements are complex to plan or rewrite, for example, if
+        the query involves a join of many tables or requires the application of several rules. If
+        the statement is relatively simple to plan and rewrite but relatively expensive to execute,
+        the performance advantage of prepared statements will be less noticeable.</p>
+    </section>
+    <section id="section4">
+      <title>Parameters</title>
+      <parml>
+        <plentry>
+          <pt><varname>name</varname></pt>
+          <pd>An arbitrary name given to this particular prepared statement. It must be unique
+            within a single session and is subsequently used to execute or deallocate a previously
+            prepared statement.</pd>
+        </plentry>
+        <plentry>
+          <pt><varname>datatype</varname></pt>
+          <pd>The data type of a parameter to the prepared statement. If the data type of a
+            particular parameter is unspecified or is specified as unknown, it will be inferred from
+            the context in which the parameter is first used. To refer to the parameters in the
+            prepared statement itself, use <codeph>$1</codeph>, <codeph>$2</codeph>, etc. </pd>
+        </plentry>
+        <plentry>
+          <pt><varname>statement</varname></pt>
+          <pd>Any <codeph>SELECT</codeph>, <codeph>INSERT</codeph>, <codeph>UPDATE</codeph>,
+              <codeph>DELETE</codeph>, or <codeph>VALUES</codeph> statement.</pd>
+        </plentry>
+      </parml>
+    </section>
+    <section id="section5">
+      <title>Notes</title>
+      <p>A prepared statement can be executed with either a <i>generic plan</i> or a <i>custom
+          plan</i>. A generic plan is the same across all executions, while a custom plan is
+        generated for a specific execution using the parameter values given in that call. Use of a
+        generic plan avoids planning overhead, but in some situations a custom plan will be much
+        more efficient to execute because the planner can make use of knowledge of the parameter
+        values. If the prepared statement has no parameters, a generic plan is always used.</p>
+      <p>By default (with the default value, <codeph>auto</codeph>, for the server configuration
+        parameter <codeph><xref href="../config_params/guc-list.xml#plan_cache_mode"
+            >plan_cache_mode</xref></codeph>), the server automatically chooses whether to use a
+        generic or custom plan for a prepared statement that has parameters. The current rule for
+        this is that the first five executions are done with custom plans and the average estimated
+        cost of those plans is calculated. Then a generic plan is created and its estimated cost is
+        compared to the average custom-plan cost. Subsequent executions use the generic plan if its
+        cost is not so much higher than the average custom-plan cost as to make repeated replanning
+        seem preferable.</p>
+      <p>This heuristic can be overridden, forcing the server to use either generic or custom plans,
+        by setting <codeph>plan_cache_mode</codeph> to <codeph>force_generic_plan</codeph> or
+          <codeph>force_custom_plan</codeph> respectively. This setting is primarily useful if the
+        generic plan's cost estimate is badly off for some reason, allowing it to be chosen even
+        though its actual cost is much more than that of a custom plan.</p>
+      <p>To examine the query plan Greenplum Database is using for a prepared statement, use
+            <codeph><xref href="../sql_commands/EXPLAIN.xml">EXPLAIN</xref></codeph>, for
+        example</p>
+      <codeblock>EXPLAIN EXECUTE &lt;name>(&lt;parameter_values>);</codeblock>
+      <p>If a generic plan is in use, it will contain parameter symbols <codeph>$n</codeph>, while a
+        custom plan will have the supplied parameter values substituted into it.</p>
+      <p>For more information on query planning and the statistics collected by Greenplum Database
+        for that purpose, see the <codeph>ANALYZE</codeph> documentation.</p>
+      <p>Although the main point of a prepared statement is to avoid repeated parse analysis and
         planning of the statement, Greenplum will force re-analysis and re-planning of the statement
         before using it whenever database objects used in the statement have undergone definitional
         (DDL) changes since the previous use of the prepared statement. Also, if the value of
@@ -60,16 +104,34 @@ or deallocate a previously prepared statement.</pd></plentry><plentry><pt><varna
         an unqualified name, and then a new table of the same name is created in a schema appearing
         earlier in the <codeph>search_path</codeph>, no automatic re-parse will occur since no
         object used in the statement changed. However, if some other change forces a re-parse, the
-        new table will be referenced in subsequent uses. </p><p>You can see all prepared statements available in the session by querying the
-          <codeph>pg_prepared_statements</codeph> system view.</p></section><section id="section6"><title>Examples</title><p>Create a prepared statement for an <codeph>INSERT</codeph> statement,
-and then execute it:</p><codeblock>PREPARE fooplan (int, text, bool, numeric) AS INSERT INTO 
+        new table will be referenced in subsequent uses. </p>
+      <p>You can see all prepared statements available in the session by querying the
+          <codeph>pg_prepared_statements</codeph> system view.</p>
+    </section>
+    <section id="section6">
+      <title>Examples</title>
+      <p>Create a prepared statement for an <codeph>INSERT</codeph> statement, and then execute
+        it:</p>
+      <codeblock>PREPARE fooplan (int, text, bool, numeric) AS INSERT INTO 
 foo VALUES($1, $2, $3, $4);
-EXECUTE fooplan(1, 'Hunter Valley', 't', 200.00);</codeblock><p>Create a prepared statement for a <codeph>SELECT</codeph> statement, and
-then execute it. Note that the data type of the second parameter is not
-specified, so it is inferred from the context in which <codeph>$2</codeph>
-is used:</p><codeblock>PREPARE usrrptplan (int) AS SELECT * FROM users u, logs l 
+EXECUTE fooplan(1, 'Hunter Valley', 't', 200.00);</codeblock>
+      <p>Create a prepared statement for a <codeph>SELECT</codeph> statement, and then execute it.
+        Note that the data type of the second parameter is not specified, so it is inferred from the
+        context in which <codeph>$2</codeph> is used:</p>
+      <codeblock>PREPARE usrrptplan (int) AS SELECT * FROM users u, logs l 
 WHERE u.usrid=$1 AND u.usrid=l.usrid AND l.date = $2;
-EXECUTE usrrptplan(1, current_date);</codeblock></section><section id="section7"><title>Compatibility</title><p>The SQL standard includes a <codeph>PREPARE</codeph> statement, but
-it is only for use in embedded SQL. This version of the <codeph>PREPARE</codeph>
-statement also uses a somewhat different syntax.</p></section><section id="section8"><title>See Also</title><p><codeph><xref href="EXECUTE.xml#topic1" type="topic" format="dita"/></codeph>, <codeph><xref
-            href="DEALLOCATE.xml#topic1" type="topic" format="dita"/></codeph></p></section></body></topic>
+EXECUTE usrrptplan(1, current_date);</codeblock>
+    </section>
+    <section id="section7">
+      <title>Compatibility</title>
+      <p>The SQL standard includes a <codeph>PREPARE</codeph> statement, but it is only for use in
+        embedded SQL. This version of the <codeph>PREPARE</codeph> statement also uses a somewhat
+        different syntax.</p>
+    </section>
+    <section id="section8">
+      <title>See Also</title>
+      <p><codeph><xref href="EXECUTE.xml#topic1" type="topic" format="dita"/></codeph>,
+            <codeph><xref href="DEALLOCATE.xml#topic1" type="topic" format="dita"/></codeph></p>
+    </section>
+  </body>
+</topic>


### PR DESCRIPTION
--Add GUC
--update PREPARE reference, Notes section

Also, minor fix in guc_category_list

HTML output in a temporary GPDB draft doc site.
https://docs-msk-gpdb6-dev.cfapps.io/7-0/ref_guide/config_params/guc-list.html#plan_cache_mode

https://docs-msk-gpdb6-dev.cfapps.io/7-0/ref_guide/sql_commands/PREPARE.html#topic1__section5

dev PR https://github.com/greenplum-db/gpdb/pull/9675