### PR TITLE
Fix memory leak in checkpointer process

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -2293,9 +2293,8 @@ TwoPhaseAddPreparedTransaction(prepared_transaction_agg_state **ptas,
  * is empty.
  */
 XLogRecPtr *
-getTwoPhaseOldestPreparedTransactionXLogRecPtr(XLogRecData *rdata)
+getTwoPhaseOldestPreparedTransactionXLogRecPtr(prepared_transaction_agg_state *ptas)
 {
-	prepared_transaction_agg_state *ptas = (prepared_transaction_agg_state *)rdata->data;
 	int			map_count = ptas->count;
 	prpt_map   *m = ptas->maps;
 	XLogRecPtr *oldest = NULL;

--- a/src/include/access/twophase.h
+++ b/src/include/access/twophase.h
@@ -94,7 +94,7 @@ extern void TwoPhaseAddPreparedTransactionInit(
 					      , int                             *maxCount);
 
 struct XLogRecData;
-extern XLogRecPtr *getTwoPhaseOldestPreparedTransactionXLogRecPtr(struct XLogRecData *rdata);
+extern XLogRecPtr *getTwoPhaseOldestPreparedTransactionXLogRecPtr(prepared_transaction_agg_state *ptas);
 
 extern void TwoPhaseAddPreparedTransaction(
                  prepared_transaction_agg_state **ptas

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -89,6 +89,9 @@ INSERT 10
 -------
  10    
 (1 row)
+1q: ... <quitting>
+3q: ... <quitting>
+4q: ... <quitting>
 
 -- Scenario 2: Inject FATAL on master after recording commit but
 -- before broadcasting COMMIT_PREPARED to segments. FATAL must convert
@@ -129,6 +132,9 @@ server closed the connection unexpectedly
 -----------------
  Success:        
 (1 row)
+5q: ... <quitting>
+6q: ... <quitting>
+7q: ... <quitting>
 
 -- Scenario 3: Inject ERROR after prepare phase has completed to
 -- trigger abort. Then on abort inject FATAL on master before sending
@@ -179,6 +185,9 @@ LINE 1: SELECT count(*) from abort_fatal_fault_test_table;
 -----------------
  Success:        
 (1 row)
+8q: ... <quitting>
+9q: ... <quitting>
+10q: ... <quitting>
 
 -- Scenario 4: QE panics after writing prepare xlog record. This
 -- should cause master to broadcast abort and QEs handle the abort in
@@ -246,15 +255,100 @@ ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=25361: server closed the c
  transaction | gid | prepared | owner | database 
 -------------+-----+----------+-------+----------
 (0 rows)
-13: SELECT gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
+11q: ... <quitting>
+12q: ... <quitting>
+13q: ... <quitting>
+
+-- Scenario 5: QE panics before committing prepared transactions. The WAL record of `prepare transaction` could have
+-- been added either before the checkpoint or after it.
+1: TRUNCATE TABLE QE_panic_test_table;
+TRUNCATE
+1: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'infinite_loop', dbid) from gp_segment_configuration where role='p' and content=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- this prepared transaction should be recorded in the checkpoint or on the file
+2&: INSERT INTO QE_panic_test_table SELECT i, i+1 from generate_series(1, 10) i;  <waiting ...>
+1: CHECKPOINT;
+CHECKPOINT
+3: BEGIN;
+BEGIN
+3: INSERT INTO QE_panic_test_table SELECT i, i+1 from generate_series(11, 20) i;
+INSERT 10
+3: CREATE TABLE QE_panic_test_table2(i int);
+CREATE
+3&: END;  <waiting ...>
+
+1: SELECT gp_wait_until_triggered_fault('finish_prepared_start_of_function', 2, dbid) from gp_segment_configuration where role='p' and content=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+1: SELECT pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 0;
+ pg_ctl 
+--------
+ OK     
+(1 row)
+4: SELECT pg_sleep(2);
+ pg_sleep 
+----------
+          
+(1 row)
+2<:  <... completed>
+INSERT 10
+3<:  <... completed>
+END
+4: SELECT * from QE_panic_test_table;
+ a  | b  
+----+----
+ 1  | 2  
+ 12 | 13 
+ 15 | 16 
+ 20 | 21 
+ 5  | 6  
+ 6  | 7  
+ 9  | 10 
+ 10 | 11 
+ 11 | 12 
+ 13 | 14 
+ 14 | 15 
+ 17 | 18 
+ 2  | 3  
+ 3  | 4  
+ 4  | 5  
+ 7  | 8  
+ 8  | 9  
+ 16 | 17 
+ 18 | 19 
+ 19 | 20 
+(20 rows)
+4: SELECT * from QE_panic_test_table2;
+ i 
+---
+(0 rows)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+4q: ... <quitting>
+
+
+
+-- cleanup
+1: SELECT gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-13: alter system reset dtx_phase2_retry_count;
+1: alter system reset dtx_phase2_retry_count;
 ALTER
-13: select pg_reload_conf();
+1: select pg_reload_conf();
  pg_reload_conf 
 ----------------
  t              
 (1 row)
+1: select dbid, content, role, status from gp_segment_configuration where role != preferred_role or status='d';
+ dbid | content | role | status 
+------+---------+------+--------
+(0 rows)
+1q: ... <quitting>

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -269,13 +269,13 @@ TRUNCATE
  Success:                 
 (1 row)
 -- this prepared transaction should be recorded in the checkpoint or on the file
-2&: INSERT INTO QE_panic_test_table SELECT i, i+1 from generate_series(1, 10) i;  <waiting ...>
+2&: INSERT INTO QE_panic_test_table SELECT i, i+1 from generate_series(1, 6) i;  <waiting ...>
 1: CHECKPOINT;
 CHECKPOINT
 3: BEGIN;
 BEGIN
-3: INSERT INTO QE_panic_test_table SELECT i, i+1 from generate_series(11, 20) i;
-INSERT 10
+3: INSERT INTO QE_panic_test_table SELECT i, i+1 from generate_series(7, 12) i;
+INSERT 6
 3: CREATE TABLE QE_panic_test_table2(i int);
 CREATE
 3&: END;  <waiting ...>
@@ -296,33 +296,25 @@ CREATE
           
 (1 row)
 2<:  <... completed>
-INSERT 10
+INSERT 6
 3<:  <... completed>
 END
-4: SELECT * from QE_panic_test_table;
- a  | b  
-----+----
- 1  | 2  
- 12 | 13 
- 15 | 16 
- 20 | 21 
- 5  | 6  
- 6  | 7  
- 9  | 10 
- 10 | 11 
- 11 | 12 
- 13 | 14 
- 14 | 15 
- 17 | 18 
- 2  | 3  
- 3  | 4  
- 4  | 5  
- 7  | 8  
- 8  | 9  
- 16 | 17 
- 18 | 19 
- 19 | 20 
-(20 rows)
+4: SELECT gp_segment_id, * from QE_panic_test_table order by gp_segment_id, a;
+ gp_segment_id | a  | b  
+---------------+----+----
+ 0             | 2  | 3  
+ 0             | 3  | 4  
+ 0             | 4  | 5  
+ 0             | 7  | 8  
+ 0             | 8  | 9  
+ 1             | 1  | 2  
+ 1             | 12 | 13 
+ 2             | 5  | 6  
+ 2             | 6  | 7  
+ 2             | 9  | 10 
+ 2             | 10 | 11 
+ 2             | 11 | 12 
+(12 rows)
 4: SELECT * from QE_panic_test_table2;
  i 
 ---

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -290,11 +290,6 @@ CREATE
 --------
  OK     
 (1 row)
-4: SELECT pg_sleep(2);
- pg_sleep 
-----------
-          
-(1 row)
 2<:  <... completed>
 INSERT 6
 3<:  <... completed>

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -167,7 +167,6 @@ $$ LANGUAGE plpgsql;
 1: SELECT gp_wait_until_triggered_fault('finish_prepared_start_of_function', 2, dbid)
    from gp_segment_configuration where role='p' and content=0;
 1: SELECT pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 0;
-4: SELECT pg_sleep(2);
 2<:
 3<:
 4: SELECT gp_segment_id, * from QE_panic_test_table order by gp_segment_id, a;

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -157,10 +157,10 @@ $$ LANGUAGE plpgsql;
 1: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'infinite_loop', dbid)
     from gp_segment_configuration where role='p' and content=0;
 -- this prepared transaction should be recorded in the checkpoint or on the file
-2&: INSERT INTO QE_panic_test_table SELECT i, i+1 from generate_series(1, 10) i;
+2&: INSERT INTO QE_panic_test_table SELECT i, i+1 from generate_series(1, 6) i;
 1: CHECKPOINT;
 3: BEGIN;
-3: INSERT INTO QE_panic_test_table SELECT i, i+1 from generate_series(11, 20) i;
+3: INSERT INTO QE_panic_test_table SELECT i, i+1 from generate_series(7, 12) i;
 3: CREATE TABLE QE_panic_test_table2(i int);
 3&: END;
 
@@ -170,7 +170,7 @@ $$ LANGUAGE plpgsql;
 4: SELECT pg_sleep(2);
 2<:
 3<:
-4: SELECT * from QE_panic_test_table;
+4: SELECT gp_segment_id, * from QE_panic_test_table order by gp_segment_id, a;
 4: SELECT * from QE_panic_test_table2;
 1q:
 2q:

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -65,6 +65,9 @@ $$ LANGUAGE plpgsql;
 4: SELECT * from commit_phase1_panic;
 4: INSERT INTO commit_phase1_panic select i,i from generate_series(1, 10)i;
 4: SELECT count(*) from commit_phase1_panic;
+1q:
+3q:
+4q:
 
 -- Scenario 2: Inject FATAL on master after recording commit but
 -- before broadcasting COMMIT_PREPARED to segments. FATAL must convert
@@ -85,6 +88,9 @@ $$ LANGUAGE plpgsql;
 7: SELECT * FROM gp_dist_random('pg_prepared_xacts');
 7: SELECT gp_inject_fault('dtm_broadcast_commit_prepared', 'reset', dbid)
    from gp_segment_configuration where role='p' and content=-1;
+5q:
+6q:
+7q:
 
 -- Scenario 3: Inject ERROR after prepare phase has completed to
 -- trigger abort. Then on abort inject FATAL on master before sending
@@ -109,6 +115,9 @@ $$ LANGUAGE plpgsql;
     from gp_segment_configuration where role='p' and content=-1;
 10: SELECT gp_inject_fault('dtm_broadcast_abort_prepared', 'reset', dbid)
     from gp_segment_configuration where role='p' and content=-1;
+8q:
+9q:
+10q:
 
 -- Scenario 4: QE panics after writing prepare xlog record. This
 -- should cause master to broadcast abort and QEs handle the abort in
@@ -138,7 +147,44 @@ $$ LANGUAGE plpgsql;
 12<:
 13: SELECT count(*) from QE_panic_test_table;
 13: SELECT * FROM gp_dist_random('pg_prepared_xacts');
-13: SELECT gp_inject_fault('fts_probe', 'reset', dbid)
+11q:
+12q:
+13q:
+
+-- Scenario 5: QE panics before committing prepared transactions. The WAL record of `prepare transaction` could have
+-- been added either before the checkpoint or after it.
+1: TRUNCATE TABLE QE_panic_test_table;
+1: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'infinite_loop', dbid)
+    from gp_segment_configuration where role='p' and content=0;
+-- this prepared transaction should be recorded in the checkpoint or on the file
+2&: INSERT INTO QE_panic_test_table SELECT i, i+1 from generate_series(1, 10) i;
+1: CHECKPOINT;
+3: BEGIN;
+3: INSERT INTO QE_panic_test_table SELECT i, i+1 from generate_series(11, 20) i;
+3: CREATE TABLE QE_panic_test_table2(i int);
+3&: END;
+
+1: SELECT gp_wait_until_triggered_fault('finish_prepared_start_of_function', 2, dbid)
+   from gp_segment_configuration where role='p' and content=0;
+1: SELECT pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 0;
+4: SELECT pg_sleep(2);
+2<:
+3<:
+4: SELECT * from QE_panic_test_table;
+4: SELECT * from QE_panic_test_table2;
+1q:
+2q:
+3q:
+4q:
+
+
+
+-- cleanup
+1: SELECT gp_inject_fault('fts_probe', 'reset', dbid)
     from gp_segment_configuration where role='p' and content=-1;
-13: alter system reset dtx_phase2_retry_count;
-13: select pg_reload_conf();
+1: alter system reset dtx_phase2_retry_count;
+1: select pg_reload_conf();
+1: select dbid, content, role, status
+    from gp_segment_configuration
+    where role != preferred_role or status='d';
+1q:


### PR DESCRIPTION
The CurrentMemoryContext in CreateCheckPoint is long-live
memory context owned by the checkpointer process. The memory context
is reset only if the error occurs. So memory leak will lead to
huge memory leak in the OS.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
