### PR TITLE
[5X] Avoid re-executing if all tuples of the plan have been emitted. (#9596)

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -2816,6 +2816,13 @@ ExecutePlan(EState *estate,
 	TupleTableSlot *result;
 
 	/*
+	 * For holdable cursor, the plan is executed without rewinding on gpdb. We
+	 * need to quit if the executor has already emitted all tuples.
+	 */
+	if (estate->es_got_eos)
+		return;
+
+	/*
 	 * initialize local variables
 	 */
 	current_tuple_count = 0;

--- a/src/test/regress/expected/portals.out
+++ b/src/test/regress/expected/portals.out
@@ -945,3 +945,20 @@ FETCH ALL FROM c1;
 (1 row)
 
 COMMIT;
+-- gpdb: Test executor should return NULL directly during commit for holdable
+-- cursor if previously executor has emitted all tuples. e.g. below test case
+-- would cause panic if without the fix.
+BEGIN;
+DECLARE foo1 CURSOR WITH HOLD FOR SELECT nspname, relname FROM pg_class c JOIN pg_namespace n ON (c.relnamespace = n.oid) WHERE nspname ~ 'test_schema_[12]';
+FETCH ALL FROM foo1;
+ nspname | relname 
+---------+---------
+(0 rows)
+
+COMMIT;
+FETCH ALL FROM foo1;
+ nspname | relname 
+---------+---------
+(0 rows)
+
+CLOSE foo1;

--- a/src/test/regress/sql/portals.sql
+++ b/src/test/regress/sql/portals.sql
@@ -399,3 +399,13 @@ BEGIN;
 DECLARE c1 CURSOR FOR SELECT * FROM LOWER('TEST');
 FETCH ALL FROM c1;
 COMMIT;
+
+-- gpdb: Test executor should return NULL directly during commit for holdable
+-- cursor if previously executor has emitted all tuples. e.g. below test case
+-- would cause panic if without the fix.
+BEGIN;
+DECLARE foo1 CURSOR WITH HOLD FOR SELECT nspname, relname FROM pg_class c JOIN pg_namespace n ON (c.relnamespace = n.oid) WHERE nspname ~ 'test_schema_[12]';
+FETCH ALL FROM foo1;
+COMMIT;
+FETCH ALL FROM foo1;
+CLOSE foo1;


### PR DESCRIPTION
On postgres, holdable cursor will rerun the executor after rewinding to put all
tuples in tuplestore during commit for later access, but for gpdb we do not
support backwards scanning so we just continue executing without rewinding the
executor, this could lead to some issues (error, panic etc) since some executor
nodes are not written or designed for the case that previously the plan has
emitted all tuples.

Reviewed-by: Hubert Zhang <hzhang@pivotal.io>

