### PR TITLE
Avoid ADD COLUMN full table rewrite for AOCO partitions

### DIFF
--- a/src/test/regress/expected/alter_table_aocs2.out
+++ b/src/test/regress/expected/alter_table_aocs2.out
@@ -774,3 +774,228 @@ alter table nonbulk_rle_tab add column b int default round(random()*100);
 insert into nonbulk_rle_tab values (-1,-5);
 ANALYZE nonbulk_rle_tab; -- To avoid NOTICE about missing stats with ORCA.
 update nonbulk_rle_tab set b = b + 3 where a = -1;
+CREATE FUNCTION descendants_of(rel regclass) RETURNS TABLE(descendant regclass)
+SET gp_recursive_cte=ON
+LANGUAGE SQL STABLE AS $fn$
+WITH RECURSIVE w AS (
+  SELECT rel AS descendant
+  UNION ALL
+  SELECT inhrelid
+  FROM pg_inherits JOIN w ON inhparent = descendant
+)
+SELECT * FROM w;
+$fn$;
+-- Scenario 1: Parent is AOCO, 1 child is AO, 1 child is heap. Heap and AO children require full table rewrite
+CREATE TABLE rewrite_optimization_aoco_parent(a int, b int, c int)
+WITH (APPENDONLY = true, ORIENTATION = column)
+DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (START (0) END (1) EVERY (1) WITH (APPENDONLY = true),
+        START (1) END (2) EVERY (1) WITH (APPENDONLY = false));
+NOTICE:  CREATE TABLE will create partition "rewrite_optimization_aoco_parent_1_prt_1" for table "rewrite_optimization_aoco_parent"
+NOTICE:  CREATE TABLE will create partition "rewrite_optimization_aoco_parent_1_prt_2" for table "rewrite_optimization_aoco_parent"
+SELECT $$
+SELECT -1 AS segno, oid::regclass AS rel, relfilenode, relstorage
+FROM pg_class
+WHERE oid IN (SELECT descendant FROM descendants_of(:'ROOT_PARTITION_UNDER_TEST'))
+UNION ALL
+SELECT gp_segment_id, oid::regclass, relfilenode, relstorage
+FROM gp_dist_random('pg_class')
+WHERE oid IN (SELECT descendant FROM descendants_of(:'ROOT_PARTITION_UNDER_TEST'))
+$$ AS qry \gset
+SELECT $$
+SELECT t.segno,
+       t.rel,
+       t.relstorage,
+       CASE
+           WHEN table_relfilenode.segno IS NULL THEN 'full table rewritten'
+           ELSE 'ADD COLUMN optimized for columnar table' END AS aoco_add_col_optimized
+FROM (:qry) t
+         LEFT JOIN table_relfilenode USING (segno, rel, relfilenode)
+WHERE t.segno IN (-1, 0)
+ORDER BY 1, 2;
+$$ AS chk_co_opt_qry \gset
+\set ROOT_PARTITION_UNDER_TEST rewrite_optimization_aoco_parent
+CREATE MATERIALIZED VIEW table_relfilenode (segno, rel, relfilenode)
+AS
+:qry
+;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segno' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO rewrite_optimization_aoco_parent SELECT i, i % 2, i FROM generate_series(1,10)i;
+ALTER TABLE rewrite_optimization_aoco_parent ADD COLUMN new_col int DEFAULT 1;
+SELECT * FROM rewrite_optimization_aoco_parent;
+ a  | b | c  | new_col 
+----+---+----+---------
+  1 | 1 |  1 |       1
+  6 | 0 |  6 |       1
+ 10 | 0 | 10 |       1
+  5 | 1 |  5 |       1
+  9 | 1 |  9 |       1
+  2 | 0 |  2 |       1
+  4 | 0 |  4 |       1
+  8 | 0 |  8 |       1
+  3 | 1 |  3 |       1
+  7 | 1 |  7 |       1
+(10 rows)
+
+:chk_co_opt_qry;
+ segno |                   rel                    | relstorage |         aoco_add_col_optimized          
+-------+------------------------------------------+------------+-----------------------------------------
+    -1 | rewrite_optimization_aoco_parent         | c          | ADD COLUMN optimized for columnar table
+    -1 | rewrite_optimization_aoco_parent_1_prt_1 | a          | full table rewritten
+    -1 | rewrite_optimization_aoco_parent_1_prt_2 | h          | full table rewritten
+     0 | rewrite_optimization_aoco_parent         | c          | ADD COLUMN optimized for columnar table
+     0 | rewrite_optimization_aoco_parent_1_prt_1 | a          | full table rewritten
+     0 | rewrite_optimization_aoco_parent_1_prt_2 | h          | full table rewritten
+(6 rows)
+
+-- ADD COLUMN for AOCO partition children should not trigger full table rewrite
+-- Scenario 2: Parent is heap, 1 child is AO, 1 child is AOCO. AO child requires full table rewrite. AOCO child does not.
+CREATE TABLE rewrite_optimization_heap_parent(a int, b int, c int) DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (START (0) END (1) EVERY (1) WITH (APPENDONLY = true),
+        START (1) END (2) EVERY (1) WITH (APPENDONLY = true, ORIENTATION = column));
+NOTICE:  CREATE TABLE will create partition "rewrite_optimization_heap_parent_1_prt_1" for table "rewrite_optimization_heap_parent"
+NOTICE:  CREATE TABLE will create partition "rewrite_optimization_heap_parent_1_prt_2" for table "rewrite_optimization_heap_parent"
+\set ROOT_PARTITION_UNDER_TEST rewrite_optimization_heap_parent
+DROP MATERIALIZED VIEW table_relfilenode;
+CREATE MATERIALIZED VIEW table_relfilenode (segno, rel, relfilenode)
+AS
+:qry
+;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segno' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO rewrite_optimization_heap_parent SELECT i, i % 2, i FROM generate_series(1,10)i;
+ALTER TABLE rewrite_optimization_heap_parent ADD COLUMN new_col int DEFAULT 1;
+SELECT * FROM rewrite_optimization_heap_parent;
+ a  | b | c  | new_col 
+----+---+----+---------
+  6 | 0 |  6 |       1
+ 10 | 0 | 10 |       1
+  5 | 1 |  5 |       1
+  9 | 1 |  9 |       1
+  2 | 0 |  2 |       1
+  4 | 0 |  4 |       1
+  8 | 0 |  8 |       1
+  3 | 1 |  3 |       1
+  7 | 1 |  7 |       1
+  1 | 1 |  1 |       1
+(10 rows)
+
+:chk_co_opt_qry;
+ segno |                   rel                    | relstorage |         aoco_add_col_optimized          
+-------+------------------------------------------+------------+-----------------------------------------
+    -1 | rewrite_optimization_heap_parent         | h          | full table rewritten
+    -1 | rewrite_optimization_heap_parent_1_prt_1 | a          | full table rewritten
+    -1 | rewrite_optimization_heap_parent_1_prt_2 | c          | ADD COLUMN optimized for columnar table
+     0 | rewrite_optimization_heap_parent         | h          | full table rewritten
+     0 | rewrite_optimization_heap_parent_1_prt_1 | a          | full table rewritten
+     0 | rewrite_optimization_heap_parent_1_prt_2 | c          | ADD COLUMN optimized for columnar table
+(6 rows)
+
+REFRESH MATERIALIZED VIEW table_relfilenode;
+ALTER TABLE rewrite_optimization_heap_parent ADD COLUMN new_col2 int DEFAULT 1, ALTER COLUMN c TYPE bigint;
+SELECT * FROM rewrite_optimization_heap_parent;
+ a  | b | c  | new_col | new_col2 
+----+---+----+---------+----------
+  1 | 1 |  1 |       1 |        1
+  6 | 0 |  6 |       1 |        1
+ 10 | 0 | 10 |       1 |        1
+  5 | 1 |  5 |       1 |        1
+  9 | 1 |  9 |       1 |        1
+  2 | 0 |  2 |       1 |        1
+  4 | 0 |  4 |       1 |        1
+  8 | 0 |  8 |       1 |        1
+  3 | 1 |  3 |       1 |        1
+  7 | 1 |  7 |       1 |        1
+(10 rows)
+
+:chk_co_opt_qry;
+ segno |                   rel                    | relstorage | aoco_add_col_optimized 
+-------+------------------------------------------+------------+------------------------
+    -1 | rewrite_optimization_heap_parent         | h          | full table rewritten
+    -1 | rewrite_optimization_heap_parent_1_prt_1 | a          | full table rewritten
+    -1 | rewrite_optimization_heap_parent_1_prt_2 | c          | full table rewritten
+     0 | rewrite_optimization_heap_parent         | h          | full table rewritten
+     0 | rewrite_optimization_heap_parent_1_prt_1 | a          | full table rewritten
+     0 | rewrite_optimization_heap_parent_1_prt_2 | c          | full table rewritten
+(6 rows)
+
+-- Parent is heap, child is heap, grandchild is AOCO.
+CREATE TABLE subpartition_aoco_leaf(a int, b int, c int)
+DISTRIBUTED BY (a)
+  PARTITION BY RANGE(b) SUBPARTITION BY RANGE(c) 
+      (PARTITION intermediate START (0) END (2)
+        (SUBPARTITION leaf START (0) END(2) WITH (APPENDONLY = true, ORIENTATION = column))
+      );
+NOTICE:  CREATE TABLE will create partition "subpartition_aoco_leaf_1_prt_intermediate" for table "subpartition_aoco_leaf"
+NOTICE:  CREATE TABLE will create partition "subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf" for table "subpartition_aoco_leaf_1_prt_intermediate"
+INSERT INTO subpartition_aoco_leaf SELECT i, i % 2, i % 2 FROM generate_series(1,10)i;
+\set ROOT_PARTITION_UNDER_TEST subpartition_aoco_leaf
+DROP MATERIALIZED VIEW table_relfilenode;
+CREATE MATERIALIZED VIEW table_relfilenode (segno, rel, relfilenode)
+AS
+:qry
+;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segno' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Scenario 1: ADD COLUMN for AOCO subpartitioned table should not trigger full
+-- table rewrite. AOCO leaf only writes new column
+ALTER TABLE subpartition_aoco_leaf ADD COLUMN new_col int DEFAULT 1;
+SELECT * FROM subpartition_aoco_leaf;
+ a  | b | c | new_col 
+----+---+---+---------
+  1 | 1 | 1 |       1
+  5 | 1 | 1 |       1
+  6 | 0 | 0 |       1
+  9 | 1 | 1 |       1
+ 10 | 0 | 0 |       1
+  2 | 0 | 0 |       1
+  3 | 1 | 1 |       1
+  4 | 0 | 0 |       1
+  7 | 1 | 1 |       1
+  8 | 0 | 0 |       1
+(10 rows)
+
+:chk_co_opt_qry;
+ segno |                         rel                          | relstorage |         aoco_add_col_optimized          
+-------+------------------------------------------------------+------------+-----------------------------------------
+    -1 | subpartition_aoco_leaf                               | h          | full table rewritten
+    -1 | subpartition_aoco_leaf_1_prt_intermediate            | h          | full table rewritten
+    -1 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | c          | ADD COLUMN optimized for columnar table
+     0 | subpartition_aoco_leaf                               | h          | full table rewritten
+     0 | subpartition_aoco_leaf_1_prt_intermediate            | h          | full table rewritten
+     0 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | c          | ADD COLUMN optimized for columnar table
+(6 rows)
+
+REFRESH MATERIALIZED VIEW table_relfilenode;
+-- Scenario 2: mixing ADD COLUMN with ALTER COLUMN TYPE should trigger full
+-- table rewrite for every level
+ALTER TABLE subpartition_aoco_leaf ADD COLUMN new_col2 int DEFAULT 1, ALTER COLUMN new_col TYPE bigint;
+SELECT * FROM subpartition_aoco_leaf;
+ a  | b | c | new_col | new_col2 
+----+---+---+---------+----------
+  1 | 1 | 1 |       1 |        1
+  2 | 0 | 0 |       1 |        1
+  3 | 1 | 1 |       1 |        1
+  4 | 0 | 0 |       1 |        1
+  7 | 1 | 1 |       1 |        1
+  8 | 0 | 0 |       1 |        1
+  5 | 1 | 1 |       1 |        1
+  6 | 0 | 0 |       1 |        1
+  9 | 1 | 1 |       1 |        1
+ 10 | 0 | 0 |       1 |        1
+(10 rows)
+
+:chk_co_opt_qry;
+ segno |                         rel                          | relstorage | aoco_add_col_optimized 
+-------+------------------------------------------------------+------------+------------------------
+    -1 | subpartition_aoco_leaf                               | h          | full table rewritten
+    -1 | subpartition_aoco_leaf_1_prt_intermediate            | h          | full table rewritten
+    -1 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | c          | full table rewritten
+     0 | subpartition_aoco_leaf                               | h          | full table rewritten
+     0 | subpartition_aoco_leaf_1_prt_intermediate            | h          | full table rewritten
+     0 | subpartition_aoco_leaf_1_prt_intermediate_2_prt_leaf | c          | full table rewritten
+(6 rows)
+

--- a/src/test/regress/sql/alter_table_aocs2.sql
+++ b/src/test/regress/sql/alter_table_aocs2.sql
@@ -490,3 +490,124 @@ alter table nonbulk_rle_tab add column b int default round(random()*100);
 insert into nonbulk_rle_tab values (-1,-5);
 ANALYZE nonbulk_rle_tab; -- To avoid NOTICE about missing stats with ORCA.
 update nonbulk_rle_tab set b = b + 3 where a = -1;
+
+
+CREATE FUNCTION descendants_of(rel regclass) RETURNS TABLE(descendant regclass)
+SET gp_recursive_cte=ON
+LANGUAGE SQL STABLE AS $fn$
+WITH RECURSIVE w AS (
+  SELECT rel AS descendant
+  UNION ALL
+  SELECT inhrelid
+  FROM pg_inherits JOIN w ON inhparent = descendant
+)
+SELECT * FROM w;
+$fn$;
+
+-- Scenario 1: Parent is AOCO, 1 child is AO, 1 child is heap. Heap and AO children require full table rewrite
+CREATE TABLE rewrite_optimization_aoco_parent(a int, b int, c int)
+WITH (APPENDONLY = true, ORIENTATION = column)
+DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (START (0) END (1) EVERY (1) WITH (APPENDONLY = true),
+        START (1) END (2) EVERY (1) WITH (APPENDONLY = false));
+SELECT $$
+SELECT -1 AS segno, oid::regclass AS rel, relfilenode, relstorage
+FROM pg_class
+WHERE oid IN (SELECT descendant FROM descendants_of(:'ROOT_PARTITION_UNDER_TEST'))
+UNION ALL
+SELECT gp_segment_id, oid::regclass, relfilenode, relstorage
+FROM gp_dist_random('pg_class')
+WHERE oid IN (SELECT descendant FROM descendants_of(:'ROOT_PARTITION_UNDER_TEST'))
+$$ AS qry \gset
+
+SELECT $$
+SELECT t.segno,
+       t.rel,
+       t.relstorage,
+       CASE
+           WHEN table_relfilenode.segno IS NULL THEN 'full table rewritten'
+           ELSE 'ADD COLUMN optimized for columnar table' END AS aoco_add_col_optimized
+FROM (:qry) t
+         LEFT JOIN table_relfilenode USING (segno, rel, relfilenode)
+WHERE t.segno IN (-1, 0)
+ORDER BY 1, 2;
+$$ AS chk_co_opt_qry \gset
+
+\set ROOT_PARTITION_UNDER_TEST rewrite_optimization_aoco_parent
+CREATE MATERIALIZED VIEW table_relfilenode (segno, rel, relfilenode)
+AS
+:qry
+;
+
+INSERT INTO rewrite_optimization_aoco_parent SELECT i, i % 2, i FROM generate_series(1,10)i;
+
+ALTER TABLE rewrite_optimization_aoco_parent ADD COLUMN new_col int DEFAULT 1;
+
+SELECT * FROM rewrite_optimization_aoco_parent;
+
+:chk_co_opt_qry;
+
+-- ADD COLUMN for AOCO partition children should not trigger full table rewrite
+-- Scenario 2: Parent is heap, 1 child is AO, 1 child is AOCO. AO child requires full table rewrite. AOCO child does not.
+CREATE TABLE rewrite_optimization_heap_parent(a int, b int, c int) DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (START (0) END (1) EVERY (1) WITH (APPENDONLY = true),
+        START (1) END (2) EVERY (1) WITH (APPENDONLY = true, ORIENTATION = column));
+
+\set ROOT_PARTITION_UNDER_TEST rewrite_optimization_heap_parent
+DROP MATERIALIZED VIEW table_relfilenode;
+CREATE MATERIALIZED VIEW table_relfilenode (segno, rel, relfilenode)
+AS
+:qry
+;
+
+INSERT INTO rewrite_optimization_heap_parent SELECT i, i % 2, i FROM generate_series(1,10)i;
+
+ALTER TABLE rewrite_optimization_heap_parent ADD COLUMN new_col int DEFAULT 1;
+
+SELECT * FROM rewrite_optimization_heap_parent;
+
+:chk_co_opt_qry;
+
+REFRESH MATERIALIZED VIEW table_relfilenode;
+ALTER TABLE rewrite_optimization_heap_parent ADD COLUMN new_col2 int DEFAULT 1, ALTER COLUMN c TYPE bigint;
+
+SELECT * FROM rewrite_optimization_heap_parent;
+
+:chk_co_opt_qry;
+
+-- Parent is heap, child is heap, grandchild is AOCO.
+CREATE TABLE subpartition_aoco_leaf(a int, b int, c int)
+DISTRIBUTED BY (a)
+  PARTITION BY RANGE(b) SUBPARTITION BY RANGE(c) 
+      (PARTITION intermediate START (0) END (2)
+        (SUBPARTITION leaf START (0) END(2) WITH (APPENDONLY = true, ORIENTATION = column))
+      );
+
+INSERT INTO subpartition_aoco_leaf SELECT i, i % 2, i % 2 FROM generate_series(1,10)i;
+\set ROOT_PARTITION_UNDER_TEST subpartition_aoco_leaf
+
+DROP MATERIALIZED VIEW table_relfilenode;
+CREATE MATERIALIZED VIEW table_relfilenode (segno, rel, relfilenode)
+AS
+:qry
+;
+
+-- Scenario 1: ADD COLUMN for AOCO subpartitioned table should not trigger full
+-- table rewrite. AOCO leaf only writes new column
+ALTER TABLE subpartition_aoco_leaf ADD COLUMN new_col int DEFAULT 1;
+
+SELECT * FROM subpartition_aoco_leaf;
+
+:chk_co_opt_qry;
+
+REFRESH MATERIALIZED VIEW table_relfilenode;
+
+-- Scenario 2: mixing ADD COLUMN with ALTER COLUMN TYPE should trigger full
+-- table rewrite for every level
+ALTER TABLE subpartition_aoco_leaf ADD COLUMN new_col2 int DEFAULT 1, ALTER COLUMN new_col TYPE bigint;
+
+SELECT * FROM subpartition_aoco_leaf;
+
+:chk_co_opt_qry;


### PR DESCRIPTION
Backpatch of #9694 
ALTER TABLE ADD COLUMN to a partition with storage type AOCO should not
trigger a full table rewrite. Instead, only data corresponding to the
new column should be written.

There was a regression caused by an implementation detail of the ALTER
TABLE machinery. 6c572399859 in upstream Postgres (Postgres 9.1+ and
GPDB6+), changed ALTER TABLE ADD COLUMN.

Before 6c572399859, ATPrepAddColumn() recursively processed child
partitions during the "prep" phase (phase 2), appending subcmds to the
AlteredTableInfo such that each partition table had a copy of all
AlterTableCmds. After 6c572399859, ATExecAddColumn() recursively
processes children during the "exec" phase (phase 3), which happens
after subcmds are populated.

The AOCO ADD COLUMN code did a sanity check for the presence of
AlteredTableInfo->subcmds to determine if we can write only the new
column and avoid a full table rewrite. Child partitions were missing
these subcmds, so ALTER TABLE ADD COLUMN always did a full table
rewrite.

We initially considered moving the recursion back to the "prep" phase.
Other subcommand types (e.g. ALTER TABLE ALTER COLUMN TYPE) do recursion
during the "prep" phase. However, this would result in an unnecessary
and potentially incorrect diff from upstream Postgres.

Instead, we decoupled the logic for the table rewrite optimization from
the contents of the AlteredTableInfo->subcmds.  Based on the ADD COLUMN
subcommands of the root partition, we determine if the optimization is
*possible*. Then we recurse to all descendant partitions, and, based on
the storage type of each of those relations, set the flag to indicate
whether or not the full table rewrite is required

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>
Co-authored-by: Jesse Zhang <sbjesse@gmail.com>
Co-authored-by: Melanie Plageman <mplageman@pivotal.io>
Reviewed-by: Asim R P <apraveen@pivotal.io>
Reviewed-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>
(cherry picked from commit e707c19c885fadffe50095cc699e52af1ee64f4b)