### PR TITLE
Fix interconnect hung issue

### DIFF
--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -569,8 +569,7 @@ forceEosToPeers(ChunkTransportState *transportStates,
  * even if SetupInterconnect did not complete correctly.
  */
 void
-TeardownInterconnect(ChunkTransportState *transportStates,
-					 bool forceEOS, bool hasError)
+TeardownInterconnect(ChunkTransportState *transportStates, bool forceEOS)
 {
 	interconnect_handle_t *h = find_interconnect_handle(transportStates);
 
@@ -580,7 +579,7 @@ TeardownInterconnect(ChunkTransportState *transportStates,
 	}
 	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
 	{
-		TeardownTCPInterconnect(transportStates, forceEOS, hasError);
+		TeardownTCPInterconnect(transportStates, forceEOS);
 	}
 
 	if (h != NULL)
@@ -853,7 +852,7 @@ cleanup_interconnect_handle(interconnect_handle_t *h)
 		destroy_interconnect_handle(h);
 		return;
 	}
-	TeardownInterconnect(h->interconnect_context, true /* force EOS */, true);
+	TeardownInterconnect(h->interconnect_context, true /* force EOS */);
 }
 
 static void

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1809,8 +1809,7 @@ SetupTCPInterconnect(EState *estate)
  * adding errors!).
  */
 void
-TeardownTCPInterconnect(ChunkTransportState *transportStates,
-						bool forceEOS, bool hasError)
+TeardownTCPInterconnect(ChunkTransportState *transportStates, bool forceEOS)
 {
 	ListCell   *cell;
 	ChunkTransportStateEntry *pEntry = NULL;
@@ -1928,7 +1927,7 @@ TeardownTCPInterconnect(ChunkTransportState *transportStates,
 
 		getChunkTransportState(transportStates, mySlice->sliceIndex, &pEntry);
 
-		if (forceEOS && !hasError)
+		if (forceEOS)
 			forceEosToPeers(transportStates, mySlice->sliceIndex);
 
 		for (i = 0; i < pEntry->numConns; i++)
@@ -2016,7 +2015,7 @@ TeardownTCPInterconnect(ChunkTransportState *transportStates,
 		 * If some errors are happening, senders can skip this step to avoid hung
 		 * issues, QD will take care of the error handling.
 		 */
-		if (!hasError)
+		if (!forceEOS)
 			waitOnOutbound(pEntry);
 
 		for (i = 0; i < pEntry->numConns; i++)

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1602,7 +1602,7 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 		 * mark the estate to "cancelUnfinished" and then try to do a
 		 * normal interconnect teardown).
 		 */
-		TeardownInterconnect(estate->interconnect_context, estate->cancelUnfinished, false);
+		TeardownInterconnect(estate->interconnect_context, estate->cancelUnfinished);
 		estate->interconnect_context = NULL;
 		estate->es_interconnect_is_setup = false;
 	}
@@ -1690,7 +1690,7 @@ void mppExecutorCleanup(QueryDesc *queryDesc)
 	/* Clean up the interconnect. */
 	if (estate->es_interconnect_is_setup)
 	{
-		TeardownInterconnect(estate->interconnect_context, true /* force EOS */, true);
+		TeardownInterconnect(estate->interconnect_context, true /* force EOS */);
 		estate->es_interconnect_is_setup = false;
 	}
 

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1592,6 +1592,21 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 
 	currentSlice = getCurrentSlice(estate, LocallyExecutingSliceIndex(estate));
 
+	/* Teardown the Interconnect */
+	if (estate->es_interconnect_is_setup)
+	{
+		/*
+		 * MPP-3413: If we got here during cancellation of a cursor,
+		 * we need to set the "forceEos" argument correctly --
+		 * otherwise we potentially hang (cursors cancel on the QEs,
+		 * mark the estate to "cancelUnfinished" and then try to do a
+		 * normal interconnect teardown).
+		 */
+		TeardownInterconnect(estate->interconnect_context, estate->cancelUnfinished, false);
+		estate->interconnect_context = NULL;
+		estate->es_interconnect_is_setup = false;
+	}
+
 	/*
 	 * If QD, wait for QEs to finish and check their results.
 	 */
@@ -1653,20 +1668,6 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 		estate->dispatcherState = NULL;
 		cdbdisp_destroyDispatcherState(ds);
 	}
-
-	/* Teardown the Interconnect */
-	if (estate->es_interconnect_is_setup)
-	{
-		/*
-		 * MPP-3413: If we got here during cancellation of a cursor,
-		 * we need to set the "forceEos" argument correctly --
-		 * otherwise we potentially hang (cursors cancel on the QEs,
-		 * mark the estate to "cancelUnfinished" and then try to do a
-		 * normal interconnect teardown).
-		 */
-		TeardownInterconnect(estate->interconnect_context, estate->cancelUnfinished, false);
-		estate->es_interconnect_is_setup = false;
-	}
 }
 
 /*
@@ -1686,6 +1687,12 @@ void mppExecutorCleanup(QueryDesc *queryDesc)
 	/* GPDB hook for collecting query info */
 	if (query_info_collect_hook && QueryCancelCleanup)
 		(*query_info_collect_hook)(METRICS_QUERY_CANCELING, queryDesc);
+	/* Clean up the interconnect. */
+	if (estate->es_interconnect_is_setup)
+	{
+		TeardownInterconnect(estate->interconnect_context, true /* force EOS */, true);
+		estate->es_interconnect_is_setup = false;
+	}
 
 	/*
 	 * Request any commands still executing on qExecs to stop.
@@ -1696,13 +1703,6 @@ void mppExecutorCleanup(QueryDesc *queryDesc)
 	{
 		estate->dispatcherState = NULL;
 		CdbDispatchHandleError(ds);
-	}
-
-	/* Clean up the interconnect. */
-	if (estate->es_interconnect_is_setup)
-	{
-		TeardownInterconnect(estate->interconnect_context, true /* force EOS */, true);
-		estate->es_interconnect_is_setup = false;
 	}
 
 	/* GPDB hook for collecting query info */

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1280,8 +1280,7 @@ PG_TRY();
 	/* Clean up the interconnect. */
 	if (queryDesc && queryDesc->estate && queryDesc->estate->es_interconnect_is_setup)
 	{
-		TeardownInterconnect(queryDesc->estate->interconnect_context,
-							 false, false); /* following success on QD */
+		TeardownInterconnect(queryDesc->estate->interconnect_context, false); /* following success on QD */
 		queryDesc->estate->interconnect_context = NULL;
 		queryDesc->estate->es_interconnect_is_setup = false;
 	}
@@ -1343,8 +1342,7 @@ PG_CATCH();
 	 */
 	if (queryDesc && queryDesc->estate && queryDesc->estate->es_interconnect_is_setup)
 	{
-		TeardownInterconnect(queryDesc->estate->interconnect_context,
-							 true, false);
+		TeardownInterconnect(queryDesc->estate->interconnect_context, true);
 		queryDesc->estate->interconnect_context = NULL;
 		queryDesc->estate->es_interconnect_is_setup = false;
 	}

--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -117,7 +117,7 @@ extern void SetupInterconnect(struct EState *estate);
  *
  */
 extern void TeardownInterconnect(ChunkTransportState *transportStates,
-								 bool forceEOS, bool hasError);
+								 bool forceEOS);
 
 extern void WaitInterconnectQuit(void);
 
@@ -318,7 +318,7 @@ extern void WaitInterconnectQuitUDPIFC(void);
 extern void SetupTCPInterconnect(EState *estate);
 extern void SetupUDPIFCInterconnect(EState *estate);
 extern void TeardownTCPInterconnect(ChunkTransportState *transportStates,
-								 bool forceEOS, bool hasError);
+									bool forceEOS);
 extern void TeardownUDPIFCInterconnect(ChunkTransportState *transportStates,
 								 bool forceEOS);
 


### PR DESCRIPTION
    We hit interconnect hung issue many times in many cases, all have
    the same pattern: the downstream interconnect motion senders keep
    sending the tuples and they are blind to the fact that upstream
    nodes have finished and quitted the execution earlier, the QD
    then get enough tuples and wait all QEs to quit which cause a
    deadlock.

    Many nodes may quit execution earlier, eg, LIMIT, HashJoin, Nest
    Loop, to resolve the hung issue, they need to stop the interconnect
    stream explicitly by calling ExecSquelchNode(), however, we cannot
    do that for rescan cases in which data might lose, eg, commit
    2c011ce4c. For rescan cases, we tried using QueryFinishPending to
    stop the senders in commit 02213a731 and let senders check this
    flag and quit, that commit has its own problem, firstly, QueryFini
    shPending can only set by QD, it doesn't work for INSERT or UPDATE
    cases, secondly, that commit only let the senders detect the flag
    and quit the loop in a rude way (without sending the EOS to its
    receiver), the receiver may still be stuck inreceiving tuples.

    This commit revert the QueryFinishPending method firstly.

    To resolve the hung issue, we move TeardownInterconnect to the
    ahead of cdbdisp_checkDispatchResult so it guarantees to stop
    the interconnect stream before waiting and checking the status
    of QEs.

    For UDPIFC, TeardownInterconnect() remove the ic entries, any
    packets for this interconnect context will be treated as 'past'
    packets and be acked with STOP flag.

    For TCP, TeardownInterconnect() close all connection with its
    children, the children will treat any readable data in the
    connection as a STOP message include the closure operation.

    A test case is not included, both commit 2c011ce4c and 02213a731
    contain one.