### PR TITLE
Rename BeginCopyToForExternalTable() to BeginCopyToForeignTable()

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -633,7 +633,7 @@ external_insert_init(Relation rel)
 	/* pass external table's encoding to copy's options */
 	copyFmtOpts = appendCopyEncodingOption(copyFmtOpts, extentry->encoding);
 
-	extInsertDesc->ext_pstate = BeginCopyToForExternalTable(rel, copyFmtOpts);
+	extInsertDesc->ext_pstate = BeginCopyToForeignTable(rel, copyFmtOpts);
 	InitParseState(extInsertDesc->ext_pstate,
 				   rel,
 				   true,

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -2550,16 +2550,16 @@ BeginCopyTo(Relation rel,
 }
 
 /*
- * Set up CopyState for writing to an external table.
+ * Set up CopyState for writing to a foreign or external table.
  */
 CopyState
-BeginCopyToForExternalTable(Relation extrel, List *options)
+BeginCopyToForeignTable(Relation forrel, List *options)
 {
 	CopyState	cstate;
 
-	Assert(RelationIsExternal(extrel));
+	Assert(RelationIsExternal(forrel) || RelationIsForeign(forrel));
 
-	cstate = BeginCopy(false, extrel, NULL, NULL, NIL, options, NULL);
+	cstate = BeginCopy(false, forrel, NULL, NULL, NIL, options, NULL);
 	cstate->dispatch_mode = COPY_DIRECT;
 
 	/*

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -293,7 +293,7 @@ extern CopyState BeginCopyFrom(Relation rel, const char *filename,
 extern CopyState
 BeginCopyToOnSegment(QueryDesc *queryDesc);
 extern void EndCopyToOnSegment(CopyState cstate);
-extern CopyState BeginCopyToForExternalTable(Relation extrel, List *options);
+extern CopyState BeginCopyToForeignTable(Relation forrel, List *options);
 extern void EndCopyFrom(CopyState cstate);
 extern bool NextCopyFrom(CopyState cstate, ExprContext *econtext,
 						 Datum *values, bool *nulls, Oid *tupleOid);


### PR DESCRIPTION
External tables are slowly becoming a type of foreign tables in
Greenplum. Rename BeginCopyToForExternalTable() to
BeginCopyToForeignTable() and allow foreign relations to use this
functionality.
