### PR TITLE
Fix another missing-flow bug in JSON-format EXPLAIN.

### DIFF
--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -514,7 +514,9 @@ QUERY PLAN
 -- The plan contains an Agg and a Hash node on top of each other, neither of
 -- which have a plan->flow set. Explain should be able to dig the flow from
 -- the grandchild node then.
-CREATE TEMPORARY TABLE SUBSELECT_TBL (
+CREATE SCHEMA explaintest;
+SET search_path=explaintest;
+CREATE TABLE SUBSELECT_TBL (
   f1 integer,
   f2 integer,
   f3 float
@@ -722,7 +724,175 @@ QUERY PLAN
 ]
 (1 row)
 commit;
+-- Yet another variant, with missing flow in Append. (github issue #9819)
+create table subselect_tbl_child() INHERITS (subselect_tbl);
+NOTICE:  table has parent, setting distribution columns to match parent table
+explain (verbose, format json) select * from (select * from subselect_tbl) p where f1 in (select f1 from subselect_tbl where f2 >= 19);
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Gather Motion",
+      "Senders": 3,
+      "Receivers": 1,
+      "Slice": 1,
+      "Segments": 3,
+      "Gang Type": "primary reader",
+      "Startup Cost": 2118.50,
+      "Total Cost": 4984.75,
+      "Plan Rows": 71100,
+      "Plan Width": 16,
+      "Output": ["subselect_tbl.f1", "subselect_tbl.f2", "subselect_tbl.f3"],
+      "Plans": [
+        {
+          "Node Type": "Hash Join",
+          "Parent Relationship": "Outer",
+          "Slice": 1,
+          "Segments": 3,
+          "Gang Type": "primary reader",
+          "Join Type": "Inner",
+          "Startup Cost": 2118.50,
+          "Total Cost": 4984.75,
+          "Plan Rows": 71100,
+          "Plan Width": 16,
+          "Output": ["subselect_tbl.f1", "subselect_tbl.f2", "subselect_tbl.f3"],
+          "Hash Cond": "(subselect_tbl.f1 = subselect_tbl_1.f1)",
+          "Plans": [
+            {
+              "Node Type": "Append",
+              "Parent Relationship": "Outer",
+              "Slice": 1,
+              "Segments": 3,
+              "Gang Type": "primary reader",
+              "Startup Cost": 0.00,
+              "Total Cost": 1622.00,
+              "Plan Rows": 142200,
+              "Plan Width": 16,
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Member",
+                  "Slice": 1,
+                  "Segments": 3,
+                  "Gang Type": "primary reader",
+                  "Relation Name": "subselect_tbl",
+                  "Schema": "explaintest",
+                  "Alias": "subselect_tbl",
+                  "Startup Cost": 0.00,
+                  "Total Cost": 811.00,
+                  "Plan Rows": 71100,
+                  "Plan Width": 16,
+                  "Output": ["subselect_tbl.f1", "subselect_tbl.f2", "subselect_tbl.f3"]
+                },
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Member",
+                  "Slice": 1,
+                  "Segments": 3,
+                  "Gang Type": "primary reader",
+                  "Relation Name": "subselect_tbl_child",
+                  "Schema": "explaintest",
+                  "Alias": "subselect_tbl_child",
+                  "Startup Cost": 0.00,
+                  "Total Cost": 811.00,
+                  "Plan Rows": 71100,
+                  "Plan Width": 16,
+                  "Output": ["subselect_tbl_child.f1", "subselect_tbl_child.f2", "subselect_tbl_child.f3"]
+                }
+              ]
+            },
+            {
+              "Node Type": "Hash",
+              "Parent Relationship": "Inner",
+              "Slice": 1,
+              "Segments": 3,
+              "Gang Type": "primary reader",
+              "Startup Cost": 2106.00,
+              "Total Cost": 2106.00,
+              "Plan Rows": 1000,
+              "Plan Width": 4,
+              "Output": ["subselect_tbl_1.f1"],
+              "Plans": [
+                {
+                  "Node Type": "Aggregate",
+                  "Strategy": "Hashed",
+                  "Parent Relationship": "Outer",
+                  "Slice": 1,
+                  "Segments": 3,
+                  "Gang Type": "primary reader",
+                  "Startup Cost": 2096.00,
+                  "Total Cost": 2106.00,
+                  "Plan Rows": 1000,
+                  "Plan Width": 4,
+                  "Output": ["subselect_tbl_1.f1"],
+                  "Group Key": ["subselect_tbl_1.f1"],
+                  "Plans": [
+                    {
+                      "Node Type": "Append",
+                      "Parent Relationship": "Outer",
+                      "Slice": 1,
+                      "Segments": 3,
+                      "Gang Type": "primary reader",
+                      "Startup Cost": 0.00,
+                      "Total Cost": 1977.50,
+                      "Plan Rows": 47400,
+                      "Plan Width": 4,
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Member",
+                          "Slice": 1,
+                          "Segments": 3,
+                          "Gang Type": "primary reader",
+                          "Relation Name": "subselect_tbl",
+                          "Schema": "explaintest",
+                          "Alias": "subselect_tbl_1",
+                          "Startup Cost": 0.00,
+                          "Total Cost": 988.75,
+                          "Plan Rows": 23700,
+                          "Plan Width": 4,
+                          "Output": ["subselect_tbl_1.f1"],
+                          "Filter": "(subselect_tbl_1.f2 >= 19)"
+                        },
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Member",
+                          "Slice": 1,
+                          "Segments": 3,
+                          "Gang Type": "primary reader",
+                          "Relation Name": "subselect_tbl_child",
+                          "Schema": "explaintest",
+                          "Alias": "subselect_tbl_child_1",
+                          "Startup Cost": 0.00,
+                          "Total Cost": 988.75,
+                          "Plan Rows": 23700,
+                          "Plan Width": 4,
+                          "Output": ["subselect_tbl_child_1.f1"],
+                          "Filter": "(subselect_tbl_child_1.f2 >= 19)"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Settings": {
+      "Optimizer": "Postgres query optimizer",
+      "Settings": ["optimizer=off"]
+    }
+  }
+]
+(1 row)
 -- Cleanup
+RESET search_path;
+DROP SCHEMA explaintest cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table explaintest.subselect_tbl
+drop cascades to table explaintest.subselect_tbl_child
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -497,7 +497,9 @@ QUERY PLAN
 -- The plan contains an Agg and a Hash node on top of each other, neither of
 -- which have a plan->flow set. Explain should be able to dig the flow from
 -- the grandchild node then.
-CREATE TEMPORARY TABLE SUBSELECT_TBL (
+CREATE SCHEMA explaintest;
+SET search_path=explaintest;
+CREATE TABLE SUBSELECT_TBL (
   f1 integer,
   f2 integer,
   f3 float
@@ -723,7 +725,175 @@ QUERY PLAN
 ]
 (1 row)
 commit;
+-- Yet another variant, with missing flow in Append. (github issue #9819)
+create table subselect_tbl_child() INHERITS (subselect_tbl);
+NOTICE:  table has parent, setting distribution columns to match parent table
+explain (verbose, format json) select * from (select * from subselect_tbl) p where f1 in (select f1 from subselect_tbl where f2 >= 19);
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Gather Motion",
+      "Senders": 3,
+      "Receivers": 1,
+      "Slice": 1,
+      "Segments": 3,
+      "Gang Type": "primary reader",
+      "Startup Cost": 2118.50,
+      "Total Cost": 4984.75,
+      "Plan Rows": 71100,
+      "Plan Width": 16,
+      "Output": ["subselect_tbl.f1", "subselect_tbl.f2", "subselect_tbl.f3"],
+      "Plans": [
+        {
+          "Node Type": "Hash Join",
+          "Parent Relationship": "Outer",
+          "Slice": 1,
+          "Segments": 3,
+          "Gang Type": "primary reader",
+          "Join Type": "Inner",
+          "Startup Cost": 2118.50,
+          "Total Cost": 4984.75,
+          "Plan Rows": 71100,
+          "Plan Width": 16,
+          "Output": ["subselect_tbl.f1", "subselect_tbl.f2", "subselect_tbl.f3"],
+          "Hash Cond": "(subselect_tbl.f1 = subselect_tbl_1.f1)",
+          "Plans": [
+            {
+              "Node Type": "Append",
+              "Parent Relationship": "Outer",
+              "Slice": 1,
+              "Segments": 3,
+              "Gang Type": "primary reader",
+              "Startup Cost": 0.00,
+              "Total Cost": 1622.00,
+              "Plan Rows": 142200,
+              "Plan Width": 16,
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Member",
+                  "Slice": 1,
+                  "Segments": 3,
+                  "Gang Type": "primary reader",
+                  "Relation Name": "subselect_tbl",
+                  "Schema": "explaintest",
+                  "Alias": "subselect_tbl",
+                  "Startup Cost": 0.00,
+                  "Total Cost": 811.00,
+                  "Plan Rows": 71100,
+                  "Plan Width": 16,
+                  "Output": ["subselect_tbl.f1", "subselect_tbl.f2", "subselect_tbl.f3"]
+                },
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Member",
+                  "Slice": 1,
+                  "Segments": 3,
+                  "Gang Type": "primary reader",
+                  "Relation Name": "subselect_tbl_child",
+                  "Schema": "explaintest",
+                  "Alias": "subselect_tbl_child",
+                  "Startup Cost": 0.00,
+                  "Total Cost": 811.00,
+                  "Plan Rows": 71100,
+                  "Plan Width": 16,
+                  "Output": ["subselect_tbl_child.f1", "subselect_tbl_child.f2", "subselect_tbl_child.f3"]
+                }
+              ]
+            },
+            {
+              "Node Type": "Hash",
+              "Parent Relationship": "Inner",
+              "Slice": 1,
+              "Segments": 3,
+              "Gang Type": "primary reader",
+              "Startup Cost": 2106.00,
+              "Total Cost": 2106.00,
+              "Plan Rows": 1000,
+              "Plan Width": 4,
+              "Output": ["subselect_tbl_1.f1"],
+              "Plans": [
+                {
+                  "Node Type": "Aggregate",
+                  "Strategy": "Hashed",
+                  "Parent Relationship": "Outer",
+                  "Slice": 1,
+                  "Segments": 3,
+                  "Gang Type": "primary reader",
+                  "Startup Cost": 2096.00,
+                  "Total Cost": 2106.00,
+                  "Plan Rows": 1000,
+                  "Plan Width": 4,
+                  "Output": ["subselect_tbl_1.f1"],
+                  "Group Key": ["subselect_tbl_1.f1"],
+                  "Plans": [
+                    {
+                      "Node Type": "Append",
+                      "Parent Relationship": "Outer",
+                      "Slice": 1,
+                      "Segments": 3,
+                      "Gang Type": "primary reader",
+                      "Startup Cost": 0.00,
+                      "Total Cost": 1977.50,
+                      "Plan Rows": 47400,
+                      "Plan Width": 4,
+                      "Plans": [
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Member",
+                          "Slice": 1,
+                          "Segments": 3,
+                          "Gang Type": "primary reader",
+                          "Relation Name": "subselect_tbl",
+                          "Schema": "explaintest",
+                          "Alias": "subselect_tbl_1",
+                          "Startup Cost": 0.00,
+                          "Total Cost": 988.75,
+                          "Plan Rows": 23700,
+                          "Plan Width": 4,
+                          "Output": ["subselect_tbl_1.f1"],
+                          "Filter": "(subselect_tbl_1.f2 >= 19)"
+                        },
+                        {
+                          "Node Type": "Seq Scan",
+                          "Parent Relationship": "Member",
+                          "Slice": 1,
+                          "Segments": 3,
+                          "Gang Type": "primary reader",
+                          "Relation Name": "subselect_tbl_child",
+                          "Schema": "explaintest",
+                          "Alias": "subselect_tbl_child_1",
+                          "Startup Cost": 0.00,
+                          "Total Cost": 988.75,
+                          "Plan Rows": 23700,
+                          "Plan Width": 4,
+                          "Output": ["subselect_tbl_child_1.f1"],
+                          "Filter": "(subselect_tbl_child_1.f2 >= 19)"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Settings": {
+      "Optimizer": "Postgres query optimizer",
+      "Settings": ["optimizer=on"]
+    }
+  }
+]
+(1 row)
 -- Cleanup
+RESET search_path;
+DROP SCHEMA explaintest cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table explaintest.subselect_tbl
+drop cascades to table explaintest.subselect_tbl_child
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -108,7 +108,9 @@ EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
 -- The plan contains an Agg and a Hash node on top of each other, neither of
 -- which have a plan->flow set. Explain should be able to dig the flow from
 -- the grandchild node then.
-CREATE TEMPORARY TABLE SUBSELECT_TBL (
+CREATE SCHEMA explaintest;
+SET search_path=explaintest;
+CREATE TABLE SUBSELECT_TBL (
   f1 integer,
   f2 integer,
   f3 float
@@ -127,7 +129,14 @@ set local enable_bitmapscan=on;
 explain (format json, costs off) select * from subselect_tbl where f1 < 10;
 commit;
 
+-- Yet another variant, with missing flow in Append. (github issue #9819)
+create table subselect_tbl_child() INHERITS (subselect_tbl);
+explain (verbose, format json) select * from (select * from subselect_tbl) p where f1 in (select f1 from subselect_tbl where f2 >= 19);
+
 -- Cleanup
+RESET search_path;
+DROP SCHEMA explaintest cascade;
+
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;


### PR DESCRIPTION
Similar to 3bdece19da and 512578487b, an Append node doesn't always have
a Flow attached to it. Teach EXPLAIN code to dig into its children.

This seems to be a recurring issue, but since it's been refactored away in
'master', I guess we'll just whack these on 6X_STABLE as they're reported.
Downgrade it to a WARNING, though; an assertion failure seems too harsh
for this. Now you get the warning even on non-assertion builds, but I
think that's fine.

Fixes https://github.com/greenplum-db/gpdb/issues/9819
