### PR TITLE
Expose BeginCopy to be used by foreign data wrappers

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -147,9 +147,6 @@ static const char BinarySignature[11] = "PGCOPY\n\377\r\n\0";
 
 
 /* non-export function prototypes */
-static CopyState BeginCopy(bool is_from, Relation rel, Node *raw_query,
-						   const char *queryString, List *attnamelist, List *options,
-						   TupleDesc tupDesc);
 static void EndCopy(CopyState cstate);
 static CopyState BeginCopyTo(Relation rel, Node *query, const char *queryString,
 							 const char *filename, bool is_program, List *attnamelist,
@@ -1738,7 +1735,7 @@ ProcessCopyOptions(CopyState cstate,
  * If in the text format, delimit columns with delimiter <delim> and print
  * NULL values as <null_print>.
  */
-static CopyState
+CopyState
 BeginCopy(bool is_from,
 		  Relation rel,
 		  Node *raw_query,

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -290,6 +290,9 @@ extern CopyState BeginCopyFrom(Relation rel, const char *filename,
 			  bool is_program, copy_data_source_cb data_source_cb,
 			  void *data_source_cb_extra,
 			  List *attnamelist, List *options, List *ao_segnos);
+extern CopyState BeginCopy(bool is_from, Relation rel, Node *raw_query,
+						   const char *queryString, List *attnamelist, List *options,
+						   TupleDesc tupDesc);
 extern CopyState
 BeginCopyToOnSegment(QueryDesc *queryDesc);
 extern void EndCopyToOnSegment(CopyState cstate);


### PR DESCRIPTION
Currently, BeginCopyToForExternalTable allows External Tables to hook
into the copy code for writing. Instead of adding a similar
BeginCopyToForForeignTable function, we instead expose BeginCopy.

This will allow pxf_fdw to get a CopyState for write data from greenplum
to an external source through PXF.

Co-authored-by: Francisco Guerrero <aguerrero@pivotal.io>
Co-authored-by: Oliver Albertini <oalbertini@pivotal.io>
