### PR TITLE
[PRE-ARM-REGRESSION-TEST]Fix contrib compile warning

### DIFF
--- a/contrib/btree_gin/btree_gin.c
+++ b/contrib/btree_gin/btree_gin.c
@@ -88,6 +88,7 @@ gin_btree_extract_query(FunctionCallInfo fcinfo,
 		case BTGreaterEqualStrategyNumber:
 		case BTGreaterStrategyNumber:
 			*ptr_partialmatch = true;
+            break;
 		case BTEqualStrategyNumber:
 			entries[0] = datum;
 			break;

--- a/contrib/pgrowlocks/pgrowlocks.c
+++ b/contrib/pgrowlocks/pgrowlocks.c
@@ -75,6 +75,7 @@ pgrowlocks(PG_FUNCTION_ARGS)
 	Datum		result;
 	MyData	   *mydata;
 	Relation	rel;
+    rel = NULL;
 
 	if (SRF_IS_FIRSTCALL())
 	{


### PR DESCRIPTION
Here only can reproduce on aarch64.
gcc will return some warning about:
this statement may fall through werror implicit fallthrough
and
ref is not initialize before use.