### PR TITLE
gpcloud: Use destination buffer size in string copying

### DIFF
--- a/gpcontrib/gpcloud/src/s3key_reader.cpp
+++ b/gpcontrib/gpcloud/src/s3key_reader.cpp
@@ -217,9 +217,9 @@ uint64_t S3KeyReader::read(char* buf, uint64_t count) {
     do {
         // confirm there is no more available data, done with this file
         if (this->transferredKeyLen >= fileLen) {
-            if (!this->hasEol && !this->eolAppended) {
-                uint64_t eolLen = strlen(eolString);
-                strncpy(buf, eolString, eolLen);
+            uint64_t eolLen = strlen(eolString);
+            if (!this->hasEol && !this->eolAppended && eolLen <= count) {
+                strncpy(buf, eolString, count);
 
                 this->eolAppended = true;
 


### PR DESCRIPTION
When copying the EOL string into the destination buffer, the length of the
EOL string was passed to strncpy() rather than the length of the buffer.
This results in a warning in gcc8, and is prone to overflowing in case the
buffer is too small.
```
src/s3key_reader.cpp: In member function ‘virtual uint64_t S3KeyReader::read(char*, uint64_t)’:
src/s3key_reader.cpp:222:24: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
                 strncpy(buf, eolString, eolLen);
                 ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
src/s3key_reader.cpp:221:41: note: length computed here
                 uint64_t eolLen = strlen(eolString);
                                   ~~~~~~^~~~~~~~~~~
```
Fix by using the length of the buffer instead.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
