### PR TITLE
[PRE-ARM-REGRESSION-TEST]Add arm regression test badge into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 **Concourse Pipeline** [![Concourse Build Status](https://prod.ci.gpdb.pivotal.io/api/v1/teams/main/pipelines/gpdb_master/badge)](https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master) |
 **Travis Build** [![Travis Build Status](https://travis-ci.org/greenplum-db/gpdb.svg?branch=master)](https://travis-ci.org/greenplum-db/gpdb) |
-**Zuul Regression Test On Arm**[![Zuul Regression Test On Arm](http://openlabtesting.org:15000/badge?project=greenplum-db%2Fgpdb&job_name=gpdb-installcheck-world-tests-on-arm64)](https://status.openlabtesting.org/builds/builds?project=greenplum-db%2Fgpdb&job_name=gpdb-installcheck-world-tests-on-arm64)
+**Zuul Regression Test On Arm** [![Zuul Regression Test Status](http://openlabtesting.org:15000/badge?project=greenplum-db%2Fgpdb)](https://status.openlabtesting.org/builds/builds?project=greenplum-db%2Fgpdb&job_name=gpdb-installcheck-world-tests-on-arm64)
+
 ----------------------------------------------------------------------
 
 ![Greenplum](logo-greenplum.png)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **Concourse Pipeline** [![Concourse Build Status](https://prod.ci.gpdb.pivotal.io/api/v1/teams/main/pipelines/gpdb_master/badge)](https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master) |
-**Travis Build** [![Travis Build Status](https://travis-ci.org/greenplum-db/gpdb.svg?branch=master)](https://travis-ci.org/greenplum-db/gpdb)
-
+**Travis Build** [![Travis Build Status](https://travis-ci.org/greenplum-db/gpdb.svg?branch=master)](https://travis-ci.org/greenplum-db/gpdb) |
+**Zuul Regression Test On Arm**[![Zuul Regression Test On Arm](http://openlabtesting.org:15000/badge?project=greenplum-db%2Fgpdb&job_name=gpdb-installcheck-world-tests-on-arm64)](https://status.openlabtesting.org/builds/builds?project=greenplum-db%2Fgpdb&job_name=gpdb-installcheck-world-tests-on-arm64)
 ----------------------------------------------------------------------
 
 ![Greenplum](logo-greenplum.png)


### PR DESCRIPTION
I have setup a periodic task in openlab env for gpdb.
It runs installcheck-world per UTC12:00 every day.

we can check the status with link https://status.openlabtesting.org/builds/builds?project=greenplum-db%2Fgpdb&job_name=gpdb-installcheck-world-tests-on-arm64
And get the necessary log in each build.
Also that build definition could be changed anytime. You guys can tell me the changes you want. Thanks

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
