### PR TITLE
Remove incorrect function prototypes and unnecessary headers.

### DIFF
--- a/src/include/gpopt/utils/gpdbdefs.h
+++ b/src/include/gpopt/utils/gpdbdefs.h
@@ -19,14 +19,10 @@
 extern "C" {
 
 #include "postgres.h"
-#include <string.h>
+
 #include "nodes/nodes.h"
 #include "nodes/plannodes.h"
-#include "nodes/execnodes.h"
-#include "nodes/print.h"
 #include "nodes/pg_list.h"
-#include "executor/execdesc.h"
-#include "executor/nodeMotion.h"
 #include "parser/parsetree.h"
 #include "utils/inval.h"
 #include "utils/lsyscache.h"
@@ -58,8 +54,6 @@ extern "C" {
 #include "utils/elog.h"
 #include "utils/rel.h"
 #include "utils/uri.h"
-#include "access/relscan.h"
-#include "access/heapam.h"
 #include "catalog/pg_proc.h"
 #include "tcop/dest.h"
 #include "commands/trigger.h"
@@ -67,36 +61,6 @@ extern "C" {
 #include "utils/selfuncs.h"
 #include "utils/faultinjector.h"
 #include "funcapi.h"
-
-extern
-Query *preprocess_query_optimizer(Query *query, ParamListInfo boundParams);
-
-extern
-PlannedStmt *pg_plan_query(Query *pqueryTree, ParamListInfo boundParams);
-
-extern
-char * get_rel_name(Oid relid);
-
-extern
-Relation RelationIdGetRelation(Oid relationId);
-
-extern
-void RelationClose(Relation relation);
-
-extern
-Oid get_atttype(Oid relid, AttrNumber attnum);
-
-extern
-RegProcedure get_opcode(Oid opid);
-
-extern
-void ExecutorStart(QueryDesc *pqueryDesc, int iEFlags);
-
-extern
-void ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count);
-
-extern
-void ExecutorEnd(QueryDesc *pqueryDesc);
 
 } // end extern C
 


### PR DESCRIPTION
As @hidva pointed out, the prototype for pg_plan_query() in gpdbdefs.h
was incorrect. On close inspection, the preprocess_query_optimizer()
prototype at least was also incorrect. But none of these prototypes in
gpdbdefs.h are actually needed. Some of them are not used in ORCA at all,
and others in the headers that are #included. Remove them all.

Also remove a few of the #includes that are not needed. Many more of them
could probably be removed, I didn't systematically go through all of them,
I just removed a few that seemed unlikely to be needed.