### PR TITLE
5X: syslogger: do not write to alert log file if fail to open it

### DIFF
--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -716,7 +716,6 @@ open_alert_log_file()
         Gp_role == GP_ROLE_DISPATCH &&
         gpperfmon_log_alert_level != GPPERFMON_LOG_ALERT_LEVEL_NONE)
     {
-        alert_log_level_opened = true;
         if(mkdir(gp_perf_mon_directory, 0700) == -1)
 		{
 			ereport(WARNING,
@@ -736,6 +735,12 @@ open_alert_log_file()
         else
         {
             setvbuf(alertLogFile, NULL, LBF_MODE, 0);
+
+			/*
+			 * Do not mark this flag as true until we really have opened the
+			 * file successfully.
+			 */
+			alert_log_level_opened = true;
         }
         pfree(alert_file_name);
     }


### PR DESCRIPTION
The syslogger will open the gpperfmon log alert file when
gpperfmon_log_alert_level is not NONE, however even if it fails to open
the file it still writes to it, which causes a crash like this:

    #0  fwrite () from /lib64/libc.so.6
    #1  write_binary_to_file (fh=NULL, ...) at syslogger.c:1885
    #2  write_syslogger_file_binary (...) at syslogger.c:1917
    #3  syslogger_append_current_timestamp (...) at syslogger.c:1103
    #4  syslogger_log_chunk_list (...) at syslogger.c:1571
    #5  syslogger_handle_chunk (...) at syslogger.c:1766
    #6  SysLoggerMain (argv=0x0, argc=0) at syslogger.c:576
    #7  SysLogger_Start () at syslogger.c:850
    #8  do_reaper () at postmaster.c:4984
    #9  ServerLoop () at postmaster.c:2417
    #10 PostmasterMain (...) at postmaster.c:1528
    #11 main (argc=15, argv=0x1dc1680) at main.c:206

To fix the issue we won't mark alert_log_level_opened as true until the
file is really opened successfully.

Reviewed-by: Paul Guo <pguo@pivotal.io>
(cherry picked from commit e2f14143b0e3b011b9d5db56c3f4d6850ef40838)

This is the 5X version of https://github.com/greenplum-db/gpdb/pull/9778

## Here are some reminders before you submit the pull request
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
