### PR TITLE
Fix fts probe response deserialization

### DIFF
--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -596,25 +596,20 @@ probeRecordResponse(fts_segment_info *ftsInfo, PGresult *result)
 {
 	ftsInfo->result.isPrimaryAlive = true;
 
-	int isMirrorAlive = *PQgetvalue(result, 0,
-											Anum_fts_message_response_is_mirror_up);
-	ftsInfo->result.isMirrorAlive = isMirrorAlive;
+	ftsInfo->result.isMirrorAlive = *PQgetvalue(result, 0,
+			Anum_fts_message_response_is_mirror_up);
 
-	int isInSync = *PQgetvalue(result, 0,
-								   Anum_fts_message_response_is_in_sync);
-	ftsInfo->result.isInSync = isInSync;
+	ftsInfo->result.isInSync = *PQgetvalue(result, 0,
+			Anum_fts_message_response_is_in_sync);
 
-	int isSyncRepEnabled = *PQgetvalue(result, 0,
-											   Anum_fts_message_response_is_syncrep_enabled);
-	ftsInfo->result.isSyncRepEnabled = isSyncRepEnabled;
+	ftsInfo->result.isSyncRepEnabled = *PQgetvalue(result, 0,
+			Anum_fts_message_response_is_syncrep_enabled);
 
-	int isRoleMirror = *PQgetvalue(result, 0,
-										   Anum_fts_message_response_is_role_mirror);
-	ftsInfo->result.isRoleMirror = isRoleMirror;
+	ftsInfo->result.isRoleMirror = *PQgetvalue(result, 0,
+			Anum_fts_message_response_is_role_mirror);
 
-	int retryRequested = *PQgetvalue(result, 0,
-											 Anum_fts_message_response_request_retry);
-	ftsInfo->result.retryRequested = retryRequested;
+	ftsInfo->result.retryRequested = *PQgetvalue(result, 0,
+			Anum_fts_message_response_request_retry);
 
 	elogif(gp_log_fts >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "FTS: segment (content=%d, dbid=%d, role=%c) reported "

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -596,30 +596,25 @@ probeRecordResponse(fts_segment_info *ftsInfo, PGresult *result)
 {
 	ftsInfo->result.isPrimaryAlive = true;
 
-	int *isMirrorAlive = (int *) PQgetvalue(result, 0,
+	int isMirrorAlive = *PQgetvalue(result, 0,
 											Anum_fts_message_response_is_mirror_up);
-	Assert (isMirrorAlive);
-	ftsInfo->result.isMirrorAlive = *isMirrorAlive;
+	ftsInfo->result.isMirrorAlive = isMirrorAlive;
 
-	int *isInSync = (int *) PQgetvalue(result, 0,
+	int isInSync = *PQgetvalue(result, 0,
 								   Anum_fts_message_response_is_in_sync);
-	Assert (isInSync);
-	ftsInfo->result.isInSync = *isInSync;
+	ftsInfo->result.isInSync = isInSync;
 
-	int *isSyncRepEnabled = (int *) PQgetvalue(result, 0,
+	int isSyncRepEnabled = *PQgetvalue(result, 0,
 											   Anum_fts_message_response_is_syncrep_enabled);
-	Assert (isSyncRepEnabled);
-	ftsInfo->result.isSyncRepEnabled = *isSyncRepEnabled;
+	ftsInfo->result.isSyncRepEnabled = isSyncRepEnabled;
 
-	int *isRoleMirror = (int *) PQgetvalue(result, 0,
+	int isRoleMirror = *PQgetvalue(result, 0,
 										   Anum_fts_message_response_is_role_mirror);
-	Assert (isRoleMirror);
-	ftsInfo->result.isRoleMirror = *isRoleMirror;
+	ftsInfo->result.isRoleMirror = isRoleMirror;
 
-	int *retryRequested = (int *) PQgetvalue(result, 0,
+	int retryRequested = *PQgetvalue(result, 0,
 											 Anum_fts_message_response_request_retry);
-	Assert (retryRequested);
-	ftsInfo->result.retryRequested = *retryRequested;
+	ftsInfo->result.retryRequested = retryRequested;
 
 	elogif(gp_log_fts >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "FTS: segment (content=%d, dbid=%d, role=%c) reported "


### PR DESCRIPTION
In probeRecordResponse(), columns are read using PQgetvalue() and cast to int
pointers. Then values are stored as bools.  However, SendFtsResponse() writes
only one byte per column so we really probably should not be casting to int
pointers as we have no guarantee what the high bits will be. This could lead to
unexpected behavior.

Issue is that depending on the underlying type of bool, we could
inadvertantly use the undefined high bits behind the int pointer cast
dereference to decide the value to store into the bool. Thus we could
read unexpected values for isMirrorAlive, isInSync, isSyncRepEnabled,
etc.

For example, in this code `b` and `c` have different values:
```
int i = 0x1000;
unsigned char c = *&i;
bool b = *&i;
```

This was caught during postgres 12 merge iteration due to postgres 11 commit
9a95a77d9d5d which changed the preferred definition of bool to use stdbool.h
instead of typedef unsigned char.

Issue can be reproduced outside the merge branch by simply adding includes for
`<stdbool.h>` inside fts.c and ftsprobe.h files.

Co-authored-by: Ashwin Agrawal <aagrawal@pivotal.io>