### PR TITLE
Handle concurrent update 'distributed oldestXmin'

### DIFF
--- a/src/backend/access/rmgrdesc/distributedlogdesc.c
+++ b/src/backend/access/rmgrdesc/distributedlogdesc.c
@@ -30,13 +30,6 @@ DistributedLog_desc(StringInfo buf, XLogReaderState *record)
 		memcpy(&page, rec, sizeof(int));
 		appendStringInfo(buf, "zeropage: %d", page);
 	}
-	else if (info == DISTRIBUTEDLOG_TRUNCATE)
-	{
-		int			page;
-
-		memcpy(&page, rec, sizeof(int));
-		appendStringInfo(buf, "truncate before: %d", page);
-	}
 	else
 		appendStringInfo(buf, "UNKNOWN");
 }
@@ -51,8 +44,8 @@ DistributedLog_identify(uint8 info)
 		case DISTRIBUTEDLOG_ZEROPAGE:
 			id = "DISTRIBUTEDLOG_ZEROPAGE";
 			break;
-		case DISTRIBUTEDLOG_TRUNCATE:
-			id = "DISTRIBUTEDLOG_TRUNCATE";
+		default:
+			id = "UNKNOWN";
 			break;
 	}
 

--- a/src/backend/access/transam/test/distributedlog_test.c
+++ b/src/backend/access/transam/test/distributedlog_test.c
@@ -40,8 +40,6 @@ MPP_20426(void **state, TransactionId nextXid)
 	ShmemVariableCache = &data;
 	ShmemVariableCache->oldestXid = 3;
 	ShmemVariableCache->latestCompletedXid = 4;
-	DistributedLogShmem dls;
-	DistributedLogShared = &dls;
 
 	/* Setup DistributedLogCtl */
 	DistributedLogCtl->shared = (SlruShared) malloc(sizeof(SlruSharedData));
@@ -68,6 +66,10 @@ MPP_20426(void **state, TransactionId nextXid)
 	expect_any(SimpleLruReadPage, write_ok);
 	expect_value(SimpleLruReadPage, xid, nextXid);
 	will_return(SimpleLruReadPage, 0);
+
+	expect_value(SimpleLruTruncateWithLock, ctl, DistributedLogCtl);
+	expect_any(SimpleLruTruncateWithLock, cutoffPage);
+	will_be_called(SimpleLruTruncateWithLock);
 
 	expect_value(LWLockRelease, lock, DistributedLogControlLock);
 	will_be_called(LWLockRelease);
@@ -127,6 +129,10 @@ setup(TransactionId nextXid)
 	expect_any(SimpleLruReadPage, write_ok);
 	expect_value(SimpleLruReadPage, xid, nextXid);
 	will_return(SimpleLruReadPage, 0);
+
+	expect_value(SimpleLruTruncateWithLock, ctl, DistributedLogCtl);
+	expect_any(SimpleLruTruncateWithLock, cutoffPage);
+	will_be_called(SimpleLruTruncateWithLock);
 
 	expect_value(LWLockRelease, lock, DistributedLogControlLock);
 	will_be_called(LWLockRelease);

--- a/src/backend/storage/lmgr/lwlocknames.txt
+++ b/src/backend/storage/lmgr/lwlocknames.txt
@@ -58,5 +58,4 @@ ErrorLogLock						48
 SessionStateLock					49
 RelfilenodeGenLock					50
 WorkFileManagerLock					51
-DistributedLogTruncateLock			52
-TwophaseCommitLock				53
+TwophaseCommitLock				52

--- a/src/bin/pg_controldata/pg_controldata.c
+++ b/src/bin/pg_controldata/pg_controldata.c
@@ -238,6 +238,8 @@ main(int argc, char *argv[])
 		   ControlFile->checkPointCopy.oldestXidDB);
 	printf(_("Latest checkpoint's oldestActiveXID:  %u\n"),
 		   ControlFile->checkPointCopy.oldestActiveXid);
+	printf(_("Latest checkpoint's oldestXmin:  %u\n"),
+		   ControlFile->checkPointCopy.oldestXmin);
 	printf(_("Latest checkpoint's oldestMultiXid:   %u\n"),
 		   ControlFile->checkPointCopy.oldestMulti);
 	printf(_("Latest checkpoint's oldestMulti's DB: %u\n"),

--- a/src/bin/pg_resetxlog/pg_resetxlog.c
+++ b/src/bin/pg_resetxlog/pg_resetxlog.c
@@ -791,6 +791,7 @@ GuessControlValues(void)
 	ControlFile.checkPointCopy.oldestMultiDB = InvalidOid;
 	ControlFile.checkPointCopy.time = (pg_time_t) time(NULL);
 	ControlFile.checkPointCopy.oldestActiveXid = InvalidTransactionId;
+	ControlFile.checkPointCopy.oldestXmin = InvalidTransactionId;
 
 	ControlFile.state = DB_SHUTDOWNED;
 	ControlFile.time = (pg_time_t) time(NULL);

--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -73,7 +73,6 @@ extern void DistributedLog_CheckPoint(void);
 extern void DistributedLog_Extend(TransactionId newestXid);
 extern bool DistributedLog_GetLowWaterXid(
 							  TransactionId *lowWaterXid);
-extern void DistributedLog_InitOldestXmin(void);
 
 /* XLOG stuff */
 #define DISTRIBUTEDLOG_ZEROPAGE		0x00

--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -61,6 +61,7 @@ extern TransactionId DistributedLog_AdvanceOldestXmin(TransactionId oldestInProg
 								 DistributedTransactionTimeStamp distribTimeStamp,
 								 DistributedTransactionId oldestDistribXid);
 extern TransactionId DistributedLog_GetOldestXmin(TransactionId oldestLocalXmin);
+extern void DistributedLog_SetOldestXmin(TransactionId oldestXmin);
 
 extern Size DistributedLog_ShmemSize(void);
 extern void DistributedLog_ShmemInit(void);
@@ -76,7 +77,6 @@ extern bool DistributedLog_GetLowWaterXid(
 
 /* XLOG stuff */
 #define DISTRIBUTEDLOG_ZEROPAGE		0x00
-#define DISTRIBUTEDLOG_TRUNCATE		0x10
 
 extern void DistributedLog_redo(XLogReaderState *record);
 extern void DistributedLog_desc(StringInfo buf, XLogReaderState *record);

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -118,6 +118,15 @@ typedef struct VariableCacheData
 										 * aborted */
 	TransactionId latestCompletedDxid;	/* newest distributed XID that has
 										   committed or aborted */
+	/*
+	 * Oldest local XID that is still visible to some distributed snapshot.
+	 *
+	 * This is initialized by DistributedLog_InitOldestXmin() after
+	 * postmaster startup, and advanced whenever we receive a new
+	 * distributed snapshot from the QD (or in the QD itself, whenever
+	 * we compute a new snapshot).
+	 */
+	volatile TransactionId	oldestXmin;
 } VariableCacheData;
 
 typedef VariableCacheData *VariableCache;

--- a/src/include/catalog/pg_control.h
+++ b/src/include/catalog/pg_control.h
@@ -65,6 +65,9 @@ typedef struct CheckPoint
 	 */
 	TransactionId oldestActiveXid;
 
+	/* distributed oldestXmin */
+	TransactionId oldestXmin;
+
 	/* IN XLOG RECORD, MORE DATA FOLLOWS AT END OF STRUCT FOR DTM CHECKPOINT */
 } CheckPoint;
 


### PR DESCRIPTION
The distributed oldestXmin (DistributedLogShared->oldestXmin) is caculated with
xminAllDistributedSnapshots (in distributed snapshot) and the local oldestXmin,
each backend should has its own. However, we need a valid initial value for a
new spawn backend, so we make it shared across backends on one segment. It
won't jeopardize the correctness, because when a backend use a oldestXmin
beyond its xminAllDistributedSnapshots, the distributed transaction id of the
oldestXmin will still smaller than the xmin of its distributed snapshot.

As the backends share the oldestXmin, it can be updated concurrently, we need to
make sure we don't overwritten the value with a smaller one.

Besides, SimpleLruReadPage may release the lock, truncate the distributed log when
advancing the oldestXmin may cause conflicts. So change the timing of truncate file.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
