### PR TITLE
Add a GUC gp_resource_group_queuing_timeout

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3739,7 +3739,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		1000, 1000, INT_MAX,
 		NULL, NULL, NULL
 	},
-
+	{
+		{"gp_resource_group_queuing_timeout", PGC_USERSET, RESOURCES_MGM,
+			gettext_noop("A transaction gives up on queuing on a resource group after this timeout (in ms)."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_UNIT_MS
+		},
+		&gp_resource_group_queuing_timeout,
+		0, 0, INT_MAX,
+		NULL, NULL, NULL
+	},
 	{
 		{"gp_blockdirectory_entry_min_range", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("Minimal range in bytes one block directory entry covers."),

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -100,6 +100,7 @@ extern int gp_resource_group_cpu_priority;
 extern double gp_resource_group_cpu_limit;
 extern double gp_resource_group_memory_limit;
 extern bool gp_resource_group_bypass;
+extern int gp_resource_group_queuing_timeout;
 
 /*
  * Non-GUC global variables.

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -222,6 +222,7 @@
 		"gp_resource_group_cpu_limit",
 		"gp_resource_group_cpu_priority",
 		"gp_resource_group_memory_limit",
+		"gp_resource_group_queuing_timeout",
 		"gp_resource_manager",
 		"gp_resqueue_memory_policy",
 		"gp_resqueue_priority",


### PR DESCRIPTION
A transaction gives up queuing on a resource group and reports an error after
this timeout, the default value 0 means never timeout.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
