### PR TITLE
Bring our bitmap scan private cost formula back

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -937,11 +937,24 @@ cost_bitmap_heap_scan(Path *path, PlannerInfo *root, RelOptInfo *baserel,
 	 * appropriate to charge spc_seq_page_cost apiece.	The effect is
 	 * nonlinear, too. For lack of a better idea, interpolate like this to
 	 * determine the cost per page.
+	 *
+	 * GPDB:
+	 * The original formula from Postgres is still more like linear, in which
+	 * the cost per page will be dominated by random_page_cost, because the
+	 * default value of random_page_cost is 100x larger than seq_page_cost in
+	 * GPDB. Therefore, we update it to the following non-linear formula to
+	 * reflect the real cost per page when a majority of pages are fetched.
+	 *
+	 * https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/T8kB23vva6M
+	 *
+	 * This formula is not perfect though. We bumped up random_page_cost to 100,
+	 * since some unknown practise reason, we have to reduce the impact in bitmap
+	 * scan. Otherwise, most of the time seqscan cost always win bitmap index scan.
+	 *
 	 */
 	if (pages_fetched >= 2.0)
-		cost_per_page = spc_random_page_cost -
-			(spc_random_page_cost - spc_seq_page_cost)
-			* sqrt(pages_fetched / T);
+		cost_per_page = seq_page_cost *
+			pow(random_page_cost / seq_page_cost, 1 - sqrt(pages_fetched / T));
 	else
 		cost_per_page = spc_random_page_cost;
 
@@ -1058,11 +1071,23 @@ cost_bitmap_appendonly_scan(Path *path, PlannerInfo *root, RelOptInfo *baserel,
 	 * appropriate to charge spc_seq_page_cost apiece.  The effect is
 	 * nonlinear, too. For lack of a better idea, interpolate like this to
 	 * determine the cost per page.
+	 *
+	 * GPDB:
+	 * The original formula from Postgres is still more like linear, in which
+	 * the cost per page will be dominated by random_page_cost, because the
+	 * default value of random_page_cost is 100x larger than seq_page_cost in
+	 * GPDB. Therefore, we update it to the following non-linear formula to
+	 * reflect the real cost per page when a majority of pages are fetched.
+	 *
+	 * https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/T8kB23vva6M
+	 *
+	 * This formula is not perfect though. We bumped up random_page_cost to 100,
+	 * since some unknown practise reason, we have to reduce the impact in bitmap
+	 * scan. Otherwise, most of the time seqscan cost always win bitmap index scan.
 	 */
 	if (pages_fetched >= 2.0)
-		cost_per_page = spc_random_page_cost -
-			(spc_random_page_cost - spc_seq_page_cost)
-			* sqrt(pages_fetched / T);
+		cost_per_page = seq_page_cost *
+			pow(random_page_cost / seq_page_cost, 1 - sqrt(pages_fetched / T));
 	else
 		cost_per_page = spc_random_page_cost;
 

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -3092,20 +3092,16 @@ SET enable_bitmapscan = ON;
 EXPLAIN (COSTS OFF)
 SELECT * FROM tenk1
   WHERE thousand = 42 AND (tenthous = 1 OR tenthous = 3 OR tenthous = 42);
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Bitmap Heap Scan on tenk1
-         Recheck Cond: (((thousand = 42) AND (tenthous = 1)) OR ((thousand = 42) AND (tenthous = 3)) OR ((thousand = 42) AND (tenthous = 42)))
-         ->  BitmapOr
-               ->  Bitmap Index Scan on tenk1_thous_tenthous
-                     Index Cond: ((thousand = 42) AND (tenthous = 1))
-               ->  Bitmap Index Scan on tenk1_thous_tenthous
-                     Index Cond: ((thousand = 42) AND (tenthous = 3))
-               ->  Bitmap Index Scan on tenk1_thous_tenthous
-                     Index Cond: ((thousand = 42) AND (tenthous = 42))
+         Recheck Cond: (thousand = 42)
+         Filter: ((tenthous = 1) OR (tenthous = 3) OR (tenthous = 42))
+         ->  Bitmap Index Scan on tenk1_thous_tenthous
+               Index Cond: (thousand = 42)
  Optimizer: Postgres query optimizer
-(11 rows)
+(7 rows)
 
 SELECT * FROM tenk1
   WHERE thousand = 42 AND (tenthous = 1 OR tenthous = 3 OR tenthous = 42);
@@ -3117,23 +3113,18 @@ SELECT * FROM tenk1
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM tenk1
   WHERE hundred = 42 AND (thousand = 42 OR thousand = 99);
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Bitmap Heap Scan on tenk1
-                     Recheck Cond: ((hundred = 42) AND ((thousand = 42) OR (thousand = 99)))
-                     ->  BitmapAnd
-                           ->  Bitmap Index Scan on tenk1_hundred
-                                 Index Cond: (hundred = 42)
-                           ->  BitmapOr
-                                 ->  Bitmap Index Scan on tenk1_thous_tenthous
-                                       Index Cond: (thousand = 42)
-                                 ->  Bitmap Index Scan on tenk1_thous_tenthous
-                                       Index Cond: (thousand = 99)
+                     Recheck Cond: (hundred = 42)
+                     Filter: ((thousand = 42) OR (thousand = 99))
+                     ->  Bitmap Index Scan on tenk1_hundred
+                           Index Cond: (hundred = 42)
  Optimizer: Postgres query optimizer
-(14 rows)
+(9 rows)
 
 SELECT count(*) FROM tenk1
   WHERE hundred = 42 AND (thousand = 42 OR thousand = 99);

--- a/src/test/regress/expected/equivclass.out
+++ b/src/test/regress/expected/equivclass.out
@@ -260,27 +260,33 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss1
   where ss1.x = ec1.f1 and ec1.ff = 42::int8 and ec1.ff = ec1.f1;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: (((ss0.ff + 1)) = ec1.f1)
          ->  Append
                ->  Subquery Scan on ss0
                      ->  Append
-                           ->  Seq Scan on ec1 ec1_1
-                                 Filter: (((ff + 2) + 1) = '42'::bigint)
-                           ->  Seq Scan on ec1 ec1_2
-                                 Filter: (((ff + 3) + 1) = '42'::bigint)
-               ->  Seq Scan on ec1 ec1_3
-                     Filter: ((ff + 4) = '42'::bigint)
+                           ->  Bitmap Heap Scan on ec1 ec1_1
+                                 Recheck Cond: (((ff + 2) + 1) = '42'::bigint)
+                                 ->  Bitmap Index Scan on ec1_expr2
+                                       Index Cond: (((ff + 2) + 1) = '42'::bigint)
+                           ->  Bitmap Heap Scan on ec1 ec1_2
+                                 Recheck Cond: (((ff + 3) + 1) = '42'::bigint)
+                                 ->  Bitmap Index Scan on ec1_expr3
+                                       Index Cond: (((ff + 3) + 1) = '42'::bigint)
+               ->  Bitmap Heap Scan on ec1 ec1_3
+                     Recheck Cond: ((ff + 4) = '42'::bigint)
+                     ->  Bitmap Index Scan on ec1_expr4
+                           Index Cond: ((ff + 4) = '42'::bigint)
          ->  Materialize
                ->  Broadcast Motion 1:3  (slice2; segments: 1)
                      ->  Index Scan using ec1_pkey on ec1
                            Index Cond: ((ff = '42'::bigint) AND (ff = '42'::bigint))
                            Filter: (ff = f1)
  Optimizer: Postgres query optimizer
-(18 rows)
+(24 rows)
 
 explain (costs off)
   select * from ec1,

--- a/src/test/regress/expected/plancache.out
+++ b/src/test/regress/expected/plancache.out
@@ -270,14 +270,16 @@ analyze test_mode;
 prepare test_mode_pp (int) as select count(*) from test_mode where a = $1;
 -- up to 5 executions, custom plan is used
 explain (costs off) execute test_mode_pp(2);
-                        QUERY PLAN                        
-----------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Index Only Scan using test_mode_a_idx on test_mode
-               Index Cond: (a = 2)
+         ->  Bitmap Heap Scan on test_mode
+               Recheck Cond: (a = 2)
+               ->  Bitmap Index Scan on test_mode_a_idx
+                     Index Cond: (a = 2)
  Optimizer: Postgres query optimizer
-(5 rows)
+(7 rows)
 
 -- force generic plan
 set plan_cache_mode to force_generic_plan;
@@ -326,25 +328,29 @@ execute test_mode_pp(1); -- 5x
 
 -- we should now get a really bad plan
 explain (costs off) execute test_mode_pp(2);
-         QUERY PLAN          
------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Index Only Scan using test_mode_a_idx on test_mode
-               Index Cond: (a = 2)
+         ->  Bitmap Heap Scan on test_mode
+               Recheck Cond: (a = 2)
+               ->  Bitmap Index Scan on test_mode_a_idx
+                     Index Cond: (a = 2)
  Optimizer: Postgres query optimizer
-(5 rows)
+(7 rows)
 
 -- but we can force a custom plan
 set plan_cache_mode to force_custom_plan;
 explain (costs off) execute test_mode_pp(2);
-                        QUERY PLAN                        
-----------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Index Only Scan using test_mode_a_idx on test_mode
-               Index Cond: (a = 2)
+         ->  Bitmap Heap Scan on test_mode
+               Recheck Cond: (a = 2)
+               ->  Bitmap Index Scan on test_mode_a_idx
+                     Index Cond: (a = 2)
  Optimizer: Postgres query optimizer
-(5 rows)
+(7 rows)
 
 drop table test_mode;


### PR DESCRIPTION
Before, we have our gpdb private bitmap cost formula [#4172](https://github.com/greenplum-db/gpdb/pull/4172).

For some unknown practice reason, we bumped up random_page_cost to 100.
Hence, seqscan costs always win bitmap scan. we gave this formula to reduce 
the predomination of random_page_cost.

During 9.2 merge, this formula disturbs index only scan plan chosen, so
we rid of it. That leads to our old issue to recover.

From my point of view, we need to backport this formula first. Then,
turning random_page_cost value or rebalance bitmap and index only scan
cost later.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
