### PR TITLE
Remove redundant lib specification

### DIFF
--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -20,7 +20,6 @@ ifeq ($(PORTNAME),aix)
 endif
 
 ifeq ($(have_yaml),yes)
-  GPFDIST_LIBS += -lyaml
   OBJS += transform.o
   ifneq ($(PORTNAME),win32)
     override CPPFLAGS := -DGPFXDIST $(CPPFLAGS)


### PR DESCRIPTION
#9815 made me look around, and so I found a reudundant `-lyaml` definition. If `have_yaml` is set to yes, the autoconf has already added `-lyaml` to LIBS so there is no need to add it again. This is merely hygiene, the double libs do no harm.