### PR TITLE
6X: Start WAL receiver as early as possible - version2

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7279,6 +7279,8 @@ StartupXLOG(void)
 				/* Now apply the WAL record itself */
 				RmgrTable[record->xl_rmid].rm_redo(ReadRecPtr, EndRecPtr, record);
 
+				SIMPLE_FAULT_INJECTOR("wal_redo");
+
 				/* Pop the error context stack */
 				error_context_stack = errcallback.previous;
 

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -420,6 +420,8 @@ WalReceiverMain(void)
 					ereport(FATAL,
 							(errmsg("cannot continue WAL streaming, recovery has already ended")));
 
+				SIMPLE_FAULT_INJECTOR("walrcv_loop");
+
 				/* Process any requests or signals received recently */
 				ProcessWalRcvInterrupts();
 

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -69,6 +69,7 @@
 int			wal_receiver_status_interval = 10;
 int			wal_receiver_timeout;
 bool		hot_standby_feedback;
+int 		wal_receiver_start_condition;
 
 /* libpqreceiver hooks to these when loaded */
 walrcv_connect_type walrcv_connect = NULL;

--- a/src/backend/replication/walreceiverfuncs.c
+++ b/src/backend/replication/walreceiverfuncs.c
@@ -259,10 +259,6 @@ RequestXLogStreaming(TimeLineID tli, XLogRecPtr recptr, const char *conninfo,
 
 	SpinLockAcquire(&walrcv->mutex);
 
-	/* It better be stopped if we try to restart it */
-	Assert(walrcv->walRcvState == WALRCV_STOPPED ||
-		   walrcv->walRcvState == WALRCV_WAITING);
-
 	if (conninfo != NULL)
 		strlcpy((char *) walrcv->conninfo, conninfo, MAXCONNINFO);
 	else
@@ -273,12 +269,26 @@ RequestXLogStreaming(TimeLineID tli, XLogRecPtr recptr, const char *conninfo,
 	else
 		walrcv->slotname[0] = '\0';
 
+	/*
+	 * We used to assert that the WAL receiver is either in WALRCV_STOPPED or
+	 * in WALRCV_WAITING state.
+	 *
+	 * Such an assertion is not possible, now that this function is called by
+	 * startup process on two occasions.  One is just before starting to
+	 * replay WAL when starting up.  And the other is when it has finished
+	 * replaying all WAL in pg_xlog directory.  If the standby is starting up
+	 * after clean shutdown, there is not much WAL to be replayed and both
+	 * calls to this funcion can occur in quick succession.  By the time the
+	 * second request to start streaming is made, the WAL receiver can be in
+	 * any state.  We therefore cannot make any assertion on the state here.
+	 */
+
 	if (walrcv->walRcvState == WALRCV_STOPPED)
 	{
 		launch = true;
 		walrcv->walRcvState = WALRCV_STARTING;
 	}
-	else
+	else if (walrcv->walRcvState == WALRCV_WAITING)
 		walrcv->walRcvState = WALRCV_RESTARTING;
 	walrcv->startTime = now;
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -219,6 +219,11 @@ static double defunct_double = 0;
  *
  * NOTE! Option values may not contain double quotes!
  */
+const struct config_enum_entry wal_rcv_start_options[] = {
+	{"catchup", WAL_RCV_START_AT_CATCHUP, true},
+	{"consistency", WAL_RCV_START_AT_CONSISTENCY, true},
+	{NULL, 0, false}
+};
 
 static const struct config_enum_entry bytea_output_options[] = {
 	{"escape", BYTEA_OUTPUT_ESCAPE, false},
@@ -3592,6 +3597,16 @@ static struct config_enum ConfigureNamesEnum[] =
 		},
 		&plan_cache_mode,
 		PLAN_CACHE_MODE_AUTO, plan_cache_mode_options,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"wal_receiver_start_condition", PGC_POSTMASTER, REPLICATION_STANDBY,
+			gettext_noop("When to start WAL receiver."),
+			NULL,
+		},
+		&wal_receiver_start_condition,
+		WAL_RCV_START_AT_CATCHUP, wal_rcv_start_options,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/replication/walreceiver.h
+++ b/src/include/replication/walreceiver.h
@@ -18,10 +18,17 @@
 #include "storage/spin.h"
 #include "pgtime.h"
 
+typedef enum
+{
+	WAL_RCV_START_AT_CATCHUP, /* start a WAL receiver  after replaying all WAL files */
+	WAL_RCV_START_AT_CONSISTENCY /* start a WAL receiver once consistency has been reached */
+} WalRcvStartCondition;
+
 /* user-settable parameters */
 extern int	wal_receiver_status_interval;
 extern int	wal_receiver_timeout;
 extern bool hot_standby_feedback;
+extern int  wal_receiver_start_condition;
 
 /*
  * MAXCONNINFO: maximum size of a connection string.

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -521,3 +521,4 @@
 		"xmlbinary",
 		"xmloption",
 		"zero_damaged_pages",
+		"wal_receiver_start_condition",

--- a/src/test/regress/expected/replay_lag.out
+++ b/src/test/regress/expected/replay_lag.out
@@ -1,0 +1,100 @@
+-- Test to validate that replay process on mirror does not affect
+-- synchronous replication when the mirror restarts.  If a mirror
+-- develops replay lag, transactions should not wait for replication
+-- when the mirror restarts.  WAL replay is performed asynchronously
+-- by a separate replay process and that shouldn't interfere with
+-- synchronous replication.
+select gp_inject_fault_infinite('fts_probe', 'skip', dbid)
+from gp_segment_configuration where content = -1 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t
+(1 row)
+
+select gp_wait_until_triggered_fault('fts_probe', 1, dbid)
+from gp_segment_configuration where content = -1 and role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
+create table replay_lag_test(a int, b text, c timestamp with time zone)
+distributed by (a);
+-- Switch WAL so that streaming start point (segment number, TLI) is
+-- remembered on mirrors.  This is useful only when the test is run
+-- against a newly created cluster, where the first WAL segment is not
+-- filled up yet.
+select pg_switch_xlog() > '0/0' from gp_dist_random('gp_id');
+ ?column? 
+----------
+ t
+ t
+ t
+(3 rows)
+
+-- Deliberately slow down WAL replay by 10 seconds on content 1
+-- mirror.  Enabling this fault also has the effect of setting
+-- wal_receiver_start_condition GUC on the mirror to 'consistency'.
+select gp_inject_fault('wal_redo', 'sleep', '', '', '', 1, -1, 10, dbid)
+from gp_segment_configuration where role = 'm' and content = 1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Induce replay lag of 10 * 3 = 30 seconds on content 1 mirror.  All
+-- tuples inserted below are hashed to content 1.
+insert into replay_lag_test select 1, 'before disconnect', now()
+from generate_series(1,3);
+-- Disconnect replication connection by killing WAL receiver process.
+select gp_inject_fault('walrcv_loop', 'fatal', dbid)
+from gp_segment_configuration where content = 1 and role = 'm';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select gp_wait_until_triggered_fault('walrcv_loop', 1, dbid)
+from gp_segment_configuration where content = 1 and role = 'm';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
+insert into replay_lag_test values (1, 'after disconnect', now());
+-- Replay lag should continue to exist after WAL receiver restart, as
+-- we have not reset the wal_redo fault yet.
+select replay_location < flush_location from gp_stat_replication
+where gp_segment_id = 1;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- The insert should finish before the replay process catches up.
+-- Expect WAL receiver to resume streaming within 20 seconds.
+select (now() - c) < '20 seconds' from replay_lag_test where b = 'after disconnect';
+ ?column? 
+----------
+ t
+(1 row)
+
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+(8 rows)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -245,6 +245,10 @@ test: session_reset
 # below test(s) inject faults so each of them need to be in a separate group
 test: fts_error
 
+# The test affects WAL replication between a primary / mirror pair,
+# run it by itself so as not to interfere with other tests.
+test: replay_lag
+
 test: psql_gp_commands pg_resetxlog dropdb_check_shared_buffer_cache gp_upgrade_cornercases
 
 # Check for shmem leak for instrumentation slots

--- a/src/test/regress/sql/replay_lag.sql
+++ b/src/test/regress/sql/replay_lag.sql
@@ -1,0 +1,52 @@
+-- Test to validate that replay process on mirror does not affect
+-- synchronous replication when the mirror restarts.  If a mirror
+-- develops replay lag, transactions should not wait for replication
+-- when the mirror restarts.  WAL replay is performed asynchronously
+-- by a separate replay process and that shouldn't interfere with
+-- synchronous replication.
+
+select gp_inject_fault_infinite('fts_probe', 'skip', dbid)
+from gp_segment_configuration where content = -1 and role = 'p';
+select gp_request_fts_probe_scan();
+select gp_wait_until_triggered_fault('fts_probe', 1, dbid)
+from gp_segment_configuration where content = -1 and role = 'p';
+
+create table replay_lag_test(a int, b text, c timestamp with time zone)
+distributed by (a);
+
+-- Switch WAL so that streaming start point (segment number, TLI) is
+-- remembered on mirrors.  This is useful only when the test is run
+-- against a newly created cluster, where the first WAL segment is not
+-- filled up yet.
+select pg_switch_xlog() > '0/0' from gp_dist_random('gp_id');
+
+-- Deliberately slow down WAL replay by 10 seconds on content 1
+-- mirror.  Enabling this fault also has the effect of setting
+-- wal_receiver_start_condition GUC on the mirror to 'consistency'.
+select gp_inject_fault('wal_redo', 'sleep', '', '', '', 1, -1, 10, dbid)
+from gp_segment_configuration where role = 'm' and content = 1;
+
+-- Induce replay lag of 10 * 3 = 30 seconds on content 1 mirror.  All
+-- tuples inserted below are hashed to content 1.
+insert into replay_lag_test select 1, 'before disconnect', now()
+from generate_series(1,3);
+
+-- Disconnect replication connection by killing WAL receiver process.
+select gp_inject_fault('walrcv_loop', 'fatal', dbid)
+from gp_segment_configuration where content = 1 and role = 'm';
+
+select gp_wait_until_triggered_fault('walrcv_loop', 1, dbid)
+from gp_segment_configuration where content = 1 and role = 'm';
+
+insert into replay_lag_test values (1, 'after disconnect', now());
+
+-- Replay lag should continue to exist after WAL receiver restart, as
+-- we have not reset the wal_redo fault yet.
+select replay_location < flush_location from gp_stat_replication
+where gp_segment_id = 1;
+
+-- The insert should finish before the replay process catches up.
+-- Expect WAL receiver to resume streaming within 20 seconds.
+select (now() - c) < '20 seconds' from replay_lag_test where b = 'after disconnect';
+
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;


### PR DESCRIPTION
This is alternative solution to #9698.  Basic idea is the same - start WAL receiver before pending replay of existing WAL is finished.  The difference is how the streaming start point is determined.  In this patch, the stream start point is computed by scanning first page of WAL segments, one file at a time.

If this approach turns out better than #9698 in review, the [upstream proposal](https://www.postgresql.org/message-id/b271715f-f945-35b0-d1f5-c9de3e56f65e@postgrespro.ru) can be changed accordingly.