### PR TITLE
[5x] Translator changes for "Support opfamilies/opclass for distribution in ORCA"

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5296,17 +5296,6 @@ CTranslatorDXLToPlStmt::TranslateHashExprList
 	for (ULONG ul = 0; ul < arity; ul++)
 	{
 		CDXLNode *hash_expr_dxlnode = (*hash_expr_list_dxlnode)[ul];
-		CDXLScalarHashExpr *hash_expr_dxlop = CDXLScalarHashExpr::Cast(hash_expr_dxlnode->GetOperator());
-
-		// the type of the hash expression in GPDB is computed as the left operand 
-		// of the equality operator of the actual hash expression type
-		const IMDType *md_type = m_md_accessor->RetrieveType(hash_expr_dxlop->MdidType());
-		const IMDScalarOp *md_scalar_op = m_md_accessor->RetrieveScOp(md_type->GetMdidForCmpType(IMDType::EcmptEq));
-		
-		const IMDId *mdid_hash_type = md_scalar_op->GetLeftMdid();
-		
-		hash_expr_types_list = gpdb::LAppendOid(hash_expr_types_list, CMDIdGPDB::CastMdid(mdid_hash_type)->Oid());
-
 		GPOS_ASSERT(1 == hash_expr_dxlnode->Arity());
 		CDXLNode *expr_dxlnode = (*hash_expr_dxlnode)[0];
 
@@ -5320,8 +5309,10 @@ CTranslatorDXLToPlStmt::TranslateHashExprList
 																);
 
 		Expr *expr = m_translator_dxl_to_scalar->TranslateDXLToScalar(expr_dxlnode, &colid_var_mapping);
+		OID typeoid = gpdb::ExprType((Node *) expr);
 
 		hash_expr_list = gpdb::LAppend(hash_expr_list, expr);
+		hash_expr_types_list = gpdb::LAppendOid(hash_expr_types_list, typeoid);
 
 		GPOS_ASSERT((ULONG) gpdb::ListLength(hash_expr_list) == ul + 1);
 	}

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -889,6 +889,7 @@ CTranslatorQueryToDXL::TranslateCTASToDXL()
 									GPOS_NEW(m_mp) CDXLCtasStorageOptions(md_tablespace_name, ctas_commit_action, ctas_storage_options),
 									rel_distr_policy,
 									distribution_colids,
+									NULL, /* distr_opfamilies */
 									into_clause->rel->istemp,
 									has_oids,
 									rel_storage_type,

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -673,6 +673,7 @@ CTranslatorRelcacheToDXL::RetrieveRel
 							dist,
 							mdcol_array,
 							distr_cols,
+							NULL, /* distr_opfamilies */
 							convert_hash_to_random,
 							keyset_array,
 							md_index_info_array,
@@ -701,6 +702,7 @@ CTranslatorRelcacheToDXL::RetrieveRel
 							dist,
 							mdcol_array,
 							distr_cols,
+							NULL, /* distr_opfamilies */
 							part_keys,
 							part_types,
 							num_leaf_partitions,
@@ -1645,6 +1647,8 @@ CTranslatorRelcacheToDXL::RetrieveType
 						 is_fixed_length,
 						 length,
 						 is_passed_by_value,
+						 NULL, /* mdid_distr_opfamily */
+						 NULL, /* mdid_legacy_distr_opfamily */
 						 mdid_op_eq,
 						 mdid_op_neq,
 						 mdid_op_lt,
@@ -1768,7 +1772,9 @@ CTranslatorRelcacheToDXL::RetrieveScOp
 											m_mdid_inverse_opr,
 											cmp_type,
 											returns_null_on_null_input,
-											RetrieveScOpOpFamilies(mp, mdid)
+											RetrieveScOpOpFamilies(mp, mdid),
+											NULL, /* mdid_hash_opfamily */
+											NULL /* mdid_legacy_hash_opfamily */
 											);
 	return md_scalar_op;
 }


### PR DESCRIPTION
This commit contains translator changes need to compile with the latest
ORCA. It does not introduce or enable any new features. There are minor
changes listed below:

1. Pass in NULL for any function call in ORCA that requires any kind of
   opfamily. Since the traceflag EopttraceConsiderOpfamiliesForDistribution
   is unset, ORCA should ignore opfamilies, preserving current 5X
   behavior.
2. HashExprList no longer carries the type of the expression (it is
   inferred from the expr instead).

ORCA PR: https://github.com/greenplum-db/gporca/pull/563