### PR TITLE
Fix incorrect list duplication for constraint names

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -8229,7 +8229,7 @@ fixCreateStmtForPartitionedTable(CreateStmt *stmt)
 		}
 	}
 
-	used_names = list_union(used_names, NIL);	/* eliminate dups */
+	used_names = list_union(NIL, used_names);	/* eliminate dups */
 
 	for (i = 0; i < list_length(unnamed_cons); i++)
 	{


### PR DESCRIPTION
Calling x = list_union(x, NIL); creates a verbatim copy of the list, as duplicates are only in the second argument. Fix by reversing the arguments.

I  wasn't able to trigger an error with this bug, but I'm not sure if that indicates that the call can be removed instead..