### PR TITLE
[PRE-ARM-REGRESSION-TEST]Fix compile error during install gpmapreduce

### DIFF
--- a/gpcontrib/gpmapreduce/Makefile
+++ b/gpcontrib/gpmapreduce/Makefile
@@ -42,7 +42,7 @@ $(MAPREDOBJS): override CPPFLAGS += -DFRONTEND
 all: submake-libpq gpmapreduce all-lib
 
 gpmapreduce: $(MAPREDOBJS) $(libpq_builddir)/libpq.a
-	$(CC) $(CFLAGS) $(MAPREDOBJS) $(libpq_pgport) $(LDFLAGS) $(LIBS) -o $@$(X)
+	$(CC) $(CFLAGS) $(MAPREDOBJS) $(libpq_pgport) $(LDFLAGS) $(LIBS) -lyaml -o $@$(X)
 
 $(SRCDIR)/yaml_scan.c: $(SRCDIR)/yaml_parse.h $(SRCDIR)/yaml_scan.l
 ifdef FLEX


### PR DESCRIPTION
Reproduce on X86 and aarch64 Ubuntu 1804.
Both test env is in docker container. For this issue, I propose to add "-lyaml" into Makefile.
traceback:
greenplum@76ac41ff8c0a:~/src/gpdb/gpcontrib/gpmapreduce$ make install
make -C ../../src/interfaces/libpq all
make[1]: Entering directory '/home/greenplum/src/gpdb/src/interfaces/libpq'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/greenplum/src/gpdb/src/interfaces/libpq'
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-but-set-variable -Werror=implicit-fallthrough=3 -Wno-format-truncation -O3 -std=gnu99   -Werror=uninitialized -Werror=implicit-function-declaration -fPIC -Wno-implicit-fallthrough ./src/main.o ./src/mapred.o ./src/parse.o ./src/yaml_scan.o ./src/yaml_parse.o -L../../src/common -lpgcommon -L../../src/port -lpgport -L../../src/interfaces/libpq -lpq -L../../src/port -L../../src/common    -Wl,--as-needed -Wl,-rpath,'/home/greenplum/src/gpdb/gpsql/lib',--enable-new-dtags -lpgcommon -lpgport -lbz2 -lrt -lssl -lcrypto -lgssapi_krb5 -lzstd -lz -lrt -lcrypt -ldl -lm  -lcurl -o gpmapreduce
./src/parse.o: In function `mapred_parse_string':
parse.c:(.text+0x7500): undefined reference to `yaml_parser_initialize'
parse.c:(.text+0x75e8): undefined reference to `yaml_parser_initialize'
parse.c:(.text+0x7604): undefined reference to `yaml_parser_set_input_string'
parse.c:(.text+0x7618): undefined reference to `yaml_parser_delete'
./src/parse.o: In function `mapred_parse_file':
parse.c:(.text+0x76b0): undefined reference to `yaml_parser_initialize'
parse.c:(.text+0x7798): undefined reference to `yaml_parser_initialize'
parse.c:(.text+0x77a8): undefined reference to `yaml_parser_set_input_file'
parse.c:(.text+0x77bc): undefined reference to `yaml_parser_delete'
./src/yaml_parse.o: In function `yaml_yylex':
yaml_parse.c:(.text+0x5e0): undefined reference to `yaml_parser_parse'
yaml_parse.c:(.text+0x7c8): undefined reference to `yaml_event_delete'
collect2: error: ld returned 1 exit status
Makefile:45: recipe for target 'gpmapreduce' failed
make: *** [gpmapreduce] Error 1

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
