### PR TITLE
5X_STABLE: Fix incorrect returnvalue in ExecutePlan fast-path

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -2840,7 +2840,7 @@ ExecutePlan(EState *estate,
 	 * need to quit if the executor has already emitted all tuples.
 	 */
 	if (estate->es_got_eos)
-		return;
+		return NULL;
 
 	/*
 	 * initialize local variables


### PR DESCRIPTION
Commit 00607099901c14aa8d41ca85b9c030552f6c0f5e backported a bugfix for re- execution of holdable cursors. In master, ExecutePlan is a void function but in 5X_STABLE it is defined as returning a TupleTableSlot pointer. Fix the fast-path exit by explicitly returning NULL since the current coding yields a compiler error on Clang (gcc throws a warning instead):
```
execMain.c:2843:3: error: non-void function 'ExecutePlan' should return a value [-Wreturn-type]
                return;
                ^
1 error generated.
```
Reported-by: Jesse Zhang <jzhang@pivotal.io>