### PR TITLE
PXF: Encode header values for custom headers (Backport from 6X)

### DIFF
--- a/gpAux/extensions/pxf/src/pxfheaders.c
+++ b/gpAux/extensions/pxf/src/pxfheaders.c
@@ -108,6 +108,7 @@ build_http_headers(PxfInputData *input)
 		ereport(ERROR,
 				(errcode(ERRCODE_INTERNAL_ERROR),
 						errmsg("user identity is unknown")));
+	churl_headers_append(headers, "X-GP-ENCODED-HEADER-VALUES", "true");
 	churl_headers_append(headers, "X-GP-USER", ev.GP_USER);
 
 	churl_headers_append(headers, "X-GP-SEGMENT-ID", ev.GP_SEGMENT_ID);

--- a/gpAux/extensions/pxf/test/pxfheaders_test.c
+++ b/gpAux/extensions/pxf/test/pxfheaders_test.c
@@ -162,6 +162,7 @@ test_build_http_headers(void **state)
 	expect_headers_append(input_data->headers, "X-GP-OPTIONS-ENCODING", "UTF8");
 	expect_headers_append(input_data->headers, "X-GP-ATTRS", "0");
 
+	expect_headers_append(input_data->headers, "X-GP-ENCODED-HEADER-VALUES", "true");
 	expect_headers_append(input_data->headers, "X-GP-USER", "pxfuser");
 	expect_headers_append(input_data->headers, "X-GP-SEGMENT-ID", "SegId");
 	expect_headers_append(input_data->headers, "X-GP-SEGMENT-COUNT", "10");
@@ -267,6 +268,7 @@ void test__build_http_header__where_is_not_supported(void **state)
 //	expect_any(extractPxfAttributes, qualsAreSupported);
 	will_return(extractPxfAttributes, NULL);
 
+	expect_headers_append(input_data->headers, "X-GP-ENCODED-HEADER-VALUES", "true");
 	expect_headers_append(input_data->headers, "X-GP-USER", "pxfuser");
 	expect_headers_append(input_data->headers, "X-GP-SEGMENT-ID", mock_extvar.GP_SEGMENT_ID);
 	expect_headers_append(input_data->headers, "X-GP-SEGMENT-COUNT", mock_extvar.GP_SEGMENT_COUNT);


### PR DESCRIPTION
Starting in Tomcat version 7.0.100, HTTP header validation was tightened
disallowing invalid header values. These changed in Tomcat were a side
effect of fixes for CVE-2020-1935. This issue manifests when a table is
created with non printable delimiters, for example:

    CREATE EXTERNAL TABLE foo ()
    LOCATION ('pxf://some/path?PROFILE=demo&SERVER=demo')
    FORMAT 'CSV' ( DELIMITER E'\x01' );

The delimiter value is passed to PXF Server in an HTTP header, however
unencoded. This is causing Tomcat drop headers with invalid header
values, and causing PXF to behave incorrectly.

In this commit, we encode custom (X-GP-*) header values, and add a new
header to indicate that custom header values are encoded, so they can be
appropriately decoded on the PXF Server side.
