### PR TITLE
Fix the hang issue in PR(#9726)

### DIFF
--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -1951,6 +1951,10 @@ ABORT
 
 -- 2.6 select for update NOWAIT/SKIP LOCKED
 -- with GDD, select for update could be optimized to not upgrade lock.
+1: set optimizer = off;
+SET
+2: set optimizer = off;
+SET
 1: begin;
 BEGIN
 1: select * from t_lockmods where c<3 for share;

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -590,6 +590,8 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 
 -- 2.6 select for update NOWAIT/SKIP LOCKED
 -- with GDD, select for update could be optimized to not upgrade lock.
+1: set optimizer = off;
+2: set optimizer = off;
 1: begin;
 1: select * from t_lockmods where c<3 for share;
 2: select * from t_lockmods for share;


### PR DESCRIPTION
The Postgres planner could optimize SelectLockingClause to acquire
RowShareLock instead of ExclusiveLock, but the orca doesn't optimize
it. So the following tests may hang with orca:
```
1: begin;
1: select * from t_lockmods where c<3 for share;
2: select * from t_lockmods for share;
2: select * from t_lockmods for update skip locked;
2: select * from t_lockmods where c>=3 for update nowait;
2: select * from t_lockmods for update nowait;
```

- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
