### PR TITLE
gpinitsystem: Improve handling of -I input file

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -951,7 +951,7 @@ CREATE_QE_ARRAY () {
 	SEG_DIR_VECTOR=0
 	MIR_COUNT=-1
 	MASTER_HOST=`HOST_LOOKUP $MASTER_HOSTNAME`
-	QD_PRIMARY_ARRAY=${MASTER_HOST}~${MASTER_HOSTNAME}~${MASTER_PORT}~${MASTER_DIRECTORY}/${SEG_PREFIX}${CONTENT_COUNT}~${DBID_COUNT}~${CONTENT_COUNT}~0
+	QD_PRIMARY_ARRAY=${MASTER_HOST}~${MASTER_HOSTNAME}~${MASTER_PORT}~${MASTER_DIRECTORY}/${SEG_PREFIX}${CONTENT_COUNT}~${DBID_COUNT}~${CONTENT_COUNT}
 	((DBID_COUNT=$DBID_COUNT+1));((CONTENT_COUNT=$CONTENT_COUNT+1))
 	for QE_PAIR in ${M_HOST_ARRAY[@]}
 	do
@@ -1149,29 +1149,6 @@ DISPLAY_CONFIG () {
 		GET_REPLY "Continue with Greenplum creation" 
 	fi
 	LOG_MSG "[INFO]:-End Function $FUNCNAME"
-}
-
-SET_VAR () {
-    # 
-    # MPP-13617: If segment contains a ~, we assume ~ is the field delimiter.
-    # Otherwise we assume : is the delimiter.  This allows us to easily 
-    # handle IPv6 addresses which may contain a : by using a ~ as a delimiter. 
-    # 
-    I=$1
-    case $I in
-        *~*)
-	    S="~"
-            ;;
-        *)
-	    S=":"
-            ;;
-    esac
-    GP_HOSTNAME=`$ECHO $I|$CUT -d$S -f1`
-    GP_HOSTADDRESS=`$ECHO $I|$CUT -d$S -f2`
-    GP_PORT=`$ECHO $I|$CUT -d$S -f3`
-    GP_DIR=`$ECHO $I|$CUT -d$S -f4`
-    GP_DBID=`$ECHO $I|$CUT -d$S -f5`
-    GP_CONTENT=`$ECHO $I|$CUT -d$S -f6`
 }
 
 CREATE_QD_DB () {

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -68,29 +68,6 @@ CHK_CALL () {
 	fi
 }
 
-SET_VAR () {
-    # 
-    # MPP-13617: If segment contains a ~, we assume ~ is the field delimiter.
-    # Otherwise we assume : is the delimiter.  This allows us to easily 
-    # handle IPv6 addresses which may contain a : by using a ~ as a delimiter. 
-    # 
-    I=$1
-    case $I in
-        *~*)
-	    S="~"
-            ;;
-        *)
-	    S=":"
-            ;;
-    esac
-    GP_HOSTNAME=`$ECHO $I|$CUT -d$S -f1`
-    GP_HOSTADDRESS=`$ECHO $I|$CUT -d$S -f2`
-    GP_PORT=`$ECHO $I|$CUT -d$S -f3`
-    GP_DIR=`$ECHO $I|$CUT -d$S -f4`
-    GP_DBID=`$ECHO $I|$CUT -d$S -f5`
-    GP_CONTENT=`$ECHO $I|$CUT -d$S -f6`
-}
-
 PARA_EXIT () {
 	if [ $1 -ne 0 ];then
 		$ECHO "FAILED:$SEGMENT_TO_CREATE" >> $PARALLEL_STATUS_FILE

--- a/gpMgmt/bin/test/gpinitsystem_test.bash
+++ b/gpMgmt/bin/test/gpinitsystem_test.bash
@@ -57,9 +57,121 @@ it_should_quote_the_password_during_alter_user_in_SET_GP_USER_PW() {
   fi
 }
 
+it_should_work_with_a_hostname() {
+  ARRAY_LINE="sdw1~sdw1~50433~/data/primary/gpseg0~1~0"
+  SET_VAR $ARRAY_LINE
+  if [ "$GP_HOSTNAME" != "sdw1" ]; then
+    echo "got hostname $GP_HOSTNAME, wanted sdw1"
+    exit 1
+  fi
+  if [ "$GP_HOSTADDRESS" != "sdw1" ]; then
+    echo "got address $GP_HOSTADDRESS, wanted sdw1"
+    exit 1
+  fi
+  if [ "$GP_PORT" != "50433" ]; then
+    echo "got port $GP_PORT, wanted 50433"
+    exit 1
+  fi
+  if [ "$GP_DIR" != "/data/primary/gpseg0" ]; then
+    echo "got data directory $GP_DIR, wanted /data/primary/gpseg0"
+    exit 1
+  fi
+  if [ "$GP_DBID" != "1" ]; then
+    echo "got dbid $GP_DBID, wanted 1"
+    exit 1
+  fi
+  if [ "$GP_CONTENT" != "0" ]; then
+    echo "got content $GP_CONTENT, wanted 0"
+    exit 1
+  fi
+}
+
+it_should_work_without_a_hostname() {
+  ARRAY_LINE="sdw1~50433~/data/primary/gpseg0~1~0"
+  SET_VAR $ARRAY_LINE
+  if [ "$GP_HOSTNAME" != "sdw1" ]; then
+    echo "got hostname $GP_HOSTNAME, wanted sdw1"
+    exit 1
+  fi
+  if [ "$GP_HOSTADDRESS" != "sdw1" ]; then
+    echo "got address $GP_HOSTADDRESS, wanted sdw1"
+    exit 1
+  fi
+  if [ "$GP_PORT" != "50433" ]; then
+    echo "got port $GP_PORT, wanted 50433"
+    exit 1
+  fi
+  if [ "$GP_DIR" != "/data/primary/gpseg0" ]; then
+    echo "got data directory $GP_DIR, wanted /data/primary/gpseg0"
+    exit 1
+  fi
+  if [ "$GP_DBID" != "1" ]; then
+    echo "got dbid $GP_DBID, wanted 1"
+    exit 1
+  fi
+  if [ "$GP_CONTENT" != "0" ]; then
+    echo "got content $GP_CONTENT, wanted 0"
+    exit 1
+  fi
+}
+
+set_var_should_error_out_if_given_the_wrong_number_of_fields() {
+  IGNORE_WARNINGS=0
+
+  LONG_ARRAY_LINE="one~two~3~/four~5~6~7"
+  ret=$(SET_VAR $LONG_ARRAY_LINE)
+  if [[ "$ret" != *"wrong number of fields"* ]]; then
+      echo "did not error out on too many fields"
+      exit 1
+  fi
+
+  SHORT_ARRAY_LINE="one~two~3~/four"
+  ret=$(SET_VAR $SHORT_ARRAY_LINE)
+  if [[ "$ret" != *"wrong number of fields"* ]]; then
+      echo "did not error out on too few fields"
+      exit 1
+  fi
+}
+
+set_var_should_error_out_if_given_bad_field_values() {
+  IGNORE_WARNINGS=0
+
+  BAD_PORT_ARRAY_LINE="host~address~port~/dir~0~1"
+  ret=$(SET_VAR $BAD_PORT_ARRAY_LINE)
+  if [[ "$ret" != *"non-numeric value"* ]]; then
+      echo "did not error out on non-numeric port value"
+      exit 1
+  fi
+
+  BAD_DBID_ARRAY_LINE="host~address~5432~/dir~dbid~1"
+  ret=$(SET_VAR $BAD_DBID_ARRAY_LINE)
+  if [[ "$ret" != *"non-numeric value"* ]]; then
+      echo "did not error out on non-numeric dbid value"
+      exit 1
+  fi
+
+  BAD_CONTENT_ARRAY_LINE="host~address~5432~/dir~0~content"
+  ret=$(SET_VAR $BAD_CONTENT_ARRAY_LINE)
+  if [[ "$ret" != *"non-numeric value"* ]]; then
+      echo "did not error out on non-numeric content value"
+      exit 1
+  fi
+
+  BAD_DIR_ARRAY_LINE="host~address~5432~dir~0~1"
+  ret=$(SET_VAR $BAD_DIR_ARRAY_LINE)
+  if [[ "$ret" != *"not a valid path"* ]]; then
+      echo "did not error out on invalid directory value"
+      exit 1
+  fi
+}
+
 main() {
   it_should_quote_the_username_during_alter_user_in_SET_GP_USER_PW
   it_should_quote_the_password_during_alter_user_in_SET_GP_USER_PW
+  it_should_work_with_a_hostname
+  it_should_work_without_a_hostname
+  set_var_should_error_out_if_given_the_wrong_number_of_fields
+  set_var_should_error_out_if_given_bad_field_values
 }
 
 main


### PR DESCRIPTION
Previously, gpinitsystem did not allow the user to specify a hostname and
address for each segment in the input file used with -I; it only accepted one
value per segment and used it for both hostname and address.

This commit changes the behavior so that the user must specify both hostname and
address.  The old format is no longer supported, so if the user specifies only
the address, gpinitsystem will error out.  It also adds a few tests around input
file parsing so SET_VAR is more resilient to further refactors.

The specific changes involved are the following:
- Change SET_VAR to parse the new format (host and address) of the segment array
  representation.
- Move SET_VAR from gpinitsystem to gp_bash_functions.sh and remove the
  redundant copy in gpcreateseg.sh.
- Remove a hardcoded "~0" in QD_PRIMARY_ARRAY in gpinitsystem, representing a
  replication port value, that was left over from 5X.
- Improve the check for the number of fields in the segment array representation.