### PR TITLE
Travis: try to fix the recent pip breakage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ script:
             --enable-mapreduce \
             --enable-orafce \
             $C
-        make -s install
+        make -j 2 -s install
         source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
         make -s unittest-check
         make -C gpAux/gpdemo cluster
@@ -172,7 +172,7 @@ script:
             --enable-mapreduce \
             --enable-orafce \
             $C
-        make -s install
+        make -j 2 -s install
         source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
         make -s unittest-check
         make -C gpAux/gpdemo cluster

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,18 @@ matrix:
               apt:
                   sources: *common_sources
                   packages: *common_packages
+        # Build without lots of things, not because it's a recommended setup
+        # but because it might trigger compiler warnings otherwise not seen.
+        - os: linux
+          dist: bionic
+          compiler: gcc
+          env:
+              - T=debug C="--without-openssl --disable-strong-random --disable-atomics --disable-spinlocks"
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+          addons:
+              apt:
+                  sources: *common_sources
+                  packages: *common_packages
 
 ## ----------------------------------------------------------------------
 ## Build tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,11 +60,6 @@ matrix:
                   packages:
                       - *common_packages
                       - clang-7
-        # macOS, XCode11
-        - os: osx
-          compiler: clang
-          osx_image: xcode11
-          env: T=macos
         #
         # Configuration variations
         # ----------------------------------------------------------------
@@ -157,24 +152,6 @@ script:
         make -C gpAux/gpdemo cluster
         source gpAux/gpdemo/gpdemo-env.sh
         make -C src/test/regress installcheck-small
-      fi
-  - |
-      set -eo pipefail
-      if [ "$T" = "macos" ]; then
-        ./configure \
-            --prefix=${TRAVIS_BUILD_DIR}/gpsql \
-            --with-perl \
-            --with-python \
-            --disable-orca \
-            --enable-orafce \
-            --disable-gpfdist \
-            --disable-pxf \
-            --disable-gpcloud \
-            --without-zstd \
-            $C
-        make -s install
-        source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
-        make -s unittest-check
       fi
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ sudo: false
 git:
   submodules: false
 
+env:
+  global:
+    - EXPERIMENTAL=no
+
+jobs:
+
 addons:
     apt:
         config:
@@ -28,6 +34,9 @@ addons:
             - libzstd1-dev
 
 matrix:
+    allow_failures:
+      - env: - T=experimental OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+    fast_finish: true
     include:
         # OS and Compiler variations
         # ----------------------------------------------------------------
@@ -66,7 +75,7 @@ matrix:
           compiler: gcc
           arch: arm64
           env:
-              - T=debug C=""
+              - T=experimental
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
           addons:
               apt:
@@ -95,18 +104,6 @@ matrix:
           compiler: gcc
           env:
               - T=debug C="--without-zlib --without-libbz2 --without-zstd --without-quicklz"
-              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
-          addons:
-              apt:
-                  sources: *common_sources
-                  packages: *common_packages
-        # Build without lots of things, not because it's a recommended setup
-        # but because it might trigger compiler warnings otherwise not seen.
-        - os: linux
-          dist: bionic
-          compiler: gcc
-          env:
-              - T=debug C="--without-openssl --disable-strong-random --disable-atomics --disable-spinlocks"
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
           addons:
               apt:
@@ -190,6 +187,32 @@ script:
         source gpAux/gpdemo/gpdemo-env.sh
         make -C src/test/regress installcheck-small
       fi
+  - |
+      set -eo pipefail
+      if [ "$T" = "experimental" ]; then
+        ./configure \
+            --prefix=${TRAVIS_BUILD_DIR}/gpsql \
+            --enable-cassert \
+            --enable-debug \
+            --enable-debug-extensions \
+            --with-perl \
+            --with-python \
+            --disable-orca \
+            --with-openssl \
+            --with-ldap \
+            --with-libcurl \
+            --with-libxml \
+            --enable-mapreduce \
+            --enable-orafce \
+            $C
+        make -j 2 -s install
+        source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
+        make -s unittest-check
+        make -C gpAux/gpdemo cluster
+        source gpAux/gpdemo/gpdemo-env.sh
+        make -C src/test/regress installcheck-small
+      fi
+
 
 after_script:
   - source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,17 @@ matrix:
         # Configuration variations
         # ----------------------------------------------------------------
         #
+        # Production build without any debugging or assertions
+        - os: linux
+          dist: bionic
+          compiler: gcc
+          env:
+              - T=production C=""
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+          addons:
+              apt:
+                  sources: *common_sources
+                  packages: *common_packages
         # Debug build without any compression algorithms supplied
         - os: linux
           dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,6 @@ sudo: false
 git:
   submodules: false
 
-env:
-  global:
-    - EXPERIMENTAL=no
-
-jobs:
-
 addons:
     apt:
         config:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         # OS and Compiler variations
         # ----------------------------------------------------------------
         #
-        # Ubuntu Bionic, gcc 8
+        # Ubuntu Bionic, gcc 8, AMD64
         - os: linux
           dist: bionic
           compiler: gcc
@@ -45,7 +45,7 @@ matrix:
                       - *common_sources
                   packages:
                       - *common_packages
-        # Ubuntu Xenial, clang 7
+        # Ubuntu Xenial, clang 7, AMD64
         - os: linux
           dist: xenial
           compiler: clang
@@ -60,6 +60,20 @@ matrix:
                   packages:
                       - *common_packages
                       - clang-7
+        # Ubuntu Bionic, gcc 8, ARM64
+        - os: linux
+          dist: bionic
+          compiler: gcc
+          arch: arm64
+          env:
+              - T=debug C=""
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                  packages:
+                      - *common_packages
         #
         # Configuration variations
         # ----------------------------------------------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,11 @@ matrix:
                       - *common_sources
                   packages:
                       - *common_packages
+        # macOS, XCode11
+        - os: osx
+          compiler: clang
+          osx_image: xcode11
+          env: T=macos
         #
         # Configuration variations
         # ----------------------------------------------------------------
@@ -116,16 +121,6 @@ before_install:
     - eval "${OVERRIDE_CXX}"
 
 ## ----------------------------------------------------------------------
-## Install supporting Python modules
-## ----------------------------------------------------------------------
-
-install:
-    - pip install --user --upgrade pip
-    - pip install --user --pre psutil
-    - pip install --user lockfile
-    - pip install --user setuptools
-
-## ----------------------------------------------------------------------
 ## Perform build:
 ## ----------------------------------------------------------------------
 
@@ -136,6 +131,10 @@ before_script:
 script:
   - |
       set -eo pipefail
+      pip install --user --upgrade pip
+      pip install --user --pre psutil
+      pip install --user lockfile
+      pip install --user setuptools
       if [ "$T" = "debug" ]; then
         ./configure \
             --prefix=${TRAVIS_BUILD_DIR}/gpsql \
@@ -161,6 +160,10 @@ script:
       fi
   - |
       set -eo pipefail
+      pip install --user --upgrade pip
+      pip install --user --pre psutil
+      pip install --user lockfile
+      pip install --user setuptools
       if [ "$T" = "production" ]; then
         ./configure \
             --prefix=${TRAVIS_BUILD_DIR}/gpsql \
@@ -183,6 +186,10 @@ script:
       fi
   - |
       set -eo pipefail
+      pip install --user --upgrade pip
+      pip install --user --pre psutil
+      pip install --user lockfile
+      pip install --user setuptools
       if [ "$T" = "experimental" ]; then
         ./configure \
             --prefix=${TRAVIS_BUILD_DIR}/gpsql \
@@ -206,7 +213,24 @@ script:
         source gpAux/gpdemo/gpdemo-env.sh
         make -C src/test/regress installcheck-small
       fi
-
+  - |
+      set -eo pipefail
+      if [ "$T" = "macos" ]; then
+        ./configure \
+            --prefix=${TRAVIS_BUILD_DIR}/gpsql \
+            --with-perl \
+            --with-python \
+            --disable-orca \
+            --enable-orafce \
+            --disable-gpfdist \
+            --disable-pxf \
+            --disable-gpcloud \
+            --without-zstd \
+            $C
+        make -s install
+        source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
+        make -s unittest-check
+      fi
 
 after_script:
   - source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4448,7 +4448,7 @@ process_postgres_switches(int argc, char *argv[], GucContext ctx,
  * received, and is used to construct the error message.
  */
 static void
-check_forbidden_in_gpdb_handlers(char firstchar)
+check_forbidden_in_gpdb_handlers(int firstchar)
 {
 	if (am_ftshandler || IsFaultHandler)
 	{


### PR DESCRIPTION
It seems that `pip` is no longer in `PATH` for the macOS instances on Travis. Let's try to get it working again before the more drastic measure of removing the macOS builds..