### PR TITLE
Do not exit from critical section in filerep shutdown handler

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -82,6 +82,7 @@
 #include "cdb/cdbtm.h"
 #include "cdb/cdbfilerep.h"
 #include "cdb/cdbfilerepresyncmanager.h"
+#include "cdb/cdbfilerepservice.h"
 #include "cdb/cdbvars.h"
 #include "cdb/cdbpersistentrelation.h"
 #include "cdb/cdbmirroredflatfile.h"
@@ -2223,6 +2224,11 @@ XLogFlush(XLogRecPtr record)
 #endif
 
 	START_CRIT_SECTION();
+
+#ifdef FAULT_INJECTOR
+	if (fileRepProcessType == FileRepProcessTypeResyncManager)
+		SIMPLE_FAULT_INJECTOR(FileRepResyncManagerXLogFlush);
+#endif
 
 	/*
 	 * Since fsync is usually a horribly expensive operation, we try to

--- a/src/backend/cdb/cdbfilerepresyncworker.c
+++ b/src/backend/cdb/cdbfilerepresyncworker.c
@@ -166,6 +166,7 @@ FileRepPrimary_RunResyncWorker(void)
 				}					
 				
 				status = FileRepResync_UpdateEntry(entry);
+				SIMPLE_FAULT_INJECTOR(FileRepResyncOneRelComplete);
 			}
 		}
 		

--- a/src/backend/cdb/cdbfilerepservice.c
+++ b/src/backend/cdb/cdbfilerepservice.c
@@ -38,6 +38,7 @@
 #include "storage/proc.h"
 #include "storage/sinvaladt.h"
 #include "tcop/tcopprot.h"
+#include "utils/faultinjector.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"
 #include "utils/ps_status.h"
@@ -164,13 +165,14 @@ FileRepSubProcess_ShutdownHandler(SIGNAL_ARGS)
 				 */
 				if (fileRepProcessType == FileRepProcessTypeResyncManager)
 				{
+					SIMPLE_FAULT_INJECTOR(FileRepResyncShutdown);
 					FileRepResync_Cleanup();
 				}
 				else
 				{
 					LockReleaseAll(DEFAULT_LOCKMETHOD, false);
 				}
-				
+
 				/*
 				 * We remove ourself from LW waiter list (if applicable).
 				 *

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -153,6 +153,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault before fsync is issued to file system */
 	_("filerep_resync"),
 		/* inject fault while InResync when first relations is inserted to be resynced */
+	_("filerep_resync_shutdown"),
+		/* inject fault in shutdown handler of filerep resync backends */
 	_("filerep_resync_in_progress"),
 		/* inject fault while InResync when more then 10 relations in progress */
 	_("filerep_resync_worker"),
@@ -181,6 +183,10 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault just before sending SIGQUIT to child flerep processes */
 	_("checkpoint"),
 		/* inject fault before checkpoint is taken */
+	_("filerep_resync_manager_xlog_flush"),
+		/* inject fault in a filerep process that is in critical section of XLogFlush */
+	_("filerep_resync_one_rel_complete"),
+		/* inject fault in filerep resync worker once a relation is completely sync'ed */
 	_("change_tracking_compacting_report"),
 		/* report if compacting is in progress */
 	_("change_tracking_disable"),
@@ -1082,6 +1088,8 @@ FaultInjector_NewHashEntry(
 			case DecreaseToastMaxChunkSize:
 			case ProcessStartupPacketFault:
 			case DynamicIndexScanContextReset:
+			case FileRepResyncShutdown:
+			case FileRepResyncManagerXLogFlush:
 
 				break;
 			default:

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -59,6 +59,8 @@ typedef enum FaultInjectorIdentifier_e {
 	
 	FileRepResync,
 	
+	FileRepResyncShutdown,
+
 	FileRepResyncInProgress,	
 	
 	FileRepResyncWorker,
@@ -84,7 +86,11 @@ typedef enum FaultInjectorIdentifier_e {
 	FileRepImmediateShutdownRequested,
 	
 	Checkpoint,
-	
+
+	FileRepResyncManagerXLogFlush,
+
+	FileRepResyncOneRelComplete,
+
 	ChangeTrackingCompactingReport,
 	
 	ChangeTrackingDisable,

--- a/src/test/isolation2/sql/resync_shutdown_critical_section.sql
+++ b/src/test/isolation2/sql/resync_shutdown_critical_section.sql
@@ -1,0 +1,120 @@
+-- start_ignore
+create language plpythonu;
+create language plpgsql;
+CREATE EXTENSION gp_inject_fault;
+-- end_ignore
+
+create or replace function stop_segment(datadir text)
+returns text as $$
+    import subprocess
+    cmd = 'pg_ctl -l postmaster.log -D %s -w -m immediate stop' % datadir
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace('.', '')
+$$ language plpythonu;
+
+-- Wait for content 0 to assume specified mode
+create or replace function wait_for_content0(target_mode char) /*in func*/
+returns void as $$ /*in func*/
+declare /*in func*/
+    iterations int := 0; /*in func*/ 
+begin /*in func*/
+    while iterations < 120 loop /*in func*/
+        perform pg_sleep(1); /*in func*/
+        if exists (select * from gp_segment_configuration where content = 0 and mode = target_mode) then /*in func*/
+                return; /*in func*/
+        end if; /*in func*/
+        iterations := iterations + 1; /*in func*/
+    end loop; /*in func*/
+end $$ /*in func*/
+language plpgsql;
+
+create table resync_shutdown1(a int, b varchar) distributed by (a);
+create table resync_shutdown2(a int, b varchar)
+with (appendonly=true) distributed by (a);
+
+-- Stop content 0 mirror so that primary transitions to change tracking
+select stop_segment(fselocation) from pg_filespace_entry fe, gp_segment_configuration c, pg_filespace f
+where fe.fsedbid = c.dbid and c.content=0 and c.role='m' and f.oid = fe.fsefsoid and f.fsname = 'pg_system';
+
+select wait_for_content0('c');
+
+-- generate enough work for resync workers
+insert into resync_shutdown1 select 1, i from generate_series(1,100)i;
+insert into resync_shutdown2 select * from resync_shutdown1;
+create table resync_shutdown3(a int, b varchar)
+with (appendonly=true, orientation=column) distributed by (a);
+insert into resync_shutdown3 select * from resync_shutdown1;
+create table resync_shutdown4(a int, b varchar)
+with (appendonly=true, orientation=column) distributed by (a);
+insert into resync_shutdown4 select * from resync_shutdown1;
+create table resync_shutdown5(a int, b varchar)
+with (appendonly=true) distributed by (a);
+insert into resync_shutdown5 select * from resync_shutdown1;
+create table resync_shutdown6(a int, b varchar) distributed by (a);
+insert into resync_shutdown6 select * from resync_shutdown1;
+alter table resync_shutdown6 add column c int default 1;
+
+-- Skip fault in resync-backend specific branch in shutdown handler
+select gp_inject_fault_new('filerep_resync_shutdown', 'skip', dbid)
+from gp_segment_configuration where content=0 and role='p';
+
+-- Suspend a resync worker after one relation has been completely
+-- resynchronized.  That's when resync manager updates the PT entry
+-- and performs xlog flush.
+select gp_inject_fault_new('filerep_resync_one_rel_complete', 'suspend', dbid)
+from gp_segment_configuration where content=0 and role='p';
+
+-- Inject fault to suspend xlog flush in critical section.  Resync
+-- manager performs xlog flush during resync, after all workers have
+-- been started.
+select gp_inject_fault_new('filerep_resync_manager_xlog_flush', 'suspend', dbid)
+from gp_segment_configuration where content=0 and role='p';
+
+-- start_ignore
+! gprecoverseg -a;
+-- end_ignore
+
+select gp_wait_until_triggered_fault('filerep_resync_one_rel_complete', 1, dbid)
+from gp_segment_configuration where content=0 and role='p';
+
+-- Resync manager should now be updating the PT entry for the
+-- completed relation and hit the suspend fault in critical section of
+-- xlog flush.
+select gp_wait_until_triggered_fault('filerep_resync_manager_xlog_flush', 1, dbid)
+from gp_segment_configuration where content=0 and role='p';
+
+-- Now let one worker error out.
+select gp_inject_fault_new('filerep_resync_worker', 'error', dbid)
+from gp_segment_configuration where content=0 and role='p';
+
+-- Unleash the suspended worker.
+select gp_inject_fault_new('filerep_resync_one_rel_complete', 'reset', dbid)
+from gp_segment_configuration where content=0 and role='p';
+
+-- start_ignore
+! ps -ef | grep '[r]esync manager';
+-- end_ignore
+
+-- Verify that shutdown singal handler was called for resync manager,
+-- while it was suspended.  Such a situation would lead to PANIC.
+select gp_wait_until_triggered_fault('filerep_resync_shutdown', 1, dbid)
+from gp_segment_configuration where content=0 and role='p';
+
+-- Unleash the resync manager.  It should receive the shutdown signal
+-- once again after this, and that's when it will actually shutdown.
+select gp_inject_fault_new('filerep_resync_manager_xlog_flush', 'reset', dbid)
+from gp_segment_configuration where content=0 and role='p';
+
+-- Verify that shutdown signal was received by resync manager the
+-- second time.
+select gp_wait_until_triggered_fault('filerep_resync_shutdown', 2, dbid)
+from gp_segment_configuration where content=0 and role='p';
+
+-- Reset all faults
+select gp_inject_fault('all', 'reset', dbid)
+from gp_segment_configuration where content=0 and role='p';
+
+-- start_ignore
+! gprecoverseg -a;
+-- end_ignore
+
+select wait_for_content0('s');


### PR DESCRIPTION
If a process exits from critical section, it causes PANIC.  Such a PANIC was observed in production due to filerep resync manager process dying from critical section.  This patch changes the shutdown signal handler so that the process does not exit if signaled in the middle of a critical section.  The filerep main process is expected to send the shutdown signal again until the process finally exits.

Tested this manually, writing an isolation2 test with several new faults to achieve specific interleaving of resync manager, resync workers and the shutdown signal turned out to be too complex to implement in a reliable way.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
