### PR TITLE
Fix memory accounting

### DIFF
--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -347,7 +347,6 @@ static void AllocSetStats(MemoryContext context, int level, bool print,
 
 static void AllocSetDeclareAccountingRoot(MemoryContext context);
 static Size AllocSetGetCurrentUsage(MemoryContext context);
-static Size AllocSetGetLocalUsage(MemoryContext context);
 static Size AllocSetGetPeakUsage(MemoryContext context);
 static Size AllocSetSetPeakUsage(MemoryContext context, Size nbytes);
 
@@ -372,7 +371,6 @@ static MemoryContextMethods AllocSetMethods = {
 	/* GPDB additions */
 	AllocSetDeclareAccountingRoot,
 	AllocSetGetCurrentUsage,
-	AllocSetGetLocalUsage,
 	AllocSetGetPeakUsage,
 	AllocSetSetPeakUsage
 #ifdef MEMORY_CONTEXT_CHECKING
@@ -1517,13 +1515,6 @@ AllocSetGetCurrentUsage(MemoryContext context)
 }
 
 static Size
-AllocSetGetLocalUsage(MemoryContext context)
-{
-	AllocSet	set = (AllocSet) context;
-	return set->localAllocated;
-}
-
-static Size
 AllocSetGetPeakUsage_recurse(MemoryContext parent, MemoryContext context)
 {
 	MemoryContext child;
@@ -1603,7 +1594,7 @@ AllocSetTransferAccounting(MemoryContext context, MemoryContext new_parent)
 		set->currentAllocated = set->localAllocated;
 		set->peakAllocated = set->localAllocated;
 	}
-	
+
 }
 
 #ifdef MEMORY_CONTEXT_CHECKING

--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -356,6 +356,9 @@ MemoryContextSetParent(MemoryContext context, MemoryContext new_parent)
 	if (new_parent == context->parent)
 		return;
 
+	/* update memory accounting */
+	AllocSetTransferAccounting(context, new_parent);
+
 	/* Delink from existing parent, if any */
 	if (context->parent)
 	{

--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -601,24 +601,6 @@ MemoryContextGetCurrentSpace(MemoryContext context)
 }                               /* MemoryContextGetCurrentSpace */
 
 /*
- * MemoryContextGetLocalSpace
- *		Returns the number of bytes currently used in the memory context.
- *
- * This is the amount of space used by the callers which contains the chunk header,
- * the user memory and the padding/fraction. When the memory context is reset, all
- * memory objects in this memory context are logically freed and of course its local
- * memory usage is 0. It's helpful to check if a long-live memory context has leaked
- * the memory.
- */
-Size
-MemoryContextGetLocalSpace(MemoryContext context)
-{
-	AssertArg(MemoryContextIsValid(context));
-
-	return (*context->methods->get_local_usage) (context);
-}                               /* MemoryContextGetLocalSpace */
-
-/*
  * MemoryContextGetPeakSpace
  *		Return the peak number of bytes occupied by the memory context.
  *

--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -598,6 +598,24 @@ MemoryContextGetCurrentSpace(MemoryContext context)
 }                               /* MemoryContextGetCurrentSpace */
 
 /*
+ * MemoryContextGetLocalSpace
+ *		Returns the number of bytes currently used in the memory context.
+ *
+ * This is the amount of space used by the callers which contains the chunk header,
+ * the user memory and the padding/fraction. When the memory context is reset, all
+ * memory objects in this memory context are logically freed and of course its local
+ * memory usage is 0. It's helpful to check if a long-live memory context has leaked
+ * the memory.
+ */
+Size
+MemoryContextGetLocalSpace(MemoryContext context)
+{
+	AssertArg(MemoryContextIsValid(context));
+
+	return (*context->methods->get_local_usage) (context);
+}                               /* MemoryContextGetLocalSpace */
+
+/*
  * MemoryContextGetPeakSpace
  *		Return the peak number of bytes occupied by the memory context.
  *

--- a/src/include/nodes/memnodes.h
+++ b/src/include/nodes/memnodes.h
@@ -68,6 +68,7 @@ typedef struct MemoryContextMethods
 									  MemoryContextCounters *totals);
 	void		(*declare_accounting_root) (MemoryContext context);
 	Size		(*get_current_usage) (MemoryContext context);
+	Size		(*get_local_usage) (MemoryContext context);
 	Size		(*get_peak_usage) (MemoryContext context);
 	Size		(*set_peak_usage) (MemoryContext context, Size nbytes);
 #ifdef MEMORY_CONTEXT_CHECKING

--- a/src/include/nodes/memnodes.h
+++ b/src/include/nodes/memnodes.h
@@ -68,7 +68,6 @@ typedef struct MemoryContextMethods
 									  MemoryContextCounters *totals);
 	void		(*declare_accounting_root) (MemoryContext context);
 	Size		(*get_current_usage) (MemoryContext context);
-	Size		(*get_local_usage) (MemoryContext context);
 	Size		(*get_peak_usage) (MemoryContext context);
 	Size		(*set_peak_usage) (MemoryContext context, Size nbytes);
 #ifdef MEMORY_CONTEXT_CHECKING

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -118,6 +118,7 @@ extern bool MemoryContextIsEmpty(MemoryContext context);
 /* Statistics */
 extern void MemoryContextDeclareAccountingRoot(MemoryContext context);
 extern Size MemoryContextGetCurrentSpace(MemoryContext context);
+extern Size MemoryContextGetLocalSpace(MemoryContext context);
 extern Size MemoryContextGetPeakSpace(MemoryContext context);
 extern Size MemoryContextSetPeakSpace(MemoryContext context, Size nbytes);
 

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -118,7 +118,6 @@ extern bool MemoryContextIsEmpty(MemoryContext context);
 /* Statistics */
 extern void MemoryContextDeclareAccountingRoot(MemoryContext context);
 extern Size MemoryContextGetCurrentSpace(MemoryContext context);
-extern Size MemoryContextGetLocalSpace(MemoryContext context);
 extern Size MemoryContextGetPeakSpace(MemoryContext context);
 extern Size MemoryContextSetPeakSpace(MemoryContext context, Size nbytes);
 

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -163,6 +163,10 @@ extern MemoryContext AllocSetContextCreate(MemoryContext parent,
 					  Size initBlockSize,
 					  Size maxBlockSize);
 
+/* this function should be only called by MemoryContextSetParent() */
+extern void AllocSetTransferAccounting(MemoryContext context,
+									   MemoryContext new_parent);
+
 /* mpool.c */
 typedef struct MPool MPool;
 extern MPool *mpool_create(MemoryContext parent,


### PR DESCRIPTION
`localAllocated` is not set to 0 when resetting the memory context, which
makes the statistics data incorrect. `localAllocated` is used to account
the local usage of the memory context alone. It's better to expose this
value to track how much memory allocated from the memory context, which
is helpful to determine whether the memory leaks or not in a specific
memory context.

Size is an unsigned integer, and `MEMORY_ACCOUNT_UPDATE_ALLOCATED` uses
the opposite value for subtraction. Since they have the same bit width
and the same bit results. We'd avoid using it this way.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
