### PR TITLE
5x: Only get necessary relids for partition table in InitPlan

### DIFF
--- a/src/test/isolation2/expected/ao_partition_lock.out
+++ b/src/test/isolation2/expected/ao_partition_lock.out
@@ -1,0 +1,83 @@
+-- Previously, even directly insert into a partition ao
+-- table's child partition, the transaction will lock
+-- all the tables' aoseg table in this partition on
+-- each segment. This test case is to test that extra
+-- lock is not acquired.
+
+create table test_ao_partition_lock ( field_dk integer ,field_part integer) with (appendonly=true) DISTRIBUTED BY (field_dk) PARTITION BY LIST(field_part) ( partition val1 values(1), partition val2 values(2), partition val3 values(3) );
+CREATE
+
+1: begin;
+BEGIN
+1: insert into test_ao_partition_lock_1_prt_val1 values(1,1);
+INSERT 1
+
+2: begin;
+BEGIN
+2: alter table test_ao_partition_lock truncate partition for (2);
+ALTER
+2: end;
+END
+
+1: end;
+END
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+drop table test_ao_partition_lock;
+DROP
+
+-- The following test cases is from a real bug.
+-- Previously, user wants to concurrently do the
+-- job (each job is a transaction):
+--   1. truncate a leaf partition
+--   2. insert some new data this leaf partition
+--   3. analyze this leaf partition
+-- These jobs should be running on different leaf
+-- partitions.
+CREATE TABLE test_partition (field_dk bigint, field_part date, field_attr text ) DISTRIBUTED BY (field_dk) PARTITION BY RANGE(field_part) ( PARTITION  p201902 START ('2019-02-01'::date) END ('2019-03-01'::date) WITH (orientation=row, appendonly=true), PARTITION  p201903 START ('2019-03-01'::date) END ('2019-04-01'::date) WITH (orientation=row, appendonly=true), PARTITION  p201904 START ('2019-04-01'::date) END ('2019-05-01'::date) WITH (orientation=row, appendonly=true) 
+);
+CREATE
+
+insert into test_partition select id, '2019-02-01'::date + interval '1 days' * mod (id,30), '0' from generate_series(1,123) id;
+INSERT 123
+
+-- set following GUC to avoid analyze the root partition
+-- during insert into a leaf partition.
+1: set optimizer_analyze_enable_merge_of_leaf_stats=off;
+SET
+
+2: set optimizer_analyze_enable_merge_of_leaf_stats=off;
+SET
+
+1: begin;
+BEGIN
+1: truncate test_partition_1_prt_p201902;
+TRUNCATE
+
+2: begin;
+BEGIN
+2: truncate test_partition_1_prt_p201903;
+TRUNCATE
+
+-- The following insert statement should only
+-- hold locks on their own  leaf partitions so
+-- that they could run concurrently.
+1: insert into test_partition_1_prt_p201902 select id, '2019-02-01'::date, 0 from generate_series(1, 100)id;
+INSERT 100
+2: insert into test_partition_1_prt_p201903 select id, '2019-03-01'::date, 0 from generate_series(1, 100)id;
+INSERT 100
+
+1: analyze test_partition_1_prt_p201902;
+ANALYZE
+2: analyze test_partition_1_prt_p201903;
+ANALYZE
+
+1: end;
+END
+2: end;
+END
+
+drop table test_partition;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,3 +1,4 @@
+test: ao_partition_lock
 test: modify_table_data_corrupt
 test: setup
 # this case contains fault injection, must be put in a separate test group

--- a/src/test/isolation2/sql/ao_partition_lock.sql
+++ b/src/test/isolation2/sql/ao_partition_lock.sql
@@ -1,0 +1,80 @@
+-- Previously, even directly insert into a partition ao
+-- table's child partition, the transaction will lock
+-- all the tables' aoseg table in this partition on
+-- each segment. This test case is to test that extra
+-- lock is not acquired.
+
+create table test_ao_partition_lock
+( field_dk integer ,field_part integer)
+with (appendonly=true)
+DISTRIBUTED BY (field_dk)
+PARTITION BY LIST(field_part)
+(
+  partition val1 values(1),
+  partition val2 values(2),
+  partition val3 values(3)
+);
+
+1: begin;
+1: insert into test_ao_partition_lock_1_prt_val1 values(1,1);
+
+2: begin;
+2: alter table test_ao_partition_lock truncate partition for (2);
+2: end;
+
+1: end;
+
+1q:
+2q:
+
+drop table test_ao_partition_lock;
+
+-- The following test cases is from a real bug.
+-- Previously, user wants to concurrently do the
+-- job (each job is a transaction):
+--   1. truncate a leaf partition
+--   2. insert some new data this leaf partition
+--   3. analyze this leaf partition
+-- These jobs should be running on different leaf
+-- partitions.
+CREATE TABLE test_partition
+(field_dk bigint,
+field_part date,
+field_attr text
+)
+DISTRIBUTED BY (field_dk)
+PARTITION BY RANGE(field_part)
+(
+  PARTITION  p201902 START ('2019-02-01'::date) END ('2019-03-01'::date) WITH (orientation=row, appendonly=true),
+  PARTITION  p201903 START ('2019-03-01'::date) END ('2019-04-01'::date) WITH (orientation=row, appendonly=true),
+  PARTITION  p201904 START ('2019-04-01'::date) END ('2019-05-01'::date) WITH (orientation=row, appendonly=true)
+
+);
+
+insert into test_partition select id, '2019-02-01'::date + interval '1 days' * mod (id,30), '0' from generate_series(1,123) id;
+
+-- set following GUC to avoid analyze the root partition
+-- during insert into a leaf partition.
+1: set optimizer_analyze_enable_merge_of_leaf_stats=off;
+
+2: set optimizer_analyze_enable_merge_of_leaf_stats=off;
+
+1: begin;
+1: truncate test_partition_1_prt_p201902;
+
+2: begin;
+2: truncate test_partition_1_prt_p201903;
+
+-- The following insert statement should only
+-- hold locks on their own  leaf partitions so
+-- that they could run concurrently.
+1: insert into test_partition_1_prt_p201902 select id, '2019-02-01'::date, 0 from generate_series(1, 100)id;
+2: insert into test_partition_1_prt_p201903 select id, '2019-03-01'::date, 0 from generate_series(1, 100)id;
+
+1: analyze test_partition_1_prt_p201902;
+2: analyze test_partition_1_prt_p201903;
+
+1: end;
+2: end;
+
+drop table test_partition;


### PR DESCRIPTION
Previously, during initializing ResultRelations in InitPlan on
QD, it always builds the relids as all the relation oids in a
partition table (including root and all its inheritors).
Sometimes we does not need all the relids.

A typical case is for ao partition table. When we directly
insert into a specific child partition, the plan's ResultRelation
only contains the child partition. And if we still make relids
as root and all its inheritors, during `assignPerRelSegno`,
it might lock each aoseg file on AccessShare mode on QEs. It
causes confusion that the insert statement is only for a child
partition but holding other partition's lock.

This commit changes the relids building logic as:
  - if the ResultRelation contains the root partition, then
    relids is root and all its inheritors
  - otherwise, relids is a map of ResultRelations to get the
    element's relation oid

-----------------

This pr brings back the previously closed one https://github.com/greenplum-db/gpdb/pull/7134

The closed pr 7134 is merged into master and 6x already.

In this pr, I add a new test from a bug that hit the same issue.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
