### PR TITLE
Fix a bug that reader gang always fail due to missing writer gang.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -29,6 +29,7 @@
 #include "cdb/cdbfts.h"
 #include "cdb/cdbgang.h"
 #include "cdb/cdbgang_async.h"
+#include "cdb/cdbtm.h"
 #include "cdb/cdbvars.h"
 #include "miscadmin.h"
 
@@ -211,6 +212,8 @@ create_gang_retry:
 						}
 						else
 						{
+							if (segment_failure_due_to_missing_writer(PQerrorMessage(segdbDesc->conn)))
+								markCurrentGxactWriterGangLost();
 							ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 											errmsg("failed to acquire resources on one or more segments"),
 											errdetail("%s (%s)", PQerrorMessage(segdbDesc->conn), segdbDesc->whoami)));

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -868,10 +868,12 @@ LockAcquireExtended(const LOCKTAG *locktag,
 					lockHolderProcPtr = proc;
 				}
 				else
-					elog(ERROR, "reader could not find writer proc entry, "
-						 "lock [%u,%u] %s %d", locktag->locktag_field1,
-						 locktag->locktag_field2, lock_mode_names[lockmode],
-						 (int)locktag->locktag_type);
+					ereport(FATAL,
+							(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+							 errmsg(WRITER_IS_MISSING_MSG),
+							 errdetail("lock [%u,%u] %s %d", locktag->locktag_field1,
+									   locktag->locktag_field2, lock_mode_names[lockmode],
+									   (int)locktag->locktag_type)));
 			}
 		}
 	}

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -67,8 +67,6 @@ extern const char *gangTypeToString(GangType type);
 
 extern void setupCdbProcessList(ExecSlice *slice);
 
-extern bool GangOK(Gang *gp);
-
 extern List *getCdbProcessesForQD(int isPrimary);
 
 extern Gang *AllocateGang(struct CdbDispatcherState *ds, enum GangType type, List *segments);
@@ -86,6 +84,7 @@ bool build_gpqeid_param(char *buf, int bufsz, bool is_writer, int identifier, in
 
 char *makeOptions(void);
 extern bool segment_failure_due_to_recovery(const char *error_message);
+extern bool segment_failure_due_to_missing_writer(const char *error_message);
 
 /*
  * cdbgang_parse_gpqeid_params

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -26,6 +26,8 @@
  * ----- Declarations of Greenplum-specific global variables ------
  */
 
+#define WRITER_IS_MISSING_MSG "reader could not find writer proc entry"
+
 #ifdef sparc
 #define TUPLE_CHUNK_ALIGN	4
 #else

--- a/src/test/isolation2/expected/terminate_in_gang_creation.out
+++ b/src/test/isolation2/expected/terminate_in_gang_creation.out
@@ -1,3 +1,12 @@
+include: helpers/server_helpers.sql;
+CREATE
+-- start_matchsubs
+-- m/seg0 [0-9.]+:\d+/
+-- s/seg0 [0-9.]+:\d+/seg0 IP:PORT/
+-- m/lock \[\d+,\d+\]/
+-- s/lock \[\d+,\d+\]//
+-- end_matchsubs
+
 -- SIGSEGV issue when freeing gangs
 --
 -- When SIGTERM is handled during gang creation we used to trigger
@@ -65,3 +74,58 @@ server closed the connection unexpectedly
 
 DROP TABLE foo;
 DROP
+
+-- Test a bug that if cached idle primary QE is gone (e.g. after kill-9, pg_ctl
+-- restart, etc), a new query needs a new created reader gang could fail with
+-- error like this:
+--
+-- DETAIL:  FATAL:  reader could not find writer proc entry, lock [0,1260] AccessShareLock 0 (lock.c:874)
+--  (seg0 192.168.235.128:7002)
+--
+-- This is expected since the writer gang is gone, but previously QD code does
+-- not reset all gangs (just retry creating the new reader gang) so re-running
+-- this query could always fail with the same error since the reader gang would
+-- always fail to create. The below test is used to test the fix.
+
+-- skip FTS probes to avoid segment being marked down on restart
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+SELECT gp_wait_until_triggered_fault('fts_probe', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+11: CREATE TABLE foo (c1 int, c2 int) DISTRIBUTED BY (c1);
+CREATE
+-- ORCA optimizes value scan so there is no additional reader gang in below INSERT.
+11: SET optimizer = off;
+SET
+SELECT pg_ctl(datadir, 'restart', 'immediate') FROM gp_segment_configuration WHERE role='p' AND content=0;
+ pg_ctl 
+--------
+ OK     
+(1 row)
+11: INSERT INTO foo values(2),(1);
+ERROR:  failed to acquire resources on one or more segments
+DETAIL:  FATAL:  reader could not find writer proc entry
+DETAIL:  lock [0,1260] AccessShareLock 0
+ (seg0 192.168.235.128:7002)
+11: INSERT INTO foo values(2),(1);
+INSERT 2
+11: DROP TABLE foo;
+DROP
+
+SELECT gp_inject_fault('fts_probe', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)

--- a/src/test/isolation2/sql/terminate_in_gang_creation.sql
+++ b/src/test/isolation2/sql/terminate_in_gang_creation.sql
@@ -1,3 +1,11 @@
+include: helpers/server_helpers.sql;
+-- start_matchsubs
+-- m/seg0 [0-9.]+:\d+/
+-- s/seg0 [0-9.]+:\d+/seg0 IP:PORT/
+-- m/lock \[\d+,\d+\]/
+-- s/lock \[\d+,\d+\]//
+-- end_matchsubs
+
 -- SIGSEGV issue when freeing gangs
 --
 -- When SIGTERM is handled during gang creation we used to trigger
@@ -38,3 +46,34 @@ SELECT gp_inject_fault('create_gang_in_progress', 'resume', 1);
 10q:
 
 DROP TABLE foo;
+
+-- Test a bug that if cached idle primary QE is gone (e.g. after kill-9, pg_ctl
+-- restart, etc), a new query needs a new created reader gang could fail with
+-- error like this:
+--
+-- DETAIL:  FATAL:  reader could not find writer proc entry, lock [0,1260] AccessShareLock 0 (lock.c:874)
+--  (seg0 192.168.235.128:7002)
+--
+-- This is expected since the writer gang is gone, but previously QD code does
+-- not reset all gangs (just retry creating the new reader gang) so re-running
+-- this query could always fail with the same error since the reader gang would
+-- always fail to create. The below test is used to test the fix.
+
+-- skip FTS probes to avoid segment being marked down on restart
+SELECT gp_inject_fault_infinite('fts_probe', 'skip', dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content=-1;
+SELECT gp_request_fts_probe_scan();
+SELECT gp_wait_until_triggered_fault('fts_probe', 1, dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content=-1;
+
+11: CREATE TABLE foo (c1 int, c2 int) DISTRIBUTED BY (c1);
+-- ORCA optimizes value scan so there is no additional reader gang in below INSERT.
+11: SET optimizer = off;
+SELECT pg_ctl(datadir, 'restart', 'immediate')
+	FROM gp_segment_configuration WHERE role='p' AND content=0;
+11: INSERT INTO foo values(2),(1);
+11: INSERT INTO foo values(2),(1);
+11: DROP TABLE foo;
+
+SELECT gp_inject_fault('fts_probe', 'reset', dbid)
+FROM gp_segment_configuration WHERE role='p' AND content=-1;


### PR DESCRIPTION
The reason is that new created reader gang would fail on QE due to missing
writer gang process in locking code, and retry would fail again with the same
reason, since the cached writer gang is still used because QD does not know &
check the real libpq network status. See below for the repro case.

Fixing this by checking the error message and then reset all gangs if seeing
the error message, similar to the code logic that checks the startup/recovery
message in gang create function. We could have other fixes, e.g. checking the
writer gang network status, etc but those fixes seem to be ugly after trying.

create table t1(f1 int, f2 text);
<kill -9 one idle QE>

insert into t1 values(2),(1),(5);
ERROR:  failed to acquire resources on one or more segments
DETAIL:  FATAL:  reader could not find writer proc entry, lock [0,1260] AccessShareLock 0 (lock.c:874)
 (seg0 192.168.235.128:7002)

insert into t1 values(2),(1),(5);
 ERROR:  failed to acquire resources on one or more segments
 DETAIL:  FATAL:  reader could not find writer proc entry, lock [0,1260] AccessShareLock 0 (lock.c:874)
  (seg0 192.168.235.128:7002)

<-- Above query fails again.

The patch removes useless function GangOK() - this is not relevant of this fix
though.