### PR TITLE
6X gpinitsystem: Improve handling of -I input file

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -973,7 +973,7 @@ CREATE_QE_ARRAY () {
 	SEG_DIR_VECTOR=0
 	MIR_COUNT=-1
 	MASTER_HOST=`HOST_LOOKUP $MASTER_HOSTNAME`
-	QD_PRIMARY_ARRAY=${MASTER_HOST}~${MASTER_HOSTNAME}~${MASTER_PORT}~${MASTER_DIRECTORY}/${SEG_PREFIX}${CONTENT_COUNT}~${DBID_COUNT}~${CONTENT_COUNT}~0
+	QD_PRIMARY_ARRAY=${MASTER_HOST}~${MASTER_HOSTNAME}~${MASTER_PORT}~${MASTER_DIRECTORY}/${SEG_PREFIX}${CONTENT_COUNT}~${DBID_COUNT}~${CONTENT_COUNT}
 	((DBID_COUNT=$DBID_COUNT+1));((CONTENT_COUNT=$CONTENT_COUNT+1))
 	for QE_PAIR in ${M_HOST_ARRAY[@]}
 	do
@@ -1028,10 +1028,10 @@ ARRAY_REORDER() {
             ;;
     esac
 
-    QE_REORDER_ARRAY=(`$ECHO ${QE_PRIMARY_ARRAY[@]}|$TR ' ' '\n'|$SORT -t$S -n -k2,2|$TR '\n' ' '`)
+    QE_REORDER_ARRAY=(`$ECHO ${QE_PRIMARY_ARRAY[@]}|$TR ' ' '\n'|$SORT -t'~' -n -k2,2|$TR '\n' ' '`)
     QE_PRIMARY_ARRAY=(${QE_REORDER_ARRAY[@]})
     if [ $MIRROR_TYPE -eq 1 ];then
-	QE_REORDER_ARRAY=(`$ECHO ${QE_MIRROR_ARRAY[@]}|$TR ' ' '\n'|$SORT -t$S -n -k2,2|$TR '\n' ' '`)
+	QE_REORDER_ARRAY=(`$ECHO ${QE_MIRROR_ARRAY[@]}|$TR ' ' '\n'|$SORT -t'~' -n -k2,2|$TR '\n' ' '`)
 	QE_MIRROR_ARRAY=(${QE_REORDER_ARRAY[@]})
     fi
     LOG_MSG "[INFO]:-End Function $FUNCNAME"
@@ -1043,10 +1043,10 @@ CREATE_ARRAY_SORTED_ON_CONTENT_ID() {
 
     local REORDERING_ON_CONTENT
 
-    REORDERING_ON_CONTENT=(`$ECHO ${QE_PRIMARY_ARRAY[@]}|$TR ' ' '\n'|$SORT -t$S -n -k5,5|$TR '\n' ' '`)
+    REORDERING_ON_CONTENT=(`$ECHO ${QE_PRIMARY_ARRAY[@]}|$TR ' ' '\n'|$SORT -t'~' -n -k5,5|$TR '\n' ' '`)
     QE_PRIMARY_ARRAY_SORTED_ON_CONTENT_ID=(${REORDERING_ON_CONTENT[@]})
     if [ $MIRRORING -ne 0 ] ; then
-      REORDERING_ON_CONTENT=(`$ECHO ${QE_MIRROR_ARRAY[@]}|$TR ' ' '\n'|$SORT -t$S -n -k5,5|$TR '\n' ' '`)
+      REORDERING_ON_CONTENT=(`$ECHO ${QE_MIRROR_ARRAY[@]}|$TR ' ' '\n'|$SORT -t'~' -n -k5,5|$TR '\n' ' '`)
       QE_MIRROR_ARRAY_SORTED_ON_CONTENT_ID=(${REORDERING_ON_CONTENT[@]})
     fi
     LOG_MSG "[INFO]:-End Function $FUNCNAME"
@@ -1172,29 +1172,6 @@ DISPLAY_CONFIG () {
 		GET_REPLY "Continue with Greenplum creation" 
 	fi
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-SET_VAR () {
-    # 
-    # MPP-13617: If segment contains a ~, we assume ~ is the field delimiter.
-    # Otherwise we assume : is the delimiter.  This allows us to easily 
-    # handle IPv6 addresses which may contain a : by using a ~ as a delimiter. 
-    # 
-    I=$1
-    case $I in
-        *~*)
-	    S="~"
-            ;;
-        *)
-	    S=":"
-            ;;
-    esac
-    GP_HOSTNAME=`$ECHO $I|$CUT -d$S -f1`
-    GP_HOSTADDRESS=`$ECHO $I|$CUT -d$S -f2`
-    GP_PORT=`$ECHO $I|$CUT -d$S -f3`
-    GP_DIR=`$ECHO $I|$CUT -d$S -f4`
-    GP_DBID=`$ECHO $I|$CUT -d$S -f5`
-    GP_CONTENT=`$ECHO $I|$CUT -d$S -f6`
 }
 
 CREATE_QD_DB () {

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -1314,6 +1314,63 @@ SET_GP_USER_PW () {
     LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
+SET_VAR () {
+	# MPP-13617: If segment contains a ~, we assume ~ is the field delimiter.
+	# Otherwise we assume : is the delimiter.  This allows us to easily 
+	# handle IPv6 addresses which may contain a : by using a ~ as a delimiter. 
+	I=$1
+	case $I in
+		*~*)
+			S="~"
+			;;
+		*)
+			S=":"
+			;;
+	esac
+	if [ -z "$I" ]; then
+		return
+	fi
+
+	local fields=()
+	IFS=$S read -ra fields <<< "$I"
+
+	# The input_config format for specifying a segment array changed in a 6X
+	# minor release to include the hostname in addition to the address.  To
+	# maintain backwards compatibility, detect when the incoming array needs
+	# the host field to be prepended.  For example, an input line of
+	# QD_PRIMARY_ARRAY=mdw~5432~/data/master/gpseg-1~1~-1
+	# would be treated as
+	# QD_PRIMARY_ARRAY=mdw~mdw~5432~/data/master/gpseg-1~1~-1
+	if [[ ! ( "${#fields[@]}" == "5" || "${#fields[@]}" == "6" ) ]]; then
+		ERROR_EXIT "[FATAL]:-$I has the wrong number of fields" 2
+	fi
+
+	if [ "${#fields[@]}" == "5" ]; then
+		GP_HOSTNAME="${fields[0]}"
+		GP_HOSTADDRESS=$GP_HOSTNAME
+		GP_PORT="${fields[1]}"
+		GP_DIR="${fields[2]}"
+		GP_DBID="${fields[3]}"
+		GP_CONTENT="${fields[4]}"
+	else
+		GP_HOSTNAME="${fields[0]}"
+		GP_HOSTADDRESS="${fields[1]}"
+		GP_PORT="${fields[2]}"
+		GP_DIR="${fields[3]}"
+		GP_DBID="${fields[4]}"
+		GP_CONTENT="${fields[5]}"
+	fi
+
+	# Quick sanity checks on value types to ensure that e.g. passing a 5.X
+	# config file isn't misread as a new-format 6.X file and mis-parsed.
+	if ! [[ "$GP_PORT" =~ ^[0-9]+$ && "$GP_DBID" =~ ^[0-9]+$ && "$GP_CONTENT" =~ ^-?[0-9]+$ ]]; then
+		ERROR_EXIT "[FATAL]:-One or more numeric fields in $I have a non-numeric value" 2
+	fi
+	if ! [[ "$GP_DIR" =~ ^/[^/]+ ]]; then
+		ERROR_EXIT "[FATAL]:-Value for directory field in $I is not a valid path" 2
+	fi
+}
+
 #******************************************************************************
 # Main Section
 #******************************************************************************

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -69,29 +69,6 @@ CHK_CALL () {
 	fi
 }
 
-SET_VAR () {
-    # 
-    # MPP-13617: If segment contains a ~, we assume ~ is the field delimiter.
-    # Otherwise we assume : is the delimiter.  This allows us to easily 
-    # handle IPv6 addresses which may contain a : by using a ~ as a delimiter. 
-    # 
-    I=$1
-    case $I in
-        *~*)
-	    S="~"
-            ;;
-        *)
-	    S=":"
-            ;;
-    esac
-    GP_HOSTNAME=`$ECHO $I|$CUT -d$S -f1`
-    GP_HOSTADDRESS=`$ECHO $I|$CUT -d$S -f2`
-    GP_PORT=`$ECHO $I|$CUT -d$S -f3`
-    GP_DIR=`$ECHO $I|$CUT -d$S -f4`
-    GP_DBID=`$ECHO $I|$CUT -d$S -f5`
-    GP_CONTENT=`$ECHO $I|$CUT -d$S -f6`
-}
-
 PARA_EXIT () {
 	if [ $1 -ne 0 ];then
 		$ECHO "FAILED:$SEGMENT_TO_CREATE" >> $PARALLEL_STATUS_FILE

--- a/gpMgmt/bin/test/gpinitsystem_test.bash
+++ b/gpMgmt/bin/test/gpinitsystem_test.bash
@@ -57,9 +57,121 @@ it_should_quote_the_password_during_alter_user_in_SET_GP_USER_PW() {
   fi
 }
 
+it_should_work_with_a_hostname() {
+  ARRAY_LINE="sdw1~sdw1~50433~/data/primary/gpseg0~1~0"
+  SET_VAR $ARRAY_LINE
+  if [ "$GP_HOSTNAME" != "sdw1" ]; then
+    echo "got hostname $GP_HOSTNAME, wanted sdw1"
+    exit 1
+  fi
+  if [ "$GP_HOSTADDRESS" != "sdw1" ]; then
+    echo "got address $GP_HOSTADDRESS, wanted sdw1"
+    exit 1
+  fi
+  if [ "$GP_PORT" != "50433" ]; then
+    echo "got port $GP_PORT, wanted 50433"
+    exit 1
+  fi
+  if [ "$GP_DIR" != "/data/primary/gpseg0" ]; then
+    echo "got data directory $GP_DIR, wanted /data/primary/gpseg0"
+    exit 1
+  fi
+  if [ "$GP_DBID" != "1" ]; then
+    echo "got dbid $GP_DBID, wanted 1"
+    exit 1
+  fi
+  if [ "$GP_CONTENT" != "0" ]; then
+    echo "got content $GP_CONTENT, wanted 0"
+    exit 1
+  fi
+}
+
+it_should_work_without_a_hostname() {
+  ARRAY_LINE="sdw1~50433~/data/primary/gpseg0~1~0"
+  SET_VAR $ARRAY_LINE
+  if [ "$GP_HOSTNAME" != "sdw1" ]; then
+    echo "got hostname $GP_HOSTNAME, wanted sdw1"
+    exit 1
+  fi
+  if [ "$GP_HOSTADDRESS" != "sdw1" ]; then
+    echo "got address $GP_HOSTADDRESS, wanted sdw1"
+    exit 1
+  fi
+  if [ "$GP_PORT" != "50433" ]; then
+    echo "got port $GP_PORT, wanted 50433"
+    exit 1
+  fi
+  if [ "$GP_DIR" != "/data/primary/gpseg0" ]; then
+    echo "got data directory $GP_DIR, wanted /data/primary/gpseg0"
+    exit 1
+  fi
+  if [ "$GP_DBID" != "1" ]; then
+    echo "got dbid $GP_DBID, wanted 1"
+    exit 1
+  fi
+  if [ "$GP_CONTENT" != "0" ]; then
+    echo "got content $GP_CONTENT, wanted 0"
+    exit 1
+  fi
+}
+
+set_var_should_error_out_if_given_the_wrong_number_of_fields() {
+  IGNORE_WARNINGS=0
+
+  LONG_ARRAY_LINE="one~two~3~/four~5~6~7"
+  ret=$(SET_VAR $LONG_ARRAY_LINE)
+  if [[ "$ret" != *"wrong number of fields"* ]]; then
+      echo "did not error out on too many fields"
+      exit 1
+  fi
+
+  SHORT_ARRAY_LINE="one~two~3~/four"
+  ret=$(SET_VAR $SHORT_ARRAY_LINE)
+  if [[ "$ret" != *"wrong number of fields"* ]]; then
+      echo "did not error out on too few fields"
+      exit 1
+  fi
+}
+
+set_var_should_error_out_if_given_bad_field_values() {
+  IGNORE_WARNINGS=0
+
+  BAD_PORT_ARRAY_LINE="host~address~port~/dir~0~1"
+  ret=$(SET_VAR $BAD_PORT_ARRAY_LINE)
+  if [[ "$ret" != *"non-numeric value"* ]]; then
+      echo "did not error out on non-numeric port value"
+      exit 1
+  fi
+
+  BAD_DBID_ARRAY_LINE="host~address~5432~/dir~dbid~1"
+  ret=$(SET_VAR $BAD_DBID_ARRAY_LINE)
+  if [[ "$ret" != *"non-numeric value"* ]]; then
+      echo "did not error out on non-numeric dbid value"
+      exit 1
+  fi
+
+  BAD_CONTENT_ARRAY_LINE="host~address~5432~/dir~0~content"
+  ret=$(SET_VAR $BAD_CONTENT_ARRAY_LINE)
+  if [[ "$ret" != *"non-numeric value"* ]]; then
+      echo "did not error out on non-numeric content value"
+      exit 1
+  fi
+
+  BAD_DIR_ARRAY_LINE="host~address~5432~dir~0~1"
+  ret=$(SET_VAR $BAD_DIR_ARRAY_LINE)
+  if [[ "$ret" != *"not a valid path"* ]]; then
+      echo "did not error out on invalid directory value"
+      exit 1
+  fi
+}
+
 main() {
   it_should_quote_the_username_during_alter_user_in_SET_GP_USER_PW
   it_should_quote_the_password_during_alter_user_in_SET_GP_USER_PW
+  it_should_work_with_a_hostname
+  it_should_work_without_a_hostname
+  set_var_should_error_out_if_given_the_wrong_number_of_fields
+  set_var_should_error_out_if_given_bad_field_values
 }
 
 main


### PR DESCRIPTION
**_Note_**: This is a draft PR as we wait for the full pipeline to finish.

Previously, gpinitsystem did not allow the user to specify a hostname and address for each segment in the input file used with -I; it only accepted one value per segment and used it for both hostname and address.

This commit changes the behavior so that the user can specify both hostname and address.  If the user specifies only the address (such as by using an old config file), it will preserve the old behavior and set both hostname and address to that value.  It also adds a few tests around input file parsing so SET_VAR is more resilient to further refactors.

The specific changes involved are the following:
- Change SET_VAR to be able to parse either the old format (address only) or new   format (host and address) of the segment array representation.
- Remove the option to use ':' as a separator in SET_VAR, as the rest of the  code assumes the use of '~'.
- Move SET_VAR from gpinitsystem to gp_bash_functions.sh and remove the  redundant copy in gpcreateseg.sh.
- Remove a hardcoded "~0" in QD_PRIMARY_ARRAY in gpinitsystem, representing a  replication port value, that was left over from 5X.
- Improve the check for the number of fields in the segment array representation.

