### PR TITLE
Do final commit (notification) for one phase before local transaction…

### DIFF
--- a/src/backend/cdb/cdbtmutils.c
+++ b/src/backend/cdb/cdbtmutils.c
@@ -56,6 +56,10 @@ DtxStateToString(DtxState state)
 			return "None";
 		case DTX_STATE_ACTIVE_DISTRIBUTED:
 			return "Active Distributed";
+		case DTX_STATE_ONE_PHASE_COMMIT:
+			return "One Phase Commit (Before Notifying)";
+		case DTX_STATE_NOTIFYING_ONE_PHASE_COMMIT:
+			return "Notifying One Phase";
 		case DTX_STATE_PREPARING:
 			return "Preparing";
 		case DTX_STATE_PREPARED:

--- a/src/test/isolation2/expected/segwalrep/die_commit_pending_replication.out
+++ b/src/test/isolation2/expected/segwalrep/die_commit_pending_replication.out
@@ -100,6 +100,38 @@ select gp_segment_id, * from die_commit_pending_replication;
  1             | 1 |   
 (2 rows)
 
+--
+-- Test 1PC: if there is transaction xlog commit on QD, and QE quits during the
+-- "notification" stage, QD won't panic. Previously the notification code is
+-- after xlog commit code on QD so QE quitting will cause notification on QD
+-- elog(ERROR) but at that moment the transaction can not be aborted (caused by
+-- elog(ERROR)), else panic with message as below, "cannot abort transaction
+-- %u, it was already committed".
+--
+
+2: create temp table die_commit_pending_replication2(a int);
+CREATE
+2: insert into die_commit_pending_replication2 values(2),(1);
+INSERT 2
+
+-- Insert fault before the "notification" code on QE and susped there.
+select gp_inject_fault_infinite('start_performDtxProtocolCommitOnePhase', 'error', dbid) from gp_segment_configuration where role='p' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Start an one phase query that writes commit xlog on QD.
+2: begin; select txid_current(); select * from die_commit_pending_replication2; end;
+ERROR:  fault triggered, fault name:'start_performDtxProtocolCommitOnePhase' fault type:'error'  (seg0 192.168.235.128:7002 pid=63969)
+
+-- Reset start_performDtxProtocolCommitOnePhase.
+select gp_inject_fault_infinite('start_performDtxProtocolCommitOnePhase', 'reset', dbid) from gp_segment_configuration where role='p' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
 -- cleanup
 drop table die_commit_pending_replication;
 DROP


### PR DESCRIPTION
… commit recording on QD.

Previously that code is after local transaction commit recording. If notification fails,
elog(ERROR) would cause long-jumping to do transaction aborting however that causes panic:
"cannot abort transaction %u, it was already committed".