### PR TITLE
[6X]Fix variable length arrays error in pg_dump.

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -13942,13 +13942,14 @@ dumpExternal(Archive *fout, TableInfo *tbinfo, PQExpBuffer q, PQExpBuffer delq)
 						error_log_len += 6;
 				if (strlen(options) - error_log_len != 0)
 				{
-					char opts[strlen(options) - error_log_len + 1];
+					char *opts = pg_malloc(sizeof(char) * (strlen(options) - error_log_len + 1));
 					int prev_len = pos - options;
 					if (prev_len > 0)
 						strncpy(opts, options, prev_len);
 					StrNCpy(opts + prev_len, pos + error_log_len,
 							strlen(options) - prev_len - error_log_len + 1 /* for \0 */);
 					appendPQExpBuffer(q, "OPTIONS (\n %s\n )\n", opts);
+					free(opts);
 				}
 			}
 			else


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
