### PR TITLE
docs - use correct name for a wal guc

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/configure.xml
+++ b/gpdb-doc/dita/admin_guide/managing/configure.xml
@@ -1195,14 +1195,14 @@
         <p>The parameters in this topic control the configuration of the replication between
           Greenplum Database primary master and standby master.</p>
         <ul>
-          <li id="kh184294">
-            <codeph>keep_wal_segments</codeph>
-          </li>
           <li id="kh184295">
             <codeph>repl_catchup_within_range</codeph>
           </li>
           <li id="kh184296">
             <codeph>replication_timeout</codeph>
+          </li>
+          <li id="kh184294">
+            <codeph>wal_keep_segments</codeph>
           </li>
           <li id="kh184297">
             <codeph>wal_receiver_status_interval</codeph>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -9217,7 +9217,7 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
         files that are saved by the by the active Greenplum Database master if a checkpoint
         operation occurs.</p>
       <p>The segment files are used to synchronize the active master on the standby master. </p>
-      <table id="keep_wal_segments_table">
+      <table id="wal_keep_segments_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
           <colspec colnum="2" colname="col2" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1491,11 +1491,11 @@
             <p><xref href="guc-list.xml#wait_for_replication_threshold" type="section"
                 >wait_for_replication_threshold</xref>
             </p>
+            <p><xref href="guc-list.xml#wal_keep_segments" type="section">wal_keep_segments</xref>
+            </p>
             <p>
               <xref href="guc-list.xml#wal_receiver_status_interval" type="section"
                 >wal_receiver_status_interval</xref>
-            </p>
-            <p><xref href="guc-list.xml#wal_keep_segments" type="section">wal_keep_segments</xref>
             </p>
           </stentry>
         </strow>


### PR DESCRIPTION
clean up some incorrect references to keep_wal_segments.
