### PR TITLE
ic: implement proxy mode

### DIFF
--- a/configure
+++ b/configure
@@ -722,6 +722,7 @@ GREP
 with_apr_config
 with_libcurl
 with_rt
+with_libuv
 with_quicklz
 with_zstd
 with_libbz2
@@ -887,6 +888,7 @@ with_zlib
 with_libbz2
 with_zstd
 with_quicklz
+with_libuv
 with_rt
 with_libcurl
 with_apr_config
@@ -1593,6 +1595,7 @@ Optional Packages:
   --without-zstd          do not build with Zstandard
   --with-quicklz          build with QuickLZ support (requires quicklz
                           library)
+  --without-libuv         do not use libuv
   --without-rt            do not use Realtime Library
   --without-libcurl       do not use libcurl
   --with-apr-config=PATH  path to apr-1-config utility
@@ -8068,6 +8071,35 @@ fi
 
 
 #
+# libuv. Used for ic-proxy
+#
+
+
+
+# Check whether --with-libuv was given.
+if test "${with_libuv+set}" = set; then :
+  withval=$with_libuv;
+  case $withval in
+    yes)
+      :
+      ;;
+    no)
+      :
+      ;;
+    *)
+      as_fn_error $? "no argument expected for --with-libuv option" "$LINENO" 5
+      ;;
+  esac
+
+else
+  with_libuv=yes
+
+fi
+
+
+
+
+#
 # Realtime library
 #
 
@@ -11647,6 +11679,56 @@ _ACEOF
 
 else
   as_fn_error $? "quicklz library not found." "$LINENO" 5
+fi
+
+fi
+
+if test "$with_libuv" = yes; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for uv_default_loop in -luv" >&5
+$as_echo_n "checking for uv_default_loop in -luv... " >&6; }
+if ${ac_cv_lib_uv_uv_default_loop+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-luv  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char uv_default_loop ();
+int
+main ()
+{
+return uv_default_loop ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_uv_uv_default_loop=yes
+else
+  ac_cv_lib_uv_uv_default_loop=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_uv_uv_default_loop" >&5
+$as_echo "$ac_cv_lib_uv_uv_default_loop" >&6; }
+if test "x$ac_cv_lib_uv_uv_default_loop" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBUV 1
+_ACEOF
+
+  LIBS="-luv $LIBS"
+
+else
+  as_fn_error $? "libuv library not found." "$LINENO" 5
 fi
 
 fi

--- a/configure
+++ b/configure
@@ -722,7 +722,6 @@ GREP
 with_apr_config
 with_libcurl
 with_rt
-with_libuv
 with_quicklz
 with_zstd
 with_libbz2
@@ -742,6 +741,7 @@ with_perl
 with_tcl
 enable_thread_safety
 INCLUDES
+enable_ic_proxy
 HAVE_CXX14
 enable_gpcloud
 enable_mapreduce
@@ -863,6 +863,7 @@ enable_cassert
 enable_orca
 enable_mapreduce
 enable_gpcloud
+enable_ic_proxy
 enable_thread_safety
 with_tcl
 with_tclconfig
@@ -888,7 +889,6 @@ with_zlib
 with_libbz2
 with_zstd
 with_quicklz
-with_libuv
 with_rt
 with_libcurl
 with_apr_config
@@ -1546,6 +1546,8 @@ Optional Features:
   --disable-orca          disable ORCA optimizer
   --enable-mapreduce      enable Greenplum Mapreduce support
   --disable-gpcloud       disable gpcloud support
+  --enable-ic-proxy       enable interconnect proxy mode (requires libuv
+                          library)
   --disable-thread-safety disable thread-safety in client libraries
   --disable-largefile     omit support for large files
 
@@ -1595,7 +1597,6 @@ Optional Packages:
   --without-zstd          do not build with Zstandard
   --with-quicklz          build with QuickLZ support (requires quicklz
                           library)
-  --without-libuv         do not use libuv
   --without-rt            do not use Realtime Library
   --without-libcurl       do not use libcurl
   --with-apr-config=PATH  path to apr-1-config utility
@@ -7143,6 +7144,36 @@ $as_echo "#define HAVE_CXX14 1" >>confdefs.h
 fi # fi
 
 #
+# ic-proxy
+#
+
+
+# Check whether --enable-ic-proxy was given.
+if test "${enable_ic_proxy+set}" = set; then :
+  enableval=$enable_ic_proxy;
+  case $enableval in
+    yes)
+
+$as_echo "#define ENABLE_IC_PROXY 1" >>confdefs.h
+
+      ;;
+    no)
+      :
+      ;;
+    *)
+      as_fn_error $? "no argument expected for --enable-ic-proxy option" "$LINENO" 5
+      ;;
+  esac
+
+else
+  enable_ic_proxy=no
+
+fi
+
+
+
+
+#
 # Include directories
 #
 ac_save_IFS=$IFS
@@ -8064,35 +8095,6 @@ if test "${with_quicklz+set}" = set; then :
 
 else
   with_quicklz=no
-
-fi
-
-
-
-
-#
-# libuv. Used for ic-proxy
-#
-
-
-
-# Check whether --with-libuv was given.
-if test "${with_libuv+set}" = set; then :
-  withval=$with_libuv;
-  case $withval in
-    yes)
-      :
-      ;;
-    no)
-      :
-      ;;
-    *)
-      as_fn_error $? "no argument expected for --with-libuv option" "$LINENO" 5
-      ;;
-  esac
-
-else
-  with_libuv=yes
 
 fi
 
@@ -11683,7 +11685,7 @@ fi
 
 fi
 
-if test "$with_libuv" = yes; then
+if test "$enable_ic_proxy" = yes; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for uv_default_loop in -luv" >&5
 $as_echo_n "checking for uv_default_loop in -luv... " >&6; }
 if ${ac_cv_lib_uv_uv_default_loop+:} false; then :
@@ -11728,7 +11730,7 @@ _ACEOF
   LIBS="-luv $LIBS"
 
 else
-  as_fn_error $? "libuv library not found." "$LINENO" 5
+  as_fn_error $? "libuv library not found, it is required by --enable-ic-proxy." "$LINENO" 5
 fi
 
 fi

--- a/configure.in
+++ b/configure.in
@@ -1153,6 +1153,13 @@ PGAC_ARG_BOOL(with, quicklz, no,
 AC_SUBST(with_quicklz)
 
 #
+# libuv. Used for ic-proxy
+#
+PGAC_ARG_BOOL(with, libuv, yes,
+			  [do not use libuv])
+AC_SUBST(with_libuv)
+
+#
 # Realtime library
 #
 PGAC_ARG_BOOL(with, rt, yes,
@@ -1463,6 +1470,11 @@ fi
 if test "$with_quicklz" = yes; then
   AC_CHECK_LIB(quicklz, qlz_compress, [],
                [AC_MSG_ERROR([quicklz library not found.])])
+fi
+
+if test "$with_libuv" = yes; then
+  AC_CHECK_LIB(uv, uv_default_loop, [],
+               [AC_MSG_ERROR([libuv library not found.])])
 fi
 
 if test "$enable_spinlocks" = yes; then

--- a/configure.in
+++ b/configure.in
@@ -862,6 +862,15 @@ AS_IF([test "$enable_orca" = yes || test "$enable_gpcloud" = yes],
 ]) # fi
 
 #
+# ic-proxy
+#
+PGAC_ARG_BOOL(enable, ic-proxy, no,
+              [enable interconnect proxy mode (requires libuv library)],
+              [AC_DEFINE(ENABLE_IC_PROXY, 1,
+                         [Define to 1 to build with ic-proxy support (--enable-ic-proxy)])])
+AC_SUBST(enable_ic_proxy)
+
+#
 # Include directories
 #
 ac_save_IFS=$IFS
@@ -1151,13 +1160,6 @@ AC_SUBST(with_zstd)
 PGAC_ARG_BOOL(with, quicklz, no,
               [build with QuickLZ support (requires quicklz library)])
 AC_SUBST(with_quicklz)
-
-#
-# libuv. Used for ic-proxy
-#
-PGAC_ARG_BOOL(with, libuv, yes,
-			  [do not use libuv])
-AC_SUBST(with_libuv)
 
 #
 # Realtime library
@@ -1472,9 +1474,9 @@ if test "$with_quicklz" = yes; then
                [AC_MSG_ERROR([quicklz library not found.])])
 fi
 
-if test "$with_libuv" = yes; then
+if test "$enable_ic_proxy" = yes; then
   AC_CHECK_LIB(uv, uv_default_loop, [],
-               [AC_MSG_ERROR([libuv library not found.])])
+               [AC_MSG_ERROR([libuv library not found, it is required by --enable-ic-proxy.])])
 fi
 
 if test "$enable_spinlocks" = yes; then

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -220,6 +220,7 @@ enable_debug_extensions = @enable_debug_extensions@
 enable_orafce		= @enable_orafce@
 enable_mapreduce    = @enable_mapreduce@
 enable_gpcloud 	    = @enable_gpcloud@
+enable_ic_proxy     = @enable_ic_proxy@
 
 enable_tap_tests = @enable_tap_tests@
 
@@ -247,7 +248,6 @@ YAML_LIBS		= @YAML_LIBS@
 with_zstd 		= @with_zstd@
 with_quicklz		= @with_quicklz@
 EVENT_LIBS		= @EVENT_LIBS@
-with_libuv		= @with_libuv@
 
 
 ##########################################################################

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -247,6 +247,7 @@ YAML_LIBS		= @YAML_LIBS@
 with_zstd 		= @with_zstd@
 with_quicklz		= @with_quicklz@
 EVENT_LIBS		= @EVENT_LIBS@
+with_libuv		= @with_libuv@
 
 
 ##########################################################################

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -200,6 +200,15 @@ bool		gp_interconnect_log_stats = false;	/* emit stats at log-level */
 
 bool		gp_interconnect_cache_future_packets = true;
 
+/*
+ * format: dbid:content:address:port,dbid:content:address:port ...
+ * example: 1:-1:10.0.0.1:2000 2:0:10.0.0.2:2000 3:1:10.0.0.2:2001
+ *
+ * FIXME: at the moment:
+ * - the address must be specified as IP;
+ */
+char	   *gp_interconnect_proxy_addresses = NULL;
+
 int			Gp_udp_bufsize_k;	/* UPD recv buf size, in KB */
 
 #ifdef USE_ASSERT_CHECKING

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -535,6 +535,7 @@ makeCdbProcess(SegmentDatabaseDescriptor *segdbDesc)
 
 	process->pid = segdbDesc->backendPid;
 	process->contentid = segdbDesc->segindex;
+	process->dbid = qeinfo->config->dbid;
 	return process;
 }
 
@@ -628,6 +629,7 @@ getCdbProcessesForQD(int isPrimary)
 
 	proc->pid = MyProcPid;
 	proc->contentid = -1;
+	proc->dbid = qdinfo->config->dbid;
 
 	list = lappend(list, proc);
 	return list;

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -530,7 +530,8 @@ makeCdbProcess(SegmentDatabaseDescriptor *segdbDesc)
 
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
 		process->listenerPort = (segdbDesc->motionListener >> 16) & 0x0ffff;
-	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
+	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP ||
+			 Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
 		process->listenerPort = (segdbDesc->motionListener & 0x0ffff);
 
 	process->pid = segdbDesc->backendPid;
@@ -624,7 +625,8 @@ getCdbProcessesForQD(int isPrimary)
 
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
 		proc->listenerPort = (Gp_listener_port >> 16) & 0x0ffff;
-	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
+	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP ||
+			 Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
 		proc->listenerPort = (Gp_listener_port & 0x0ffff);
 
 	proc->pid = MyProcPid;

--- a/src/backend/cdb/motion/Makefile
+++ b/src/backend/cdb/motion/Makefile
@@ -15,4 +15,23 @@ override CPPFLAGS := -I$(libpq_srcdir) $(CPPFLAGS)
 OBJS = cdbmotion.o tupchunklist.o tupser.o  \
 	ic_common.o ic_tcp.o ic_udpifc.o htupfifo.o tupleremap.o
 
+ifeq ($(with_libuv),yes)
+# server
+OBJS += ic_proxy_bgworker.o
+OBJS += ic_proxy_main.o
+OBJS += ic_proxy_client.o
+OBJS += ic_proxy_peer.o
+OBJS += ic_proxy_router.o
+
+# backend
+OBJS += ic_proxy_backend.o
+
+# utils
+OBJS += ic_proxy_addr.o
+OBJS += ic_proxy_key.o
+OBJS += ic_proxy_packet.o
+OBJS += ic_proxy_pkt_cache.o
+OBJS += ic_proxy_iobuf.o
+endif  # with_libuv
+
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/cdb/motion/Makefile
+++ b/src/backend/cdb/motion/Makefile
@@ -15,7 +15,7 @@ override CPPFLAGS := -I$(libpq_srcdir) $(CPPFLAGS)
 OBJS = cdbmotion.o tupchunklist.o tupser.o  \
 	ic_common.o ic_tcp.o ic_udpifc.o htupfifo.o tupleremap.o
 
-ifeq ($(with_libuv),yes)
+ifeq ($(enable_ic_proxy),yes)
 # server
 OBJS += ic_proxy_bgworker.o
 OBJS += ic_proxy_main.o
@@ -32,6 +32,6 @@ OBJS += ic_proxy_key.o
 OBJS += ic_proxy_packet.o
 OBJS += ic_proxy_pkt_cache.o
 OBJS += ic_proxy_iobuf.o
-endif  # with_libuv
+endif  # enable_ic_proxy
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/cdb/motion/README.ic-proxy.md
+++ b/src/backend/cdb/motion/README.ic-proxy.md
@@ -1,0 +1,736 @@
+# IC Proxy
+
+ic-proxy is a new interconnect mode, it requires only one network connection
+between every two segments, so it consumes less total amount of connections and
+ports than the ic-tcp mode, and has better performance than ic-udp mode in
+high-latency network.
+
+## Installation
+
+ic-proxy is developed with libuv, the minimal supported libuv version is
+1.18.0, you could install it with rpm, apt, or build from the source code.
+
+ic-proxy is disabled by default, we could enable it with `configure
+--enable-ic-proxy`.
+
+After the installation we also need to setup the ic-proxy network, it is done
+by setting the GUC `gp_interconnect_proxy_addresses`, for example:
+
+    gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'1:-1:127.0.0.1:2000,2:0:127.0.0.1:2002,3:1:127.0.0.1:2003,4:2:127.0.0.1:2004,5:0:127.0.0.1:2005,6:1:127.0.0.1:2006,7:2:127.0.0.1:2007,8:-1:127.0.0.1:2001'"
+
+It contains information for all the master, standby, primary and mirror
+segments, for each segment it contains below information:
+
+    dbid:segid:ip:port[,dbid:segid:ip:port]
+
+It is important to specify the value as a single-quoted string, otherwise it
+will be parsed as an interger with invalid format.
+
+It is recommended to setup this GUC with a script like below:
+
+    #!/usr/bin/env bash
+    
+    : ${delta:=-5000}
+    
+    psql -tqA -d postgres -P pager=off -F ' ' \
+        -c "select dbid, content, port+$delta as port, address from gp_segment_configuration order by 1" \
+    | while read -r dbid content port addr; do
+        # below 2 lines convert the segment hostname to ip address, it is only
+        # an example, replace them with a proper way in your side
+        ip=$(host "$addr" | fgrep -v IPv6 | head -n1)
+        ip=${ip##* }
+
+        echo "$dbid:$content:$ip:$port"
+      done \
+    | paste -sd, - \
+    | xargs -rI'{}' gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'{}'"
+
+Restart the cluster for the GUC to take effect, a `gpstop -u` does not work.
+
+Now we are able to run queries in the ic-proxy mode by setting the GUC
+`gp_interconnect_type=proxy`, we could set it cluster level or session level,
+for example:
+
+    # launch a session in ic-proxy mode
+    PGOPTIONS="-c gp_interconnect_type=proxy" psql
+
+## Design
+
+### Logical Connection
+
+In ic-tcp mode, there are TCP connections between QEs (including QD).  Take an
+gather motion for example:
+
+    ┌    ┐
+    │    │  <=====  [ QE1 ]
+    │ QD │
+    │    │  <=====  [ QE2 ]
+    └    ┘
+
+In ic-udp mode, there are no TCP connections, but there are still logical
+connections: if two QEs communicate to each other, there is a logical
+connection:
+
+    ┌    ┐
+    │    │  <-----  [ QE1 ]
+    │ QD │
+    │    │  <-----  [ QE2 ]
+    └    ┘
+
+In ic-proxy mode, we also use the concept of logical connections:
+
+    ┌    ┐          ┌       ┐
+    │    │          │       │  <====>  [ proxy ]  <~~~~>  [ QE1 ]
+    │ QD │  <~~~~>  │ proxy │
+    │    │          │       │  <====>  [ proxy ]  <~~~~>  [ QE2 ]
+    └    ┘          └       ┘
+
+- in a N:1 gather motion there are N logical connections;
+- in a N:N redistribute / broadcast motion there are `N*N` logical connections;
+
+### Logical Connection Direction
+
+In ic-tcp and ic-udp modes every connection has a direction, in the above
+gather motion example, the QD has two incoming connections, each QE has one
+outgoing connection.  Besides the control messages, like the STOP in ic-tcp
+mode and ACK in ic-udp mode, DATA are always transfered from the sender to the
+receiver.
+
+In ic-proxy mode we do not distinguish the direction.  In theory DATA could be
+transfered bidirectionally, but the backends do not do this currently.
+
+### Logical Connection Identifier
+
+To identify a logical connection we need to know who is the sender and who is
+the receiver.  In ic-proxy we do not distinguish the direction of a logical
+connection, we use the names local and remote as the end points.  An end point
+is at least identified by the content id (the segindex) and the pid, so a
+logical connection could be identified by:
+
+    seg1,p1->seg2,p2
+
+However this is not enough to distinguish the logical connections of different
+subplans in a query.  We must also put the sender & receiver slice indices into
+consideration:
+
+    slice[a->b] seg1,p1->seg2,p2
+
+However consider that the backend processes can be used in different queries of
+the session, and the lifecycle of them are not strictly in-sync, we must also
+put the command id into the identifier:
+
+    cmd1,slice[a->b] seg1,p1->seg2,p2
+
+For debugging purpose we also put the session id in the identifier, however in
+practice it should never clash.
+
+When putting mirrors or standby into consideration, we must realize that a
+connection to seg1's primary is different with a connection to seg1's mirror,
+so we also need to put dbid into the identifier:
+
+    cmd1,slice[a->b] seg1,dbid3,p1->seg2,dbid5,p2
+
+### Load balancer
+TODO: a heavy-load logical connection should not consume all the bandwidth, and
+should not cause high-latency in other light-load ones, not implemented yet.
+
+### Flow control
+
+When a proxy receives a DATA from the remote side, it routes it to the
+corresponding backend.  If the backend is not receiving, the DATA needs to stay
+in a write queue.  If the sender sends the DATA faster than the receiver, the
+write queue could become too large and even cause OOM.
+
+A flow control is needed due to this.  In ic-tcp mode if the receiver is not
+receiving the sender can not send the DATA out; in ic-proxy mode flow control
+is done by dropping packets.  In ic-proxy mode we could not stop receiving
+because all the logical connections from the remote segment share the same
+proxy-proxy connection; we could not drop packets, because currently the
+proxy-proxy connection is tcp based, when we see a packet we already received
+it, no chance to drop.
+
+In ic-proxy mode we do flow control like this:
+- when too many DATA are pending in the write queue, the receiver sends a PAUSE
+  message to the sender; when the write queue is empty enough, the receiver
+  sends a RESUME to the sender;
+- when the sender receives a PAUSE from the sender, it stops receiving from its
+  backend; accordiningly, on a RESUME it continues receiving.
+
+This is a simple and naive and unstrict flow control, when a PAUSE is sent out
+the receiver could still receive more DATA until the receiver actually paused
+and the socket buffer is drained.  In practice it is good enough in both
+performance and memory usage.
+
+Note that we could not pause at any time.  In ic-proxy mode the backend sends
+DATA as ic-tcp packets, it will retry infinitely until a complete packet is
+sent, or being canceled.  So the sender proxy must only stop receiving from the
+backend on ic-tcp packet boundaries.  Similarly, the backend expects to receive
+only complete ic-tcp packets, it will also retry on incomplete ones.  If we do
+not follow this policy there would be deadlocks or infinite waiting.
+
+## Proxy-Backend Communication
+
+The backends (QD/QE) communicate with the proxy via IPC, domain socket is used
+in current implementation.
+
+### Packet
+
+To transfer data between proxies, a header must be added to form a packet.  In
+ic-proxy we use the `icpkthdr`, the one used by ic-udp.  The header is 64
+bytes.  TODO: as some fields are not actually used in ic-proxy mode, we might
+remove them in the future.
+
+Although it's possible to convert data of any length to a packet, we follow the
+same size limit of ic-udp, `gp_max_packet_size`, which is 8192 bytes by
+default.
+
+### Outgoing buffer
+
+On the other hand, to reduce the overhead of the packet header, the outgoing
+data in a logical connection is cached in an outgoing buffer, it's only sent in
+two conditions: 1) cached enough data to build a full-size packet, or 2) no
+more data to sent (the BYE message).
+
+TODO: maybe we could trigger the flush also with a timeout.
+
+### Incoming buffer
+
+As the data are transfered as packets, the proxy will have to save the incoming
+data in a incoming buffer, when a complete packet is received it's routed to
+the target backend.
+
+TODO: in fact as long as the header is completely received we could begin
+routing the data to the target backend, this could save some memory copying, as
+well as reduce the latency.
+
+### Control message
+
+Besides the data there are also control messages:
+- HELLO [backend -> proxy]: the first packet sent from a backend, contains the
+  logical connection key;
+- HELLO ACK [backend <- proxy]: once the proxy received the HELLO message it
+  sends back the HELLO ACK;
+- BYE [backend -> proxy -> proxy -> backend]: when a backend disconnects it
+  sends BYE to the proxy, the proxy will route it to the target backend.  It is
+  similar to the EOS in ic-tcp and ic-udp, however EOS will not trigger BYE,
+  maybe we should do this;
+
+TODO: there is also proxy-proxy HELLO message; we'd better separate the p2p
+messages with the b2p messages; introduce the PAUSE/RESUME;
+
+A control message is usually a header-only packet.
+
+TODO: at the moment data and control messages are handled separately, we could
+consider merge them.
+
+### Local destination
+
+Sometimes the source backend and target backend are on the same segment, in
+such a case the data is routed back directly.
+
+                          ┌       ┐
+    [ backend1 ]  <~~~~>  │       │
+                          │ proxy │
+    [ backend2 ]  <~~~~>  │       │
+                          └       ┘
+
+### Domain Socket
+
+By using domain socket as the IPC, the communication is like this:
+
+    backend  <~~~~>  proxy  <====>  proxy  <~~~~> backend
+
+When there are multiple logical connections, multiple domain socket connections
+need to be established between the backend and its proxy.  For example, for a
+2:1 gather motion, the logical connections are like this:
+
+    ┌    ┐
+    │    │  <---->  [ QE1 ]
+    │ QD │
+    │    │  <---->  [ QE2 ]
+    └    ┘
+
+Then the physical connections are like this:
+
+    ┌    ┐          ┌       ┐
+    │    │  <~~~~>  │       │  <====>  [ proxy ]  <~~~~>  [ QE1 ]
+    │ QD │          │ proxy │
+    │    │  <~~~~>  │       │  <====>  [ proxy ]  <~~~~>  [ QE2 ]
+    └    ┘          └       ┘
+
+Note that the proxies are all on different segments.
+
+We have to establish two domain socket connections between QD and proxy, this
+is to reuse the ic-tcp sending & receving logic.
+
+#### Establish the connection
+
+A registering process is needed to let the proxy knows who the backend is, this
+is similar to ic-tcp, but we call it HELLO in ic-proxy.
+
+    ┌───────────────────────┐                    ┌───────────────────────┐
+    │        backend        │                    │         proxy         │
+    ╞═══════════════════════╡                    ╞═══════════════════════╡
+    │ creates a socket      │                    │                       │
+    │                       │ >>                 │                       │
+    │                       │ >> connects        │                       │
+    │                       │ >>                 │                       │
+    │                       │                    │ accepts it as a       │
+    │                       │                    │ unidentified client   │
+    │                       │ >>                 │                       │
+    │                       │ >> sends HELLO     │                       │
+    │                       │ >>                 │                       │
+    │                       │                    │ receives the HELLO,   │
+    │                       │                    │ extracts the key,     │
+    │                       │                    │ binds the client      │
+    │                       │                 << │                       │
+    │                       │ sends HELLO ACK << │                       │
+    │                       │                 << │                       │
+    │ receives HELLO ACK    │                    │ ready to receive data │
+    └───────────────────────┘                    └───────────────────────┘
+
+Now the connection is established.
+
+#### Shutdown the connection
+
+When a backend shuts down the connection to the proxy, the shutdown process is
+triggered, its proxy will inform the remote proxy to shuts down the connection
+to the remote backend, too.  When a backend shuts down on both incoming and
+outgoing directions, the logical connection to the proxy can be closed.
+
+    ┌─────────┐          ┌─────────┐       ┌─────────┐          ┌─────────┐
+    │ backend │          │  proxy  │       │  proxy  │          │ backend │
+    └────┬────┘          └────┬────┘       └────┬────┘          └────┬────┘
+         │                    │                 │                    │
+         ├───── shutdown ────>│                 │                    │
+         │                    │                 │                    │
+         │                    ╞══════ BYE ═════>│                    │
+         │                    │                 │                    │
+         │                    │                 ├───── shutdown ────>│
+         │                    │                 │                    │
+         │                    │                 │<──── shutdown ─────┤
+         │                    │                 ├────────/  /────────┤
+         │                    │                 │                    │
+         │                    │<═════ BYE ══════╡                    │
+         │                    │                 │                    │
+         │<──── shutdown ─────┤                 │                    │
+         ├────────/  /────────┤                 │                    │
+         │                    │                 │                    │
+         ┴                    ┴                 ┴                    ┴
+
+A special case is that both backends are on the same segment, the BYE message
+is not needed:
+
+    ┌─────────┐          ┌─────────┐          ┌─────────┐
+    │ backend │          │  proxy  │          │ backend │
+    └────┬────┘          └────┬────┘          └────┬────┘
+         │                    │                    │
+         ├───── shutdown ────>│                    │
+         │                    │                    │
+         │                    ├───── shutdown ────>│
+         │                    │                    │
+         │                    │<──── shutdown ─────┤
+         │                    ├────────/  /────────┤
+         │                    │                    │
+         │<──── shutdown ─────┤                    │
+         ├────────/  /────────┤                    │
+         │                    │                    │
+         ┴                    ┴                    ┴
+
+#### spike: use single domain socket between QD and proxy
+
+It is possible to use only one single connection between QD and proxy:
+
+    ┌    ┐          ┌       ┐
+    │    │          │       │  <====>  [ proxy ]  <~~~~>  [ QE1 ]
+    │ QD │  <~~~~>  │ proxy │
+    │    │          │       │  <====>  [ proxy ]  <~~~~>  [ QE2 ]
+    └    ┘          └       ┘
+
+This requires several changes:
+- moving the outgoing buffer to QD: a buffer for outgoing data is always needed
+  to reduce the overhead of the packet header, now the QD must handle it by
+  itself; further more, the data sent to QE1 and QE2 can be interlaced, so a
+  separate outgoing buffer is needed for every destination;
+- adding a incoming buffer in QD: the proxy won't send data to a backend unless
+  a complete packet is received, it has incoming buffers to do this, then why a
+  backend needs a incoming buffer, too?  Because the data might not arrive in
+  the reading order.  When waiting for data from QE1 the QE2's data might
+  arrive earlier, these packets must be by cached QD itself;
+- adding a packet selector in QD: when a packet is received, QD needs to
+  identify the source of it manually from the packet header;
+
+So it might be better to stick with the current implementation, by establishing
+a domain socket connection for each logical connection we let the proxy handle
+all of these.
+
+#### spike: reuse domain socket connections
+
+In current implmentation the domain socket connections are established in
+`SetupInterconnect()` and closed in `TeardownInterconnect()`.  For OLTP queries
+it adds a significant overhead doing the connecting and registering logic.  In
+fact we are able to cache these connections, we only need to re-register on
+next query.
+
+### spike: Shared Memory Message Queue
+
+The domain socket approach is easy to implement, and can reuse most of the
+ic-tcp logic, however data has to be transfered 3 times to reach the target,
+this increases the latency significantly.  To improve this we could use a
+shared memory message queue.
+
+To use the shared memory based IPC we still need to handle below problems, like
+in any other implementations:
+
+1. the mapping between the logical connections and the source/destination
+   backends;
+2. packet queueing in every logical connection;
+3. block reading when incoming queue is empty;
+4. block sending when outgoing queue is full;
+
+So a general design is like this:
+
+For incoming data:
+
+                                          ┌     ┐         ┌       ┐
+    [ backend ]  <~~~~  [ queue ]  <~~~~  │     │         │       │
+                                          │ map │  <~~~~  │ proxy │
+    [ backend ]  <~~~~  [ queue ]  <~~~~  │     │         │       │
+                                          └     ┘         └       ┘
+
+For outgoing data, we could use a similar structure, but in different
+directions:
+
+                                          ┌     ┐         ┌       ┐
+    [ backend ]  ~~~~>  [ queue ]  ~~~~>  │     │         │       │
+                                          │ map │  ~~~~>  │ proxy │
+    [ backend ]  ~~~~>  [ queue ]  ~~~~>  │     │         │       │
+                                          └     ┘         └       ┘
+
+An easy implementation is to use a shmem hashtab as the map, and use a shmem
+ring buffer as the queue.
+
+The problem for shared memory is about waiting.  The proxy or the backend have
+to wait for multiple shared memory queues to become readable or writable, then
+if one of the queues becomes available, how could we tell which one is it
+efficiently?  We need to check all the queues one by one.  The good part for
+sockets is that epoll()/poll()/select() can be used to wait for multiple
+objects, but there is not such thing for locks.
+
+### spike: proxy pool
+
+The global view of the proxy network of one segment is like this:
+
+    ╔═════════════════════════╗
+    ║                         ║          ╔═════════════════════════╗
+    ║                         ║  <====>  ║           seg           ║
+    ║                         ║          ╚═════════════════════════╝
+    ║                         ║
+    ║                         ║          ╔═════════════════════════╗
+    ║                         ║  <====>  ║           seg           ║
+    ║                         ║          ╚═════════════════════════╝
+    ║           seg           ║
+    ║                         ║          ╔═════════════════════════╗
+    ║                         ║  <====>  ║           seg           ║
+    ║                         ║          ╚═════════════════════════╝
+    ║                         ║
+    ║                         ║          ╔═════════════════════════╗
+    ║                         ║  <====>  ║           seg           ║
+    ║                         ║          ╚═════════════════════════╝
+    ╚═════════════════════════╝
+
+If we look inside it, take a gather motion for example, it's like this:
+
+    ╔═════════════════════════╗
+    ║ ┌    ┐        ┌       ┐ ║          ╔═════════════════════════╗
+    ║ │    │ <~~~~> │       │ ║  <====>  ║ [ proxy ] <~~~~> [ QE ] ║
+    ║ │    │        │       │ ║          ╚═════════════════════════╝
+    ║ │    │        │       │ ║
+    ║ │    │        │       │ ║          ╔═════════════════════════╗
+    ║ │    │ <~~~~> │       │ ║  <====>  ║ [ proxy ] <~~~~> [ QE ] ║
+    ║ │    │        │       │ ║          ╚═════════════════════════╝
+    ║ │ QD │        │ proxy │ ║
+    ║ │    │        │       │ ║          ╔═════════════════════════╗
+    ║ │    │ <~~~~> │       │ ║  <====>  ║ [ proxy ] <~~~~> [ QE ] ║
+    ║ │    │        │       │ ║          ╚═════════════════════════╝
+    ║ │    │        │       │ ║
+    ║ │    │        │       │ ║          ╔═════════════════════════╗
+    ║ │    │ <~~~~> │       │ ║  <====>  ║ [ proxy ] <~~~~> [ QE ] ║
+    ║ └    ┘        └       ┘ ║          ╚═════════════════════════╝
+    ╚═════════════════════════╝
+
+Each segment only has one proxy process, each process can use at most 100% of
+one cpu core, then can the proxy process become the performance bottleneck?
+
+The answer is yes.  When running the select-only test with `pgbench -S` on a
+8x32 cluster (8 hosts, 32 segments per host) on GCP, the master proxy bgworker
+process will reach 100% cpu usage at concurrency=15, the overall cpu usage of
+all the QD processes are 25%, which indicates the master proxy process is the
+bottleneck.
+
+To leverage more cpu cores we could consider using a proxy pool, like this:
+
+    ╔═════════════════════════╗
+    ║ ┌    ┐        ┌       ┐ ║          ╔═════════════════════════╗
+    ║ │    │ <~~~~> │       │ ║  <====>  ║ [ proxy ] <~~~~> [ QE ] ║
+    ║ │    │        │       │ ║          ╚═════════════════════════╝
+    ║ │    │        │ proxy │ ║
+    ║ │    │        │       │ ║          ╔═════════════════════════╗
+    ║ │    │ <~~~~> │       │ ║  <====>  ║ [ proxy ] <~~~~> [ QE ] ║
+    ║ │    │        └       ┘ ║          ╚═════════════════════════╝
+    ║ │ QD │                  ║
+    ║ │    │        ┌       ┐ ║          ╔═════════════════════════╗
+    ║ │    │ <~~~~> │       │ ║  <====>  ║ [ proxy ] <~~~~> [ QE ] ║
+    ║ │    │        │       │ ║          ╚═════════════════════════╝
+    ║ │    │        │ proxy │ ║
+    ║ │    │        │       │ ║          ╔═════════════════════════╗
+    ║ │    │ <~~~~> │       │ ║  <====>  ║ [ proxy ] <~~~~> [ QE ] ║
+    ║ └    ┘        └       ┘ ║          ╚═════════════════════════╝
+    ╚═════════════════════════╝
+
+In this example, the pool size is 2, the `proxy[0]` only connects to
+`seg[0~1]`, the `proxy[1]` only connects to `seg[2~3]`.  In general if the pool
+size is K, then there are K proxy bgworkers:
+- the `proxy[0]` connects to `seg[0 ~ K-1]`;
+- the `proxy[i]` connects to `seg[i*K ~ (i+1)K-1]`.
+
+When the remote content id of a logical connection is X, the backend needs to
+connect to the `proxy[X / K]`, and sends the data through the `peer[X % K]` of
+it.
+
+With above two charts we could also see that, the flow count is unrelative to
+the pool size K, it's because that there is always only 1 connection tween 2
+segments.
+
+The port count is changed, there is still at most `N-1` incoming connections,
+but it needs to listen on K ports.  So in worst case, where `K=N-1`, the total
+needed port count is doubled, but that should still be acceptable, and in
+theory we do not need K to be large as that, in our example, let `K=4` is
+enough to resolve the bottleneck.
+
+Specifically, when `K=1` it's exactly the same with our original design, when
+`K=N-1`, where N is the count of segments (including the master), a proxy
+bgworker only connects to one remote segment:
+
+    ╔═════════════════════════╗
+    ║ ┌    ┐        ┌       ┐ ║          ╔═════════════════════════╗
+    ║ │    │ <~~~~> │ proxy │ ║  <====>  ║ [ proxy ] <~~~~> [ QE ] ║
+    ║ │    │        └       ┘ ║          ╚═════════════════════════╝
+    ║ │    │                  ║
+    ║ │    │        ┌       ┐ ║          ╔═════════════════════════╗
+    ║ │    │ <~~~~> │ proxy │ ║  <====>  ║ [ proxy ] <~~~~> [ QE ] ║
+    ║ │    │        └       ┘ ║          ╚═════════════════════════╝
+    ║ │ QD │                  ║
+    ║ │    │        ┌       ┐ ║          ╔═════════════════════════╗
+    ║ │    │ <~~~~> │ proxy │ ║  <====>  ║ [ proxy ] <~~~~> [ QE ] ║
+    ║ │    │        └       ┘ ║          ╚═════════════════════════╝
+    ║ │    │                  ║
+    ║ │    │        ┌       ┐ ║          ╔═════════════════════════╗
+    ║ │    │ <~~~~> │ proxy │ ║  <====>  ║ [ proxy ] <~~~~> [ QE ] ║
+    ║ └    ┘        └       ┘ ║          ╚═════════════════════════╝
+    ╚═════════════════════════╝
+
+When `K=N-1`, there is an extra benefit.  We do not need a proxy-proxy listener
+in this case, when establishing a proxy-proxy connection between segment X and
+Y, we could do it in a similar way as WalRep:
+
+1. segment X launchs a proxy process X;
+2. X connects to the postmaster of segment Y;
+3. the postmaster Y accepts the connection and forks the proxy process Y;
+
+So we do not need to consume the listener ports.
+
+However launching so many proxy bgworkers might not be a good idea.
+
+## Proxy-Proxy Communication
+
+In a Greenplum cluster there is one master segment and N primary segments,
+there is a connection between every two of them, all these connections make the
+proxy network.  In current implementation the proxy-proxy communication is via
+TCP, but it is possible to switch to something like QUIC or udpifc.
+
+### Setup
+
+To setup the proxy network, every proxy process connects to all the other
+segments on startup, obviously this will result in two connections between
+segment I and segment J: `I ==> J` and `J ==> I`.
+
+It is not really a problem to have two connections between two segments, but we
+could solve it easily: segment I only connects to segment J if `I < J`.  It is
+simply enough and is what we used initially, but is it good enough?
+
+For any solution it must be able to handle several cases:
+
+0. establish the connections between proxies;
+1. if the a proxy is relaunched, due to crash or critical errors, the
+   connections between it and all the other segments must be re-established;
+2. if the corresponding standby, or mirror, is launched, the standby proxy must
+   be able to establish the connections to all the other segments, too,
+   furthermore, the connections with the previous master proxy must be replaced
+   with the standby ones;
+
+So we only need to improve our simple solution slightly: a timer is put in the
+proxy bgworker, it is triggered every second.  On every trigger the proxy
+attempts to connect to every other proxies as long as `I < J`, no matter the
+remote is a primary or mirror; an existing connection will not be reconnected
+unless the previous connection is dropped, which usually means the remote is
+down or crashed.
+
+The solution can handle mirror promotion and recover from proxy crash
+automatically with a low enough latency, the only bad part is that it needs to
+retry to mirror connections again and again.
+
+### Standby and Mirror
+
+The ic-proxy bgworker processes are launched on all the master and primary
+segments, as long as a ic-proxy bgworker is launched it listens to its port,
+and connects to other proxies.  The master and standby proxies will listen on
+different ports, so they can co-exist even if they are on the same host; the
+same to primary and mirror proxies.
+
+By doing so, the ic-proxy does not need to care about the standby activation
+and mirror promotion:
+
+- if a standby or mirror is activated, its proxy bgworker is launched
+  automatically, then the proxy-proxy connections are established
+  accordiningly;
+- if a primary segment is marked as down it will stop its proxy bgworker
+  automatically;
+- a motion slice contains information about which dbid it communicates to, the
+  primary or the mirror, so the packets will be routed to the primary or mirror
+  proxies accordiningly;
+
+In summary, a proxy bgworker's life cycle is controled by the postmaster during
+the standby activation and mirror promotion, the bgworker itself can establish
+the proxy-proxy connections unconditionally.
+
+### Cluster Expansion
+
+A cluster can be expanded online with the `gpexpand` command, however the
+ic-proxy does not support online expansion at the moment: the GUC
+`gp_interconnect_proxy_addresses` must be updated to include the information
+for the new segments, however changes to this GUC only take effect after a
+cluster restart.
+
+TODO: make below changes to support online expansion:
+
+1. let the `gpexpand` utility updates the `gp_interconnect_proxy_addresses`
+   automatically;
+2. let the `gp_interconnect_proxy_addresses` be able to be reloaded without a
+   cluster restart;
+ 
+## Misc
+
+### Packet types
+
+#### Chunk
+
+```C
+struct TupleChunkHeader
+{
+    uint16      size;
+    uint16      type;       /* TupleChunkType */
+};
+```
+
+- This struct is not defined, only described in `"cdb/tupchunk.h"`;
+- Chunks are always aligned to 4 bytes;
+- The `size` does not contain the header itself;
+- The header and the body are always in native byte order, not in network byte
+  order;
+- There are some helpers like `GetChunkDataSize()`, they are implemented via
+  `memcpy()` to support the non-aligned case, but the performance is bad;
+
+Chunks can be very small, so are usually transferred in batches, as ic-tcp or
+ic-udp packets.
+
+#### ic-tcp packet
+
+```C
+struct TcpPacketHeader
+{
+    uint32      length;
+};
+```
+
+- The struct is not defined, only described in `"cdb/ml_ipc.h"`;
+- The `length` is the total size, including the header itself;
+- The max packet size is `Gp_max_packet_size`;
+- A ic-tcp packet only contains complete chunks;
+
+### ic-udp packet
+
+```C
+typedef struct icpkthdr
+{
+	int32		motNodeId;
+
+	/*
+	 * three pairs which seem useful for identifying packets.
+	 *
+	 * MPP-4194:
+	 * It turns out that these can cause collisions; but the
+	 * high bit (1<<31) of the dstListener port is now used
+	 * for disambiguation with mirrors.
+	 */
+	int32		srcPid;
+	int32		srcListenerPort;
+
+	int32		dstPid;
+	int32		dstListenerPort;
+
+    int32       sessionId;
+    uint32      icId;
+
+    int32       recvSliceIndex;
+    int32       sendSliceIndex;
+	int32       srcContentId;
+	int32		dstContentId;
+
+	/* MPP-6042: add CRC field */
+	uint32		crc;
+
+	/* packet specific info */
+	int32		flags;
+	int32		len;
+
+    uint32      seq;
+    uint32      extraSeq;
+} icpkthdr;
+```
+
+- Defined in `"cdb/cdbinterconnect.h"`;
+- The header is 64 bytes;
+- The `len` is the total size, including the header itself;
+- The max packet size is `Gp_max_packet_size`;
+- A udp-tcp packet only contains complete chunks;
+
+### ic-proxy packet
+
+```C
+struct ICProxyPkt
+{
+	uint16		len;
+	uint16		type;
+
+	int16		srcContentId;
+	uint16		srcDbid;
+	int32		srcPid;
+
+	int16		dstContentId;
+	uint16		dstDbid;
+	int32		dstPid;
+
+	int32		sessionId;
+	uint32		commandId;
+	int16		sendSliceIndex;
+	int16		recvSliceIndex;
+};
+```
+
+The ic-proxy packet is similar to the ic-udp one, the essential different is
+that the ic-proxy packet also stores the content ids in the packet.  The field
+widths are also tailered so few overhead is added, the ic-proxy packet header
+is only 32 bytes.
+
+ vi: et ai :

--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -165,7 +165,8 @@ createMotionLayerState(int maxMotNodeID)
 
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
 		Gp_max_tuple_chunk_size = Gp_max_packet_size - sizeof(struct icpkthdr) - TUPLE_CHUNK_HEADER_SIZE;
-	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
+	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP ||
+			 Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
 		Gp_max_tuple_chunk_size = Gp_max_packet_size - PACKET_HEADER_SIZE - TUPLE_CHUNK_HEADER_SIZE;
 
 	/*

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -97,7 +97,8 @@ RecvTupleChunk(MotionConn *conn, ChunkTransportState *transportStates)
 	uint32		tcSize;
 	int			bytesProcessed = 0;
 
-	if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
+	if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP ||
+		Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
 	{
 		/* read the packet in from the network. */
 		readPacket(conn, transportStates);
@@ -164,7 +165,8 @@ RecvTupleChunk(MotionConn *conn, ChunkTransportState *transportStates)
 		 * we only check for interrupts here when we don't have a guaranteed
 		 * full-message
 		 */
-		if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
+		if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP ||
+			Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
 		{
 			if (tcSize >= conn->msgSize)
 			{
@@ -236,7 +238,8 @@ InitMotionLayerIPC(void)
 
 	/* activated = false; */
 
-	if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
+	if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP ||
+		Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
 		InitMotionTCP(&TCP_listenerFd, &tcp_listener);
 	else if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
 		InitMotionUDPIFC(&UDP_listenerFd, &udp_listener);
@@ -253,7 +256,8 @@ CleanUpMotionLayerIPC(void)
 	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 		elog(DEBUG3, "Cleaning Up Motion Layer IPC...");
 
-	if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
+	if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP ||
+		Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
 		CleanupMotionTCP();
 	else if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
 		CleanupMotionUDPIFC();
@@ -533,7 +537,8 @@ SetupInterconnect(EState *estate)
 
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
 		SetupUDPIFCInterconnect(estate);
-	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
+	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP ||
+			 Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
 		SetupTCPInterconnect(estate);
 	else
 		elog(ERROR, "unsupported expected interconnect type");
@@ -557,7 +562,8 @@ TeardownInterconnect(ChunkTransportState *transportStates, bool hasErrors)
 	{
 		TeardownUDPIFCInterconnect(transportStates, hasErrors);
 	}
-	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
+	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP ||
+			 Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
 	{
 		TeardownTCPInterconnect(transportStates, hasErrors);
 	}

--- a/src/backend/cdb/motion/ic_proxy.h
+++ b/src/backend/cdb/motion/ic_proxy.h
@@ -1,0 +1,57 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy.h
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef IC_PROXY_H
+#define IC_PROXY_H
+
+#include "postgres.h"
+
+#include "cdb/cdbinterconnect.h"
+#include "cdb/cdbvars.h"
+#include "nodes/pg_list.h"
+#include "postmaster/postmaster.h"
+
+#define IC_PROXY_BACKLOG 1024
+#define IC_PROXY_INVALID_CONTENT ((uint16) -2)
+#define IC_PROXY_INVALID_DBID ((int16) 0)
+#define IC_PROXY_TRESHOLD_PAUSE 4
+#define IC_PROXY_TRESHOLD_RESUME 2
+
+#ifndef IC_PROXY_LOG_LEVEL
+#define IC_PROXY_LOG_LEVEL LOG
+#endif
+
+#define ic_proxy_alloc(size) palloc(size)
+#define ic_proxy_free(ptr) pfree(ptr)
+#define ic_proxy_new(type) ic_proxy_alloc(sizeof(type))
+
+#define ic_proxy_log(elevel, msg...) do { \
+	if (elevel >= IC_PROXY_LOG_LEVEL) \
+	{ \
+		elog(elevel, msg); \
+	} \
+} while (0)
+
+/*
+ * Build the domain socket path.
+ *
+ * Every proxy on the same host must use a different path, this is important to
+ * let proxies from different segments or even different clusters to coexist.
+ *
+ * This is ensured by including the postmaster port in the path.
+ */
+static inline void
+ic_proxy_build_server_sock_path(char *buf, size_t bufsize)
+{
+	snprintf(buf, bufsize, "/tmp/.s.proxy.%d", PostPortNumber);
+}
+
+#endif   /* IC_PROXY_H */

--- a/src/backend/cdb/motion/ic_proxy_addr.c
+++ b/src/backend/cdb/motion/ic_proxy_addr.c
@@ -1,0 +1,156 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_addr.c
+ *
+ *    Interconnect Proxy Addresses
+ *
+ * Maintain the address information of all the proxies, which is set by the GUC
+ * gp_interconnect_proxy_addresses.
+ *
+ * FIXME: currently that GUC can not be reloaded with "gpstop -u", so we must
+ * restart the cluster to update the setting.  This causes problems during
+ * online expansion, when new segments are added to the cluster, we must update
+ * this GUC to include their information, so until the cluster is restarted all
+ * the ic-proxy mode queries will hang.
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+
+#include <uv.h>
+
+#include "ic_proxy.h"
+#include "ic_proxy_addr.h"
+
+
+/*
+ * List<ICProxyAddr *>, the addresses list.
+ */
+List	   *ic_proxy_addrs;
+
+/*
+ * Reload the addresses from the GUC gp_interconnect_proxy_addresses.
+ *
+ * The caller is responsible to load the up-to-date setting of that GUC by
+ * calling ProcessConfigFile().
+ */
+void
+ic_proxy_reload_addresses(void)
+{
+	int			max_content_id;
+	int			uniq_content_count;
+
+	/* reset the old addresses */
+	{
+		ListCell   *cell;
+
+		foreach(cell, ic_proxy_addrs)
+		{
+			ic_proxy_free(lfirst(cell));
+		}
+
+		list_free(ic_proxy_addrs);
+		ic_proxy_addrs = NIL;
+	}
+
+	max_content_id = IC_PROXY_INVALID_CONTENT;
+
+	/* parse the new addresses */
+	{
+		int			size = strlen(gp_interconnect_proxy_addresses) + 1;
+		char	   *buf;
+		FILE	   *f;
+		int			dbid;
+		int			content;
+		int			port;
+		char		ip[HOST_NAME_MAX];
+
+		buf = ic_proxy_alloc(size);
+		memcpy(buf, gp_interconnect_proxy_addresses, size);
+
+		f = fmemopen(buf, size, "r");
+
+		/*
+		 * format: dbid:segid:ip:port
+		 */
+		while (fscanf(f, "%d:%d:%[0-9.]:%d,", &dbid, &content, ip, &port) == 4)
+		{
+			ICProxyAddr *addr = ic_proxy_new(ICProxyAddr);
+			int			ret;
+
+			addr->dbid = dbid;
+			addr->content = content;
+
+			ic_proxy_log(LOG, "ic-proxy-server: addr: seg%d,dbid%d: %s:%d",
+						 content, dbid, ip, port);
+
+			ret = uv_ip4_addr(ip, port, (struct sockaddr_in *) addr);
+			if (ret < 0)
+				ic_proxy_log(WARNING,
+							 "ic-proxy-server: invalid address: seg%d,dbid%d: %s:%d: %s",
+							 content, dbid, ip, port, uv_strerror(ret));
+
+			ic_proxy_addrs = lappend(ic_proxy_addrs, addr);
+
+			max_content_id = Max(max_content_id, content);
+		}
+
+		fclose(f);
+		ic_proxy_free(buf);
+	}
+
+	/*
+	 * We have found the max content id, convert it to a count by adding 2, as
+	 * content ids are counted from -1.
+	 */
+	uniq_content_count = max_content_id + 2;
+
+	ic_proxy_log(LOG, "ic-proxy-server: %d unique content ids",
+				 uniq_content_count);
+}
+
+/*
+ * Get the port of current segment.
+ *
+ * Return -1 if cannot find the port.
+ */
+int
+ic_proxy_get_my_port(void)
+{
+	ListCell   *cell;
+	int			dbid = GpIdentity.dbid;
+
+	foreach(cell, ic_proxy_addrs)
+	{
+		ICProxyAddr *addr = lfirst(cell);
+
+		if (addr->dbid == dbid)
+			return ic_proxy_addr_get_port(addr);
+	}
+
+	ic_proxy_log(WARNING, "ic-proxy-addr: cannot get my port");
+	return -1;
+}
+
+/*
+ * Get the port from an address.
+ *
+ * Return -1 if cannot find the port.
+ */
+int
+ic_proxy_addr_get_port(const ICProxyAddr *addr)
+{
+	if (addr->addr.ss_family == AF_INET)
+		return ntohs(((struct sockaddr_in *) addr)->sin_port);
+	else if (addr->addr.ss_family == AF_INET6)
+		return ntohs(((struct sockaddr_in6 *) addr)->sin6_port);
+
+	ic_proxy_log(WARNING,
+				 "ic-proxy-addr: invalid address family %d for seg%d,dbid%d",
+				 addr->addr.ss_family, addr->content, addr->dbid);
+	return -1;
+}

--- a/src/backend/cdb/motion/ic_proxy_addr.h
+++ b/src/backend/cdb/motion/ic_proxy_addr.h
@@ -1,0 +1,39 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_addr.h
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef IC_PROXY_ADDR_H
+#define IC_PROXY_ADDR_H
+
+
+typedef struct ICProxyAddr ICProxyAddr;
+
+
+struct ICProxyAddr
+{
+	struct sockaddr_storage addr;
+
+	int			dbid;
+	int			content;
+};
+
+
+/*
+ * List<ICProxyAddr *>
+ */
+extern List		   *ic_proxy_addrs;
+
+
+extern void ic_proxy_reload_addresses(void);
+extern int ic_proxy_get_my_port(void);
+extern int ic_proxy_addr_get_port(const ICProxyAddr *addr);
+
+
+#endif   /* IC_PROXY_ADDR_H */

--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -1,0 +1,141 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_backend.c
+ *
+ *    Interconnect Proxy Backend
+ *
+ * The functions in this file are all called by the backends.
+ *
+ * A backend and a client is the 2 end points of a domain socket, the backend
+ * is in the QD/QE backend process, the client is in the proxy bgworker
+ * process.
+ *
+ * TODO: at the moment the ic-tcp backend logic is reused by ic-proxy, in fact
+ * the ic-proxy logic just lives inside ic_tcp.c, but in the future we may want
+ * to build the ic-proxy logic independently, the potential benefits are:
+ * - concurrent connection establishments: in current ic-tcp based
+ *   implementation we establish the connections to the proxy one by one, it
+ *   causes higher latency; in the new logic we could do them concurrently;
+ * - send / receive as ICProxyPkt directly: ic-tcp sends with a 4-byte header,
+ *   in the proxy bgworker we need to unpack them and repack them into
+ *   ICProxyPkt packets; the receiver needs to do it reversely; if we send /
+ *   receive as ICProxyPkt directly we could reduce the parsing and memory
+ *   copying;
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "cdb/cdbgang.h"
+#include "cdb/cdbvars.h"
+#include "executor/execdesc.h"
+
+#include "ic_proxy.h"
+#include "ic_proxy_backend.h"
+#include "ic_proxy_packet.h"
+#include "ic_proxy_key.h"
+
+#include <unistd.h>
+
+/*
+ * Connect to a proxy and finish the hand shaking.
+ *
+ * FIXME: this function is to make the debugging easier, however as it
+ * establishes the connection, as well as the registeration, one by one, it has
+ * bad performance.
+ */
+int
+ic_proxy_backend_connect(ChunkTransportStateEntry *pEntry, MotionConn *conn)
+{
+	struct sockaddr_un addr;
+	ICProxyKey	key;
+	ICProxyPkt	pkt;
+	int			fd;
+	int			ret;
+	char	   *data;
+	int			size;
+
+	ic_proxy_key_init(&key,								/* key */
+					  gp_session_id,					/* sessionId */
+					  gp_command_count,					/* commandId */
+					  pEntry->sendSlice->sliceIndex,	/* sendSliceIndex */
+					  pEntry->recvSlice->sliceIndex,	/* recvSliceIndex */
+					  GpIdentity.segindex,				/* localContentId */
+					  GpIdentity.dbid,					/* localDbid */
+					  MyProcPid,						/* localPid */
+					  conn->cdbProc->contentid,			/* remoteContentId */
+					  conn->cdbProc->dbid,				/* remoteDbid */
+					  conn->cdbProc->pid);				/* remotePid */
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	ic_proxy_build_server_sock_path(addr.sun_path, sizeof(addr.sun_path));
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd == PGINVALID_SOCKET)
+		ic_proxy_log(ERROR, "ic-proxy-backend: fail to create a socket: %m");
+
+	do
+	{
+		ret = connect(fd, (struct sockaddr *) &addr, sizeof(addr));
+
+		if (ret == -1 && errno == EINTR)
+			continue;
+
+		if (ret == -1)
+		{
+			ic_proxy_log(LOG, "ic-proxy-backend: fail to connect to %s: %m",
+						 addr.sun_path);
+			pg_usleep(100000);
+			continue;
+		}
+	} while (ret == -1);
+
+	ic_proxy_message_init(&pkt, IC_PROXY_MESSAGE_HELLO, &key);
+
+	/* send HELLO */
+	data = (char *) &pkt;
+	size = pkt.len;
+	while (size > 0)
+	{
+		do
+		{
+			ret = send(fd, data, size, 0);
+		} while (ret == -1 && errno == EINTR);
+		if (ret == -1)
+			ic_proxy_log(ERROR, "ic-proxy-backend: fail to send HELLO: %m");
+		data += ret;
+		size -= ret;
+	}
+
+	/* recv HELLO ACK */
+	data = (char *) &pkt;
+	size = sizeof(pkt);
+	while (size > 0)
+	{
+		do
+		{
+			ret = recv(fd, data, size, 0);
+		} while (ret == -1 && errno == EINTR);
+		if (ret == -1)
+			ic_proxy_log(ERROR, "ic-proxy-backend: fail to recv HELLO ACK: %m");
+		else if (ret == 0)
+		{
+			ic_proxy_log(LOG, "ic-proxy-backend: the peer is not ready");
+
+			shutdown(fd, SHUT_RDWR);
+			close(fd);
+			fd = -1;
+			break;
+		}
+		data += ret;
+		size -= ret;
+	}
+
+	return fd;
+}

--- a/src/backend/cdb/motion/ic_proxy_backend.h
+++ b/src/backend/cdb/motion/ic_proxy_backend.h
@@ -1,0 +1,22 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_backend.h
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef IC_PROXY_BACKEND_H
+#define IC_PROXY_BACKEND_H
+
+#include "postgres.h"
+
+#include "cdb/cdbinterconnect.h"
+
+extern int ic_proxy_backend_connect(ChunkTransportStateEntry *pEntry,
+									MotionConn *conn);
+
+#endif   /* IC_PROXY_BACKEND_H */

--- a/src/backend/cdb/motion/ic_proxy_bgworker.c
+++ b/src/backend/cdb/motion/ic_proxy_bgworker.c
@@ -1,0 +1,37 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_bgworker.c
+ *
+ *    Interconnect Proxy Background Worker
+ *
+ * This is only a wrapper, the actual main loop is in ic_proxy_main.c .
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "storage/ipc.h"
+
+#include "cdb/ic_proxy_bgworker.h"
+#include "ic_proxy_server.h"
+
+bool
+ICProxyStartRule(Datum main_arg)
+{
+	return true;
+}
+
+/*
+ * ICProxyMain
+ */
+void
+ICProxyMain(Datum main_arg)
+{
+	/* main loop */
+	proc_exit(ic_proxy_server_main());
+}

--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -1,0 +1,1405 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_client.c
+ *
+ *    Interconnect Proxy Client
+ *
+ * A client lives in the proxy bgworker and connects to a backend, each logical
+ * connection needs a client, so there could be multiple connections between
+ * one backend process and the proxy bgworker, the same amount of clients are
+ * needed, too.
+ *
+ * A local client communicates to exact one remote client, a special case is
+ * that both clients are on the same segment, in which case both are called
+ * loopback clients.
+ *
+ * A client is created on a new backend connection, it is registered after the
+ * hand shaking.  The hand shaking is made between the backend and the client,
+ * this is different with the ic-tcp or ic-udp modes, they do the hand shaking
+ * between the local and remote backends.
+ *
+ * A client is identified with a key, every packet also contains such a key, so
+ * when a packet is received we could know which client to route it to.
+ *
+ * Packets can arrive before the client registration, in such a case a
+ * placeholder is registered to hold the early coming packets.  Once the client
+ * finishes the hand shaking it replaces the placeholder and handles these
+ * early packets in the arriving order.
+ *
+ * The interconnect treats the motion sender and the receiver differently,
+ * however in ic-proxy we do not distinguish the sender client or the receiver
+ * client.  Sometimes we will mention the words sender or receiver, they only
+ * have logical meanings, and are not marked in the code.
+ *
+ * Sometimes a backend receives slower than the sender, so more and more
+ * packets are put in the writing queue.  To prevent it consuming too many
+ * memory we have a simple flow control.  The receiver client sends a PAUSE
+ * request to the sender, the sender pauses reading from its backend, so the
+ * data flow is paused.  Once the receiver consumes some packets and the
+ * writing queue is empty enough the receiver sends a RESUME request to the
+ * sender, the sender resumes reading from its backend, so the data flow is
+ * resumed.
+ *
+ * Packets are routed in 2 directions, c2p and p2c:
+ * - c2p packets are routed from a client to a peer;
+ * - p2c packets are routed from a peer to a client;
+ * - there is no term "c2c" because loopback packets are also handled as c2p
+ *   by the sender and p2c by the receiver;
+ *
+ * The directions are not named as incoming and outgoing because the they can
+ * lead to confusing descriptions: "a client receives an outgoing packet from
+ * its backend", or, "a client sends an incoming packet to its backend".
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "ic_proxy_server.h"
+#include "ic_proxy_pkt_cache.h"
+#include "ic_proxy_router.h"
+
+#include <uv.h>
+
+
+typedef struct ICProxyClientEntry ICProxyClientEntry;
+
+
+/*
+ * TODO: a client only has one target, it's either a peer, or a loopback
+ * client, there is no need to lookup it every time, the loopback client lookup
+ * is expansive.
+ *
+ * We used to save the target since the very beginning, however it was buggy on
+ * placeholders, so we disabled it.  If we want to reenable it be careful on
+ * below notes:
+ * - a peer can be a placeholder;
+ * - a loopback client can be a placeholder;
+ * - ibuf/obuf functions are not reentrantable, delayed queue is necessary;
+ */
+struct ICProxyClient
+{
+	uv_pipe_t	pipe;			/* the libuv handle */
+
+	ICProxyKey	key;			/* the key to identify a client */
+
+	uint32		state;			/* or'ed bits of below ones */
+#define IC_PROXY_CLIENT_STATE_RECEIVED_HELLO  0x00000001
+#define IC_PROXY_CLIENT_STATE_SENT_HELLO_ACK  0x00000002
+#define IC_PROXY_CLIENT_STATE_REGISTERED      0x00000004
+#define IC_PROXY_CLIENT_STATE_PLACEHOLDER     0x00000008
+#define IC_PROXY_CLIENT_STATE_C2P_SHUTTING    0x00000010
+#define IC_PROXY_CLIENT_STATE_C2P_SHUTTED     0x00000020
+#define IC_PROXY_CLIENT_STATE_P2C_SHUTTING    0x00000040
+#define IC_PROXY_CLIENT_STATE_P2C_SHUTTED     0x00000080
+#define IC_PROXY_CLIENT_STATE_CLOSING         0x00000100
+#define IC_PROXY_CLIENT_STATE_CLOSED          0x00000200
+#define IC_PROXY_CLIENT_STATE_PAUSING         0x00000400
+#define IC_PROXY_CLIENT_STATE_PAUSED          0x00000800
+#define IC_PROXY_CLIENT_STATE_REMOTE_PAUSE    0x00001000
+
+	int			unconsumed;		/* count of the packets that are unconsumed by
+								 * the backend */
+	int			sending;		/* count of the packets being sent, both c2p &
+								 * p2c, both data & message */
+
+	ICProxyOBuf	obuf;			/* obuf merges small outgoing packets into
+								 * large ones to reduce network overhead */
+	ICProxyIBuf	ibuf;			/* ibuf detects the packet boundaries */
+
+	ICProxyClient *successor;	/* if a client is registered while a previous
+								 * one with the same key is still alive, the
+								 * registration is delayed, the new one marks
+								 * itself as the successor of the previous one,
+								 * when the previous one is deregistered the
+								 * new one gets actually registered. */
+
+	List	   *pkts;			/* early coming packets */
+
+	char	   *name;			/* name of the client, only for logging */
+#define IC_PROXY_CLIENT_NAME_SIZE 256
+
+	/* TODO: statistics */
+};
+
+/*
+ * Client hash table entry.
+ */
+struct ICProxyClientEntry
+{
+	ICProxyKey	key;			/* the hash key */
+
+	ICProxyClient *client;		/* the client */
+};
+
+
+static void ic_proxy_client_clear_name(ICProxyClient *client);
+static void ic_proxy_client_shutdown_c2p(ICProxyClient *client);
+static void ic_proxy_client_shutdown_p2c(ICProxyClient *client);
+static void ic_proxy_client_close(ICProxyClient *client);
+static void ic_proxy_client_read_data(ICProxyClient *client);
+static void ic_proxy_client_cache_p2c_pkt(ICProxyClient *client,
+										  ICProxyPkt *pkt);
+static void ic_proxy_client_cache_p2c_pkts(ICProxyClient *client, List *pkts);
+static void ic_proxy_client_drop_p2c_cache(ICProxyClient *client);
+static void ic_proxy_client_handle_p2c_cache(ICProxyClient *client);
+static void ic_proxy_client_maybe_start_read_data(ICProxyClient *client);
+static void ic_proxy_client_maybe_request_pause(ICProxyClient *client);
+static void ic_proxy_client_maybe_request_resume(ICProxyClient *client);
+static void ic_proxy_client_maybe_pause(ICProxyClient *client);
+static void ic_proxy_client_maybe_resume(ICProxyClient *client);
+
+
+/*
+ * The client register table.
+ */
+static HTAB		   *ic_proxy_clients = NULL;
+
+
+void
+ic_proxy_client_table_init(void)
+{
+	HASHCTL		hashctl;
+
+	hashctl.hash = (HashValueFunc) ic_proxy_key_hash;
+	hashctl.match = (HashCompareFunc) ic_proxy_key_equal_for_hash;
+	hashctl.keycopy = memcpy;
+
+	hashctl.keysize = sizeof(ICProxyKey);
+	hashctl.entrysize = sizeof(ICProxyClientEntry);
+
+	ic_proxy_clients = hash_create("ic-proxy clients",
+								   MaxConnections /* nelem */,
+								   &hashctl,
+								   HASH_ELEM | HASH_FUNCTION |
+								   HASH_COMPARE | HASH_KEYCOPY);
+}
+
+void
+ic_proxy_client_table_uninit(void)
+{
+	if (ic_proxy_clients)
+	{
+		hash_destroy(ic_proxy_clients);
+		ic_proxy_clients = NULL;
+	}
+}
+
+/*
+ * Shutdown all the clients who communicate with dbid.
+ *
+ * When a proxy-proxy connection to dbid is lost, all the logical connections
+ * from or to it must be dropped, too.
+ */
+void
+ic_proxy_client_table_shutdown_by_dbid(uint16 dbid)
+{
+	ICProxyClientEntry *entry;
+	HASH_SEQ_STATUS seq;
+
+	ic_proxy_log(LOG,
+				 "ic-proxy-clients: shutting down all the clients by dbid %hu",
+				 dbid);
+
+	hash_seq_init(&seq, ic_proxy_clients);
+
+	while ((entry = hash_seq_search(&seq)))
+	{
+		ICProxyClient *client = entry->client;
+
+		/* cached pkts must also be dropped */
+		ic_proxy_client_drop_p2c_cache(client);
+
+		if (client->state & IC_PROXY_CLIENT_STATE_PLACEHOLDER)
+			continue;
+
+		if (client->key.remoteDbid != dbid)
+			continue;
+
+		ic_proxy_client_shutdown_c2p(client);
+		ic_proxy_client_shutdown_p2c(client);
+	}
+}
+
+/*
+ * Register a client with its key.
+ *
+ * - if there was a placeholder, replace it;
+ * - if there was a legacy but still alive one, make the client as its
+ *   successor and delay the registration;
+ */
+static void
+ic_proxy_client_register(ICProxyClient *client)
+{
+	ICProxyClientEntry *entry;
+	bool		found;
+
+	/* this should never happen */
+	if (client->state & IC_PROXY_CLIENT_STATE_REGISTERED)
+	{
+		ic_proxy_log(WARNING, "%s: already registered",
+					 ic_proxy_client_get_name(client));
+		return;
+	}
+
+	entry = hash_search(ic_proxy_clients, &client->key, HASH_ENTER, &found);
+
+	if (found)
+	{
+		/* someone with the same identifier comes earlier than me */
+		ICProxyClient *placeholder = entry->client;
+
+		/* this should never happen, if it does, sth. serious is wrong */
+		if (placeholder == client)
+		{
+			ic_proxy_log(ERROR,
+						 "%s: unregistered client found in the client table",
+						 ic_proxy_client_get_name(client));
+			return;
+		}
+
+		if (!(placeholder->state & IC_PROXY_CLIENT_STATE_PLACEHOLDER))
+		{
+			/*
+			 * it's the client of last statement, for example in the query
+			 * "alter table set distributed by", it contains multiple
+			 * statements, some of them share the same command id.
+			 *
+			 * TODO: we believe the old one is shutting down, but what if not?
+			 */
+			ic_proxy_log(WARNING,
+						 "%s: delay the register as the previous client is still shutting down",
+						 ic_proxy_client_get_name(client));
+
+			/* this should never happen, if it does, sth. serious is wrong */
+			if (placeholder->successor != NULL)
+				ic_proxy_log(ERROR,
+							 "%s: the previous client already has a successor",
+							 ic_proxy_client_get_name(client));
+
+			/*
+			 * register client as a successor, it will be actually registered
+			 * when the placeholder unregister.
+			 */
+			placeholder->successor = client;
+			return;
+		}
+
+		/* it's a placeholder, this happens if the pkts arrived before me */
+		ic_proxy_log(LOG, "%s: replace my placeholder %s",
+					 ic_proxy_client_get_name(client),
+					 ic_proxy_client_get_name(placeholder));
+
+		/*
+		 * the only purpose of a placeholder is to save the early coming
+		 * pkts, there should be no chance for it to be empty; but in case
+		 * it really happens, don't panic, nothing serious.
+		 */
+		if (placeholder->pkts == NIL)
+			ic_proxy_log(LOG, "%s: no cached pkts in the placeholder %s",
+						 ic_proxy_client_get_name(client),
+						 ic_proxy_client_get_name(placeholder));
+
+		/* replace the placeholder / legacy client */
+		entry->client = client;
+
+		/* transfer the cached pkts */
+		ic_proxy_client_cache_p2c_pkts(client, placeholder->pkts);
+		placeholder->pkts = NIL;
+
+		if (placeholder->state & IC_PROXY_CLIENT_STATE_PLACEHOLDER)
+		{
+			/*
+			 * need to free the placeholder, but no need to unregister it as we
+			 * replaced it already.  The placeholder has nothing more than
+			 * itself, so free it directly.
+			 */
+			ic_proxy_free(placeholder);
+			ic_proxy_log(LOG, "%s: freed my placeholder",
+						 ic_proxy_client_get_name(client));
+		}
+	}
+	else
+	{
+		entry->client = client;
+	}
+
+	client->state |= IC_PROXY_CLIENT_STATE_REGISTERED;
+
+	/* clear the name so we could show the new name */
+	ic_proxy_client_clear_name(client);
+
+	ic_proxy_log(LOG, "%s: registered, %ld in total",
+				 ic_proxy_client_get_name(client),
+				 hash_get_num_entries(ic_proxy_clients));
+}
+
+/*
+ * Unregister a client.
+ *
+ * If it has a successor, trigger its registration.
+ */
+static void
+ic_proxy_client_unregister(ICProxyClient *client)
+{
+	if (!(client->state & IC_PROXY_CLIENT_STATE_REGISTERED))
+		return;
+
+	hash_search(ic_proxy_clients, &client->key, HASH_REMOVE, NULL);
+
+	client->state &= ~IC_PROXY_CLIENT_STATE_REGISTERED;
+
+	ic_proxy_log(LOG, "%s: unregistered, %ld in total",
+				 ic_proxy_client_get_name(client),
+				 hash_get_num_entries(ic_proxy_clients));
+
+	if (client->successor)
+	{
+		ICProxyClient *successor;
+
+		successor = client->successor;
+		client->successor = NULL;
+
+		ic_proxy_log(LOG, "%s: re-register my successor",
+					 ic_proxy_client_get_name(client));
+
+		/* the successor must have not registered */
+		Assert(!(successor->state & IC_PROXY_CLIENT_STATE_REGISTERED));
+
+		ic_proxy_client_register(successor);
+
+		/* the successor must have successfully registered */
+		Assert(successor->state & IC_PROXY_CLIENT_STATE_REGISTERED);
+
+		ic_proxy_client_maybe_start_read_data(successor);
+	}
+}
+
+/*
+ * Look up a client with a key.
+ */
+static ICProxyClient *
+ic_proxy_client_lookup(const ICProxyKey *key)
+{
+	ICProxyClientEntry *entry;
+	bool		found;
+
+	entry = hash_search(ic_proxy_clients, key, HASH_FIND, &found);
+
+	return found ? entry->client : NULL;
+}
+
+/*
+ * Look up a client with a key, create a placeholder if not found.
+ */
+ICProxyClient *
+ic_proxy_client_blessed_lookup(uv_loop_t *loop, const ICProxyKey *key)
+{
+	ICProxyClient *client = ic_proxy_client_lookup(key);
+
+	if (!client)
+	{
+		client = ic_proxy_client_new(loop, true);
+		client->key = *key;
+		ic_proxy_client_register(client);
+
+		ic_proxy_log(LOG, "%s: registered as a placeholder",
+					 ic_proxy_client_get_name(client));
+	}
+
+	return client;
+}
+
+/*
+ * Pass a c2p packet to the router.
+ */
+static void
+ic_proxy_client_route_c2p_data(void *opaque, const void *data, uint16 size)
+{
+	const ICProxyPkt *pkt = data;
+	ICProxyClient *client = opaque;
+
+	Assert(ic_proxy_pkt_is_from_client(pkt, &client->key));
+	Assert(ic_proxy_pkt_is_live(pkt, &client->key));
+
+	ic_proxy_router_route(client->pipe.loop, ic_proxy_pkt_dup(pkt), NULL, NULL);
+}
+
+/*
+ * Received a complete c2p packet.
+ */
+static void
+ic_proxy_client_on_c2p_data_pkt(void *opaque, const void *data, uint16 size)
+{
+	ICProxyClient *client = opaque;
+
+	ic_proxy_log(LOG, "%s: received B2C PKT [%d bytes] from the backend",
+				 ic_proxy_client_get_name(client), size);
+
+	/*
+	 * Send it out, but maybe not immediately.  The obuf helps to merge small
+	 * packets into large ones, which reduces the network overhead
+	 * significantly.
+	 */
+	ic_proxy_obuf_push(&client->obuf, data, size,
+					   ic_proxy_client_route_c2p_data, client);
+}
+
+/*
+ * Received c2p data, or events (error, eof).
+ */
+static void
+ic_proxy_client_on_c2p_data(uv_stream_t *stream,
+							ssize_t nread, const uv_buf_t *buf)
+{
+	ICProxyClient *client = CONTAINER_OF((void *) stream, ICProxyClient, pipe);
+
+	if (unlikely(nread < 0))
+	{
+		if (nread != UV_EOF)
+			ic_proxy_log(WARNING, "%s: fail to receive c2p DATA: %s",
+						 ic_proxy_client_get_name(client), uv_strerror(nread));
+		else
+			ic_proxy_log(LOG, "%s: received EOF while waiting for c2p DATA",
+						 ic_proxy_client_get_name(client));
+
+		if (buf->base)
+			ic_proxy_pkt_cache_free(buf->base);
+
+		/*
+		 * If a backend shuts down normally the ibuf should be empty, or
+		 * contains exactly 1 byte, the STOP message.  However it's possible
+		 * that the backend shuts down due to exception, in such a case there
+		 * can be any amount of data left in the ibuf.
+		 */
+		if (client->ibuf.len > 0)
+		{
+			ic_proxy_log(LOG,
+						 "%s: the ibuf still contains %d bytes,"
+						 " flush before shutting down",
+						 ic_proxy_client_get_name(client), client->ibuf.len);
+
+			ic_proxy_ibuf_push(&client->ibuf, NULL, 0,
+							   ic_proxy_client_on_c2p_data_pkt, client);
+		}
+
+		/* flush unsent data */
+		ic_proxy_obuf_push(&client->obuf, NULL, 0,
+						   ic_proxy_client_route_c2p_data, client);
+
+		/* stop reading from the backend */
+		uv_read_stop((uv_stream_t *) &client->pipe);
+
+		/* inform the other side of the logical connection to close, too */
+		ic_proxy_client_shutdown_c2p(client);
+		return;
+	}
+	else if (unlikely(nread == 0))
+	{
+		if (buf->base)
+			ic_proxy_pkt_cache_free(buf->base);
+
+		/* EAGAIN or EWOULDBLOCK, retry */
+		return;
+	}
+
+	/* TODO: Will this really happen? */
+	if (client->state & IC_PROXY_CLIENT_STATE_PAUSED)
+		ic_proxy_log(ERROR,
+					 "%s: paused already, but still received DATA[%zd bytes] from the backend, state is 0x%08x",
+					 ic_proxy_client_get_name(client), nread, client->state);
+
+	ic_proxy_log(LOG, "%s: received DATA[%zd bytes] from the backend",
+				 ic_proxy_client_get_name(client), nread);
+
+	/*
+	 * The c2p data needs to be handled as packets, the ibuf helps to find the
+	 * boundaries.
+	 */
+	ic_proxy_ibuf_push(&client->ibuf, buf->base, nread,
+					   ic_proxy_client_on_c2p_data_pkt, client);
+	ic_proxy_pkt_cache_free(buf->base);
+
+	/* Handle pending PAUSE request */
+	ic_proxy_client_maybe_pause(client);
+}
+
+/*
+ * Start reading from backend if the client is successfully registered.
+ */
+static void
+ic_proxy_client_maybe_start_read_data(ICProxyClient *client)
+{
+	if (!(client->state & IC_PROXY_CLIENT_STATE_REGISTERED))
+		/*
+		 * the register is delayed as the previous client is still shutting
+		 * down, do not send the ACK until that's done.
+		 */
+		return;
+
+	ic_proxy_log(LOG, "%s: start receiving DATA",
+				 ic_proxy_client_get_name(client));
+
+	/* since now on, the client and backend communicate only via b2c packets */
+	Assert(ic_proxy_ibuf_empty(&client->ibuf));
+	ic_proxy_ibuf_uninit(&client->ibuf);
+	ic_proxy_ibuf_init_b2c(&client->ibuf);
+
+	/* and do not forget to init the obuf header */
+	ic_proxy_message_init(ic_proxy_obuf_ensure_buffer(&client->obuf),
+						  0, &client->key);
+
+	/*
+	 * some pkts might arrived before the client, handle them before reading
+	 * new pkts.
+	 */
+	ic_proxy_client_handle_p2c_cache(client);
+
+	/*
+	 * now it's time to receive the normal data
+	 */
+	ic_proxy_client_read_data(client);
+}
+
+/*
+ * The HELLO ACK is sent out.
+ */
+static void
+ic_proxy_client_on_sent_hello_ack(void *opaque,
+								  const ICProxyPkt *pkt, int status)
+{
+	ICProxyClient *client = opaque;
+
+	if (status < 0)
+	{
+		ic_proxy_client_shutdown_p2c(client);
+		return;
+	}
+
+	client->state |= IC_PROXY_CLIENT_STATE_SENT_HELLO_ACK;
+
+	ic_proxy_client_register(client);
+
+	ic_proxy_client_maybe_start_read_data(client);
+}
+
+/*
+ * Received the complete HELLO message.
+ */
+static void
+ic_proxy_client_on_hello_pkt(void *opaque, const void *data, uint16 size)
+{
+	const ICProxyPkt *pkt = data;
+	ICProxyClient *client = opaque;
+	ICProxyKey	key;
+	ICProxyPkt *ackpkt;
+
+	/* we only expect one HELLO message */
+	uv_read_stop((uv_stream_t *) &client->pipe);
+
+	if (!ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_HELLO))
+	{
+		ic_proxy_log(WARNING, "%s: invalid %s",
+					 ic_proxy_client_get_name(client),
+					 ic_proxy_pkt_to_str(pkt));
+
+		ic_proxy_client_shutdown_p2c(client);
+		return;
+	}
+
+	ic_proxy_log(LOG, "%s: received %s from the backend",
+				 ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt));
+
+	client->state |= IC_PROXY_CLIENT_STATE_RECEIVED_HELLO;
+
+	ic_proxy_key_from_c2p_pkt(&key, pkt);
+
+	/*
+	 * If we register before the HELLO ACK is sent, the peer has a chance to
+	 * route data before HELLO ACK.  So we must register in the write callback.
+	 */
+
+	client->key = key;
+
+	/* clear the name so we could show the new name */
+	ic_proxy_client_clear_name(client);
+
+	/* build a HELLO ACK */
+	ic_proxy_key_reverse(&key);
+	ackpkt = ic_proxy_message_new(IC_PROXY_MESSAGE_HELLO_ACK, &key);
+
+	ic_proxy_router_write((uv_stream_t *) &client->pipe, ackpkt, 0,
+						  ic_proxy_client_on_sent_hello_ack, client);
+}
+
+/*
+ * Received the HELLO message, maybe only part of.
+ */
+static void
+ic_proxy_client_on_hello_data(uv_stream_t *stream,
+							  ssize_t nread, const uv_buf_t *buf)
+{
+	ICProxyClient *client = CONTAINER_OF((void *) stream, ICProxyClient, pipe);
+
+	if (unlikely(nread < 0))
+	{
+		if (nread != UV_EOF)
+			ic_proxy_log(WARNING, "%s: fail to receive HELLO: %s",
+						 ic_proxy_client_get_name(client), uv_strerror(nread));
+		else
+			ic_proxy_log(LOG, "%s: received EOF while waiting for HELLO",
+						 ic_proxy_client_get_name(client));
+
+		if (buf->base)
+			ic_proxy_pkt_cache_free(buf->base);
+
+		ic_proxy_log(ERROR, "%s, TODO: fail to receive HELLO",
+					 ic_proxy_client_get_name(client));
+		return;
+	}
+	else if (unlikely(nread == 0))
+	{
+		if (buf->base)
+			ic_proxy_pkt_cache_free(buf->base);
+
+		/* EAGAIN or EWOULDBLOCK, retry */
+		return;
+	}
+
+	/* Hand shaking is done via p2p packets */
+	ic_proxy_ibuf_push(&client->ibuf, buf->base, nread,
+					   ic_proxy_client_on_hello_pkt, client);
+	ic_proxy_pkt_cache_free(buf->base);
+}
+
+/*
+ * Start reading the HELLO message.
+ */
+int
+ic_proxy_client_read_hello(ICProxyClient *client)
+{
+	/* start reading the HELLO message */
+	return uv_read_start((uv_stream_t *) &client->pipe,
+						 ic_proxy_pkt_cache_alloc_buffer,
+						 ic_proxy_client_on_hello_data);
+}
+
+/*
+ * Start reading the DATA.
+ */
+static void
+ic_proxy_client_read_data(ICProxyClient *client)
+{
+	int			ret;
+
+	ret = uv_read_start((uv_stream_t *) &client->pipe,
+						ic_proxy_pkt_cache_alloc_buffer,
+						ic_proxy_client_on_c2p_data);
+
+	if (ret < 0)
+	{
+		ic_proxy_log(WARNING, "%s: state=0x%08x: fail to start reading data: %s",
+					 ic_proxy_client_get_name(client),
+					 client->state, uv_strerror(ret));
+
+		ic_proxy_client_shutdown_c2p(client);
+	}
+}
+
+/*
+ * Get the client name.
+ *
+ * The name is constructed from the state lazily.  When the state gets changed,
+ * call ic_proxy_client_clear_name() to clear the name, so we could reconstruct
+ * the name from the new state.
+ */
+const char *
+ic_proxy_client_get_name(ICProxyClient *client)
+{
+	if (unlikely(client->name == NULL))
+	{
+		uint32		namesize = IC_PROXY_CLIENT_NAME_SIZE;
+		const char *keystr = "";
+		const char *suffix = "";
+
+		if (client->state & IC_PROXY_CLIENT_STATE_REGISTERED)
+			keystr = ic_proxy_key_to_str(&client->key);
+
+		if (client->state & IC_PROXY_CLIENT_STATE_PLACEHOLDER)
+			suffix = ".placeholder";
+
+		client->name = ic_proxy_alloc(namesize);
+		snprintf(client->name, namesize, "client%s%s", suffix, keystr);
+	}
+
+	return client->name;
+}
+
+static void
+ic_proxy_client_clear_name(ICProxyClient *client)
+{
+	if (client->name)
+	{
+		ic_proxy_free(client->name);
+		client->name = NULL;
+	}
+}
+
+/*
+ * Return the libuv stream handle of a client.
+ */
+uv_stream_t *
+ic_proxy_client_get_stream(ICProxyClient *client)
+{
+	return (uv_stream_t *) &client->pipe;
+}
+
+ICProxyClient *
+ic_proxy_client_new(uv_loop_t *loop, bool placeholder)
+{
+	ICProxyClient *client;
+
+	client = ic_proxy_new(ICProxyClient);
+	uv_pipe_init(loop, &client->pipe, false);
+
+	client->pkts = NIL;
+	client->state = 0;
+	client->unconsumed = 0;
+	client->sending = 0;
+	client->successor = NULL;
+	client->name = NULL;
+
+	ic_proxy_obuf_init_p2p(&client->obuf);
+
+	/* hand shaking messages are in the p2p format */
+	ic_proxy_ibuf_init_p2p(&client->ibuf);
+
+	if (placeholder)
+		client->state |= IC_PROXY_CLIENT_STATE_PLACEHOLDER;
+
+	return client;
+}
+
+/*
+ * Free a non-placeholder client.
+ *
+ * The placeholders are free()'ed directly in ic_proxy_client_register(), only
+ * the non-placeholder clients will need this function.
+ */
+static void
+ic_proxy_client_free(ICProxyClient *client)
+{
+	ic_proxy_log(LOG, "%s: freeing", ic_proxy_client_get_name(client));
+
+	/*
+	 * This should not happen, but in case it happens we want to leave a
+	 * message in the logs to help us understand why.
+	 */
+	ic_proxy_client_drop_p2c_cache(client);
+
+	ic_proxy_obuf_uninit(&client->obuf);
+	ic_proxy_ibuf_uninit(&client->ibuf);
+
+	Assert(client->successor == NULL);
+
+	ic_proxy_client_clear_name(client);
+	ic_proxy_free(client);
+}
+
+/*
+ * The client is closed.
+ */
+static void
+ic_proxy_client_on_close(uv_handle_t *handle)
+{
+	ICProxyClient *client = CONTAINER_OF((void *) handle, ICProxyClient, pipe);
+
+	if (client->state & IC_PROXY_CLIENT_STATE_CLOSED)
+		ic_proxy_log(ERROR, "%s: double close",
+					 ic_proxy_client_get_name(client));
+
+	client->state |= IC_PROXY_CLIENT_STATE_CLOSED;
+
+	ic_proxy_log(LOG, "%s: closed", ic_proxy_client_get_name(client));
+
+	ic_proxy_client_free(client);
+}
+
+/*
+ * Close a client.
+ */
+static void
+ic_proxy_client_close(ICProxyClient *client)
+{
+	if (client->state & IC_PROXY_CLIENT_STATE_CLOSING)
+		return;
+
+	client->state |= IC_PROXY_CLIENT_STATE_CLOSING;
+
+	ic_proxy_client_unregister(client);
+
+	ic_proxy_log(LOG, "%s: closing", ic_proxy_client_get_name(client));
+	uv_close((uv_handle_t *) &client->pipe, ic_proxy_client_on_close);
+}
+
+/*
+ * Close a client if it is ready to close.
+ *
+ * Where ready means below conditions are both met:
+ * - no data or message pkts being sent;
+ * - both c2p and p2c are shutted down;
+ *
+ * Return true if it is ready to close, false otherwise.
+ */
+static bool
+ic_proxy_client_maybe_close(ICProxyClient *client)
+{
+	uint32		bits = 0;
+
+	bits |= IC_PROXY_CLIENT_STATE_C2P_SHUTTED;
+	bits |= IC_PROXY_CLIENT_STATE_P2C_SHUTTED;
+
+	if (client->sending == 0 && ((client->state & bits) == bits))
+	{
+		ic_proxy_client_close(client);
+		return true;
+	}
+
+	return false;
+}
+
+/*
+ * Sent the c2p BYE message.
+ */
+static void
+ic_proxy_client_on_sent_c2p_bye(void *opaque, const ICProxyPkt *pkt, int status)
+{
+	ICProxyClient *client = opaque;
+
+	if (status < 0)
+	{
+		/*
+		 * Failed to send the c2p BYE, maybe the peer connection is already
+		 * lost.  This can be safely ignored, we could just behave as it is
+		 * sent out.
+		 */
+		ic_proxy_log(LOG, "%s: fail to shutdown c2p",
+					 ic_proxy_client_get_name(client));
+
+		/*
+		 * When we fail to send the BYE, should we trigger the shutdown_p2c
+		 * process immediately?
+		 */
+	}
+
+	ic_proxy_log(LOG, "%s: shutted down c2p", ic_proxy_client_get_name(client));
+
+	client->sending--;
+
+	client->state |= IC_PROXY_CLIENT_STATE_C2P_SHUTTED;
+	ic_proxy_client_maybe_close(client);
+}
+
+/*
+ * Shutdown in c2p direction.
+ */
+static void
+ic_proxy_client_shutdown_c2p(ICProxyClient *client)
+{
+	/* Do not re-shutdown if we are already doing so or even have done */
+	if (client->state & IC_PROXY_CLIENT_STATE_C2P_SHUTTING)
+	{
+		ic_proxy_client_maybe_close(client);
+		return;
+	}
+
+	ic_proxy_log(LOG, "%s: shutting down c2p",
+				 ic_proxy_client_get_name(client));
+
+	client->state |= IC_PROXY_CLIENT_STATE_C2P_SHUTTING;
+
+	if (client->state & IC_PROXY_CLIENT_STATE_REGISTERED)
+	{
+		/*
+		 * For a registered client, try to send a c2p BYE message to the
+		 * remote.
+		 */
+
+		ICProxyPkt *pkt = ic_proxy_message_new(IC_PROXY_MESSAGE_BYE,
+											   &client->key);
+
+		client->sending++;
+
+		ic_proxy_router_route(client->pipe.loop, pkt,
+							  ic_proxy_client_on_sent_c2p_bye, client);
+	}
+	else
+	{
+		/*
+		 * For a non-registered client, simply behave as if there is a remote
+		 * and it has received the BYE and sent back a P2C BYE.
+		 */
+
+		ic_proxy_log(LOG, "%s: shutted down c2p",
+					 ic_proxy_client_get_name(client));
+
+		client->state |= IC_PROXY_CLIENT_STATE_C2P_SHUTTED;
+
+		ic_proxy_client_shutdown_p2c(client);
+	}
+}
+
+/*
+ * Shutted down in p2c direction.
+ */
+static void
+ic_proxy_client_on_shutdown_p2c(uv_shutdown_t *req, int status)
+{
+	ICProxyClient *client = CONTAINER_OF((void *) req->handle, ICProxyClient, pipe);
+
+	ic_proxy_free(req);
+
+	if (status < 0)
+		ic_proxy_log(WARNING, "%s: fail to shutdown p2c: %s",
+					 ic_proxy_client_get_name(client), uv_strerror(status));
+	else
+		ic_proxy_log(LOG, "%s: shutted down p2c",
+					 ic_proxy_client_get_name(client));
+
+	client->state |= IC_PROXY_CLIENT_STATE_P2C_SHUTTED;
+	ic_proxy_client_maybe_close(client);
+}
+
+/*
+ * Shutdown in p2c direction.
+ */
+static void
+ic_proxy_client_shutdown_p2c(ICProxyClient *client)
+{
+	uv_shutdown_t *req;
+
+	if (client->state & IC_PROXY_CLIENT_STATE_P2C_SHUTTING)
+	{
+		ic_proxy_client_maybe_close(client);
+		return;
+	}
+
+	ic_proxy_log(LOG, "%s: shutting down p2c",
+				 ic_proxy_client_get_name(client));
+
+	client->state |= IC_PROXY_CLIENT_STATE_P2C_SHUTTING;
+
+	req = ic_proxy_new(uv_shutdown_t);
+	uv_shutdown(req, (uv_stream_t *) &client->pipe,
+				ic_proxy_client_on_shutdown_p2c);
+}
+
+/*
+ * Sent c2p RESUME message.
+ */
+static void
+ic_proxy_client_on_sent_c2p_resume(void *opaque,
+								   const ICProxyPkt *pkt, int status)
+{
+	ICProxyClient *client = opaque;
+
+	if (status < 0)
+	{
+		/*
+		 * TODO: Fail to send the RESUME, should we retry instead of shutting
+		 * down?
+		 */
+		ic_proxy_client_shutdown_p2c(client);
+	}
+
+	client->sending--;
+
+	ic_proxy_client_maybe_close(client);
+}
+
+/*
+ * Sent c2p PAUSE message.
+ */
+static void
+ic_proxy_client_on_sent_c2p_pause(void *opaque,
+								  const ICProxyPkt *pkt, int status)
+{
+	ICProxyClient *client = opaque;
+
+	if (status < 0)
+	{
+		/*
+		 * TODO: Fail to send the PAUSE, should we retry instead of shutting
+		 * down?
+		 */
+		ic_proxy_client_shutdown_p2c(client);
+	}
+
+	client->sending--;
+
+	ic_proxy_client_maybe_close(client);
+}
+
+/*
+ * Routed p2c DATA to the backend.
+ */
+static void
+ic_proxy_client_on_sent_p2c_data(void *opaque,
+								 const ICProxyPkt *pkt, int status)
+{
+	ICProxyClient *client = opaque;
+
+	/* this could happen if the backend errored out */
+	if (status < 0)
+		ic_proxy_client_shutdown_c2p(client);
+
+	client->unconsumed--;
+	client->sending--;
+
+	ic_proxy_client_maybe_request_resume(client);
+}
+
+/*
+ * Received a complete p2c message.
+ *
+ * This should not be called by a placeholder.
+ */
+static void
+ic_proxy_client_on_p2c_message(ICProxyClient *client, const ICProxyPkt *pkt,
+							   ic_proxy_sent_cb callback, void *opaque)
+{
+	if (ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_BYE))
+	{
+		ic_proxy_log(LOG, "%s: received %s",
+					 ic_proxy_client_get_name(client),
+					 ic_proxy_pkt_to_str(pkt));
+
+		ic_proxy_client_maybe_resume(client);
+
+		ic_proxy_client_shutdown_p2c(client);
+	}
+	else if (ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_PAUSE))
+	{
+		ic_proxy_log(LOG, "%s: received %s",
+					 ic_proxy_client_get_name(client),
+					 ic_proxy_pkt_to_str(pkt));
+
+		/*
+		 * the PAUSE message should only be handled when the b2c ibuf
+		 * is empty, so we mark the PAUSING flag, on next c2p data we will
+		 * actuall stop reading if the b2c ibuf is empty.
+		 */
+		client->state |= IC_PROXY_CLIENT_STATE_PAUSING;
+
+		/*
+		 * if the b2c ibuf is already empty, we can stop reading immediately
+		 */
+		ic_proxy_client_maybe_pause(client);
+	}
+	else if (ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_RESUME))
+	{
+		ic_proxy_log(LOG, "%s: received %s",
+					 ic_proxy_client_get_name(client),
+					 ic_proxy_pkt_to_str(pkt));
+
+		ic_proxy_client_maybe_resume(client);
+	}
+	else
+	{
+		ic_proxy_log(ERROR, "%s: unsupported message",
+					 ic_proxy_client_get_name(client));
+	}
+}
+
+/*
+ * Received a complete p2c DATA / MESSAGE packet.
+ *
+ * The client will takes the ownership of the pkt.
+ */
+void
+ic_proxy_client_on_p2c_data(ICProxyClient *client, ICProxyPkt *pkt,
+							ic_proxy_sent_cb callback, void *opaque)
+{
+	/* A placeholder does not send any packets, it always cache them */
+	if (client->state & IC_PROXY_CLIENT_STATE_PLACEHOLDER)
+	{
+		/* FIXME: also save the callback */
+		ic_proxy_client_cache_p2c_pkt(client, pkt);
+	}
+#ifdef USE_ASSERT_CHECKING
+	else if (!ic_proxy_pkt_is_to_client(pkt, &client->key))
+	{
+		ic_proxy_log(WARNING, "%s: the %s is not to me",
+					 ic_proxy_client_get_name(client),
+					 ic_proxy_pkt_to_str(pkt));
+		/* TODO: callback? */
+		ic_proxy_pkt_cache_free(pkt);
+	}
+#endif /* USE_ASSERT_CHECKING */
+	else if (!ic_proxy_pkt_is_live(pkt, &client->key))
+	{
+		if (ic_proxy_pkt_is_out_of_date(pkt, &client->key))
+		{
+			ic_proxy_log(LOG, "%s: drop out-of-date %s",
+						 ic_proxy_client_get_name(client),
+						 ic_proxy_pkt_to_str(pkt));
+			/* TODO: callback? */
+			ic_proxy_pkt_cache_free(pkt);
+		}
+		else
+		{
+			Assert(ic_proxy_pkt_is_in_the_future(pkt, &client->key));
+
+			ic_proxy_log(LOG, "%s: future %s",
+						 ic_proxy_client_get_name(client),
+						 ic_proxy_pkt_to_str(pkt));
+			/* FIXME: also save the callback */
+			ic_proxy_client_cache_p2c_pkt(client, pkt);
+		}
+	}
+	/* the pkt is valid and live, send it to the backend */
+	else if (ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_DATA))
+	{
+		if (client->state & IC_PROXY_CLIENT_STATE_P2C_SHUTTING)
+		{
+			/*
+			 * a special kind of future packet happens between different stats
+			 * of a query, the client and its successor have the same keys,
+			 * such a future packet can not be detected in previous checks,
+			 * we could only tell accoding to the client state.
+			 */
+			ic_proxy_client_cache_p2c_pkt(client, pkt);
+			return;
+		}
+
+		client->unconsumed++;
+		client->sending++;
+
+		Assert(callback == NULL);
+		ic_proxy_router_write((uv_stream_t *) &client->pipe,
+							  pkt, sizeof(*pkt),
+							  ic_proxy_client_on_sent_p2c_data, client);
+
+		ic_proxy_client_maybe_request_pause(client);
+	}
+	else
+	{
+		ic_proxy_client_on_p2c_message(client, pkt, callback, opaque);
+		ic_proxy_pkt_cache_free(pkt);
+	}
+}
+
+/*
+ * Save a packet for later handling.
+ *
+ * The client will takes the ownership of the pkt.
+ */
+static void
+ic_proxy_client_cache_p2c_pkt(ICProxyClient *client, ICProxyPkt *pkt)
+{
+	/* TODO: drop out-of-date pkt directly */
+	/* TODO: verify the pkt is to client */
+
+	client->pkts = lappend(client->pkts, pkt);
+
+	ic_proxy_log(LOG, "%s: cached a %s for future use, %d in the list",
+				 ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt),
+				 list_length(client->pkts));
+}
+
+/*
+ * Save a list of packets for later handling.
+ *
+ * The client will takes the ownership of the pkts.
+ */
+static void
+ic_proxy_client_cache_p2c_pkts(ICProxyClient *client, List *pkts)
+{
+	/* TODO: verify the pkts is to client */
+
+	client->pkts = list_concat(client->pkts, pkts);
+
+	ic_proxy_log(LOG,
+				 "%s: cached %d pkts for future use, %d in the list",
+				 ic_proxy_client_get_name(client),
+				 list_length(pkts), list_length(client->pkts));
+}
+
+/*
+ * Drop all the cached p2c packets.
+ */
+static void
+ic_proxy_client_drop_p2c_cache(ICProxyClient *client)
+{
+	ListCell   *cell;
+
+	if (!client->pkts)
+		return;
+
+	foreach(cell, client->pkts)
+	{
+		ICProxyPkt *pkt = lfirst(cell);
+
+		ic_proxy_log(WARNING, "%s: unhandled cached %s, dropping it",
+					 ic_proxy_client_get_name(client),
+					 ic_proxy_pkt_to_str(pkt));
+
+		ic_proxy_pkt_cache_free(pkt);
+	}
+
+	list_free(client->pkts);
+	client->pkts = NIL;
+}
+
+/*
+ * Handle all the cached p2c packets.
+ *
+ * Out-of-date ones will be droped, future ones will still be cached, only the
+ * live ones are handled.
+ *
+ * This function is only called on a new client, so it is not so expansive
+ * to rebuild the cache list.
+ */
+static void
+ic_proxy_client_handle_p2c_cache(ICProxyClient *client)
+{
+	List	   *pkts;
+	ListCell   *cell;
+
+	/* A placeholder does not handle any packets */
+	if (client->state & IC_PROXY_CLIENT_STATE_PLACEHOLDER)
+		return;
+
+	if (client->pkts == NIL)
+		return;
+
+	ic_proxy_log(LOG, "%s: trying to consume the %d cached pkts",
+				 ic_proxy_client_get_name(client), list_length(client->pkts));
+
+	/* First detach all the pkts */
+	pkts = client->pkts;
+	client->pkts = NIL;
+
+	/* Then re-handle them one by one */
+	foreach(cell, pkts)
+	{
+		ICProxyPkt *pkt = lfirst(cell);
+
+		/* FIXME: callback */
+		ic_proxy_client_on_p2c_data(client, pkt, NULL, NULL);
+	}
+
+	ic_proxy_log(LOG, "%s: consumed %d cached pkts",
+				 ic_proxy_client_get_name(client),
+				 list_length(pkts) - list_length(client->pkts));
+
+	/*
+	 * the pkts ownership were transfered during ic_proxy_client_on_p2c_data(),
+	 * only need to free the list itself.
+	 */
+	list_free(pkts);
+}
+
+/*
+ * Request the sender side to PAUSE if the writing queue is too full.
+ */
+static void
+ic_proxy_client_maybe_request_pause(ICProxyClient *client)
+{
+	ic_proxy_log(LOG, "%s: %d unconsumed packets to the backend",
+				 ic_proxy_client_get_name(client), client->unconsumed);
+
+	if (client->unconsumed >= IC_PROXY_TRESHOLD_PAUSE &&
+		!(client->state & IC_PROXY_CLIENT_STATE_REMOTE_PAUSE))
+	{
+		ICProxyPkt *pkt = ic_proxy_message_new(IC_PROXY_MESSAGE_PAUSE,
+											   &client->key);
+
+		/*
+		 * We could also clear this flag in the write callback, however
+		 * that might cause us to resend the message if the sender sends
+		 * fast enough.
+		 */
+		client->state |= IC_PROXY_CLIENT_STATE_REMOTE_PAUSE;
+
+		client->sending++;
+
+		ic_proxy_router_route(client->pipe.loop, pkt,
+							  ic_proxy_client_on_sent_c2p_pause, client);
+	}
+}
+
+/*
+ * Request the sender side to RESUME if the writing queue is empty enough.
+ */
+static void
+ic_proxy_client_maybe_request_resume(ICProxyClient *client)
+{
+	ic_proxy_log(LOG, "%s: %d unconsumed packets to the backend",
+				 ic_proxy_client_get_name(client), client->unconsumed);
+
+	if (client->unconsumed <= IC_PROXY_TRESHOLD_RESUME &&
+		(client->state & IC_PROXY_CLIENT_STATE_REMOTE_PAUSE))
+	{
+		ICProxyPkt *pkt = ic_proxy_message_new(IC_PROXY_MESSAGE_RESUME,
+											   &client->key);
+
+		/*
+		 * We could also clear this flag in the write callback, however that
+		 * might cause us to resend the message if the backend receives fast
+		 * enough.
+		 */
+		client->state &= ~IC_PROXY_CLIENT_STATE_REMOTE_PAUSE;
+
+		client->sending++;
+
+		ic_proxy_router_route(client->pipe.loop, pkt,
+							  ic_proxy_client_on_sent_c2p_resume, client);
+	}
+}
+
+/*
+ * PAUSE if being requested.
+ */
+static void
+ic_proxy_client_maybe_pause(ICProxyClient *client)
+{
+	/* Handle pending PAUSE request */
+	if (((client->state & (IC_PROXY_CLIENT_STATE_PAUSING |
+						   IC_PROXY_CLIENT_STATE_PAUSED)) ==
+		 IC_PROXY_CLIENT_STATE_PAUSING) &&
+		ic_proxy_ibuf_empty(&client->ibuf))
+	{
+		client->state |= IC_PROXY_CLIENT_STATE_PAUSED;
+
+		uv_read_stop((uv_stream_t *) &client->pipe);
+
+		/* flush unsent data */
+		ic_proxy_obuf_push(&client->obuf, NULL, 0,
+						   ic_proxy_client_route_c2p_data, client);
+
+		ic_proxy_log(LOG, "%s: paused", ic_proxy_client_get_name(client));
+	}
+}
+
+/*
+ * RESUME if being requested.
+ */
+static void
+ic_proxy_client_maybe_resume(ICProxyClient *client)
+{
+	if (client->state & IC_PROXY_CLIENT_STATE_PAUSING)
+	{
+		if (client->state & IC_PROXY_CLIENT_STATE_PAUSED)
+			ic_proxy_client_read_data(client);
+
+		client->state &= ~(IC_PROXY_CLIENT_STATE_PAUSING |
+						   IC_PROXY_CLIENT_STATE_PAUSED);
+
+		ic_proxy_log(LOG, "%s: resumed", ic_proxy_client_get_name(client));
+	}
+}

--- a/src/backend/cdb/motion/ic_proxy_iobuf.c
+++ b/src/backend/cdb/motion/ic_proxy_iobuf.c
@@ -1,0 +1,407 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_iobuf.c
+ *
+ *	  Interconnect Proxy I/O Buffer
+ *
+ * An ibuf detects the boundaries of input packets and generate a callback for
+ * every complete packet.
+ *
+ * An obuf combines small output packets into large ones, which helps to reduce
+ * the overhead of packet headers.
+ *
+ * Both i/o bufs are designed to support any kind of packets, as long as they
+ * have a fixed-size packet header, and the maximum packet size does not exceed
+ * IC_PROXY_MAX_PKT_SIZE.  Two built-in packet formats are provided:
+ *
+ * - b2c packet: the the ic-tcp packet, which contains a 4-byte header;
+ * - p2p packet: the ic-proxy packet, which contains a 32-byte header;
+ *
+ * Other formats can be supported by providing custom methods.
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "cdb/ml_ipc.h"					/* for ic-tcp packet */
+
+#include "ic_proxy.h"
+#include "ic_proxy_iobuf.h"
+#include "ic_proxy_packet.h"
+#include "ic_proxy_pkt_cache.h"
+
+
+/*
+ * Initialize an ibuf.
+ *
+ * The packet format must has a fixed-size header, which is specified by
+ * header_size.  Once a complete header is received the get_packet_size()
+ * method is called to parse the packet size, including both the header and the
+ * body.
+ */
+void
+ic_proxy_ibuf_init(ICProxyIBuf *ibuf, uint16 header_size,
+				   uint16 (* get_packet_size) (const void *data))
+{
+	ibuf->len = 0;
+	ibuf->buf = NULL;
+
+	ibuf->header_size = header_size;
+	ibuf->get_packet_size = get_packet_size;
+}
+
+/*
+ * Uninitialize an ibuf.
+ */
+void
+ic_proxy_ibuf_uninit(ICProxyIBuf *ibuf)
+{
+	if (ibuf->buf)
+	{
+		ic_proxy_pkt_cache_free(ibuf->buf);
+		ibuf->buf = NULL;
+	}
+}
+
+/*
+ * Clear the ibuf.
+ *
+ * Unconsumed bytes are dropped directly.
+ */
+void
+ic_proxy_ibuf_clear(ICProxyIBuf *ibuf)
+{
+	if (ibuf->len > 0)
+		ic_proxy_log(WARNING, "ic-proxy-ibuf: dropped %d bytes", ibuf->len);
+
+	ibuf->len = 0;
+}
+
+/*
+ * Return true if the ibuf is empty.
+ */
+bool
+ic_proxy_ibuf_empty(const ICProxyIBuf *ibuf)
+{
+	return ibuf->len == 0;
+}
+
+/*
+ * Push data to the ibuf.
+ *
+ * The "data" and "size" are the pointer and the size of the data, they are
+ * appended to the "ibuf".  If a complete packet is composed the "callback" is
+ * called with the "opaque" as the callback data.
+ *
+ * If "size" is 0 then a force flush is triggered, the "callback" is called
+ * with the incomplete packet.
+ *
+ * TODO: libuv supports sending an array of buffers, so it is technically
+ * possible to prevent the memory copying in this function, we only need to let
+ * the get_packet_size() method supports parsing the packet size from an array
+ * of buffers.  However the callback function also needs to support
+ * non-continues packet, an easy way is to only copying the header into
+ * continues memory.
+ */
+void
+ic_proxy_ibuf_push(ICProxyIBuf *ibuf,
+				   const char *data, uint16 size,
+				   ic_proxy_iobuf_data_callback callback,
+				   void *opaque)
+{
+	uint16		packet_size;
+	uint16		delta;
+
+	if (unlikely(ibuf->buf == NULL))
+		ibuf->buf = ic_proxy_pkt_cache_alloc(NULL);
+
+	/* a force-flush */
+	if (unlikely(size == 0))
+	{
+		/* TODO: do we need to flush if ibuf->len is 0? */
+		callback(opaque, ibuf->buf, ibuf->len);
+		ibuf->len = 0;
+		return;
+	}
+
+	if (ibuf->len > 0)
+	{
+		if (ibuf->len < ibuf->header_size)
+		{
+			/* haven't got a complete header yet */
+
+			delta = Min(ibuf->header_size - ibuf->len, size);
+
+			memcpy(ibuf->buf + ibuf->len, data, delta);
+			ibuf->len += delta;
+			data += delta;
+			size -= delta;
+
+			if (ibuf->len < ibuf->header_size)
+				/* still not having a complete header */
+				return;
+		}
+
+		{
+			/* have a complete header now */
+
+			packet_size = ibuf->get_packet_size(ibuf->buf);
+			delta = Min(packet_size - ibuf->len, size);
+
+			memcpy(ibuf->buf + ibuf->len, data, delta);
+			ibuf->len += delta;
+			data += delta;
+			size -= delta;
+
+			if (ibuf->len < packet_size)
+				/* still not having a complete packet */
+				return;
+		}
+
+		{
+			/* have a complete pkt now */
+
+			callback(opaque, ibuf->buf, packet_size);
+			ibuf->len = 0;
+		}
+	}
+
+	while (size >= ibuf->header_size)
+	{
+		packet_size = ibuf->get_packet_size(data);
+
+		if (packet_size <= size)
+		{
+			/* got a complete pkt */
+			callback(opaque, data, packet_size);
+
+			data += packet_size;
+			size -= packet_size;
+		}
+		else
+			/* got a incomplete pkt */
+			break;
+	}
+
+	if (size > 0)
+	{
+		/* got a incomplete pkt */
+		memcpy(ibuf->buf, data, size);
+		ibuf->len = size;
+	}
+}
+
+/*
+ * Get the packet size of a b2c one.
+ *
+ * The b2c packet only contains a 4-byte packet length in host byte-order.
+ */
+static uint16
+ic_proxy_ibuf_get_packet_size_b2c(const void *data)
+{
+	return *(const uint32 *) data;
+}
+
+/*
+ * Initialize an ibuf for b2c packet.
+ */
+void
+ic_proxy_ibuf_init_b2c(ICProxyIBuf *ibuf)
+{
+	ic_proxy_ibuf_init(ibuf, PACKET_HEADER_SIZE,
+					   ic_proxy_ibuf_get_packet_size_b2c);
+}
+
+/*
+ * Get the packet size of a p2p one.
+ *
+ * The p2p packet contains a 32-byte ICProxyPkt header, all the fields are in
+ * host byte-order.
+ */
+static uint16
+ic_proxy_ibuf_get_packet_size_p2p(const void *data)
+{
+	const ICProxyPkt *pkt = data;
+
+	return pkt->len;
+}
+
+/*
+ * Initialize an ibuf for p2p packet.
+ */
+void
+ic_proxy_ibuf_init_p2p(ICProxyIBuf *ibuf)
+{
+	ic_proxy_ibuf_init(ibuf, sizeof(ICProxyPkt),
+					   ic_proxy_ibuf_get_packet_size_p2p);
+}
+
+
+/*
+ * Initialize an obuf.
+ *
+ * The packet format must has a fixed-size header, which is specified by
+ * header_size.  Once a packet is to be sent, the set_packet_size() method is
+ * called to set the packet size in the header.
+ *
+ * The ic_proxy_obuf_ensure_buffer() must be called after init and before any
+ * data is pushed.
+ */
+void
+ic_proxy_obuf_init(ICProxyOBuf *obuf, uint16 header_size,
+				   void (* set_packet_size) (void *data, uint16 size))
+{
+	obuf->len = 0;
+	obuf->buf = NULL;
+
+	obuf->header_size = header_size;
+	obuf->set_packet_size = set_packet_size;
+}
+
+/*
+ * Uninitialize an obuf.
+ */
+void
+ic_proxy_obuf_uninit(ICProxyOBuf *obuf)
+{
+	if (obuf->buf)
+	{
+		ic_proxy_pkt_cache_free(obuf->buf);
+		obuf->buf = NULL;
+	}
+}
+
+/*
+ * Ensure that the obuf has allocated its buffer.
+ *
+ * The ibuf does not allocate buffer until this function is called, this helps
+ * to prevent some unnecessary memory allocation.
+ *
+ * The buffer pointer is returned, the caller is responsible to initialize the
+ * header.  The packet size, however, should be set in the set_packet_size()
+ * method.
+ *
+ * TODO: This used to be useful to improve the performance slightly, however as
+ * we have the packet cache already, we do not need this lazy allocation
+ * anymore, we could retire it.
+ */
+void *
+ic_proxy_obuf_ensure_buffer(ICProxyOBuf *obuf)
+{
+	if (unlikely(obuf->buf == NULL))
+	{
+		obuf->buf = ic_proxy_pkt_cache_alloc(NULL);
+		obuf->len = obuf->header_size;
+	}
+
+	return obuf->buf;
+}
+
+/*
+ * Push data to the obuf.
+ *
+ * The "data" and "size" are the pointer and the size of the data, it is
+ * promised that the data is always fed to the "callback" as an entity.  If
+ * there is no enough room for the "data", the bytes in the buffer will first
+ * be fed to the "callback" to clear the room.
+ *
+ * If "size" is 0 then a force flush is triggered.
+ *
+ * The "callback" will be called with one or more complete data.  The output
+ * packet header is always set before feeding to the "callback".
+ */
+void
+ic_proxy_obuf_push(ICProxyOBuf *obuf,
+				   const char *data, uint16 size,
+				   ic_proxy_iobuf_data_callback callback,
+				   void *opaque)
+{
+	if (unlikely(obuf->buf == NULL))
+		ic_proxy_log(ERROR,
+					 "ic-proxy-obuf: the caller must init the header before pushing data");
+
+	/*
+	 * Need a flush when:
+	 * - size == 0 means a force flush;
+	 * - or no enough space for the new data;
+	 */
+	if (unlikely(size == 0 || size + obuf->len > IC_PROXY_MAX_PKT_SIZE))
+	{
+		if (obuf->header_size + size > IC_PROXY_MAX_PKT_SIZE)
+			ic_proxy_log(ERROR,
+						 "ic-proxy-obuf: no enough buffer to store the data:"
+						 " the data size is %d bytes,"
+						 " but the buffer size is only %zd bytes,"
+						 " including a %d bytes header",
+						 size, IC_PROXY_MAX_PKT_SIZE, obuf->header_size);
+
+		/* TODO: should we flush if no data in the packet? */
+		if (obuf->len == obuf->header_size)
+			ic_proxy_log(LOG, "ic-proxy-obuf: no data to flush");
+		else
+		{
+			obuf->set_packet_size(obuf->buf, obuf->len);
+			callback(opaque, obuf->buf, obuf->len);
+
+			/* we will reuse the header */
+			obuf->len = obuf->header_size;
+		}
+	}
+
+	/* the trailing data will be sent later */
+	if (size > 0)
+	{
+		memcpy(obuf->buf + obuf->len, data, size);
+		obuf->len += size;
+	}
+}
+
+/*
+ * Set the packet size of a b2c one.
+ *
+ * The b2c packet only contains a 4-byte packet length in host byte-order.
+ */
+static void
+ic_proxy_obuf_set_packet_size_b2c(void *data, uint16 size)
+{
+	*(uint32 *) data = size;
+}
+
+/*
+ * Initialize an obuf for b2c packet.
+ */
+void
+ic_proxy_obuf_init_b2c(ICProxyOBuf *obuf)
+{
+	ic_proxy_obuf_init(obuf, PACKET_HEADER_SIZE,
+					   ic_proxy_obuf_set_packet_size_b2c);
+}
+
+/*
+ * Set the packet size of a p2p one.
+ *
+ * The p2p packet contains a 32-byte ICProxyPkt header, all the fields are in
+ * host byte-order.
+ */
+static void
+ic_proxy_obuf_set_packet_size_p2p(void *data, uint16 size)
+{
+	ICProxyPkt *pkt = data;
+
+	pkt->len = size;
+}
+
+/*
+ * Initialize an obuf for p2p packet.
+ */
+void
+ic_proxy_obuf_init_p2p(ICProxyOBuf *obuf)
+{
+	ic_proxy_obuf_init(obuf, sizeof(ICProxyPkt),
+					   ic_proxy_obuf_set_packet_size_p2p);
+}

--- a/src/backend/cdb/motion/ic_proxy_iobuf.h
+++ b/src/backend/cdb/motion/ic_proxy_iobuf.h
@@ -1,0 +1,72 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_iobuf.h
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef IC_PROXY_IOBUF_H
+#define IC_PROXY_IOBUF_H
+
+
+#include "postgres.h"
+
+
+typedef struct ICProxyOBuf ICProxyOBuf;
+typedef struct ICProxyIBuf ICProxyIBuf;
+
+
+typedef void (* ic_proxy_iobuf_data_callback) (void *opaque,
+											   const void *data,
+											   uint16 size);
+
+
+struct ICProxyIBuf
+{
+	char	   *buf;
+	uint16		len;
+
+	uint16		header_size;
+	uint16		(* get_packet_size) (const void *data);
+};
+
+struct ICProxyOBuf
+{
+	char	   *buf;
+	uint16		len;
+
+	uint16		header_size;
+	void		(* set_packet_size) (void *data, uint16 size);
+};
+
+
+extern void ic_proxy_obuf_init(ICProxyOBuf *obuf, uint16 header_size,
+							   void (* set_packet_size) (void *data,
+														 uint16 size));
+extern void ic_proxy_obuf_init_b2c(ICProxyOBuf *obuf);
+extern void ic_proxy_obuf_init_p2p(ICProxyOBuf *obuf);
+extern void ic_proxy_obuf_uninit(ICProxyOBuf *obuf);
+extern void *ic_proxy_obuf_ensure_buffer(ICProxyOBuf *obuf);
+extern void ic_proxy_obuf_push(ICProxyOBuf *obuf,
+							   const char *data, uint16 size,
+							   ic_proxy_iobuf_data_callback callback,
+							   void *opaque);
+
+
+extern void ic_proxy_ibuf_init(ICProxyIBuf *ibuf, uint16 header_size,
+							   uint16 (* get_packet_size) (const void *data));
+extern void ic_proxy_ibuf_init_b2c(ICProxyIBuf *ibuf);
+extern void ic_proxy_ibuf_init_p2p(ICProxyIBuf *ibuf);
+extern void ic_proxy_ibuf_uninit(ICProxyIBuf *ibuf);
+extern void ic_proxy_ibuf_clear(ICProxyIBuf *ibuf);
+extern bool ic_proxy_ibuf_empty(const ICProxyIBuf *ibuf);
+extern void ic_proxy_ibuf_push(ICProxyIBuf *ibuf,
+							   const char *data, uint16 size,
+							   ic_proxy_iobuf_data_callback callback,
+							   void *opaque);
+
+#endif   /* IC_PROXY_IOBUF_H */

--- a/src/backend/cdb/motion/ic_proxy_key.c
+++ b/src/backend/cdb/motion/ic_proxy_key.c
@@ -1,0 +1,162 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_key.c
+ *
+ *    Interconnect Proxy Key
+ *
+ * A key is actually a logical connection identifier, it identifies the sender,
+ * the receiver, as well as the logical connection itself.
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "ic_proxy_key.h"
+
+/*
+ * Compares whether two keys are identical.
+ *
+ * Not all the attributes are compared.  Content ids are not compared as the
+ * dbids are compared.  Session ids are not compared because pids are compared.
+ */
+bool
+ic_proxy_key_equal(const ICProxyKey *key1, const ICProxyKey *key2)
+{
+	return key1->localDbid       == key2->localDbid
+		&& key1->localPid        == key2->localPid
+		&& key1->remoteDbid      == key2->remoteDbid
+		&& key1->remotePid       == key2->remotePid
+		&& key1->commandId       == key2->commandId
+		&& key1->sendSliceIndex  == key2->sendSliceIndex
+		&& key1->recvSliceIndex  == key2->recvSliceIndex
+		;
+}
+
+/*
+ * Hash function for keys.
+ *
+ * The logic is derived from CONN_HASH_VALUE(), however it is possible to build
+ * a better with less collision.
+ */
+uint32
+ic_proxy_key_hash(const ICProxyKey *key, Size keysize)
+{
+	return (key->localPid ^ key->remotePid) + key->remoteDbid + key->commandId;
+}
+
+/*
+ * Equal function for keys.
+ *
+ * Return 0 for match, otherwise for no match
+ */
+int
+ic_proxy_key_equal_for_hash(const ICProxyKey *key1,
+							const ICProxyKey *key2, Size keysize)
+{
+	return !ic_proxy_key_equal(key1, key2);
+}
+
+/*
+ * Initialize a key.
+ *
+ * All the fields are passed as arguments.
+ */
+void
+ic_proxy_key_init(ICProxyKey *key,
+				  int32 sessionId, uint32 commandId,
+				  int16 sendSliceIndex, int16 recvSliceIndex,
+				  int16 localContentId, uint16 localDbid, int32 localPid,
+				  int16 remoteContentId, uint16 remoteDbid, int32 remotePid)
+{
+	key->sessionId = sessionId;
+	key->commandId = commandId;
+	key->sendSliceIndex = sendSliceIndex;
+	key->recvSliceIndex = recvSliceIndex;
+
+	key->localContentId = localContentId;
+	key->localDbid = localDbid;
+	key->localPid = localPid;
+
+	key->remoteContentId = remoteContentId;
+	key->remoteDbid = remoteDbid;
+	key->remotePid = remotePid;
+}
+
+/*
+ * Initialize a key from a peer-to-client packet.
+ *
+ * A peer-to-client packet is to a local client, it is usually from a remote
+ * peer, but it is also possible to be from a different client on the same
+ * segment.
+ */
+void
+ic_proxy_key_from_p2c_pkt(ICProxyKey *key, const ICProxyPkt *pkt)
+{
+	ic_proxy_key_init(key, pkt->sessionId, pkt->commandId,
+					  pkt->sendSliceIndex, pkt->recvSliceIndex,
+					  pkt->dstContentId, pkt->dstDbid, pkt->dstPid,
+					  pkt->srcContentId, pkt->srcDbid, pkt->srcPid);
+}
+
+/*
+ * Initialize a key from a client-to-peer packet.
+ *
+ * A client-to-peer packet is from a local client, it is usually to a remote
+ * peer, but it is also possible to be to a different client on the same
+ * segment.
+ */
+void
+ic_proxy_key_from_c2p_pkt(ICProxyKey *key, const ICProxyPkt *pkt)
+{
+	ic_proxy_key_init(key, pkt->sessionId, pkt->commandId,
+					  pkt->sendSliceIndex, pkt->recvSliceIndex,
+					  pkt->srcContentId, pkt->srcDbid, pkt->srcPid,
+					  pkt->dstContentId, pkt->dstDbid, pkt->dstPid);
+}
+
+/*
+ * Reverse the direction of a key.
+ *
+ * Convert a peer-to-client packet to a client-to-peer one, or the reverse.
+ */
+void
+ic_proxy_key_reverse(ICProxyKey *key)
+{
+#define __swap(a, b) do { tmp = (a); (a) = (b); (b) = tmp; } while (0)
+
+	int32		tmp;
+
+	__swap(key->localContentId, key->remoteContentId);
+	__swap(key->localDbid,      key->remoteDbid);
+	__swap(key->localPid,       key->remotePid);
+
+#undef __swap
+}
+
+/*
+ * Build a describe string of a key.
+ *
+ * The string contains all the key information, can be used in log & error
+ * messages.
+ *
+ * Return the string, which must not be freed.  The string is in a static
+ * buffer, so a second call to this function will overwrite the result of the
+ * previous call.
+ */
+const char *
+ic_proxy_key_to_str(const ICProxyKey *key)
+{
+	static char	buf[256];
+
+	snprintf(buf, sizeof(buf),
+			 "[con%d,cmd%d,slice[%hd->%hd] seg%hd:dbid%hu:p%d->seg%hd:dbid%hu:p%d]",
+			 key->sessionId, key->commandId,
+			 key->sendSliceIndex, key->recvSliceIndex,
+			 key->localContentId, key->localDbid, key->localPid,
+			 key->remoteContentId, key->remoteDbid, key->remotePid);
+
+	return buf;
+}

--- a/src/backend/cdb/motion/ic_proxy_key.h
+++ b/src/backend/cdb/motion/ic_proxy_key.h
@@ -1,0 +1,62 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_key.h
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef IC_PROXY_KEY_H
+#define IC_PROXY_KEY_H
+
+#include "postgres.h"
+
+typedef struct ICProxyKey ICProxyKey;
+
+/* we have to include it after the declaration of ICProxyKey */
+#include "ic_proxy_packet.h"
+
+/*
+ * XXX: sessionId and {local,remote}ContentId are only for debugging purpose,
+ * they are not actually part of the key.
+ *
+ * dbid and segindex are both defined as int32 in type GpId, however we define
+ * them as int16 to reduce the size of ICProxyKey, we also mark dbids as
+ * unsigned in hope that the compiler could help to catch the errors if we pass
+ * them in the wrong order.
+ */
+struct ICProxyKey
+{
+	int16		localContentId;
+	uint16		localDbid;
+	int32		localPid;
+
+	int16		remoteContentId;
+	uint16		remoteDbid;
+	int32		remotePid;
+
+	int32		sessionId;
+	uint32		commandId;
+	int16		sendSliceIndex;
+	int16		recvSliceIndex;
+};
+
+extern uint32 ic_proxy_key_hash(const ICProxyKey *key, Size keysize);
+extern bool ic_proxy_key_equal(const ICProxyKey *key1, const ICProxyKey *key2);
+extern int ic_proxy_key_equal_for_hash(const ICProxyKey *key1,
+									   const ICProxyKey *key2,
+									   Size keysize);
+extern void ic_proxy_key_init(ICProxyKey *key,
+							  int32 sessionId, uint32 commandId,
+							  int16 sendSliceIndex, int16 recvSliceIndex,
+							  int16 localContentId, uint16 localDbid, int32 localPid,
+							  int16 remoteContentId, uint16 remoteDbid, int32 remotePid);
+extern void ic_proxy_key_from_p2c_pkt(ICProxyKey *key, const ICProxyPkt *pkt);
+extern void ic_proxy_key_from_c2p_pkt(ICProxyKey *key, const ICProxyPkt *pkt);
+extern void ic_proxy_key_reverse(ICProxyKey *key);
+extern const char *ic_proxy_key_to_str(const ICProxyKey *key);
+
+#endif   /* IC_PROXY_KEY_H */

--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -1,0 +1,497 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_main.c
+ *
+ *	  The main loop of the ic-proxy, it listens for both new peers and new
+ *	  clients, it also establish the peer connections.
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "postmaster/bgworker.h"
+#include "utils/guc.h"
+#include "utils/memutils.h"
+
+#include "ic_proxy_server.h"
+#include "ic_proxy_addr.h"
+#include "ic_proxy_pkt_cache.h"
+
+#include <uv.h>
+
+#include <unistd.h>
+
+static uv_loop_t	ic_proxy_server_loop;
+static uv_signal_t	ic_proxy_server_signal_hup;
+static uv_signal_t	ic_proxy_server_signal_int;
+static uv_signal_t	ic_proxy_server_signal_term;
+static uv_signal_t	ic_proxy_server_signal_stop;
+static uv_timer_t	ic_proxy_server_timer;
+
+static uv_tcp_t		ic_proxy_peer_listener;
+static bool			ic_proxy_peer_listening;
+
+static uv_pipe_t	ic_proxy_client_listener;
+static bool			ic_proxy_client_listening;
+
+static int			ic_proxy_server_exit_code = 1;
+
+/*
+ * The peer listener is closed.
+ */
+static void
+ic_proxy_server_peer_listener_on_closed(uv_handle_t *handle)
+{
+	ic_proxy_log(LOG, "ic-proxy-server: peer listener: closed");
+
+	/* A new peer listener will be created on the next timer callback */
+	ic_proxy_peer_listening = false;
+}
+
+/*
+ * New peer arrives.
+ */
+static void
+ic_proxy_server_on_new_peer(uv_stream_t *server, int status)
+{
+	ICProxyPeer *peer;
+	int			ret;
+
+	if (status < 0)
+	{
+		ic_proxy_log(WARNING, "ic-proxy-server: new peer error: %s",
+					 uv_strerror(status));
+
+		uv_close((uv_handle_t *) server,
+				 ic_proxy_server_peer_listener_on_closed);
+		return;
+	}
+
+	ic_proxy_log(LOG, "ic-proxy-server: new peer to the server");
+
+	peer = ic_proxy_peer_new(server->loop,
+							 IC_PROXY_INVALID_CONTENT, IC_PROXY_INVALID_DBID);
+
+	ret = uv_accept(server, (uv_stream_t *) &peer->tcp);
+	if (ret < 0)
+	{
+		ic_proxy_log(WARNING, "ic-proxy-server: fail to accept new peer: %s",
+					 uv_strerror(ret));
+		ic_proxy_peer_free(peer);
+		return;
+	}
+
+	/* TODO: it is better to only touch the states in peer.c */
+	peer->state |= IC_PROXY_PEER_STATE_ACCEPTED;
+
+	/* Dump some connection information, not very useful though */
+	{
+		struct sockaddr_storage peeraddr;
+		int			addrlen = sizeof(peeraddr);
+		char		name[HOST_NAME_MAX];
+
+		uv_tcp_getpeername(&peer->tcp, (struct sockaddr *) &peeraddr, &addrlen);
+		if (peeraddr.ss_family == AF_INET)
+		{
+			struct sockaddr_in *peeraddr4 = (struct sockaddr_in *) &peeraddr;
+
+			uv_ip4_name(peeraddr4, name, sizeof(name));
+
+			ic_proxy_log(LOG, "ic-proxy-server: the new peer is from %s:%d",
+						 name, ntohs(peeraddr4->sin_port));
+		}
+		else if (peeraddr.ss_family == AF_INET6)
+		{
+			struct sockaddr_in6 *peeraddr6 = (struct sockaddr_in6 *) &peeraddr;
+
+			uv_ip6_name(peeraddr6, name, sizeof(name));
+
+			ic_proxy_log(LOG, "ic-proxy-server: the new peer is from %s:%d",
+						 name, ntohs(peeraddr6->sin6_port));
+		}
+	}
+
+	ic_proxy_peer_read_hello(peer);
+}
+
+/*
+ * Setup the peer listener.
+ *
+ * The peer listener listens on a tcp socket, the peer connections will come
+ * through it.
+ */
+static void
+ic_proxy_server_peer_listener_init(uv_loop_t *loop)
+{
+	struct sockaddr_in addr;
+	uv_tcp_t   *listener = &ic_proxy_peer_listener;
+	int			port;
+	int			fd = -1;
+	int			ret;
+
+	if (ic_proxy_addrs == NIL)
+		return;
+
+	if (ic_proxy_peer_listening)
+		return;
+
+	/* Get the ip from the gp_interconnect_proxy_addresses */
+	port = ic_proxy_get_my_port();
+	if (port < 0)
+		/* Cannot get my port, maybe the setting is invalid */
+		return;
+
+	/*
+	 * TODO: listen on the ip specified in gp_interconnect_proxy_addresses for
+	 * better security.
+	 */
+	uv_ip4_addr("0.0.0.0", port, &addr);
+
+	ic_proxy_log(LOG, "ic-proxy-server: setting up peer listener on port %d",
+				 port);
+
+	/*
+	 * It is important to set TCP_NODELAY, otherwise we will suffer from
+	 * significant latency and get very bad OLTP performance.
+	 */
+	uv_tcp_init(loop, listener);
+	uv_tcp_nodelay(listener, true);
+
+	ret = uv_tcp_bind(listener, (struct sockaddr *) &addr, 0);
+	if (ret < 0)
+	{
+		ic_proxy_log(WARNING, "ic-proxy-server: tcp: fail to bind: %s",
+					 uv_strerror(ret));
+		return;
+	}
+
+	ret = uv_listen((uv_stream_t *) listener,
+					IC_PROXY_BACKLOG, ic_proxy_server_on_new_peer);
+	if (ret < 0)
+	{
+		ic_proxy_log(WARNING, "ic-proxy-server: tcp: fail to listen: %s",
+					 uv_strerror(ret));
+		return;
+	}
+
+	uv_fileno((uv_handle_t *) listener, &fd);
+	ic_proxy_log(LOG, "ic-proxy-server: tcp: listening on socket %d", fd);
+
+	ic_proxy_peer_listening = true;
+}
+
+/*
+ * The client listener is closed.
+ */
+static void
+ic_proxy_server_client_listener_on_closed(uv_handle_t *handle)
+{
+	ic_proxy_log(LOG, "ic-proxy-server: client listener: closed");
+
+	/* A new client listener will be created on the next timer callback */
+	ic_proxy_client_listening = false;
+}
+
+/*
+ * New client arrives.
+ */
+static void
+ic_proxy_server_on_new_client(uv_stream_t *server, int status)
+{
+	ICProxyClient *client;
+	int			ret;
+
+	if (status < 0)
+	{
+		ic_proxy_log(WARNING, "ic-proxy-server: new client error: %s",
+					 uv_strerror(status));
+
+		uv_close((uv_handle_t *) server,
+				 ic_proxy_server_client_listener_on_closed);
+		return;
+	}
+
+	ic_proxy_log(LOG, "ic-proxy-server: new client to the server");
+
+	client = ic_proxy_client_new(server->loop, false);
+
+	ret = uv_accept(server, ic_proxy_client_get_stream(client));
+	if (ret < 0)
+	{
+		ic_proxy_log(WARNING, "ic-proxy-server: fail to accept new client: %s",
+					 uv_strerror(ret));
+		return;
+	}
+
+	ic_proxy_client_read_hello(client);
+}
+
+/*
+ * Setup the client listener.
+ *
+ * The client listener listens on a domain socket, the client connections will
+ * come through it.
+ */
+static void
+ic_proxy_server_client_listener_init(uv_loop_t *loop)
+{
+	uv_pipe_t  *listener = &ic_proxy_client_listener;
+	char		path[MAXPGPATH];
+	int			fd = -1;
+	int			ret;
+
+	if (ic_proxy_client_listening)
+		return;
+
+	ic_proxy_build_server_sock_path(path, sizeof(path));
+
+	/* FIXME: do not unlink here */
+	ic_proxy_log(LOG, "unlink(%s) ...", path);
+	unlink(path);
+
+	ic_proxy_log(LOG, "ic-proxy-server: setting up client listener on address %s",
+				 path);
+
+	ret = uv_pipe_init(loop, listener, false);
+	if (ret < 0)
+	{
+		ic_proxy_log(WARNING,
+					 "ic-proxy-server: fail to init a client listener: %s",
+					 uv_strerror(ret));
+		return;
+	}
+
+	ret = uv_pipe_bind(listener, path);
+	if (ret < 0)
+	{
+		ic_proxy_log(WARNING, "ic-proxy-server: pipe: fail to bind(%s): %s",
+					 path, uv_strerror(ret));
+		return;
+	}
+
+	ret = uv_listen((uv_stream_t *) listener,
+					IC_PROXY_BACKLOG, ic_proxy_server_on_new_client);
+	if (ret < 0)
+	{
+		ic_proxy_log(WARNING, "ic-proxy-server: pipe: fail to listen on path %s: %s",
+					 path, uv_strerror(ret));
+		return;
+	}
+
+	uv_fileno((uv_handle_t *) listener, &fd);
+	ic_proxy_log(LOG, "ic-proxy-server: pipe: listening on socket %d", fd);
+
+	/*
+	 * Dump the inode of the domain socket file, this helps us to know that the
+	 * file is replaced by someone.  This is not likely to happen, we have
+	 * carefully choosen the file path to not conflict with each other.
+	 */
+	{
+		struct stat	st;
+
+		stat(path, &st);
+		ic_proxy_log(LOG, "ic-proxy-server: dev=%lu, inode=%lu, path=%s",
+					 st.st_dev, st.st_ino, path);
+	}
+
+	ic_proxy_client_listening = true;
+}
+
+/*
+ * Establish the peer connections.
+ *
+ * A proxy connects to all the other proxies, all these connections form the
+ * proxy network.  Only one connection is needed between 2 proxies, this is
+ * ensured by a policy that "proxy X connects to proxy Y iff X > Y".  To support
+ * mirror promotion, X attempts to connect to Y even if Y is a mirror, or even
+ * if we have connected to Y's primary.  In fact we do not know whether Y is a
+ * mirror or not, and we do not care.
+ */
+static void
+ic_proxy_server_ensure_peers(uv_loop_t *loop)
+{
+	ListCell   *cell;
+
+	foreach(cell, ic_proxy_addrs)
+	{
+		ICProxyAddr *addr = lfirst(cell);
+		ICProxyPeer *peer;
+
+		if (addr->content >= GpIdentity.segindex)
+			continue;
+		if (addr->dbid == GpIdentity.dbid)
+			continue; /* do not connect to my primary / mirror */
+
+		/*
+		 * First get the peer with the peer id, then connect to it.  The peer
+		 * can be a placeholder, can be in the progress of a connection, or can
+		 * be connected, the ic_proxy_peer_connect() function will take care of
+		 * the state.
+		 */
+		peer = ic_proxy_peer_blessed_lookup(loop, addr->content, addr->dbid);
+		ic_proxy_peer_connect(peer, (struct sockaddr_in *) addr);
+	}
+}
+
+/*
+ * Timer handler.
+ *
+ * This is used to maintain the proxy-proxy network, as well as the client and
+ * peer listeners.
+ */
+static void
+ic_proxy_server_on_timer(uv_timer_t *timer)
+{
+	ic_proxy_server_peer_listener_init(timer->loop);
+	ic_proxy_server_ensure_peers(timer->loop);
+	ic_proxy_server_client_listener_init(timer->loop);
+}
+
+/*
+ * Signal handler.
+ *
+ * Signals are handled via the signalfd() call in libuv, so this is a normal
+ * callback as others, nothing special, errors can be raised, too.
+ */
+static void
+ic_proxy_server_on_signal(uv_signal_t *handle, int signum)
+{
+	ic_proxy_log(WARNING, "ic-proxy-server: received signal %d", signum);
+
+	if (signum == SIGHUP)
+	{
+		ProcessConfigFile(PGC_SIGHUP);
+
+		ic_proxy_reload_addresses();
+
+		ic_proxy_server_peer_listener_init(handle->loop);
+		ic_proxy_server_ensure_peers(handle->loop);
+		ic_proxy_server_client_listener_init(handle->loop);
+	}
+	else
+	{
+		uv_stop(handle->loop);
+	}
+}
+
+/*
+ * The main loop of the ic-proxy.
+ */
+int
+ic_proxy_server_main(void)
+{
+	char		path[MAXPGPATH];
+
+	ic_proxy_log(LOG, "ic-proxy-server: setting up");
+
+	ic_proxy_pkt_cache_init(IC_PROXY_MAX_PKT_SIZE);
+
+	ic_proxy_reload_addresses();
+
+	uv_loop_init(&ic_proxy_server_loop);
+
+	ic_proxy_router_init(&ic_proxy_server_loop);
+	ic_proxy_peer_table_init();
+	ic_proxy_client_table_init();
+
+	ic_proxy_peer_listening = false;
+	ic_proxy_client_listening = false;
+
+	uv_signal_init(&ic_proxy_server_loop, &ic_proxy_server_signal_hup);
+	uv_signal_start(&ic_proxy_server_signal_hup, ic_proxy_server_on_signal, SIGHUP);
+
+	uv_signal_init(&ic_proxy_server_loop, &ic_proxy_server_signal_int);
+	uv_signal_start(&ic_proxy_server_signal_hup, ic_proxy_server_on_signal, SIGINT);
+
+	/* on master */
+	uv_signal_init(&ic_proxy_server_loop, &ic_proxy_server_signal_term);
+	uv_signal_start(&ic_proxy_server_signal_term, ic_proxy_server_on_signal, SIGTERM);
+
+	/* on segments */
+	uv_signal_init(&ic_proxy_server_loop, &ic_proxy_server_signal_stop);
+	uv_signal_start(&ic_proxy_server_signal_stop, ic_proxy_server_on_signal, SIGQUIT);
+
+	/* TODO: we could stop the timer if all the peers are connected */
+	uv_timer_init(&ic_proxy_server_loop, &ic_proxy_server_timer);
+	uv_timer_start(&ic_proxy_server_timer, ic_proxy_server_on_timer, 100, 1000);
+
+	ic_proxy_log(LOG, "ic-proxy-server: running");
+
+	/* We're now ready to receive signals */
+	BackgroundWorkerUnblockSignals();
+
+	/*
+	 * return non-zero value so we are restarted by the postmaster, but this
+	 * behavior can be controled by calling ic_proxy_server_quit()
+	 */
+	ic_proxy_server_exit_code = 1;
+	uv_run(&ic_proxy_server_loop, UV_RUN_DEFAULT);
+	uv_loop_close(&ic_proxy_server_loop);
+
+	ic_proxy_log(LOG, "ic-proxy-server: closing");
+
+	ic_proxy_client_table_uninit();
+	ic_proxy_peer_table_uninit();
+	ic_proxy_router_uninit();
+
+	ic_proxy_build_server_sock_path(path, sizeof(path));
+#if 0
+	ic_proxy_log(LOG, "unlink(%s) ...", path);
+	unlink(path);
+#endif
+
+	ic_proxy_pkt_cache_uninit();
+
+	ic_proxy_log(LOG, "ic-proxy-server: closed with code %d",
+				 ic_proxy_server_exit_code);
+
+	return ic_proxy_server_exit_code;
+}
+
+void
+ic_proxy_server_quit(uv_loop_t *loop, bool relaunch)
+{
+	ic_proxy_log(LOG, "ic-proxy-server: quiting");
+
+	if (relaunch)
+		/* return non-zero value so we are restarted by the postmaster */
+		ic_proxy_server_exit_code = 1;
+	else
+		ic_proxy_server_exit_code = 0;
+
+	/*
+	 * we can't close the loop directly, we need to properly shutdown all the
+	 * clients first.
+	 */
+	if (ic_proxy_peer_listening)
+	{
+		uv_unref((uv_handle_t *) &ic_proxy_peer_listener);
+		uv_close((uv_handle_t *) &ic_proxy_peer_listener, NULL);
+	}
+	if (ic_proxy_client_listening)
+	{
+		uv_unref((uv_handle_t *) &ic_proxy_client_listener);
+		uv_close((uv_handle_t *) &ic_proxy_client_listener, NULL);
+	}
+	uv_timer_stop(&ic_proxy_server_timer);
+	uv_unref((uv_handle_t *) &ic_proxy_server_signal_hup);
+	uv_unref((uv_handle_t *) &ic_proxy_server_signal_term);
+	uv_unref((uv_handle_t *) &ic_proxy_server_signal_stop);
+
+#if 0
+	uv_client_table_disconnect_all();
+#endif
+
+	/*
+	 * do not close the loop directly, it will quit automatically after all the
+	 * clients are closed.
+	 */
+#if 0
+	uv_loop_close(loop);
+#endif
+}

--- a/src/backend/cdb/motion/ic_proxy_packet.c
+++ b/src/backend/cdb/motion/ic_proxy_packet.c
@@ -1,0 +1,249 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_message.c
+ *
+ *    Interconnect Proxy Packet and Message
+ *
+ * Similar to the ic-udp, in ic-proxy mode we also need to transfer the data as
+ * packets, the packet header contains all the necessary information to
+ * identify the sender, the receiver, as well the sequence (session id, command
+ * id, slice id).
+ *
+ * A message is a special kind of packet, it contains only the header, no
+ * payload.
+ *
+ * Packets and messages are all allocated from the packet cache, they must be
+ * freed with the ic_proxy_pkt_cache_free() function.
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "ic_proxy.h"
+#include "ic_proxy_packet.h"
+#include "ic_proxy_pkt_cache.h"
+
+/*
+ * Get the name string of a message type.
+ */
+const char *
+ic_proxy_message_type_to_str(ICProxyMessageType type)
+{
+	switch (type)
+	{
+		case IC_PROXY_MESSAGE_DATA:
+			return "DATA";
+		case IC_PROXY_MESSAGE_HELLO:
+			return "HELLO";
+		case IC_PROXY_MESSAGE_HELLO_ACK:
+			return "HELLO ACK";
+		case IC_PROXY_MESSAGE_PEER_QUIT:
+			return "PEER QUIT";
+		case IC_PROXY_MESSAGE_BYE:
+			return "BYE";
+		case IC_PROXY_MESSAGE_PAUSE:
+			return "PAUSE";
+		case IC_PROXY_MESSAGE_RESUME:
+			return "RESUME";
+		default:
+			return "UNKNOWN";
+	}
+}
+
+/*
+ * Build a new message from the key.
+ *
+ * The returned packet must be freed with the ic_proxy_pkt_cache_free()
+ * function.
+ */
+ICProxyPkt *
+ic_proxy_message_new(ICProxyMessageType type, const ICProxyKey *key)
+{
+	ICProxyPkt *pkt = ic_proxy_pkt_cache_alloc(NULL);
+
+	ic_proxy_message_init(pkt, type, key);
+
+	return pkt;
+}
+
+/*
+ * Initialize a message from the key.
+ *
+ * The pkt must be large enough to contain a packet header.
+ */
+void
+ic_proxy_message_init(ICProxyPkt *pkt, ICProxyMessageType type,
+					  const ICProxyKey *key)
+{
+	pkt->type = type;
+	pkt->len = sizeof(*pkt);
+
+	pkt->sessionId      = key->sessionId;
+	pkt->commandId      = key->commandId;
+	pkt->sendSliceIndex = key->sendSliceIndex;
+	pkt->recvSliceIndex = key->recvSliceIndex;
+
+	pkt->srcContentId   = key->localContentId;
+	pkt->srcDbid        = key->localDbid;
+	pkt->srcPid         = key->localPid;
+
+	pkt->dstContentId   = key->remoteContentId;
+	pkt->dstDbid        = key->remoteDbid;
+	pkt->dstPid         = key->remotePid;
+}
+
+/*
+ * Build a new packet.
+ *
+ * The data will also be copied to the packet.
+ *
+ * The returned packet must be freed with the ic_proxy_pkt_cache_free()
+ * function.
+ */
+ICProxyPkt *
+ic_proxy_pkt_new(const ICProxyKey *key, const void *data, uint16 size)
+{
+	ICProxyPkt *pkt;
+
+	Assert(size + sizeof(*pkt) <= IC_PROXY_MAX_PKT_SIZE);
+
+	pkt = ic_proxy_pkt_cache_alloc(NULL);
+	ic_proxy_message_init(pkt, IC_PROXY_MESSAGE_DATA, key);
+
+	memcpy(((char *) pkt) + sizeof(*pkt), data, size);
+	pkt->len = sizeof(*pkt) + size;
+
+	return pkt;
+}
+
+/*
+ * Duplicate a packet.
+ *
+ * The returned packet must be freed with the ic_proxy_pkt_cache_free()
+ * function.
+ */
+ICProxyPkt *
+ic_proxy_pkt_dup(const ICProxyPkt *pkt)
+{
+	ICProxyPkt *newpkt;
+
+	newpkt = ic_proxy_pkt_cache_alloc(NULL);
+	memcpy(newpkt, pkt, pkt->len);
+
+	return newpkt;
+}
+
+/*
+ * Build a describe string of a packet.
+ *
+ * The string contains all the header information, can be used in log & error
+ * messages.
+ *
+ * Return the string, which must not be freed.  The string is in a static
+ * buffer, so a second call to this function will overwrite the result of the
+ * previous call.
+ */
+const char *
+ic_proxy_pkt_to_str(const ICProxyPkt *pkt)
+{
+	static char	buf[256];
+
+	snprintf(buf, sizeof(buf),
+			 "%s [con%d,cmd%d,slice[%hd->%hd] %hu bytes seg%hd:dbid%hu:p%d->seg%hd:dbid%hu:p%d]",
+			 ic_proxy_message_type_to_str(pkt->type),
+			 pkt->sessionId, pkt->commandId,
+			 pkt->sendSliceIndex, pkt->recvSliceIndex,
+			 pkt->len,
+			 pkt->srcContentId, pkt->srcDbid, pkt->srcPid,
+			 pkt->dstContentId, pkt->dstDbid, pkt->dstPid);
+
+	return buf;
+}
+
+/*
+ * Check whether a packet is from a client.
+ *
+ * The client is identified by the key.
+ */
+bool
+ic_proxy_pkt_is_from_client(const ICProxyPkt *pkt, const ICProxyKey *key)
+{
+	return pkt->srcDbid        == key->localDbid
+		&& pkt->srcPid         == key->localPid
+		&& pkt->dstDbid        == key->remoteDbid
+		&& pkt->dstPid         == key->remotePid
+		&& pkt->sendSliceIndex == key->sendSliceIndex
+		&& pkt->recvSliceIndex == key->recvSliceIndex
+		;
+}
+
+/*
+ * Check whether a packet is to a client.
+ *
+ * The client is identified by the key.
+ */
+bool
+ic_proxy_pkt_is_to_client(const ICProxyPkt *pkt, const ICProxyKey *key)
+{
+	return pkt->dstDbid        == key->localDbid
+		&& pkt->dstPid         == key->localPid
+		&& pkt->srcDbid        == key->remoteDbid
+		&& pkt->srcPid         == key->remotePid
+		&& pkt->sendSliceIndex == key->sendSliceIndex
+		&& pkt->recvSliceIndex == key->recvSliceIndex
+		;
+}
+
+/*
+ * Check whether a packet is live to a client.
+ *
+ * The client is identified by the key.
+ *
+ * A live packet has the same (sessionId, commandId) with the client.
+ */
+bool
+ic_proxy_pkt_is_live(const ICProxyPkt *pkt, const ICProxyKey *key)
+{
+	return pkt->sessionId == key->sessionId
+		&& pkt->commandId == key->commandId
+		;
+}
+
+/*
+ * Check whether a packet is out-of-date to a client.
+ *
+ * The client is identified by the key.
+ *
+ * A packet is out-of-date if
+ *
+ *     pkt.(sessionId, commandId) < client.(sessionId, commandId)
+ */
+bool
+ic_proxy_pkt_is_out_of_date(const ICProxyPkt *pkt, const ICProxyKey *key)
+{
+	return ((pkt->sessionId <  key->sessionId) ||
+			(pkt->sessionId == key->sessionId &&
+			 pkt->commandId <  key->commandId));
+}
+
+/*
+ * Check whether a packet is in the future to a client.
+ *
+ * The client is identified by the key.
+ *
+ * A packet is in the future if
+ *
+ *     pkt.(sessionId, commandId) > client.(sessionId, commandId)
+ */
+bool
+ic_proxy_pkt_is_in_the_future(const ICProxyPkt *pkt, const ICProxyKey *key)
+{
+	return ((pkt->sessionId >  key->sessionId) ||
+			(pkt->sessionId == key->sessionId &&
+			 pkt->commandId >  key->commandId));
+}

--- a/src/backend/cdb/motion/ic_proxy_packet.h
+++ b/src/backend/cdb/motion/ic_proxy_packet.h
@@ -1,0 +1,107 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_packet.h
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef IC_PROXY_PACKET_H
+#define IC_PROXY_PACKET_H
+
+#include "postgres.h"
+
+#include "cdb/cdbvars.h"
+
+typedef struct ICProxyPkt ICProxyPkt;
+
+/* we have to include it after the declaration of ICProxyPkt */
+#include "ic_proxy_key.h"
+
+#define IC_PROXY_MAX_PKT_SIZE (Gp_max_packet_size + sizeof(ICProxyPkt))
+
+typedef enum
+{
+	IC_PROXY_MESSAGE_DATA = 0,
+
+	/* TODO: separate peer messages and client messages */
+
+	/*
+	 * these are common messages of peers and clients, however they have
+	 * slightly different meanings between peers and clients, it's better to
+	 * separate them.
+	 * */
+	IC_PROXY_MESSAGE_HELLO,
+	IC_PROXY_MESSAGE_HELLO_ACK,
+
+	/* these are peer messages */
+	IC_PROXY_MESSAGE_PEER_QUIT,
+
+	/* these are client messages */
+	IC_PROXY_MESSAGE_BYE,
+	IC_PROXY_MESSAGE_PAUSE,
+	IC_PROXY_MESSAGE_RESUME,
+} ICProxyMessageType;
+
+struct ICProxyPkt
+{
+	uint16		len;
+	uint16		type;
+
+	int16		srcContentId;
+	uint16		srcDbid;
+	int32		srcPid;
+
+	int16		dstContentId;
+	uint16		dstDbid;
+	int32		dstPid;
+
+	int32		sessionId;
+	uint32		commandId;
+	int16		sendSliceIndex;
+	int16		recvSliceIndex;
+};
+
+const char *ic_proxy_message_type_to_str(ICProxyMessageType type);
+
+extern ICProxyPkt *ic_proxy_message_new(ICProxyMessageType type,
+										const ICProxyKey *key);
+extern void ic_proxy_message_init(ICProxyPkt *pkt,
+								  ICProxyMessageType type,
+								  const ICProxyKey *key);
+
+extern ICProxyPkt *ic_proxy_pkt_new(const ICProxyKey *key,
+									const void *data, uint16 size);
+extern ICProxyPkt *ic_proxy_pkt_dup(const ICProxyPkt *pkt);
+extern const char *ic_proxy_pkt_to_str(const ICProxyPkt *pkt);
+extern bool ic_proxy_pkt_is_from_client(const ICProxyPkt *pkt,
+										const ICProxyKey *key);
+extern bool ic_proxy_pkt_is_to_client(const ICProxyPkt *pkt,
+									  const ICProxyKey *key);
+extern bool ic_proxy_pkt_is_live(const ICProxyPkt *pkt,
+								 const ICProxyKey *key);
+extern bool ic_proxy_pkt_is_out_of_date(const ICProxyPkt *pkt,
+										const ICProxyKey *key);
+extern bool ic_proxy_pkt_is_in_the_future(const ICProxyPkt *pkt,
+										  const ICProxyKey *key);
+
+static inline ICProxyMessageType
+ic_proxy_message_get_type(const ICProxyPkt *pkt)
+{
+	return pkt->type;
+}
+
+static inline bool
+ic_proxy_pkt_is(const ICProxyPkt *pkt, ICProxyMessageType type)
+{
+	Assert(pkt);
+	Assert(pkt->len >= sizeof(*pkt));
+
+	/* then check the message type on demand */
+	return type == pkt->type;
+}
+
+#endif   /* IC_PROXY_PACKET_H */

--- a/src/backend/cdb/motion/ic_proxy_peer.c
+++ b/src/backend/cdb/motion/ic_proxy_peer.c
@@ -1,0 +1,918 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_server_peer.c
+ *
+ *    Interconnect Proxy Peer
+ *
+ * A peer lives in the proxy bgworker and connects to a proxy on an other
+ * segment.  When there are N segments, including the master, a proxy bgworker
+ * needs to connect to all the other (N - 1) segments, the same amount of peers
+ * are needed, too.
+ *
+ * A peer is identified with the dbid, so two different peers are used to
+ * connect to a remote segment's primary and mirror.  The proxy bgworker is not
+ * launched on a mirror until it is promoted, so most of time there is only the
+ * peer to the segment's primary, but there is a chance for the peer to the
+ * mirror to live together with the primary one, this happends during the
+ * mirror promotion.
+ *
+ * There are only one proxy connection between two proxies, a rule is put here
+ * that the proxy on segment X connects to the one on segment Y iff X > Y, not
+ * the reverse.  This rule is true even if X or Y crashes and relaunches the
+ * proxy bgworker.
+ *
+ * Peers always communicate to each other via ICProxyPkt, a connection must
+ * begin with the hand shaking messages.  A hand shaking is needed for a pair
+ * of peers to know the information of each other, such as the dbids.
+ *
+ * Clients can send packets before the peer hand shaking is finished, in such a
+ * case a placeholder is registered to hold the early outgoing packets.  Once
+ * the peer finishes the hand shaking it replaces the placeholder and handles
+ * these early packets in the arriving order.
+ *
+ * Incoming packets, the one received from a remote peer, is never cached in
+ * the peer, they are routed to the target clients, or their placeholders,
+ * immediately.
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "ic_proxy_server.h"
+#include "ic_proxy_pkt_cache.h"
+
+#include <uv.h>
+
+
+/*
+ * The peer register table, the peer with dbid is stored in [dbid].
+ *
+ * TODO: not using a fixed length array.
+ */
+static ICProxyPeer *ic_proxy_peers[65536];
+
+
+static void ic_proxy_peer_shutdown(ICProxyPeer *peer);
+static void ic_proxy_peer_handle_out_cache(ICProxyPeer *peer);
+static void ic_proxy_peer_on_data_pkt(void *opaque,
+									  const void *data, uint16 size);
+static void ic_proxy_peer_send_message(ICProxyPeer *peer,
+									   ICProxyMessageType mtype,
+									   const ICProxyKey *key,
+									   ic_proxy_sent_cb callback);
+
+
+/*
+ * Build a delayed packet.
+ *
+ * We'll take the packet's ownership.
+ */
+ICProxyDelay *
+ic_proxy_peer_build_delay(ICProxyPeer *peer, ICProxyPkt *pkt,
+						  ic_proxy_sent_cb callback, void *opaque)
+{
+	ICProxyDelay *delay;
+
+	delay = ic_proxy_new(ICProxyDelay);
+	delay->content = peer ? peer->content : IC_PROXY_INVALID_CONTENT;
+	delay->dbid = peer ? peer->dbid : IC_PROXY_INVALID_DBID;
+	delay->pkt = pkt;
+	delay->callback = callback;
+	delay->opaque = opaque;
+
+	return delay;
+}
+
+/*
+ * Initialize the peer register table.
+ */
+void
+ic_proxy_peer_table_init(void)
+{
+	memset(ic_proxy_peers, 0, sizeof(ic_proxy_peers));
+}
+
+void
+ic_proxy_peer_table_uninit(void)
+{
+	/*
+	 * nothing to do for the peers table:
+	 * - no need to clear the peers table, we will do that in init();
+	 * - no need to free the peers, they should already freed themselves;
+	 */
+}
+
+/*
+ * Update the peer name from the state bits.
+ */
+static void
+ic_proxy_peer_update_name(ICProxyPeer *peer)
+{
+	struct sockaddr_storage peeraddr;
+	int			addrlen = sizeof(peeraddr);
+	char		sockname[HOST_NAME_MAX] = "";
+	char		peername[HOST_NAME_MAX] = "";
+	int			sockport = 0;
+	int			peerport = 0;
+
+	/*
+	 * Show the tcp level connection information in the name, they are not very
+	 * useful, though.
+	 */
+	uv_tcp_getsockname(&peer->tcp, (struct sockaddr *) &peeraddr, &addrlen);
+	if (peeraddr.ss_family == AF_INET)
+	{
+		struct sockaddr_in *peeraddr4 = (struct sockaddr_in *) &peeraddr;
+
+		uv_ip4_name(peeraddr4, sockname, sizeof(sockname));
+		sockport = ntohs(peeraddr4->sin_port);
+	}
+	else if (peeraddr.ss_family == AF_INET6)
+	{
+		struct sockaddr_in6 *peeraddr6 = (struct sockaddr_in6 *) &peeraddr;
+
+		uv_ip6_name(peeraddr6, sockname, sizeof(sockname));
+		sockport =  ntohs(peeraddr6->sin6_port);
+	}
+
+	uv_tcp_getpeername(&peer->tcp, (struct sockaddr *) &peeraddr, &addrlen);
+	if (peeraddr.ss_family == AF_INET)
+	{
+		struct sockaddr_in *peeraddr4 = (struct sockaddr_in *) &peeraddr;
+
+		uv_ip4_name(peeraddr4, peername, sizeof(peername));
+		peerport = ntohs(peeraddr4->sin_port);
+	}
+	else if (peeraddr.ss_family == AF_INET6)
+	{
+		struct sockaddr_in6 *peeraddr6 = (struct sockaddr_in6 *) &peeraddr;
+
+		uv_ip6_name(peeraddr6, peername, sizeof(peername));
+		peerport =  ntohs(peeraddr6->sin6_port);
+	}
+
+	snprintf(peer->name, sizeof(peer->name), "peer%s[seg%hd,dbid%hu %s:%d->%s:%d]",
+			 (peer->state & IC_PROXY_PEER_STATE_LEGACY) ? ".legacy" : "",
+			 peer->content, peer->dbid, sockname, sockport, peername, peerport);
+}
+
+/*
+ * Unregister a peer.
+ */
+static void
+ic_proxy_peer_unregister(ICProxyPeer *peer)
+{
+	Assert(peer->dbid > 0);
+
+	if (ic_proxy_peers[peer->dbid] == peer)
+	{
+		/* keep the peer as a placeholder */
+
+		ic_proxy_log(LOG, "%s: unregistered", peer->name);
+
+		/* reset the state */
+		peer->state = 0;
+		ic_proxy_peer_update_name(peer);
+	}
+	else if (ic_proxy_peers[peer->dbid])
+	{
+		/*
+		 * if there is already a placeholder, transfer my cached packets to it
+		 */
+		ICProxyPeer *placeholder = ic_proxy_peers[peer->dbid];
+
+		placeholder->reqs = list_concat(placeholder->reqs, peer->reqs);
+		peer->reqs = NIL;
+
+		/* then free the peer */
+		ic_proxy_peer_free(peer);
+	}
+}
+
+/*
+ * Register a peer.
+ */
+static void
+ic_proxy_peer_register(ICProxyPeer *peer)
+{
+	ICProxyPeer *placeholder = ic_proxy_peers[peer->dbid];
+
+	Assert(peer->dbid > 0);
+
+	if (placeholder)
+	{
+		/*
+		 * FIXME: is it possible for a new peer to come before the legacy one
+		 * is ready for message?
+		 */
+
+		if (placeholder->state & IC_PROXY_PEER_STATE_READY_FOR_MESSAGE)
+		{
+			/*
+			 * This is not actually a placeholder, but a legacy peer, this
+			 * happens due to network problem, etc..
+			 */
+			ic_proxy_log(WARNING, "%s(state=0x%08x): found a legacy peer %s(state=0x%08x)",
+						 peer->name, peer->state,
+						 placeholder->name, placeholder->state);
+
+			placeholder->state |= IC_PROXY_PEER_STATE_LEGACY;
+			ic_proxy_peer_update_name(placeholder);
+
+			ic_proxy_peer_shutdown(placeholder);
+		}
+		else
+		{
+			/* This is an actual placeholder */
+			ic_proxy_log(LOG, "%s(state=0x%08x): found my placeholder %s(state=0x%08x)",
+						 peer->name, peer->state,
+						 placeholder->name, placeholder->state);
+
+			if (placeholder->ibuf.len > 0)
+				ic_proxy_log(WARNING, "%s(state=0x%08x): my placeholder %s(state=0x%08x) has %d bytes in ibuf",
+							 peer->name, peer->state,
+							 placeholder->name, placeholder->state,
+							 placeholder->ibuf.len);
+
+			/* TODO: verify that it's really a placeholder */
+
+			/* transfer the cached pkts */
+			peer->reqs = list_concat(peer->reqs, placeholder->reqs);
+			placeholder->reqs = NIL;
+
+			/* finally free the placeholder */
+			ic_proxy_peer_free(placeholder);
+		}
+	}
+
+	ic_proxy_peers[peer->dbid] = peer;
+
+	ic_proxy_log(LOG, "%s: registered", peer->name);
+}
+
+/*
+ * Lookup a peer with peerid.
+ *
+ * We require to pass both content and dbid as arguments, but only dbid is
+ * used.
+ */
+ICProxyPeer *
+ic_proxy_peer_lookup(int16 content, uint16 dbid)
+{
+	Assert(dbid > 0);
+
+	return ic_proxy_peers[dbid];
+}
+
+/*
+ * Lookup a peer with peerid, create a placeholder if not found.
+ */
+ICProxyPeer *
+ic_proxy_peer_blessed_lookup(uv_loop_t *loop, int16 content, uint16 dbid)
+{
+	Assert(dbid > 0);
+
+	if (!ic_proxy_peers[dbid])
+	{
+		ICProxyPeer *peer = ic_proxy_peer_new(loop, content, dbid);
+
+		/* register as a placeholder */
+		ic_proxy_peer_register(peer);
+	}
+
+	return ic_proxy_peers[dbid];
+}
+
+/*
+ * Received a complete DATA or MESSAGE packet from a remote peer.
+ */
+static void
+ic_proxy_peer_on_data_pkt(void *opaque, const void *data, uint16 size)
+{
+	const ICProxyPkt *pkt = data;
+	ICProxyPeer *peer = opaque;
+
+	ic_proxy_log(LOG, "%s: received %s", peer->name, ic_proxy_pkt_to_str(pkt));
+
+	if (!(peer->state & IC_PROXY_PEER_STATE_READY_FOR_DATA))
+	{
+		ic_proxy_log(WARNING, "%s: not ready to receive DATA yet: %s",
+					 peer->name, ic_proxy_pkt_to_str(pkt));
+		return;
+	}
+
+	ic_proxy_router_route(peer->tcp.loop, ic_proxy_pkt_dup(pkt), NULL, NULL);
+}
+
+/*
+ * Received bytes from a remote peer.
+ */
+static void
+ic_proxy_peer_on_data(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf)
+{
+	ICProxyPeer *peer = CONTAINER_OF((void *) stream, ICProxyPeer, tcp);
+
+	if (unlikely(nread < 0))
+	{
+		if (nread != UV_EOF)
+			ic_proxy_log(WARNING, "%s: fail to receive DATA: %s",
+						 peer->name, uv_strerror(nread));
+		else
+			ic_proxy_log(LOG, "%s: received EOF while waiting for DATA",
+						 peer->name);
+
+		if (buf->base)
+			ic_proxy_pkt_cache_free(buf->base);
+
+		ic_proxy_peer_shutdown(peer);
+		return;
+	}
+	else if (unlikely(nread == 0))
+	{
+		if (buf->base)
+			ic_proxy_pkt_cache_free(buf->base);
+
+		/* EAGAIN or EWOULDBLOCK, retry */
+		return;
+	}
+
+	ic_proxy_ibuf_push(&peer->ibuf, buf->base, nread,
+					   ic_proxy_peer_on_data_pkt, peer);
+	ic_proxy_pkt_cache_free(buf->base);
+}
+
+/*
+ * Create a peer.
+ */
+ICProxyPeer *
+ic_proxy_peer_new(uv_loop_t *loop, int16 content, uint16 dbid)
+{
+	ICProxyPeer *peer;
+
+	peer = ic_proxy_new(ICProxyPeer);
+	peer->content = content;
+	peer->dbid = dbid;
+	peer->state = 0;
+	peer->reqs = NIL;
+
+	ic_proxy_ibuf_init_p2p(&peer->ibuf);
+
+	uv_tcp_init(loop, &peer->tcp);
+	uv_tcp_nodelay(&peer->tcp, true);
+
+	ic_proxy_peer_update_name(peer);
+
+	return peer;
+}
+
+/*
+ * Free a peer.
+ *
+ * A peer should only be used if it is really unused.  Most of the time a
+ * closed peer is converted to a placeholder, so it should not be freed.  Only
+ * a replaced placeholder should be freed.
+ */
+void
+ic_proxy_peer_free(ICProxyPeer *peer)
+{
+	ListCell   *cell;
+
+	ic_proxy_log(LOG, "%s: freeing", peer->name);
+
+	foreach(cell, peer->reqs)
+	{
+		ICProxyPkt *pkt = lfirst(cell);
+
+		ic_proxy_log(WARNING, "%s: unhandled outgoing %s, dropping it",
+					 peer->name, ic_proxy_pkt_to_str(pkt));
+
+		ic_proxy_pkt_cache_free(pkt);
+	}
+
+	list_free(peer->reqs);
+
+	ic_proxy_ibuf_uninit(&peer->ibuf);
+	ic_proxy_free(peer);
+
+	/*
+	 * TODO: if a peer disconnected, should we also disconnect all the relative
+	 * clients?  The concern is that some packets might already be lost.
+	 *
+	 * Anyway, future packets should not be cached inside the peer.
+	 */
+}
+
+/*
+ * The peer is closed.
+ */
+static void
+ic_proxy_peer_on_close(uv_handle_t *handle)
+{
+	ICProxyPeer *peer = CONTAINER_OF((void *) handle, ICProxyPeer, tcp);
+
+	ic_proxy_log(LOG, "%s: closed", peer->name);
+
+	/* reset the state */
+	peer->state = 0;
+
+	/* it's unlikely that the ibuf is non-empty, but clear it for sure */
+	ic_proxy_ibuf_clear(&peer->ibuf);
+
+	ic_proxy_peer_unregister(peer);
+}
+
+/*
+ * Close a peer.
+ *
+ * A peer could only be closed after its shutdown.
+ */
+static void
+ic_proxy_peer_close(ICProxyPeer *peer)
+{
+	if (peer->state & IC_PROXY_PEER_STATE_CLOSING)
+		return;
+
+	ic_proxy_log(LOG, "%s: closing", peer->name);
+
+	peer->state |= IC_PROXY_PEER_STATE_CLOSING;
+
+	uv_close((uv_handle_t *) &peer->tcp, ic_proxy_peer_on_close);
+}
+
+/*
+ * The peer is shutted down.
+ */
+static void
+ic_proxy_peer_on_shutdown(uv_shutdown_t *req, int status)
+{
+	ICProxyPeer *peer = CONTAINER_OF((void *) req->handle, ICProxyPeer, tcp);
+
+	ic_proxy_free(req);
+
+	if (status < 0)
+		ic_proxy_log(WARNING, "%s: fail to shutdown: %s",
+					 peer->name, uv_strerror(status));
+
+	ic_proxy_log(LOG, "%s: shutted down", peer->name);
+
+	peer->state |= IC_PROXY_PEER_STATE_SHUTTED;
+
+	ic_proxy_peer_close(peer);
+}
+
+/*
+ * Shutdown a peer.
+ */
+static void
+ic_proxy_peer_shutdown(ICProxyPeer *peer)
+{
+	uv_shutdown_t *req;
+
+	if (peer->state & IC_PROXY_PEER_STATE_SHUTTING)
+		return;
+
+	ic_proxy_log(LOG, "%s: shutting down", peer->name);
+
+	peer->state |= IC_PROXY_PEER_STATE_SHUTTING;
+
+	/* disconnect all the clients */
+	ic_proxy_client_table_shutdown_by_dbid(peer->dbid);
+
+	req = ic_proxy_new(uv_shutdown_t);
+
+	uv_shutdown(req, (uv_stream_t *) &peer->tcp, ic_proxy_peer_on_shutdown);
+}
+
+/*
+ * Sent the HELLO ACK message.
+ */
+static void
+ic_proxy_peer_on_sent_hello_ack(void *opaque, const ICProxyPkt *pkt, int status)
+{
+	ICProxyPeer *peer = opaque;
+
+	if (status < 0)
+	{
+		ic_proxy_peer_shutdown(peer);
+		return;
+	}
+
+	peer->state |= IC_PROXY_PEER_STATE_SENT_HELLO_ACK;
+
+	ic_proxy_log(LOG, "%s: start receiving DATA", peer->name);
+
+	/* it's unlikely that the ibuf is non-empty, but clear it for sure */
+	ic_proxy_ibuf_clear(&peer->ibuf);
+
+	/*
+	 * If there are early coming packets, make sure to route them before
+	 * receiving new data, we must ensure that packets are routed in the same
+	 * order as they arrive.
+	 */
+	ic_proxy_peer_handle_out_cache(peer);
+
+	/* now it's time to receive the normal data */
+	uv_read_start((uv_stream_t *) &peer->tcp,
+				  ic_proxy_pkt_cache_alloc_buffer, ic_proxy_peer_on_data);
+}
+
+/*
+ * Received the complete HELLO message.
+ */
+static void
+ic_proxy_peer_on_hello_pkt(void *opaque, const void *data, uint16 size)
+{
+	const ICProxyPkt *pkt = data;
+	ICProxyPeer *peer = opaque;
+	ICProxyKey	key;
+
+	/* we only expect one hello message */
+	uv_read_stop((uv_stream_t *) &peer->tcp);
+
+	ic_proxy_key_from_p2c_pkt(&key, pkt);
+
+	/* TODO: verify that old dbid and content are both set or invalid */
+	peer->content = key.remoteContentId;
+	peer->dbid = key.remoteDbid;
+
+	ic_proxy_peer_update_name(peer);
+
+	/*
+	 * A peer could be registered as long as it knows the peer information from
+	 * the HELLO message, the client packets will still be cached until the
+	 * HELLO ACK is sent out.
+	 */
+	ic_proxy_peer_register(peer);
+
+	ic_proxy_log(LOG, "%s: received %s, sending HELLO ACK",
+				 peer->name, ic_proxy_pkt_to_str(pkt));
+
+	/*
+	 * below two state bits can be merged into one, but it is harmless to keep
+	 * them as two.
+	 */
+	peer->state |= IC_PROXY_PEER_STATE_RECEIVED_HELLO;
+
+	peer->state |= IC_PROXY_PEER_STATE_SENDING_HELLO_ACK;
+
+	ic_proxy_key_reverse(&key);
+	key.localPid = MyProcPid;
+
+	ic_proxy_peer_send_message(peer, IC_PROXY_MESSAGE_HELLO_ACK, &key,
+							   ic_proxy_peer_on_sent_hello_ack);
+}
+
+/*
+ * Received some HELLO bytes.
+ */
+static void
+ic_proxy_peer_on_hello_data(uv_stream_t *stream,
+							ssize_t nread, const uv_buf_t *buf)
+{
+	ICProxyPeer *peer = CONTAINER_OF((void *) stream, ICProxyPeer, tcp);
+
+	if (unlikely(nread < 0))
+	{
+		if (nread != UV_EOF)
+			ic_proxy_log(WARNING, "%s: fail to receive HELLO: %s",
+						 peer->name, uv_strerror(nread));
+		else
+			ic_proxy_log(LOG, "%s: received EOF while waiting for HELLO",
+						 peer->name);
+
+		if (buf->base)
+			ic_proxy_pkt_cache_free(buf->base);
+
+		ic_proxy_peer_shutdown(peer);
+		return;
+	}
+	else if (unlikely(nread == 0))
+	{
+		if (buf->base)
+			ic_proxy_pkt_cache_free(buf->base);
+
+		/* EAGAIN or EWOULDBLOCK, retry */
+		return;
+	}
+
+	ic_proxy_ibuf_push(&peer->ibuf, buf->base, nread,
+					   ic_proxy_peer_on_hello_pkt, peer);
+	ic_proxy_pkt_cache_free(buf->base);
+}
+
+/*
+ * Start reading the HELLO message.
+ */
+void
+ic_proxy_peer_read_hello(ICProxyPeer *peer)
+{
+	if (peer->state & IC_PROXY_PEER_STATE_RECEIVING_HELLO)
+		return;
+
+	ic_proxy_log(LOG, "%s: waiting for HELLO", peer->name);
+
+	peer->state |= IC_PROXY_PEER_STATE_RECEIVING_HELLO;
+
+	uv_read_start((uv_stream_t *) &peer->tcp,
+				  ic_proxy_pkt_cache_alloc_buffer, ic_proxy_peer_on_hello_data);
+}
+
+/*
+ * Received the complete HELLO ACK message.
+ */
+static void
+ic_proxy_peer_on_hello_ack_pkt(void *opaque, const void *data, uint16 size)
+{
+	const ICProxyPkt *pkt = data;
+	ICProxyPeer *peer = opaque;
+
+	if (size < sizeof(*pkt) || size != pkt->len)
+		ic_proxy_log(ERROR, "%s: received incomplete HELLO ACK: size = %d",
+					 peer->name, size);
+
+	if (peer->state & IC_PROXY_PEER_STATE_RECEIVED_HELLO_ACK)
+	{
+		/*
+		 * A DATA packet is sent together with the HELLO, so the ibuf push the
+		 * DATA here.  I still don't know how would this happen, but this does
+		 * happen on the pipeline, so at least let it work.
+		 *
+		 * TODO: as we can't draw a clear line between handshake and data, it
+		 * would be better to merge on_hello* and on_data into one.
+		 */
+		ic_proxy_log(WARNING, "%s: early DATA: %s",
+					 peer->name, ic_proxy_pkt_to_str(pkt));
+
+		ic_proxy_peer_on_data_pkt(opaque, data, size);
+		return;
+	}
+
+	if (!ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_HELLO_ACK))
+		ic_proxy_log(ERROR, "%s: received invalid HELLO ACK: %s",
+					 peer->name, ic_proxy_pkt_to_str(pkt));
+
+	if (pkt->dstDbid != peer->dbid)
+		ic_proxy_log(ERROR, "%s: received invalid HELLO ACK: %s",
+					 peer->name, ic_proxy_pkt_to_str(pkt));
+
+	/* we only expect one hello ack message */
+	uv_read_stop((uv_stream_t *) &peer->tcp);
+
+	ic_proxy_log(LOG, "%s: received %s", peer->name, ic_proxy_pkt_to_str(pkt));
+
+	peer->state |= IC_PROXY_PEER_STATE_RECEIVED_HELLO_ACK;
+
+	/* do not clear the ibuf, it could already contain incoming DATA */
+
+	/*
+	 * If there are early coming packets, make sure to route them before
+	 * receiving new data, we must ensure that packets are routed in the same
+	 * order as they arrive.
+	 */
+	ic_proxy_peer_handle_out_cache(peer);
+
+	ic_proxy_log(LOG, "%s: start receiving DATA", peer->name);
+
+	/* now it's time to receive the normal data */
+	uv_read_start((uv_stream_t *) &peer->tcp,
+				  ic_proxy_pkt_cache_alloc_buffer, ic_proxy_peer_on_data);
+}
+
+/*
+ * Received HELLO ACK bytes.
+ */
+static void
+ic_proxy_peer_on_hello_ack_data(uv_stream_t *stream,
+								ssize_t nread, const uv_buf_t *buf)
+{
+	ICProxyPeer *peer = CONTAINER_OF((void *) stream, ICProxyPeer, tcp);
+
+	if (unlikely(nread < 0))
+	{
+		if (nread != UV_EOF)
+			ic_proxy_log(WARNING, "%s: fail to recv HELLO ACK: %s",
+						 peer->name, uv_strerror(nread));
+		else
+			ic_proxy_log(LOG, "%s: received EOF while waiting for HELLO ACK",
+						 peer->name);
+
+		if (buf->base)
+			ic_proxy_pkt_cache_free(buf->base);
+
+		ic_proxy_peer_shutdown(peer);
+		return;
+	}
+	else if (unlikely(nread == 0))
+	{
+		if (buf->base)
+			ic_proxy_pkt_cache_free(buf->base);
+
+		/* EAGAIN or EWOULDBLOCK, retry */
+		return;
+	}
+
+	ic_proxy_ibuf_push(&peer->ibuf, buf->base, nread,
+					   ic_proxy_peer_on_hello_ack_pkt, peer);
+	ic_proxy_pkt_cache_free(buf->base);
+}
+
+/*
+ * Sent the HELLO message.
+ */
+static void
+ic_proxy_peer_on_sent_hello(void *opaque, const ICProxyPkt *pkt, int status)
+{
+	ICProxyPeer *peer = opaque;
+
+	if (status < 0)
+	{
+		ic_proxy_peer_shutdown(peer);
+		return;
+	}
+
+	ic_proxy_log(LOG, "%s: waiting for HELLO ACK", peer->name);
+
+	peer->state |= IC_PROXY_PEER_STATE_SENT_HELLO;
+
+	peer->state |= IC_PROXY_PEER_STATE_RECEIVING_HELLO_ACK;
+
+	/* wait for hello ack */
+	uv_read_start((uv_stream_t *) &peer->tcp,
+				  ic_proxy_pkt_cache_alloc_buffer,
+				  ic_proxy_peer_on_hello_ack_data);
+}
+
+/*
+ * Connected to a peer.
+ */
+static void
+ic_proxy_peer_on_connected(uv_connect_t *conn, int status)
+{
+	ICProxyPeer *peer = CONTAINER_OF((void *) conn->handle, ICProxyPeer, tcp);
+	ICProxyKey	key;
+
+	ic_proxy_free(conn);
+
+	if (status < 0)
+	{
+		/* the peer might just not get ready yet, retry later */
+		ic_proxy_log(LOG, "%s: fail to connect: %s",
+					 peer->name, uv_strerror(status));
+		ic_proxy_peer_close(peer);
+		return;
+	}
+
+	ic_proxy_log(LOG, "%s: connected, sending HELLO", peer->name);
+
+	peer->state |= IC_PROXY_PEER_STATE_CONNECTED;
+
+	/* TODO: increase ic_proxy_peer_contents[peer->content] */
+
+	/* hello packet must be the first one from a client */
+
+	/*
+	 * For a peer HELLO message, the only meaningful field is localDbid,
+	 * but we also set the content and pid for debugging purpose.
+	 */
+	ic_proxy_key_init(&key,
+					  0						/* sessionId */,
+					  0						/* commandId */,
+					  0						/* sendSliceIndex */,
+					  0						/* recvSliceIndex */,
+					  GpIdentity.segindex	/* localContentId */,
+					  GpIdentity.dbid		/* localDbid */,
+					  MyProcPid				/* localPid */,
+					  peer->content			/* remoteContentId */,
+					  peer->dbid			/* remoteDbid */,
+					  0						/* remotePid */);
+
+	peer->state |= IC_PROXY_PEER_STATE_SENDING_HELLO;
+
+	ic_proxy_peer_update_name(peer);
+	ic_proxy_peer_send_message(peer, IC_PROXY_MESSAGE_HELLO, &key,
+							   ic_proxy_peer_on_sent_hello);
+}
+
+/*
+ * Connect to a remote peer.
+ */
+void
+ic_proxy_peer_connect(ICProxyPeer *peer, struct sockaddr_in *dest)
+{
+	uv_connect_t *conn;
+	char		name[HOST_NAME_MAX];
+
+	if (peer->state & IC_PROXY_PEER_STATE_CONNECTING)
+		return;
+
+	peer->state |= IC_PROXY_PEER_STATE_CONNECTING;
+
+	uv_ip4_name(dest, name, sizeof(name));
+	ic_proxy_log(LOG, "%s: connecting to %s:%d",
+				 peer->name, name, ntohs(dest->sin_port));
+
+	/* reinit the tcp handle */
+	uv_tcp_init(peer->tcp.loop, &peer->tcp);
+	uv_tcp_nodelay(&peer->tcp, true);
+
+	conn = ic_proxy_new(uv_connect_t);
+
+	uv_tcp_connect(conn, &peer->tcp, (struct sockaddr *) dest,
+				   ic_proxy_peer_on_connected);
+}
+
+/*
+ * Send a packet to a remote peer.
+ */
+void
+ic_proxy_peer_route_data(ICProxyPeer *peer, ICProxyPkt *pkt,
+						 ic_proxy_sent_cb callback, void *opaque)
+{
+	if (!(peer->state & IC_PROXY_PEER_STATE_READY_FOR_DATA))
+	{
+		ICProxyDelay *delay;
+
+		ic_proxy_log(LOG, "%s: caching outgoing %s",
+					 peer->name, ic_proxy_pkt_to_str(pkt));
+
+		delay = ic_proxy_peer_build_delay(peer, pkt, callback, opaque);
+		peer->reqs = lappend(peer->reqs, delay);
+
+		return;
+	}
+
+	ic_proxy_router_write((uv_stream_t *) &peer->tcp, pkt, 0, callback, opaque);
+}
+
+/*
+ * Send the peer control message, HELLO and HELLO ACK.  The client control
+ * message should be sent with ic_proxy_peer_route_data().
+ *
+ * TODO: it's better to separate the peer messages from the client messages
+ * completely.
+ */
+static void
+ic_proxy_peer_send_message(ICProxyPeer *peer, ICProxyMessageType mtype,
+						   const ICProxyKey *key, ic_proxy_sent_cb callback)
+{
+	ICProxyPkt *pkt;
+
+	if (!(peer->state & IC_PROXY_PEER_STATE_READY_FOR_MESSAGE))
+		ic_proxy_log(ERROR,
+					 "%s: not ready to send or receive messages",
+					 peer->name);
+
+	pkt = ic_proxy_message_new(mtype, key);
+
+	ic_proxy_router_write((uv_stream_t *) &peer->tcp, pkt, 0, callback, peer);
+}
+
+/*
+ * This function is only called on a new peer, so it is not so expansive to
+ * rebuild the cache list.
+ */
+static void
+ic_proxy_peer_handle_out_cache(ICProxyPeer *peer)
+{
+	List	   *reqs;
+	ListCell   *cell;
+
+	if (!(peer->state & IC_PROXY_PEER_STATE_READY_FOR_DATA))
+		return;
+
+	if (peer->reqs == NIL)
+		return;
+
+	ic_proxy_log(LOG, "%s: trying to consume the %d cached outgoing pkts",
+				 peer->name, list_length(peer->reqs));
+
+	/* First detach all the pkts */
+	reqs = peer->reqs;
+	peer->reqs = NIL;
+
+	/* Then re-handle them one by one */
+	foreach(cell, reqs)
+	{
+		ICProxyDelay *delay = lfirst(cell);
+
+		/* TODO: can we pass the delay directly? */
+		ic_proxy_peer_route_data(peer, delay->pkt,
+								 delay->callback, delay->opaque);
+
+		ic_proxy_free(delay);
+	}
+
+	ic_proxy_log(LOG, "%s: consumed %d cached pkts",
+				 peer->name, list_length(reqs) - list_length(peer->reqs));
+
+	/*
+	 * the pkts ownership were transfered during ic_proxy_peer_route_data(),
+	 * only need to free the list itself.
+	 */
+	list_free(reqs);
+}

--- a/src/backend/cdb/motion/ic_proxy_pkt_cache.c
+++ b/src/backend/cdb/motion/ic_proxy_pkt_cache.c
@@ -1,0 +1,158 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_pkt_cache.c
+ *
+ *    Interconnect Proxy Packet Cache
+ *
+ * Libuv needs us to allocate the packet buffer, and it does not reuse the
+ * buffer, so it is expansive to repeatedly allocating and freeing the packets.
+ *
+ * To make it more efficient we save all the freed packets in a free list, and
+ * reuse them later.
+ *
+ * All the allocated packets are of the same size, the max possible packet
+ * size, discarding the size requested by libuv, so the packet buffer can be
+ * safely reused later.
+ *
+ * TODO:
+ * - many libuv requests, such as uv_write(), needs us to allocate the request
+ *   buffer, they are not reused, too, we could consider saving them in a
+ *   free list similarly, or even share the same free list with packets;
+ * - we need to limit the size of the free list, currently packets are never
+ *   freed;
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#define IC_PROXY_LOG_LEVEL WARNING
+#include "ic_proxy.h"
+#include "ic_proxy_pkt_cache.h"
+
+#include <uv.h>
+
+typedef struct ICProxyPktCache ICProxyPktCache;
+
+/*
+ * A simple free list.
+ */
+struct ICProxyPktCache
+{
+	ICProxyPktCache *next;
+};
+
+static struct 
+{
+	ICProxyPktCache *freelist;	/* the free list */
+	uint32		pkt_size;		/* the packet size for all the packets */
+	uint32		n_free;			/* count of packets in the free list */
+	uint32		n_total;		/* count of all the allocated packets */
+} ic_proxy_pkt_cache;
+
+/*
+ * Initialize the packet cache.
+ */
+void
+ic_proxy_pkt_cache_init(uint32 pkt_size)
+{
+	ic_proxy_pkt_cache.freelist = NULL;
+	ic_proxy_pkt_cache.pkt_size = pkt_size;
+	ic_proxy_pkt_cache.n_free = 0;
+	ic_proxy_pkt_cache.n_total = 0;
+}
+
+/*
+ * Cleanup the packet cache.
+ */
+void
+ic_proxy_pkt_cache_uninit(void)
+{
+	while (ic_proxy_pkt_cache.freelist)
+	{
+		ICProxyPktCache *cpkt = ic_proxy_pkt_cache.freelist;
+
+		ic_proxy_pkt_cache.freelist = cpkt->next;
+		ic_proxy_free(cpkt);
+	}
+}
+
+/*
+ * Allocate a packet from the cache.
+ *
+ * If the free list is empty a new packet is allocated and returned, otherwise
+ * one is detached from the free list and returned directly.
+ *
+ * If pkt_size is not NULL it is set with the actual packet buffer size.
+ *
+ * Return the packet buffer.
+ */
+void *
+ic_proxy_pkt_cache_alloc(size_t *pkt_size)
+{
+	ICProxyPktCache *cpkt;
+
+	if (ic_proxy_pkt_cache.freelist)
+	{
+		cpkt = ic_proxy_pkt_cache.freelist;
+
+		ic_proxy_pkt_cache.freelist = cpkt->next;
+		ic_proxy_pkt_cache.n_free--;
+	}
+	else
+	{
+		cpkt = ic_proxy_alloc(ic_proxy_pkt_cache.pkt_size);
+		ic_proxy_pkt_cache.n_total++;
+	}
+
+	if (pkt_size)
+		*pkt_size = ic_proxy_pkt_cache.pkt_size;
+
+#if 0
+	/* for debug purpose */
+	memset(cpkt, 0, ic_proxy_pkt_cache.pkt_size);
+#endif
+
+	ic_proxy_log(LOG, "pkt-cache: allocated, %d free, %d total",
+				 ic_proxy_pkt_cache.n_free, ic_proxy_pkt_cache.n_total);
+	return cpkt;
+}
+
+/*
+ * Allocate a packet from the cache, as a libuv callback.
+ *
+ * This is a wrapper of ic_proxy_pkt_cache_alloc(), this function can be used
+ * as the libuv uv_alloc_cb callback.
+ */
+void
+ic_proxy_pkt_cache_alloc_buffer(uv_handle_t *handle, size_t size, uv_buf_t *buf)
+{
+	buf->base = ic_proxy_pkt_cache_alloc(&buf->len);
+}
+
+/*
+ * Return a packet to the free list.
+ */
+void
+ic_proxy_pkt_cache_free(void *pkt)
+{
+	ICProxyPktCache *cpkt = pkt;
+
+#if 0
+	/* for debug purpose */
+	memset(cpkt, 0, ic_proxy_pkt_cache.pkt_size);
+
+	for (ICProxyPktCache *iter = ic_proxy_pkt_cache.freelist;
+		 iter; iter = iter->next)
+		Assert(iter != cpkt);
+#endif
+
+	cpkt->next = ic_proxy_pkt_cache.freelist;
+	ic_proxy_pkt_cache.freelist = cpkt;
+	ic_proxy_pkt_cache.n_free++;
+
+	ic_proxy_log(LOG, "pkt-cache: recycled, %d free, %d total",
+				 ic_proxy_pkt_cache.n_free, ic_proxy_pkt_cache.n_total);
+}

--- a/src/backend/cdb/motion/ic_proxy_pkt_cache.h
+++ b/src/backend/cdb/motion/ic_proxy_pkt_cache.h
@@ -1,0 +1,24 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_pkt_cache.h
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef IC_PROXY_PKT_CACHE_H
+#define IC_PROXY_PKT_CACHE_H
+
+#include <uv.h>
+
+extern void ic_proxy_pkt_cache_init(uint32 pkt_size);
+extern void ic_proxy_pkt_cache_uninit(void);
+extern void *ic_proxy_pkt_cache_alloc(size_t *pkt_size);
+extern void ic_proxy_pkt_cache_alloc_buffer(uv_handle_t *handle,
+											size_t size, uv_buf_t *buf);
+extern void ic_proxy_pkt_cache_free(void *pkt);
+
+#endif   /* IC_PROXY_PKT_CACHE_H */

--- a/src/backend/cdb/motion/ic_proxy_router.c
+++ b/src/backend/cdb/motion/ic_proxy_router.c
@@ -1,0 +1,304 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_router.c
+ *
+ *    Interconnect Proxy Router
+ *
+ * A router routes a packet to the correct target, a client or a peer.
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+
+#include "ic_proxy.h"
+#include "ic_proxy_server.h"
+#include "ic_proxy_router.h"
+#include "ic_proxy_packet.h"
+#include "ic_proxy_pkt_cache.h"
+#include "ic_proxy_server.h"
+
+
+typedef struct ICProxyWriteReq ICProxyWriteReq;
+typedef struct ICProxyLoopback ICProxyLoopback;
+
+
+/*
+ * A router write request.
+ *
+ * It is similar to the libuv write request, however the router will take care
+ * of the common part, such as the freeing of the packet and the request, so
+ * the caller can focus on the real business.
+ */
+struct ICProxyWriteReq
+{
+	uv_write_t	req;			/* the libuv write request */
+
+	ic_proxy_sent_cb callback;	/* the callback */
+	void	   *opaque;			/* the callback data */
+};
+
+/*
+ * The loopback packet queue.
+ *
+ * Loopback packets can not be routed immediately, refer to ICProxyDelay for
+ * details.  They are first put in a queue, and are actually routed in a libuv
+ * check callback, it is triggered after all the current I/O events are
+ * handled, so there will be no misordered packets, and no reentrance to some
+ * critical functions.
+ */
+struct ICProxyLoopback
+{
+	uv_check_t	check;					/* the libuv check handle */
+
+	List	   *queue;					/* List<ICProxyWriteReq *> */
+};
+
+
+static ICProxyLoopback ic_proxy_router_loopback;
+
+
+/*
+ * The loopback check is triggered.
+ */
+static void
+ic_proxy_router_loopback_on_check(uv_check_t *handle)
+{
+	List	   *queue;
+	ListCell   *cell;
+
+	/*
+	 * Stop the check callback, all the queued loopback packets will be routed
+	 * in this round.  This must happen before routing the packets, so if new
+	 * loopback packets are queued, the check callback can be re-turned on,
+	 * those packets will be handled next round.
+	 *
+	 * TODO: the new loopback packets can be handled in this round, too.
+	 * Queueing them to next round means it will not be triggered until some
+	 * I/O events happen.  In current logic there is the per second timer, so
+	 * in worst case the new loopback packets are delayed for 1 second.  If the
+	 * timer is paused in the future, as an optimization, then in worst case
+	 * the new packets may not get a chance to be routed.  The only concern on
+	 * handling them now is that if a infinite ping-pong happens, this function
+	 * would never return to the mainloop.  It's unlikely to happen, though,
+	 * and we could prevent that by adding a round count limit.
+	 */
+	uv_check_stop(&ic_proxy_router_loopback.check);
+
+	/*
+	 * We must detach the queue before handling it, in case some new packets
+	 * are queued during the process
+	 */
+	queue = ic_proxy_router_loopback.queue;
+	ic_proxy_router_loopback.queue = NIL;
+
+	foreach(cell, queue)
+	{
+		ICProxyDelay *delay = lfirst(cell);
+		ICProxyClient *client;
+		ICProxyKey	key;
+
+		/* Loopback packets are always to a loopback client */
+		ic_proxy_key_from_p2c_pkt(&key, delay->pkt);
+		client = ic_proxy_client_blessed_lookup(handle->loop, &key);
+
+		ic_proxy_log(LOG, "ic-proxy-router: looped back %s to %s",
+					 ic_proxy_pkt_to_str(delay->pkt),
+					 ic_proxy_client_get_name(client));
+
+		ic_proxy_client_on_p2c_data(client, delay->pkt,
+									delay->callback, delay->opaque);
+
+		/* do not forget to call the callback */
+		if (delay->callback)
+			delay->callback(delay->opaque, delay->pkt, 0);
+
+		/* and do not forget to free the memory */
+		ic_proxy_free(delay);
+	}
+
+	list_free(queue);
+}
+
+/*
+ * Push a loopback packet to the queue.
+ */
+static void
+ic_proxy_router_loopback_push(ICProxyPkt *pkt,
+							  ic_proxy_sent_cb callback, void *opaque)
+{
+	ICProxyDelay *delay;
+
+	ic_proxy_log(LOG, "ic-proxy-router: looping back %s",
+				 ic_proxy_pkt_to_str(pkt));
+
+	/*
+	 * Enable the libuv check callback if not yet.
+	 */
+	if (ic_proxy_router_loopback.queue == NIL)
+		uv_check_start(&ic_proxy_router_loopback.check,
+					   ic_proxy_router_loopback_on_check);
+
+	/*
+	 * Loopback packets are always to a loopback client, so it's safe to pass
+	 * NULL as the peer.
+	 */
+	delay = ic_proxy_peer_build_delay(NULL, pkt, callback, opaque);
+	ic_proxy_router_loopback.queue = lappend(ic_proxy_router_loopback.queue, delay);
+}
+
+/*
+ * Initialize the router.
+ */
+void
+ic_proxy_router_init(uv_loop_t *loop)
+{
+	uv_check_init(loop, &ic_proxy_router_loopback.check);
+	ic_proxy_router_loopback.queue = NIL;
+}
+
+/*
+ * Cleanup the router.
+ */
+void
+ic_proxy_router_uninit(void)
+{
+	List	   *queue;
+	ListCell   *cell;
+
+	queue = ic_proxy_router_loopback.queue;
+	ic_proxy_router_loopback.queue = NIL;
+
+	uv_check_stop(&ic_proxy_router_loopback.check);
+
+	foreach(cell, queue)
+	{
+		ICProxyDelay *delay = lfirst(cell);
+
+		/*
+		 * TODO: this function is only called on exiting, so it's better to
+		 * drop the callbacks silently, right?
+		 */
+#if 0
+		if (delay->callback)
+			delay->callback(delay->opaque, pkt, UV_ECANCELED);
+#endif
+
+		ic_proxy_pkt_cache_free(delay->pkt);
+		ic_proxy_free(delay);
+	}
+
+	list_free(queue);
+}
+
+/*
+ * Route a packet.
+ */
+void
+ic_proxy_router_route(uv_loop_t *loop, ICProxyPkt *pkt,
+					  ic_proxy_sent_cb callback, void *opaque)
+{
+	if (pkt->dstDbid == pkt->srcDbid)
+	{
+		/*
+		 * For a loopback target, we do not need to send the packet via a peer,
+		 * we could pass the packet to the target client via
+		 * ic_proxy_client_on_p2c_data(), however that function is not
+		 * reentrantable, which happens on PAUSE & RESUME messages, so we must
+		 * schedule it in a libuv check callback.
+		 *
+		 * TODO: when callback is NULL, we could pass the packet immediately.
+		 */
+		ic_proxy_router_loopback_push(pkt, callback, opaque);
+	}
+	else if (pkt->dstDbid == GpIdentity.dbid)
+	{
+		ICProxyClient *client;
+		ICProxyKey	key;
+
+		ic_proxy_key_from_p2c_pkt(&key, pkt);
+		client = ic_proxy_client_blessed_lookup(loop, &key);
+
+		ic_proxy_log(LOG, "ic-proxy-router: routing %s to %s",
+					 ic_proxy_pkt_to_str(pkt),
+					 ic_proxy_client_get_name(client));
+
+		ic_proxy_client_on_p2c_data(client, pkt, callback, opaque);
+	}
+	else
+	{
+		ICProxyPeer *peer;
+
+		peer = ic_proxy_peer_blessed_lookup(loop,
+											pkt->dstContentId, pkt->dstDbid);
+
+		ic_proxy_log(LOG, "ic-proxy-router: routing %s to %s",
+					 ic_proxy_pkt_to_str(pkt), peer->name);
+
+		ic_proxy_peer_route_data(peer, pkt, callback, opaque);
+	}
+}
+
+/*
+ * The packet is written.
+ */
+static void
+ic_proxy_router_on_write(uv_write_t *req, int status)
+{
+	ICProxyWriteReq *wreq = (ICProxyWriteReq *) req;
+	ICProxyPkt *pkt = uv_req_get_data((uv_req_t *) req);
+
+	if (status < 0)
+		ic_proxy_log(LOG, "ic-proxy-router: fail to send %s: %s",
+					 ic_proxy_pkt_to_str(pkt), uv_strerror(status));
+	else
+		ic_proxy_log(LOG, "ic-proxy-router: sent %s",
+					 ic_proxy_pkt_to_str(pkt));
+
+	if (wreq->callback)
+		wreq->callback(wreq->opaque, pkt, status);
+
+	ic_proxy_pkt_cache_free(pkt);
+	ic_proxy_free(req);
+}
+
+/*
+ * Write a packet to a libuv stream.
+ *
+ * This is a simple wrapper for the uv_write() function.  The boring parts,
+ * like buffer & request management, are handled by this wrapper, so the caller
+ * can focus on the real business.
+ *
+ * It can write the packet at a specific offset, this is useful when writing
+ * data from the client to the backend, the backend wants headless data, so the
+ * client can specify sizeof(ICProxyPkt) as the offset.
+ *
+ * - stream: the target stream, usually a peer or a client;
+ * - pkt: the data to write, the ownership is taken;
+ * - offset: the data offset to write from, usually 0 when writing to a peer,
+ *   or sizeof(ICProxyPkt) when writing to a client;
+ * - callback: the callback function;
+ * - opaque: the callback data;
+ */
+void
+ic_proxy_router_write(uv_stream_t *stream, ICProxyPkt *pkt, int32 offset,
+					  ic_proxy_sent_cb callback, void *opaque)
+{
+	ICProxyWriteReq *wreq;
+	uv_buf_t	wbuf;
+
+	ic_proxy_log(LOG, "ic-proxy-router: sending %s", ic_proxy_pkt_to_str(pkt));
+
+	wreq = ic_proxy_new(ICProxyWriteReq);
+	uv_req_set_data((uv_req_t *) wreq, pkt);
+
+	wreq->callback = callback;
+	wreq->opaque = opaque;
+
+	wbuf.base = ((char *) pkt) + offset;
+	wbuf.len = pkt->len - offset;
+
+	uv_write(&wreq->req, stream, &wbuf, 1, ic_proxy_router_on_write);
+}

--- a/src/backend/cdb/motion/ic_proxy_router.h
+++ b/src/backend/cdb/motion/ic_proxy_router.h
@@ -1,0 +1,34 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_router.h
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef IC_PROXY_ROUTER_H
+#define IC_PROXY_ROUTER_H
+
+
+#include "postgres.h"
+
+#include <uv.h>
+
+
+typedef void (* ic_proxy_sent_cb) (void *opaque,
+								   const ICProxyPkt *pkt, int status);
+
+
+extern void ic_proxy_router_init(uv_loop_t *loop);
+extern void ic_proxy_router_uninit(void);
+extern void ic_proxy_router_route(uv_loop_t *loop, ICProxyPkt *pkt,
+								  ic_proxy_sent_cb callback, void *opaque);
+extern void ic_proxy_router_write(uv_stream_t *stream,
+								  ICProxyPkt *pkt, int32 offset,
+								  ic_proxy_sent_cb callback, void *opaque);
+
+
+#endif   /* IC_PROXY_ROUTER_H */

--- a/src/backend/cdb/motion/ic_proxy_server.h
+++ b/src/backend/cdb/motion/ic_proxy_server.h
@@ -1,0 +1,160 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_server.h
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef IC_PROXY_SERVER_H
+#define IC_PROXY_SERVER_H
+
+#include "postgres.h"
+
+#include <uv.h>
+
+#include "ic_proxy.h"
+#include "ic_proxy_iobuf.h"
+#include "ic_proxy_packet.h"
+#include "ic_proxy_router.h"
+
+#if UV_VERSION_HEX < 0x011300
+static inline void
+uv_req_set_data(uv_req_t *req, void* data)
+{
+	req->data = data;
+}
+
+static inline void *
+uv_req_get_data(const uv_req_t *req)
+{
+	return req->data;
+}
+
+static inline uv_loop_t *
+uv_handle_get_loop(const uv_handle_t* handle)
+{
+	return handle->loop;
+}
+#endif
+
+typedef struct ICProxyPeer ICProxyPeer;
+typedef struct ICProxyClient ICProxyClient;
+typedef struct ICProxyDelay ICProxyDelay;
+
+/*
+ * A peer is a connection to an other proxy.
+ *
+ * TODO: allocate the name buffer on demand.
+ */
+struct ICProxyPeer
+{
+	uv_tcp_t	tcp;			/* the libuv handle */
+
+	int16		content;		/* content, aka segid, only for logging */
+	uint16		dbid;			/* dbid is peerid */
+
+	uint32		state;			/* or'ed bits of below ones */
+#define IC_PROXY_PEER_STATE_CONNECTING                  0x00000001
+#define IC_PROXY_PEER_STATE_CONNECTED                   0x00000002
+#define IC_PROXY_PEER_STATE_ACCEPTED                    0x00000004
+#define IC_PROXY_PEER_STATE_LEGACY                      0x00000008
+#define IC_PROXY_PEER_STATE_SENDING_HELLO               0x00000010
+#define IC_PROXY_PEER_STATE_SENT_HELLO                  0x00000020
+#define IC_PROXY_PEER_STATE_RECEIVING_HELLO_ACK         0x00000040
+#define IC_PROXY_PEER_STATE_RECEIVED_HELLO_ACK          0x00000080
+#define IC_PROXY_PEER_STATE_RECEIVING_HELLO             0x00000100
+#define IC_PROXY_PEER_STATE_RECEIVED_HELLO              0x00000200
+#define IC_PROXY_PEER_STATE_SENDING_HELLO_ACK           0x00000400
+#define IC_PROXY_PEER_STATE_SENT_HELLO_ACK              0x00000800
+#define IC_PROXY_PEER_STATE_SHUTTING                    0x00001000
+#define IC_PROXY_PEER_STATE_SHUTTED                     0x00002000
+#define IC_PROXY_PEER_STATE_CLOSING                     0x00004000
+#define IC_PROXY_PEER_STATE_CLOSED                      0x00008000
+
+#define IC_PROXY_PEER_STATE_READY_FOR_MESSAGE \
+	(IC_PROXY_PEER_STATE_CONNECTED | \
+	 IC_PROXY_PEER_STATE_ACCEPTED)
+
+#define IC_PROXY_PEER_STATE_READY_FOR_DATA \
+	(IC_PROXY_PEER_STATE_SENT_HELLO_ACK | \
+	 IC_PROXY_PEER_STATE_RECEIVED_HELLO_ACK)
+
+	List	   *reqs;			/* outgoing queue for data that can't be sent
+								 * immediately */
+
+	ICProxyIBuf	ibuf;			/* ibuf detects the packet boundaries */
+
+	char		name[128];		/* name of the client, only for logging */
+};
+
+/*
+ * A delay is a c2p packet that cannot be sent immediately.
+ *
+ * The libuv callbacks are all called directly from the libuv mainloop, no
+ * embedding, no nesting, this is important to ensure that all the callbacks
+ * are __atomic__, they do not need to worry about that something is modified
+ * concurrently.
+ *
+ * However most callbacks created by us are nested, for example for a pair of
+ * loopback clients, they communicate via callbacks directly, if one of them
+ * sends a control message to the other, it could cause reentrance of some of
+ * the callback functions, which will cause unexpected behavior.  To prevent
+ * that, we delay the sending of such kind of packets.
+ *
+ * A control message usually needs a callback, it is recorded for the delayed
+ * packet, so once the packet is sent out the callback can still be triggered.
+ *
+ * Note that a delay can be transferred from a legacy peer to a new one, so we
+ * must record the peer id instead of the peer pointer.
+ */
+struct ICProxyDelay
+{
+	int16		content;		/* the content of the peer, only for logging */
+	uint16		dbid;			/* the dbid and peerid of the peer */
+
+	ICProxyPkt *pkt;			/* the packet, owned by us */
+
+	ic_proxy_sent_cb callback;	/* the sent callback */
+	void	   *opaque;			/* the sent callback data */
+};
+
+
+extern int ic_proxy_server_main(void);
+extern void ic_proxy_server_quit(uv_loop_t *loop, bool relaunch);
+
+extern ICProxyClient *ic_proxy_client_new(uv_loop_t *loop, bool placeholder);
+extern const char *ic_proxy_client_get_name(ICProxyClient *client);
+extern uv_stream_t *ic_proxy_client_get_stream(ICProxyClient *client);
+extern int ic_proxy_client_read_hello(ICProxyClient *client);
+extern void ic_proxy_client_on_p2c_data(ICProxyClient *client, ICProxyPkt *pkt,
+										ic_proxy_sent_cb callback,
+										void *opaque);
+extern ICProxyClient *ic_proxy_client_blessed_lookup(uv_loop_t *loop,
+													 const ICProxyKey *key);
+extern void ic_proxy_client_table_init(void);
+extern void ic_proxy_client_table_uninit(void);
+extern void ic_proxy_client_table_shutdown_by_dbid(uint16 dbid);
+
+extern void ic_proxy_peer_table_init(void);
+extern void ic_proxy_peer_table_uninit(void);
+
+extern ICProxyPeer *ic_proxy_peer_new(uv_loop_t *loop,
+									  int16 content, uint16 dbid);
+extern void ic_proxy_peer_free(ICProxyPeer *peer);
+extern void ic_proxy_peer_read_hello(ICProxyPeer *peer);
+extern void ic_proxy_peer_connect(ICProxyPeer *peer, struct sockaddr_in *dest);
+extern void ic_proxy_peer_route_data(ICProxyPeer *peer, ICProxyPkt *pkt,
+									 ic_proxy_sent_cb callback, void *opaque);
+extern ICProxyPeer *ic_proxy_peer_lookup(int16 content, uint16 dbid);
+extern ICProxyPeer *ic_proxy_peer_blessed_lookup(uv_loop_t *loop,
+												 int16 content, uint16 dbid);
+extern ICProxyDelay *ic_proxy_peer_build_delay(ICProxyPeer *peer,
+											   ICProxyPkt *pkt,
+											   ic_proxy_sent_cb callback,
+											   void *opaque);
+
+#endif   /* IC_PROXY_SERVER_H */

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -602,7 +602,7 @@ setupOutgoingConnection(ChunkTransportState *transportStates, ChunkTransportStat
 		conn->sockfd = -1;
 	}
 
-#ifdef HAVE_LIBUV
+#ifdef ENABLE_IC_PROXY
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
 	{
 		/* TODO: setup the connections in parallel */
@@ -622,7 +622,7 @@ setupOutgoingConnection(ChunkTransportState *transportStates, ChunkTransportStat
 		conn->remoteContentId = conn->cdbProc->contentid;
 		return;
 	}
-#endif  /* HAVE_LIBUV */
+#endif  /* ENABLE_IC_PROXY */
 
 	/* Initialize hint structure */
 	MemSet(&hint, 0, sizeof(hint));
@@ -1320,7 +1320,7 @@ SetupTCPInterconnect(EState *estate)
 			if (cdbProc)
 				expectedTotalIncoming++;
 
-#ifdef HAVE_LIBUV
+#ifdef ENABLE_IC_PROXY
 			if (Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
 			{
 				conn = &pEntry->conns[i];
@@ -1354,7 +1354,7 @@ SetupTCPInterconnect(EState *estate)
 					conn->remapper = CreateTupleRemapper();
 				}
 			}
-#endif  /* HAVE_LIBUV */
+#endif  /* ENABLE_IC_PROXY */
 		}
 	}
 
@@ -1369,7 +1369,7 @@ SetupTCPInterconnect(EState *estate)
 	if (mySlice->parentIndex != -1)
 		sendingChunkTransportState = startOutgoingConnections(interconnect_context, mySlice, &expectedTotalOutgoing);
 
-#ifdef HAVE_LIBUV
+#ifdef ENABLE_IC_PROXY
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
 	{
 		for (i = 0; i < expectedTotalOutgoing; i++)
@@ -1380,7 +1380,7 @@ SetupTCPInterconnect(EState *estate)
 		}
 		outgoing_count = expectedTotalOutgoing;
 	}
-#endif  /* HAVE_LIBUV */
+#endif  /* ENABLE_IC_PROXY */
 
 	if (expectedTotalIncoming > listenerBacklog)
 		ereport(WARNING, (errmsg("SetupTCPInterconnect: too many expected incoming connections(%d), Interconnect setup might possibly fail", expectedTotalIncoming),

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -5132,6 +5132,7 @@ _copyCdbProcess(const CdbProcess *from)
 	COPY_SCALAR_FIELD(listenerPort);
 	COPY_SCALAR_FIELD(pid);
 	COPY_SCALAR_FIELD(contentid);
+	COPY_SCALAR_FIELD(dbid);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -5000,6 +5000,7 @@ _outCdbProcess(StringInfo str, const CdbProcess *node)
 	WRITE_INT_FIELD(listenerPort);
 	WRITE_INT_FIELD(pid);
 	WRITE_INT_FIELD(contentid);
+	WRITE_INT_FIELD(dbid);
 }
 
 static void

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -3960,6 +3960,7 @@ _readCdbProcess(void)
 	READ_INT_FIELD(listenerPort);
 	READ_INT_FIELD(pid);
 	READ_INT_FIELD(contentid);
+	READ_INT_FIELD(dbid);
 
 	READ_DONE();
 }

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -407,14 +407,14 @@ static BackgroundWorker PMAuxProcList[MaxPMAuxProc] =
 	 BackoffSweeperMain, {0}, {0}, 0, {0}, 0,
 	 BackoffSweeperStartRule},
 
-#ifdef HAVE_LIBUV
+#ifdef ENABLE_IC_PROXY
 	{"ic proxy process",
 	 0,
 	 BgWorkerStart_RecoveryFinished,
 	 0, /* restart immediately if ic proxy process exits with non-zero code */
 	 ICProxyMain, {0}, {0}, 0, {0}, 0,
 	 ICProxyStartRule},
-#endif  /* HAVE_LIBUV */
+#endif  /* ENABLE_IC_PROXY */
 
 	/*
 	 * Remember to set the MaxPMAuxProc to the number of items in this list

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -147,6 +147,7 @@
 #include "cdb/cdbgang.h"                /* cdbgang_parse_gpqeid_params */
 #include "cdb/cdbtm.h"
 #include "cdb/cdbvars.h"
+#include "cdb/ic_proxy_bgworker.h"
 
 /*
  * This is set in backends that are handling a GPDB specific message (FTS or
@@ -405,6 +406,15 @@ static BackgroundWorker PMAuxProcList[MaxPMAuxProc] =
 	 0, /* restart immediately if sweeper process exits with non-zero code */
 	 BackoffSweeperMain, {0}, {0}, 0, {0}, 0,
 	 BackoffSweeperStartRule},
+
+#ifdef HAVE_LIBUV
+	{"ic proxy process",
+	 0,
+	 BgWorkerStart_RecoveryFinished,
+	 0, /* restart immediately if ic proxy process exits with non-zero code */
+	 ICProxyMain, {0}, {0}, 0, {0}, 0,
+	 ICProxyStartRule},
+#endif  /* HAVE_LIBUV */
 
 	/*
 	 * Remember to set the MaxPMAuxProc to the number of items in this list

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -510,6 +510,9 @@ static const struct config_enum_entry gp_interconnect_fc_methods[] = {
 static const struct config_enum_entry gp_interconnect_types[] = {
 	{"udpifc", INTERCONNECT_TYPE_UDPIFC},
 	{"tcp", INTERCONNECT_TYPE_TCP},
+#ifdef HAVE_LIBUV
+	{"proxy", INTERCONNECT_TYPE_PROXY},
+#endif  /* HAVE_LIBUV */
 	{NULL, 0}
 };
 
@@ -4522,7 +4525,11 @@ struct config_enum ConfigureNamesEnum_gp[] =
 	{
 		{"gp_interconnect_type", PGC_BACKEND, GP_ARRAY_TUNING,
 			gettext_noop("Sets the protocol used for inter-node communication."),
-			gettext_noop("Valid values are \"tcp\" and \"udpifc\".")
+			gettext_noop("Valid values are \"tcp\", \"udpifc\""
+#ifdef HAVE_LIBUV
+						 " and \"proxy\""
+#endif  /* HAVE_LIBUV */
+						 ".")
 		},
 		&Gp_interconnect_type,
 		INTERCONNECT_TYPE_UDPIFC, gp_interconnect_types,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -510,9 +510,9 @@ static const struct config_enum_entry gp_interconnect_fc_methods[] = {
 static const struct config_enum_entry gp_interconnect_types[] = {
 	{"udpifc", INTERCONNECT_TYPE_UDPIFC},
 	{"tcp", INTERCONNECT_TYPE_TCP},
-#ifdef HAVE_LIBUV
+#ifdef ENABLE_IC_PROXY
 	{"proxy", INTERCONNECT_TYPE_PROXY},
-#endif  /* HAVE_LIBUV */
+#endif  /* ENABLE_IC_PROXY */
 	{NULL, 0}
 };
 
@@ -4358,7 +4358,7 @@ struct config_string ConfigureNamesString_gp[] =
 		NULL, NULL, NULL
 	},
 
-#ifdef HAVE_LIBUV
+#ifdef ENABLE_IC_PROXY
 	{
 		{"gp_interconnect_proxy_addresses", PGC_POSTMASTER, DEVELOPER_OPTIONS,
 			gettext_noop("Sets the ic-proxy addresses as \"content:ip:port ...\", must be ordered by content, the port is ignored at the moment."),
@@ -4369,7 +4369,7 @@ struct config_string ConfigureNamesString_gp[] =
 		"",
 		NULL, NULL, NULL
 	},
-#endif  /* HAVE_LIBUV */
+#endif  /* ENABLE_IC_PROXY */
 
 	/* End-of-list marker */
 	{
@@ -4526,9 +4526,9 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"gp_interconnect_type", PGC_BACKEND, GP_ARRAY_TUNING,
 			gettext_noop("Sets the protocol used for inter-node communication."),
 			gettext_noop("Valid values are \"tcp\", \"udpifc\""
-#ifdef HAVE_LIBUV
+#ifdef ENABLE_IC_PROXY
 						 " and \"proxy\""
-#endif  /* HAVE_LIBUV */
+#endif  /* ENABLE_IC_PROXY */
 						 ".")
 		},
 		&Gp_interconnect_type,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4355,6 +4355,19 @@ struct config_string ConfigureNamesString_gp[] =
 		NULL, NULL, NULL
 	},
 
+#ifdef HAVE_LIBUV
+	{
+		{"gp_interconnect_proxy_addresses", PGC_POSTMASTER, DEVELOPER_OPTIONS,
+			gettext_noop("Sets the ic-proxy addresses as \"content:ip:port ...\", must be ordered by content, the port is ignored at the moment."),
+			gettext_noop("e.g. \"-1:10.0.0.1:2000 0:10.0.0.2:2000 1:10.0.0.2:2001\""),
+			GUC_NO_SHOW_ALL | GUC_GPDB_NO_SYNC
+		},
+		&gp_interconnect_proxy_addresses,
+		"",
+		NULL, NULL, NULL
+	},
+#endif  /* HAVE_LIBUV */
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, NULL, NULL, NULL

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -122,6 +122,7 @@ typedef struct CdbProcess
 	int pid; /* Backend PID of the process. */
 
 	int contentid;
+	int dbid;
 } CdbProcess;
 
 typedef Gang *(*CreateGangFunc)(List *segments, SegmentType segmentType);

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -280,6 +280,7 @@ typedef enum GpVars_Interconnect_Type
 {
 	INTERCONNECT_TYPE_TCP = 0,
 	INTERCONNECT_TYPE_UDPIFC,
+	INTERCONNECT_TYPE_PROXY,
 } GpVars_Interconnect_Type;
 
 extern int Gp_interconnect_type;

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -284,6 +284,8 @@ typedef enum GpVars_Interconnect_Type
 
 extern int Gp_interconnect_type;
 
+extern char *gp_interconnect_proxy_addresses;
+
 typedef enum GpVars_Interconnect_Method
 {
 	INTERCONNECT_FC_METHOD_CAPACITY = 0,

--- a/src/include/cdb/ic_proxy_bgworker.h
+++ b/src/include/cdb/ic_proxy_bgworker.h
@@ -1,0 +1,22 @@
+/*-------------------------------------------------------------------------
+ *
+ * ic_proxy_bgworker.h
+ *	  TODO file description
+ *
+ *
+ * Copyright (c) 2020-Present Pivotal Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef IC_PROXY_BGWORKER_H
+#define IC_PROXY_BGWORKER_H
+
+#include "postgres.h"
+
+
+extern bool ICProxyStartRule(Datum main_arg);
+extern void ICProxyMain(Datum main_arg);
+
+#endif   /* IC_PROXY_BGWORKER_H */

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -54,6 +54,9 @@
 /* Define to build with GSSAPI support. (--with-gssapi) */
 #undef ENABLE_GSS
 
+/* Define to 1 to build with ic-proxy support (--enable-ic-proxy) */
+#undef ENABLE_IC_PROXY
+
 /* Define to 1 to build client libraries as thread-safe code.
    (--enable-thread-safety) */
 #undef ENABLE_THREAD_SAFETY

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -378,6 +378,9 @@
 /* Define to 1 if you have the `ssl' library (-lssl). */
 #undef HAVE_LIBSSL
 
+/* Define to 1 if you have the `uv' library (-luv). */
+#undef HAVE_LIBUV
+
 /* Define to 1 if you have the `wldap32' library (-lwldap32). */
 #undef HAVE_LIBWLDAP32
 

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -75,6 +75,12 @@ extern void ShmemBackendArrayAllocation(void);
 extern void load_auxiliary_libraries(void);
 extern bool amAuxiliaryBgWorker(void);
 
+#ifdef HAVE_LIBUV
+# define IC_PROXY_NUM_BGWORKER 1
+#else  /* HAVE_LIBUV */
+# define IC_PROXY_NUM_BGWORKER 0
+#endif  /* HAVE_LIBUV */
+
 /*
  * Note: MAX_BACKENDS is limited to 2^18-1 because that's the width reserved
  * for buffer references in buf_internals.h.  This limitation could be lifted
@@ -86,6 +92,6 @@ extern bool amAuxiliaryBgWorker(void);
  * relevant GUC check hooks and in RegisterBackgroundWorker().
  */
 #define MAX_BACKENDS	0x3FFFF
-#define MaxPMAuxProc	4
+#define MaxPMAuxProc	(4 + IC_PROXY_NUM_BGWORKER)
 
 #endif   /* _POSTMASTER_H */

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -75,11 +75,11 @@ extern void ShmemBackendArrayAllocation(void);
 extern void load_auxiliary_libraries(void);
 extern bool amAuxiliaryBgWorker(void);
 
-#ifdef HAVE_LIBUV
+#ifdef ENABLE_IC_PROXY
 # define IC_PROXY_NUM_BGWORKER 1
-#else  /* HAVE_LIBUV */
+#else  /* ENABLE_IC_PROXY */
 # define IC_PROXY_NUM_BGWORKER 0
-#endif  /* HAVE_LIBUV */
+#endif  /* ENABLE_IC_PROXY */
 
 /*
  * Note: MAX_BACKENDS is limited to 2^18-1 because that's the width reserved

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -33,6 +33,7 @@
 		"gp_interconnect_log_stats",
 		"gp_interconnect_min_retries_before_timeout",
 		"gp_interconnect_min_rto",
+		"gp_interconnect_proxy_addresses",
 		"gp_interconnect_queue_depth",
 		"gp_interconnect_setup_timeout",
 		"gp_interconnect_snd_queue_depth",


### PR DESCRIPTION
By setting gp_interconnect_proxy to 'proxy' now the interconnect could
run in the proxy mode.  In the proxy mode a proxy bgworker is launched
on each segment, the proxy bgworkers connect to each other, the backends
only connect to the bgworker on their own segment.  By doing this we
reduced the total network flows, we also reduced the required port
counts.

To enable the proxy mode we need to first configure the guc
gp_interconnect_proxy_addresses, for example:

    gpconfig \
      -c gp_interconnect_proxy_addresses \
      -v "'1:-1:10.0.0.1:2000,2:0:10.0.0.2:2001,3:1:10.0.0.3:2002'" \
      --skipvalidation

----

The ic-proxy mode is disabled in configure by default, enable it manually with `--enable-ic-proxy`.

----

Refer to the ic-proxy [README](https://github.com/greenplum-db/gpdb/blob/b1eb3026ee336260ea0380eafa26fbcb216b1d40/src/backend/cdb/motion/README.ic-proxy.md) for details.

----

Below is a simple __bash__ script to set this automatically:

    #!/usr/bin/env bash

    portbase=2000

    psql -tqA -d postgres -P pager=off -F ' ' \
        -c "select dbid, content, $portbase+dbid as port, address from gp_segment_configuration order by 1" \
    | while read -r dbid content port addr; do
        ip=$(host "$addr" | fgrep -v IPv6 | head -n1)
        ip=${ip##* }
        echo "$dbid:$content:$ip:$port"
      done \
    | paste -sd, - \
    | xargs -rI'{}' gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'{}'"

It's only verified on ubuntu linux.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
