### PR TITLE
Refactor URL parsing for external tables

### DIFF
--- a/src/backend/access/external/test/url_curl_test.c
+++ b/src/backend/access/external/test/url_curl_test.c
@@ -10,29 +10,16 @@ test__make_url(void **state)
 {
 	const char	   *url1 = "http://[:0]/foo/bar";
 	const char	   *url2 = "http://[:0]:8080/foo/bar";
-	int				result;
-	char			outbuf[1024];
+	char		   *result;
 
-	/* test ipv6 with no port, NULL outbuf */
+	/* test ipv6 with no port */
 	expect_string(getDnsAddress, hostname, ":0");
 	expect_value(getDnsAddress, port, 80);
 	expect_value(getDnsAddress, elevel, ERROR);
 	will_return(getDnsAddress, ":0");
 
-	result = make_url(url1, NULL, true);
-
-	assert_int_equal(result, strlen(url1));
-
-	/* test ipv6 with no port, valid outbuf */
-	expect_string(getDnsAddress, hostname, ":0");
-	expect_value(getDnsAddress, port, 80);
-	expect_value(getDnsAddress, elevel, ERROR);
-	will_return(getDnsAddress, ":0");
-
-	result = make_url(url1, outbuf, true);
-
-	assert_string_equal(url1, outbuf);
-	assert_int_equal(result, strlen(url1));
+	result = make_url(url1, true);
+	assert_string_equal(url1, result);
 
 	/* test ipv6 with explicit port */
 	expect_string(getDnsAddress, hostname, ":0");
@@ -40,10 +27,8 @@ test__make_url(void **state)
 	expect_value(getDnsAddress, elevel, ERROR);
 	will_return(getDnsAddress, ":0");
 
-	result = make_url(url2, outbuf, true);
-
-	assert_string_equal(url2, outbuf);
-	assert_int_equal(result, strlen(url2));
+	result = make_url(url2, true);
+	assert_string_equal(url2, result);
 }
 
 int

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -906,7 +906,7 @@ make_url(const char *url, bool is_ipv6)
 			len = authority_end - hostname_end;
 			if (len > 8)
 				ereport(ERROR,
-						(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("<port> substring size must not exceed 8 characters")));
 
 			memcpy(portstr, hostname_end + 1, len);
@@ -931,7 +931,7 @@ make_url(const char *url, bool is_ipv6)
 			int len = authority_end - hostname_end;
 			if (len > 8)
 				ereport(ERROR,
-						(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("<port> substring size must not exceed 8 characters")));
 
 			memcpy(portstr, hostname_end + 1, len);
@@ -942,7 +942,7 @@ make_url(const char *url, bool is_ipv6)
 
 	if (!port)
 		ereport(ERROR,
-				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("<port> substring must contain only digits")));	
 
 	if (hostname_end - hostname_start >= sizeof(hostname))

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -148,6 +148,7 @@ static char curl_Error_Buffer[CURL_ERROR_SIZE];
 
 static void gp_proto0_write_done(URL_CURL_FILE *file);
 static void extract_http_domain(char* i_path, char* o_domain, int dlen);
+static char * make_url(const char *url, bool is_ipv6);
 
 /* we use a global one for convenience */
 static CURLM *multi_handle = 0;
@@ -852,19 +853,18 @@ local_strstr(const char *str1, const char *str2)
 }
 
 /*
- * This function purpose is to make sure that the URL string contains a
- * numerical IP address.  The input URL is in the parameter url. The output
- * result URL is in the output parameter - buf.  When parameter - url already
- * contains a numerical ip, then output parameter - buf will be a copy of url.
- * For this case calling getDnsAddress method inside make_url, will serve the
- * purpose of IP validation.  But when parameter - url will contain a domain
- * name, then the domain name substring will be changed to a numerical ip
- * address in the buf output parameter.
+ * make_url
+ *				Address resolve a URL to contain only IP number
  *
- * Returns the length of the converted URL string, excluding null-terminator.
+ * Resolve the hostname in the URL to an IP number, and return a new URL with
+ * the same scheme and parameters using the resolved IP address. If the passed
+ * url is using an IP number, the return value will be a copy of the input.
+ * The output is a palloced string, it's the callers responsibility to free it
+ * when no longer needed. This function will error out in case a URL cannot be
+ * formed, NULL or an empty string are never returned.
  */
-static int
-make_url(const char *url, char *buf, bool is_ipv6)
+static char *
+make_url(const char *url, bool is_ipv6)
 {
 	char *authority_start = local_strstr(url, "//");
 	char *authority_end;
@@ -873,10 +873,9 @@ make_url(const char *url, char *buf, bool is_ipv6)
 	char hostname[HOST_NAME_SIZE];
 	char *hostip = NULL;
 	char portstr[9];
-	int len;
-	char *p;
 	int port = 80; /* default for http */
 	bool  domain_resolved_to_ipv6 = false;
+	StringInfoData buf;
 
 	if (!authority_start)
 		elog(ERROR, "illegal url '%s'", url);
@@ -960,7 +959,7 @@ make_url(const char *url, char *buf, bool is_ipv6)
 				 errmsg("hostname cannot be resolved '%s'", url)));
 
 	/*
-	 * test for the case where the URL originaly contained a domain name
+	 * test for the case where the URL originally contained a domain name
 	 * (so is_ipv6 was set to false) but the DNS resolution in getDnsAddress
 	 * returned an IPv6 address so know we also have to put the square
 	 * brackets [..] in the URL string.
@@ -968,41 +967,18 @@ make_url(const char *url, char *buf, bool is_ipv6)
 	if (strchr(hostip, ':') != NULL && !is_ipv6)
 		domain_resolved_to_ipv6 = true;
 
-	if (!buf)
-	{
-		int len = strlen(url) - strlen(hostname) + strlen(hostip);
-		if (domain_resolved_to_ipv6)
-			len += 2; /* for the square brackets */
-		return len;
-	}
+	initStringInfo(&buf);
 
-	p = buf;
-	len = hostname_start - url;
-	strncpy(p, url, len);
-	p += len;
-	url += len;
-
-	len = strlen(hostname);
-	url += len;
-
-	len = strlen(hostip);
+	for (int i = 0; i < (hostname_start - url); i++)
+		appendStringInfoChar(&buf, *(url + i));
 	if (domain_resolved_to_ipv6)
-	{
-		*p = '[';
-		p++;
-	}
-	strncpy(p, hostip, len);
-	p += len;
+		appendStringInfoChar(&buf, '[');
+	appendStringInfoString(&buf, hostip);
 	if (domain_resolved_to_ipv6)
-	{
-		*p = ']';
-		p++;
-	}
+		appendStringInfoChar(&buf, ']');
+	appendStringInfoString(&buf, url + (strlen(hostname) + (hostname_start - url)));
 
-	strcpy(p, url);
-	p += strlen(url);
-
-	return p - buf;
+	return buf.data;
 }
 
 /*
@@ -1017,7 +993,7 @@ extract_http_domain(char *i_path, char *o_domain, int dlen)
 	char* p_st = (char*)local_strstr(i_path, "//");
 	p_st = p_st + 2;
 	char* p_en = strchr(p_st, '/');
-	
+
 	domsz = p_en - p_st;
 	cpsz = ( domsz < dlen ) ? domsz : dlen;
 	memcpy(o_domain, p_st, cpsz);
@@ -1028,7 +1004,7 @@ url_has_ipv6_format (char *url)
 {
 	bool is6 = false;
 	char *ipv6 = local_strstr(url, "://[");
-	
+
 	if ( ipv6 )
 		ipv6 = strchr(ipv6, ']');
 	if ( ipv6 )
@@ -1053,15 +1029,15 @@ URL_FILE *
 url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 {
 	URL_CURL_FILE *file;
-	int			sz;
 	int         ip_mode;
 	int 		e;
 	bool		is_ipv6 = url_has_ipv6_format(url);
+	char	   *tmp;
 
 	/* Reset curl_Error_Buffer */
 	curl_Error_Buffer[0] = '\0';
 
-	Assert (IS_HTTP_URI(url) || IS_GPFDIST_URI(url) || IS_GPFDISTS_URI(url));
+	Assert(IS_HTTP_URI(url) || IS_GPFDIST_URI(url) || IS_GPFDISTS_URI(url));
 
 	if (!url_curl_resowner_callback_registered)
 	{
@@ -1069,9 +1045,7 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		url_curl_resowner_callback_registered = true;
 	}
 
-	sz = make_url(url, NULL, is_ipv6);
-	if (sz < 0)
-		elog(ERROR, "illegal URL: %s", url);
+	tmp = make_url(url, is_ipv6);
 
 	file = (URL_CURL_FILE *) palloc0(sizeof(URL_CURL_FILE));
 	file->common.type = CFTYPE_CURL;
@@ -1079,19 +1053,15 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	file->for_write = forwrite;
 	file->curl = create_curlhandle();
 
+	/*
+	 * We need to call is_url_ipv6 for the case where inside make_url
+	 * function a domain name was transformed to an IPv6 address.
+	 */
+	if (!is_ipv6)
+		is_ipv6 = url_has_ipv6_format(tmp);
+
 	if (!IS_GPFDISTS_URI(url))
-	{
-		file->curl_url = (char *) palloc0(sz + 1);
-
-		make_url(file->common.url, file->curl_url, is_ipv6);
-
-		/*
-		 * We need to call is_url_ipv6 for the case where inside make_url function
-		 * a domain name was transformed to an IPv6 address.
-		 */
-		if ( !is_ipv6 )
-			is_ipv6 = url_has_ipv6_format(file->curl_url);
-	}
+		file->curl_url = tmp;
 	else
 	{
 		/*
@@ -1101,18 +1071,10 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		 * not resolve the hostname in this case. I have decided
 		 * to not resolve it anyway and let libcurl do the work.
 		 */
-		char* tmp_resolved;
-
 		file->curl_url = pstrdup(file->common.url);
-
-		tmp_resolved = palloc0(sz + 1);
-		make_url(file->common.url, tmp_resolved, is_ipv6);
-			
-		/* keep the same ipv6 logic here */
-		if ( !is_ipv6 )
-			is_ipv6 = url_has_ipv6_format(tmp_resolved);
+		pfree(tmp);
 	}
-		
+
 	if (IS_GPFDIST_URI(file->curl_url) || IS_GPFDISTS_URI(file->curl_url))
 	{
 		/* replace gpfdist:// with http:// or gpfdists:// with https://
@@ -1143,7 +1105,7 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	/* 'file' is the application variable that gets passed to write_callback */
 	CURL_EASY_SETOPT(file->curl->handle, CURLOPT_WRITEDATA, file);
 
-	if ( !is_ipv6 )
+	if (!is_ipv6)
 		ip_mode = CURL_IPRESOLVE_V4;
 	else
 		ip_mode = CURL_IPRESOLVE_V6;
@@ -1685,7 +1647,7 @@ gp_proto0_write(URL_CURL_FILE *file, CopyState pstate)
 
 	if (nbytes == 0)
 		return;
-	
+
 	/* post binary data */
 	CURL_EASY_SETOPT(file->curl->handle, CURLOPT_POSTFIELDS, buf);
 


### PR DESCRIPTION
Noticed when getting annoyed about seeing compiler warnings in the back branches.

The previous coding implemented a two stage API where the `make_url` function was first called with a `NULL` buffer to calculate the required length of the buffer, and then called again with a correctly sized buffer.  This enabled safe usage of the string copying as long as the API was followed, but was prone to overflows in case a too small buffer was passed in as the length wasn't a parameter to `make_url`.

This refactors `make_url` to instead build the URL without a second call, using a dynamic buffer. Rather than using a pass-by-reference buffer it now returns an allocated and guaranteed-to-be terminated buffer. This makes the processing a hair more effective, and removes compiler warnings from unsafe string operations.

Also convert an errorcheck into an Assertion as the error condition cannot hold. The error handling was this:
```
	if ((strlen(url) - strlen(hostname) + strlen(hostip)) < 0)
		error..
```
`hostname` is copied from `url` using an offset and length (where the offset is non-zero), and `hostip` is guaranteed to be a string of at least length 0.

The second commit includes a tiny bit of error handling cleanup.