### PR TITLE
[PRE-ARM-REGRESSION-TEST]Fix resgroup.c during unittest-check on arm64

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3979,6 +3979,9 @@ CpusetToBitset(const char *cpuset, int len)
 	Bitmapset	*bms = NULL;
 	if (cpuset == NULL || len <= 0)
 		return bms;
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wuninitialized"
+	// False positive with gcc.
 	while (pos < len && cpuset[pos])
 	{
 		char c = cpuset[pos++];
@@ -4048,6 +4051,7 @@ CpusetToBitset(const char *cpuset, int len)
 			goto error_logic;
 		}
 	}
+	#pragma GCC diagnostic pop
 	if (s == Number)
 	{
 		bms = bms_union(bms, bms_make_singleton(num1));


### PR DESCRIPTION
This is only can be reproduced on aarch64 ubuntu1804.
All test env is in docker container.
This might be due to gcc. I compare the gcc between x86 and aarch64, such as below:
x86
greenplum@5eeb4fdc2e22:~/src/gpdb$ gcc --version
gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

aarch64:
greenplum@76ac41ff8c0a:~/src/gpdb$ gcc --version
gcc (Ubuntu/Linaro 7.5.0-3ubuntu1~18.04) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

I tested on both ARCH with this fix. No other affects. So I think it's good to post a PR to community.

traceback:
[ PASSED      ] 4 tests
resgroup_test.c: In function 'setup':
resgroup_test.c:22:17: warning: assignment from incompatible pointer type [-Wincompatible-pointer-types]
  MessageContext = OrigMessageContext;
                 ^
resgroup_test.c: In function 'main':
resgroup_test.c:372:21: warning: assignment from incompatible pointer type [-Wincompatible-pointer-types]
  OrigMessageContext = AllocSetContextCreate(TopMemoryContext,
                     ^
#'target_mem_ref' not supported by expression#'In file included from resgroup_test.c:1:0:
resgroup_test.c: In function 'test__CpusetToBitset_bad_arguments':
../resgroup.c:3982:28: error:  is used uninitialized in this function [-Werror=uninitialized]
  while (pos < len && cpuset[pos])
                      ~~~~~~^~~~~
cc1: some warnings being treated as errors
<builtin>: recipe for target 'resgroup_test.o' failed
make[4]: *** [resgroup_test.o] Error 1
../../../../src/backend/common.mk:52: recipe for target 'unittest-check-local' failed
make[3]: *** [unittest-check-local] Error 2
../../../src/backend/common.mk:49: recipe for target 'unittest-check-resgroup-recurse' failed
make[2]: *** [unittest-check-resgroup-recurse] Error 2
common.mk:49: recipe for target 'unittest-check-utils-recurse' failed
make[1]: *** [unittest-check-utils-recurse] Error 2
GNUmakefile:169: recipe for target 'unittest-check' failed
make: *** [unittest-check] Error 2

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
