### PR TITLE
fix memory leak when creating index

### DIFF
--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -1191,6 +1191,8 @@ tuplesort_putindextuplevalues_mk(Tuplesortstate_mk *state, Relation rel,
 
 	COPYTUP(state, &e, (void *) tuple);
 	puttuple_common(state, &e);
+	
+	pfree(tuple);
 
 	MemoryContextSwitchTo(oldcontext);
 }


### PR DESCRIPTION
Memory pointed to by tuple was not released in time. The process of creating index will crash if the count of table's rows is big enough.
This pull request is to solve the issue #9676.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
