### PR TITLE
docs - initial doc content for Greenplum R client beta

### DIFF
--- a/gpdb-doc/dita/analytics/analytics.ditamap
+++ b/gpdb-doc/dita/analytics/analytics.ditamap
@@ -19,4 +19,5 @@
       <topicref href="pl_python.xml" linking="none"/>
       <topicref href="pl_r.xml" linking="none"/>
     </topicref>
+    <topicref href="greenplum_r_client.xml" linking="none"/>
 </map>

--- a/gpdb-doc/dita/analytics/greenplum_r_client.xml
+++ b/gpdb-doc/dita/analytics/greenplum_r_client.xml
@@ -58,7 +58,7 @@
           </thead>
           <tbody>
             <row>
-              <entry colname="col1">1.0.0</entry>
+              <entry colname="col1">1.0.0 (Beta)</entry>
               <entry colname="col2">3.6+</entry>
               <entry colname="col3">6.1+</entry>
               <entry colname="col4">3.0.2+</entry>
@@ -125,7 +125,7 @@
             <xref href="https://network.pivotal.io/products/pivotal-gpdb"
               scope="external" format="html">Pivotal Network</xref></ph>.
           The naming format of the downloaded file is
-          <codeph>greenplum&#8209;db&#8209;GreenplumR&#8209;&lt;version>.tar.gz</codeph>.
+          <codeph>greenplumR&#8209;&lt;version>&#8209;beta&#8209;gp6.tar.gz</codeph>.
           <p>Note the file system location of the downloaded file.</p></li>
         <li>Install the dependent R packages: <codeph>ini</codeph>,
           <codeph>shiny</codeph>, and <codeph>RPostgreSQL</codeph>. For example,
@@ -137,7 +137,7 @@
             create a personal library.</p>
           <p>After downloading, R builds and installs these and dependent
             packages.</p></li>
-        <li>Install the GreenplumR R package:<codeblock>> install.packages("/path/to/greenplum-db-GreenplumR-&lt;version>.tar.gz", repos = NULL, type = "source")</codeblock></li>
+        <li>Install the GreenplumR R package:<codeblock>> install.packages("/path/to/greenplumR&#8209;&lt;version>&#8209;beta&#8209;gp6.tar.gz", repos = NULL, type = "source")</codeblock></li>
         <li>Install the <codeph>Rdpack</codeph> documentation package:<codeblock>> install.packages("Rdpack")</codeblock></li>
       </ol>
       <p otherprops="oss-only">Alternatively, you can use the R

--- a/gpdb-doc/dita/analytics/greenplum_r_client.xml
+++ b/gpdb-doc/dita/analytics/greenplum_r_client.xml
@@ -357,7 +357,11 @@ testdb=#\q</codeblock>
         <ul>
           <li>The <codeph>db.gpapply()</codeph> and <codeph>db.gptapply()</codeph>
             functions currently operate only on <codeph>conn.id = 1</codeph>.</li>
-          <li>The GreenplumR function reference pages are not yet published.</li>
+          <li>The GreenplumR function reference pages are not yet published. You
+            can find <codeph>html</codeph> versions of the reference pages in your
+            R library <codeph>R/&lt;platform>-library/3.6/GreenplumR/html</codeph>
+            directory. Open the <codeph>00Index.html</codeph> file in the browser
+            of your choice and select the function of interest.</li>
           <li>The <codeph>GreenplumR()</codeph> graphical user interface is
             currently unsupported.</li>
         </ul>
@@ -367,18 +371,11 @@ testdb=#\q</codeblock>
     <title>Function Summary</title>
     <body>
       <p>GreenplumR provides several functions. To obtain reference information
-        for GreenplumR functions:</p>
-      <ul>
-        <li>Navigate to the R library
-          <codeph>R/&lt;platform>-library/3.6/GreenplumR/html/00Index.html</codeph>
-            file in the browser of your choice and select the function of
-            interest. Or,</li>
-        <li>Invoke the <codeph>help()</codeph> function. For example, to
-          display the reference information for the GreenplumR
-          <codeph>db.data.frame()</codeph> function:
-          <codeblock>> help( db.data.frame )</codeblock></li>
-      </ul>
-      <p>GreenplumR provides the following functions:</p>
+        for GreenplumR functions while running the R console, invoke the
+        <codeph>help()</codeph> function. For example, to display the reference
+        information for the GreenplumR <codeph>db.data.frame()</codeph> function:
+        <codeblock>> help( db.data.frame )</codeblock></p>
+      <p>GreenplumR functions include:</p>
       <table>
         <title>GreenplumR Functions</title>
         <tgroup cols="3">
@@ -395,46 +392,67 @@ testdb=#\q</codeblock>
           <tbody>
             <row>
               <entry colname="col1">Aggregate Functions</entry>
-              <entry colname="col2">XXX</entry>
-              <entry colname="col3">Functions that perform a calculation on multiple values and return a single value.</entry>
+              <entry colname="col2">mean(), sum(), count(), max(), min(), sd(), var(), colMeans(), colSums(), colAgg(), db.array()</entry>
+              <entry colname="col3">Functions that perform a calculation on
+                multiple values and return a single value.</entry>
             </row>
             <row>
-              <entry colname="col1" morerows="4">Connection-Related Functions</entry>
+              <entry colname="col1" morerows="4">Connectivity Functions</entry>
               <entry colname="col2">connection info</entry>
-              <entry colname="col3">Extract connection information</entry>
+              <entry colname="col3">Extract connection information.</entry>
             </row>
             <row>
               <entry colname="col2">db.connect()</entry>
-              <entry colname="col3">Create a database connection</entry>
+              <entry colname="col3">Create a database connection.</entry>
             </row>
             <row>
               <entry colname="col2">db.connect.dsn()</entry>
-              <entry colname="col3">Create a database connection using a DSN</entry>
+              <entry colname="col3">Create a database connection using a DSN.</entry>
             </row>
             <row>
               <entry colname="col2">db.disconnect()</entry>
-              <entry colname="col3">Disconnect a database connection</entry>
+              <entry colname="col3">Disconnect a database connection.</entry>
             </row>
             <row>
               <entry colname="col2">db.list()</entry>
-              <entry colname="col3">List database connections</entry>
+              <entry colname="col3">List database connections.</entry>
             </row>
             <row>
               <entry colname="col1" morerows="3">Database Object Functions</entry>
               <entry colname="col2">as.db.data.frame()</entry>
-              <entry colname="col3">Create a db.data.frame from a file or data.frame, optionally writing the data to a Greenplum table.</entry>
+              <entry colname="col3">Create a db.data.frame from a file or data.frame,
+                optionally writing the data to a Greenplum table.</entry>
             </row>
             <row>
               <entry colname="col2">db.data.frame()</entry>
-              <entry colname="col3">Create a data frame that references a view or table in the database</entry>
+              <entry colname="col3">Create a data frame that references a view or
+                 table in the database.</entry>
             </row>
             <row>
               <entry colname="col2">db.objects()</entry>
-              <entry colname="col3">List the table and view objects in the database</entry>
+              <entry colname="col3">List the table and view objects in the database.</entry>
             </row>
             <row>
               <entry colname="col2">db.existsObject()</entry>
-              <entry colname="col3">Identifies whether a table or view exists in the database.</entry>
+              <entry colname="col3">Identifies whether a table or view exists in the
+                database.</entry>
+            </row>
+            <row>
+              <entry colname="col1">Mathematical Functions</entry>
+              <entry colname="col2">exp(), abs(), log(), log10(), sign(), sqrt(), factorial(), sin(), cos(), tan(), asin(), acos(), atan(), atan2()</entry>
+              <entry colname="col3">Mathematical functions that take db.obj as an
+                argument.</entry>
+            </row>
+            <row>
+              <entry colname="col1" morerows="1">Greenplum Functions</entry>
+              <entry colname="col2">db.gpapply()</entry>
+              <entry colname="col3">Wrap an R function with a UDF and run it on
+                every row of data in a Greenplum table.</entry>
+            </row>
+            <row>
+              <entry colname="col2">db.gptapply()</entry>
+              <entry colname="col3">Wrap an R function with a UDF and run it on
+                every row of data grouped by an index in a Greenplum table.</entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/analytics/greenplum_r_client.xml
+++ b/gpdb-doc/dita/analytics/greenplum_r_client.xml
@@ -1,0 +1,444 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="py212122">Greenplum Database R Client (Beta)</title>
+  <body>
+    <p>This chapter contains the following information:</p>
+    <ul>
+      <li><xref href="#about" type="topic" format="dita"/></li>
+      <li><xref href="#supplat" type="topic" format="dita"/></li>
+      <li><xref href="#prereqs" type="topic" format="dita"/></li>
+      <li><xref href="#install" format="dita"/></li>
+      <li><xref href="#exampleds" format="dita"/></li>
+      <li><xref href="#use" format="dita"/></li>
+      <li><xref href="#limits" format="dita"/></li>
+      <li><xref href="#ref" format="dita"/></li>
+    </ul>
+  </body>
+  <topic xml:lang="en" id="about">
+    <title>About Greenplum R</title>
+    <body>
+      <p>The Greenplum R Client (GreenplumR) is an interactive in-database data
+        analytics tool for Greenplum Database. The client provides an R interface
+        to tables and views, and requires no SQL knowledge to operate on these
+        database objects.</p>
+      <p>You can use GreenplumR with the Greenplum PL/R procedural language to
+        run an R function on data stored in Greenplum Database. GreenplumR parses
+        the R function and creates a user-defined function (UDF) for execution in
+        Greenplum. Greenplum runs the UDF in parallel on the segment hosts.</p>
+      <p>You can similarly use GreenplumR with Greenplum PL/Container 3 (Beta),
+        to run an R function against Greenplum data in a high-performance R
+        sandbox runtime environment.</p>
+      <p>No analytic data is loaded into R when you use GreenplumR, a key
+        requirement when dealing with large data sets. Only the R function and
+        minimal data is transferred between R and Greenplum.</p>
+    </body>
+  </topic>
+  <topic id="supplat">
+    <title>Supported Platforms</title>
+    <body>
+      <p>GreenplumR supports the following component versions:</p>
+      <table>
+        <title>GreenplumR Supported Component Versions</title>
+        <tgroup cols="5">
+          <colspec colnum="1" colname="col1" colwidth="100pt"/>
+          <colspec colnum="2" colname="col2" colwidth="100pt"/>
+          <colspec colnum="3" colname="col3" colwidth="100pt"/>
+          <colspec colnum="4" colname="col5" colwidth="100pt"/>
+          <colspec colnum="5" colname="col5" colwidth="100pt"/>
+          <thead>
+            <row>
+              <entry colname="col1">GreenplumR Version</entry>
+              <entry colname="col2">R Version</entry>
+              <entry colname="col3">Greenplum Version</entry>
+              <entry colname="col4">PL/R Version</entry>
+              <entry colname="col5">PL/Container Version</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">1.0.0</entry>
+              <entry colname="col2">3.6+</entry>
+              <entry colname="col3">6.1+</entry>
+              <entry colname="col4">3.0.2+</entry>
+              <entry colname="col5">3.0.0 (Beta)</entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="prereqs">
+    <title>Prerequisites</title>
+    <body>
+      <p>You can use GreenplumR with Greenplum Database and the PL/R and
+        PL/Container procedural languages. Before you install and run GreenplumR
+        on a client system:</p>
+      <ul>
+        <li>Ensure that your Greenplum Database installation is running version
+          6.1 or newer.</li>
+        <li>Ensure that your client development system has connectivity to the
+          Greenplum Database master host.</li>
+        <li>Ensure that <codeph>R</codeph> version 3.6.0 or newer is installed on
+          your client system, and that you set the <codeph>$R_HOME</codeph>
+          environment variable appropriately.</li>
+        <li>Determine the procedural language(s) you plan to use with GreenplumR,
+          and ensure that the language(s) is installed and configured in your
+          Greenplum Database cluster. Refer to
+          <xref href="pl_r.xml#topic1" type="topic" format="dita"></xref> and
+          <xref href="pl_container.xml#topic1" type="topic" format="dita"></xref>
+          (3.0 Beta) for language installation and configuration instructions.</li>
+        <li>Verify that you have registered the procedural language(s) in each
+          database in which you plan to use GreenplumR to read data from or write
+          data to Greenplum. For example, the following command lists the
+          extensions and languages registered in the database named
+          <codeph>testdb</codeph>:<codeblock>$ psql -h gpmaster -d testdb -c '\dx'
+                                     List of installed extensions
+    Name     | Version  |   Schema   |                          Description     
+                      
+-------------+----------+------------+----------------------------------------------------------------
+ plcontainer | 1.0.0    | public     | GPDB execution sandboxing for Python and R
+ plpgsql     | 1.0      | pg_catalog | PL/pgSQL procedural language
+ plr         | 8.3.0.16 | public     | load R interpreter and execute R script from within a database
+</codeblock>
+          <p>Check for the <codeph>plr</codeph> and/or <codeph>plcontainer</codeph>
+            extension <codeph>Name</codeph>.</p></li>
+      </ul>
+    </body>
+  </topic>
+  <topic id="install">
+    <title>Installing the Greenplum R Client</title>
+    <body>
+      <p>GreenplumR is an R package. You obtain the package from
+        <ph otherprops="oss-only">the GreenplumR <codeph>github</codeph>
+        repository</ph> <ph otherprops="pivotal">Pivotal Network</ph> and install
+        the package within the R console.</p>
+      <ol>
+        <li>Download the package from
+          <ph otherprops="oss-only">the
+            <xref href="https://github.com/greenplum-db/GreenplumR/tarball/master"
+              scope="external" format="html">GreenplumR <codeph>github</codeph>
+            repository</xref></ph>
+          <ph otherprops="pivotal"> the <i>Greenplum Procedural Languages</i>
+            filegroup on 
+            <xref href="https://network.pivotal.io/products/pivotal-gpdb"
+              scope="external" format="html">Pivotal Network</xref></ph>.
+          The naming format of the downloaded file is
+          <codeph>greenplum&#8209;db&#8209;GreenplumR&#8209;&lt;version>.tar.gz</codeph>.
+          <p>Note the file system location of the downloaded file.</p></li>
+        <li>Install the dependent R packages: <codeph>ini</codeph>,
+          <codeph>shiny</codeph>, and <codeph>RPostgreSQL</codeph>. For example,
+          enter the R console and run the following, or equivalent, command:
+          <codeblock>user@clientsys$ R
+> install.packages(c("ini", "shiny", "RPostgreSQL"))</codeblock>
+          <p>You may be prompted to select a CRAN download mirror. And, depending
+            on your client system configuration, you may be prompted to use or
+            create a personal library.</p>
+          <p>After downloading, R builds and installs these and dependent
+            packages.</p></li>
+        <li>Install the GreenplumR R package:<codeblock>> install.packages("/path/to/greenplum-db-GreenplumR-&lt;version>.tar.gz", repos = NULL, type = "source")</codeblock></li>
+        <li>Install the <codeph>Rdpack</codeph> documentation package:<codeblock>> install.packages("Rdpack")</codeblock></li>
+      </ol>
+      <p otherprops="oss-only">Alternatively, you can use the R
+        <codeph>devtools</codeph> package to install the GreenplumR package
+        directly from the <codeph>github</codeph> repository:<codeblock>> devtools::install_github("GreenplumR", "greenplum-db")</codeblock></p>
+    </body>
+  </topic>
+  <topic id="exampleds" xml:lang="en">
+    <title>Example Data Sets</title>
+    <body>
+      <p>GreenplumR includes the <codeph>abalone</codeph> and
+        <codeph>null.data</codeph> sample datasets. Refer to the reference pages
+        for more information:</p><codeblock>> help( abalone )
+> help( null.data )</codeblock>
+    </body>
+  </topic>
+  <topic id="use">
+    <title>Using the Greenplum R Client</title>
+    <body>
+      <p>You use GreenplumR to perform in-database analytics. Typical operations
+        that you may perform include:</p>
+      <ul>
+        <li>Loading the GreenplumR package.</li>
+        <li>Connecting to and disconnecting from Greenplum Database.</li>
+        <li>Examining database objects.</li>
+        <li>Analyzing and manipulating data.</li>
+        <li>Running R functions in Greenplum Database.</li>
+      </ul>
+      <section id="load">
+        <title>Loading GreenplumR</title>
+        <p>Use the R <codeph>library()</codeph> function to load GreenplumR:</p>
+        <codeblock>user@clientsys$ R
+> library("GreenplumR")</codeblock>
+      </section>
+      <section id="connect">
+        <title>Connecting to Greenplum Database</title>
+        <p>The <codeph>db.connect()</codeph> and <codeph>db.connect.dsn()</codeph>
+          GreenplumR functions establish a connection to Greenplum Database. The
+          <codeph>db.disconnect()</codeph> function closes a database connection.</p>
+        <p>The GreenplumR connect and disconnect function signatures follow:</p>
+        <codeblock>db.connect( host = "localhost", user = Sys.getenv("USER"),
+            dbname = user, password = "", port = 5432, conn.pkg = "RPostgreSQL",
+            default.schemas = NULL, verbose = TRUE, quick = FALSE )
+
+db.connect.dsn( dsn.key, db.ini = "~/db.ini", default.schemas = NULL,
+                verbose = TRUE, quick = FALSE )
+
+db.disconnect( conn.id = 1, verbose = TRUE, force = FALSE )
+</codeblock>
+         <p>When you connect to Greenplum Database, you provide the master host,
+           port, database name, user name, password, and other information via
+           function arguments or a data source name (DSN) file. If you do not
+           specify an argument or value, GreenplumR uses the default.</p>
+         <p>The <codeph>db.connect[.dsn]()</codeph> functions return an integer
+           connection identifier. You specify this identifier when you operate
+           on tables or views in the database. You also specify this identifier
+           when you close the connection.</p>
+         <p>The <codeph>db.disconnect()</codeph> function returns a logical that
+           identifies whether or not the connection was successfully disconnected.</p>
+         <p>To list and display information about active Greenplum connections,
+           use the <codeph>db.list()</codeph> function.</p>
+        <p><b>Example</b>:</p>
+         <codeblock>## connect to Greenplum database named testdb on host gpmaster
+> cid_to_testdb &lt;- db.connect( host = "gpmaster", port=5432, dbname = "testdb" )
+Loading required package: DBI
+Created a connection to database with ID 1 
+[1] 1
+
+> db.list()
+Database Connection Info
+## -------------------------------
+[Connection ID 1]
+Host     :    gpmaster
+User     :    gpadmin
+Database :    testdb
+DBMS     :    Greenplum 6
+
+> db.disconnect( cid_to_testdb )
+Connection 1 is disconnected!
+[1] TRUE</codeblock>
+      </section>
+      <section id="objs">
+        <title>Examining  Database Obects</title>
+        <p>The <codeph>db.object()</codeph> function lists the tables and views
+          in the database identified by a specific connection identifier. The
+          function signature is:</p>
+        <codeblock>db.object( search = NULL, conn.id = 1 )</codeblock>
+        <p> If you choose, you can specify a filter string to narrow the returned
+          results. For example, to list the tables and views in the
+          <codeph>public</codeph> schema in the database identified by the
+          default connection identifier, invoke the function as follows:</p>
+        <codeblock>> db.object( search = "public." )</codeblock>
+      </section>
+      <section id="data">
+        <title>Analyzing and Manipulating Data</title>
+        <p>The fundamental data structure of R is the <codeph>data.frame</codeph>.
+          A data frame is a collection of variables represented as a list of
+          vectors. GreenplumR operates on <codeph>db.data.frame</codeph> objects,
+          and exposes functions to convert to and manipulate objects of this type:</p>
+        <ul>
+          <li><codeph>as.db.data.frame()</codeph> - writes data in a file or a
+            <codeph>data.frame</codeph> into a Greenplum table. You can also use
+            the function to write the results of a query into a table, or to
+            create a local <codeph>db.data.frame</codeph>.</li>
+          <li><codeph>db.data.frame()</codeph> - creates a temporary R object
+            that references a view or table in a Greenplum database. No data is
+            loaded into R when you use this function.</li>
+        </ul>
+        <p><b>Example</b>:</p>
+        <codeblock>## create a db.data.frame from the abalone example data set;
+## abalone is a data.frame
+> abdf1 &lt;- as.db.data.frame(abalone, conn.id = cid_to_testdb, verbose = FALSE)
+
+## sort on the id column and preview the first 5 rows
+> lk( sort( abdf1, INDICES=abdf1$id ), 5 )
+  id sex length diameter height  whole shucked viscera shell rings
+1  1   M  0.455    0.365  0.095 0.5140  0.2245  0.1010 0.150    15
+2  2   M  0.350    0.265  0.090 0.2255  0.0995  0.0485 0.070     7
+3  3   F  0.530    0.420  0.135 0.6770  0.2565  0.1415 0.210     9
+4  4   M  0.440    0.365  0.125 0.5160  0.2155  0.1140 0.155    10
+5  5   I  0.330    0.255  0.080 0.2050  0.0895  0.0395 0.055     7
+
+## write the data frame to a Greenplum table named abalone_from_r;
+## use most of the function defaults
+> as.db.data.frame( abdf1, table.name = "public.abalone_from_r" ) 
+The data contained in table "pg_temp_93"."gp_temp_5bdf4ec7_42f9_9f9799_a0d76231be8f" which is wrapped by abdf1 is c
+opied into "public"."abalone_from_r" in database testdb on gpmaster !
+Table       :    "public"."abalone_from_r"
+Database    :    testdb
+Host        :    gpmaster
+Connection  :    1
+
+## list database objects, should display the newly created table
+> db.objects( search = "public.")
+[1] "public.abalone_from_r"</codeblock>
+      </section>
+      <section id="run_greenplum">
+        <title>Running R Functions in Greenplum Database</title>
+         <p>GreenplumR supports two functions that allow you to run an R function,
+           in-database, on every row of a Greenplum Database table:
+           <xref href="https://github.com/greenplum-db/GreenplumR/blob/master/db.gpapply.md"
+             scope="external" format="html"><codeph>db.gpapply()</codeph></xref> and
+           <xref href="https://github.com/greenplum-db/GreenplumR/blob/master/db.gptapply.md"
+             scope="external" format="html"><codeph>db.gptapply()</codeph></xref>.
+           You can use the Greenplum PL/R or PL/Container procedural language as
+           the vehicle in which to run the function.</p>
+         <p>The function signatures follow:</p>
+         <codeblock>db.gpapply( X, MARGIN = NULL, FUN = NULL, output.name = NULL, output.signature = NULL,
+            clear.existing = FALSE, case.sensitive = FALSE, output.distributeOn = NULL,
+            debugger.mode = FALSE, runtime.id = "plc_r_shared", language = "plcontainer", ... )
+
+db.gptapply( X, INDEX, FUN = NULL, output.name = NULL, output.signature = NULL,
+             clear.existing = FALSE, case.sensitive = FALSE,
+             output.distributeOn = NULL, debugger.mode = FALSE,
+             runtime.id = "plc_r_shared", language = "plcontainer", ... )</codeblock>
+         <p>Use the second variant of the function when the table data is indexed.</p>
+        <p><b>Example</b>:</p>
+        <p>Create a Greenplum table named <codeph>table1</codeph> in the
+          database named <codeph>testdb</codeph>. This table has a single
+          integer-type field. Populate the table with some data:</p>
+          <codeblock>user@clientsys$ psql -h gpmaster -d testdb
+testdb=# CREATE TABLE table1( id int );
+testdb=# INSERT INTO table1 SELECT generate_series(1,13);
+testdb=#\q</codeblock>
+        <p>Create an R function that increments an integer. Run the function on
+          the <codeph>table1</codeph> <codeph>id</codeph> column in Greenplum
+          using the PL/R procedural language. Then write the new values to a
+          table named <codeph>table1_r_inc</codeph>:
+        <codeblock>user@clientsys$ R
+> ## create a reference to table1
+> t1 &lt;- db.data.frame("public.table1")
+
+> ## create an R function that increment an integer by 1
+> fn.function_plus_one &lt;- function(num)
+{
+    return (num[[1]] + 1)
+}
+
+> ## create the output signature
+> .sig &lt;- list( "num" = "int" )
+
+> ## run the function in Greenplum and print
+> x &lt;- db.gpapply( t1, output.name = NULL, FUN = fn.function_plus_one,
+  output.signature = .sig, clear.existing = TRUE, case.sensitive = TRUE, language = "plr" )
+> print(x)
+   num
+1    2
+2    6
+3   12
+4   13
+5    3
+6    4
+7    5
+8    7
+9    8
+10   9
+11  10
+12  11
+13  14
+
+> ## run the function in Greenplum and write to the output table
+> db.gpapply(t1, output.name = "public.table1_r_inc", FUN = fn.function_plus_one,
+   output.signature = .sig, clear.existing = TRUE, case.sensitive = TRUE,
+   language = "plr" )
+
+## list database objects, should display the newly created table
+> db.objects( search = "public.")
+[1] "public.abalone_from_r"		"public.table1_r_inc"
+</codeblock></p>
+      </section>
+    </body>
+  </topic>
+  <topic id="limits">
+    <title>Limitations</title>
+    <body>
+      <p>GreenplumR has the following limitations:</p>
+        <ul>
+          <li>The <codeph>db.gpapply()</codeph> and <codeph>db.gptapply()</codeph>
+            functions currently operate only on <codeph>conn.id = 1</codeph>.</li>
+          <li>The GreenplumR function reference pages are not yet published.</li>
+          <li>The <codeph>GreenplumR()</codeph> graphical user interface is
+            currently unsupported.</li>
+        </ul>
+    </body>
+  </topic>
+  <topic id="ref" xml:lang="en">
+    <title>Function Summary</title>
+    <body>
+      <p>GreenplumR provides several functions. To obtain reference information
+        for GreenplumR functions:</p>
+      <ul>
+        <li>Navigate to the R library
+          <codeph>R/&lt;platform>-library/3.6/GreenplumR/html/00Index.html</codeph>
+            file in the browser of your choice and select the function of
+            interest. Or,</li>
+        <li>Invoke the <codeph>help()</codeph> function. For example, to
+          display the reference information for the GreenplumR
+          <codeph>db.data.frame()</codeph> function:
+          <codeblock>> help( db.data.frame )</codeblock></li>
+      </ul>
+      <p>GreenplumR provides the following functions:</p>
+      <table>
+        <title>GreenplumR Functions</title>
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="100pt"/>
+          <colspec colnum="2" colname="col2" colwidth="100pt"/>
+          <colspec colnum="3" colname="col3" colwidth="500pt"/>
+          <thead>
+            <row>
+              <entry colname="col1">Category</entry>
+              <entry colname="col1">Name</entry>
+              <entry colname="col2">Description</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Aggregate Functions</entry>
+              <entry colname="col2">XXX</entry>
+              <entry colname="col3">Functions that perform a calculation on multiple values and return a single value.</entry>
+            </row>
+            <row>
+              <entry colname="col1" morerows="4">Connection-Related Functions</entry>
+              <entry colname="col2">connection info</entry>
+              <entry colname="col3">Extract connection information</entry>
+            </row>
+            <row>
+              <entry colname="col2">db.connect()</entry>
+              <entry colname="col3">Create a database connection</entry>
+            </row>
+            <row>
+              <entry colname="col2">db.connect.dsn()</entry>
+              <entry colname="col3">Create a database connection using a DSN</entry>
+            </row>
+            <row>
+              <entry colname="col2">db.disconnect()</entry>
+              <entry colname="col3">Disconnect a database connection</entry>
+            </row>
+            <row>
+              <entry colname="col2">db.list()</entry>
+              <entry colname="col3">List database connections</entry>
+            </row>
+            <row>
+              <entry colname="col1" morerows="3">Database Object Functions</entry>
+              <entry colname="col2">as.db.data.frame()</entry>
+              <entry colname="col3">Create a db.data.frame from a file or data.frame, optionally writing the data to a Greenplum table.</entry>
+            </row>
+            <row>
+              <entry colname="col2">db.data.frame()</entry>
+              <entry colname="col3">Create a data frame that references a view or table in the database</entry>
+            </row>
+            <row>
+              <entry colname="col2">db.objects()</entry>
+              <entry colname="col3">List the table and view objects in the database</entry>
+            </row>
+            <row>
+              <entry colname="col2">db.existsObject()</entry>
+              <entry colname="col3">Identifies whether a table or view exists in the database.</entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+</topic>


### PR DESCRIPTION
in this PR:
- initial docs for Greenplum R Client beta
- included some examples, plan to add more and possibly revisit the presentation of the info in future work
- added new page/topic to the Analytics subnav

notes:
- need to verify install info
- this PR does not include any reference/man pages for the functions.  currently pointing user to the html files installed with the package and the help() function.
- not sure how best to present a complete list of greenplumr functions, or if this is needed.  the PR includes a Function Summary section with a table that lists some of the functions.  thoughts?

doc review site link:  http://docs-lisa-greenplumr-beta.cfapps.io/7-0/analytics/greenplum_r_client.html
