### PR TITLE
Fix cdbpathlocus_is_hashed_on_tlist.

### DIFF
--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -930,18 +930,18 @@ cdbpathlocus_is_hashed_on_tlist(CdbPathLocus locus, List *tlist,
 		{
 			DistributionKey *distkey = (DistributionKey *) lfirst(distkeycell);
 			ListCell   *distkeyeccell;
-			bool		found = false;
 
 			foreach(distkeyeccell, distkey->dk_eclasses)
 			{
 				/* Does some expr in distkey match some item in exprlist? */
 				EquivalenceClass *dk_eclass = (EquivalenceClass *) lfirst(distkeyeccell);
 				ListCell   *i;
+				bool		found = false;
 
 				if (ignore_constants && CdbEquivClassIsConstant(dk_eclass))
 				{
 					found = true;
-					break;
+					continue;
 				}
 
 				if (dk_eclass->ec_sortref != 0)
@@ -978,11 +978,9 @@ cdbpathlocus_is_hashed_on_tlist(CdbPathLocus locus, List *tlist,
 							break;
 					}
 				}
-				if (found)
-					break;
+				if (!found)
+					return false;
 			}
-			if (!found)
-				return false;
 		}
 		/* Every column of the distkey contains an expr in exprlist. */
 		return true;

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1663,6 +1663,63 @@ select count(distinct t), count(distinct t2) from int2vectortab;
      4 |     5
 (1 row)
 
+--
+-- Testing aggregate above FULL JOIN
+--
+-- SETUP
+CREATE TABLE pagg_tab1(x int, y int) DISTRIBUTED BY (x);
+CREATE TABLE pagg_tab2(x int, y int) DISTRIBUTED BY (x);
+INSERT INTO pagg_tab1 SELECT i % 30, i % 20 FROM generate_series(0, 299, 2) i;
+INSERT INTO pagg_tab2 SELECT i % 20, i % 30 FROM generate_series(0, 299, 3) i;
+ANALYZE pagg_tab1;
+ANALYZE pagg_tab2;
+-- TEST
+-- should have Redistribute Motion above the FULL JOIN
+EXPLAIN (COSTS OFF)
+SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x ORDER BY 1 NULLS LAST;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: a.x
+   ->  Sort
+         Sort Key: a.x
+         ->  Finalize HashAggregate
+               Group Key: a.x
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: a.x
+                     ->  Partial HashAggregate
+                           Group Key: a.x
+                           ->  Hash Full Join
+                                 Hash Cond: (b.y = a.x)
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                       Hash Key: b.y
+                                       ->  Seq Scan on pagg_tab2 b
+                                 ->  Hash
+                                       ->  Seq Scan on pagg_tab1 a
+ Optimizer: Postgres query optimizer
+(18 rows)
+
+SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x ORDER BY 1 NULLS LAST;
+ x  | sum  
+----+------
+  0 |  500
+  2 |     
+  4 |     
+  6 | 1100
+  8 |     
+ 10 |     
+ 12 |  700
+ 14 |     
+ 16 |     
+ 18 | 1300
+ 20 |     
+ 22 |     
+ 24 |  900
+ 26 |     
+ 28 |     
+    |  500
+(16 rows)
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1662,6 +1662,66 @@ select count(distinct t), count(distinct t2) from int2vectortab;
      4 |     5
 (1 row)
 
+--
+-- Testing aggregate above FULL JOIN
+--
+-- SETUP
+CREATE TABLE pagg_tab1(x int, y int) DISTRIBUTED BY (x);
+CREATE TABLE pagg_tab2(x int, y int) DISTRIBUTED BY (x);
+INSERT INTO pagg_tab1 SELECT i % 30, i % 20 FROM generate_series(0, 299, 2) i;
+INSERT INTO pagg_tab2 SELECT i % 20, i % 30 FROM generate_series(0, 299, 3) i;
+ANALYZE pagg_tab1;
+ANALYZE pagg_tab2;
+-- TEST
+-- should have Redistribute Motion above the FULL JOIN
+EXPLAIN (COSTS OFF)
+SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x ORDER BY 1 NULLS LAST;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: pagg_tab1.x
+   ->  Finalize GroupAggregate
+         Group Key: pagg_tab1.x
+         ->  Sort
+               Sort Key: pagg_tab1.x
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: pagg_tab1.x
+                     ->  Streaming Partial HashAggregate
+                           Group Key: pagg_tab1.x
+                           ->  Merge Full Join
+                                 Merge Cond: (pagg_tab1.x = pagg_tab2.y)
+                                 ->  Sort
+                                       Sort Key: pagg_tab1.x
+                                       ->  Seq Scan on pagg_tab1
+                                 ->  Sort
+                                       Sort Key: pagg_tab2.y
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                             Hash Key: pagg_tab2.y
+                                             ->  Seq Scan on pagg_tab2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.95.0
+(21 rows)
+
+SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x ORDER BY 1 NULLS LAST;
+ x  | sum  
+----+------
+  0 |  500
+  2 |     
+  4 |     
+  6 | 1100
+  8 |     
+ 10 |     
+ 12 |  700
+ 14 |     
+ 16 |     
+ 18 | 1300
+ 20 |     
+ 22 |     
+ 24 |  900
+ 26 |     
+ 28 |     
+    |  500
+(16 rows)
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;


### PR DESCRIPTION
The DistributionKey for path of FULL JOIN may contain multiple ECs. We
need to make sure each of them contains expr belonging to the given
list, to tell grouping on this given set of exprs can be done in place
without motion.

Fixes #9784.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
