### PR TITLE
Fix error with DISTINCT on a datatype without btree opclass.

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -1402,6 +1402,18 @@ make_distribution_exprs_for_groupclause(PlannerInfo *root, List *groupclause, Li
 		if (!sortcl->hashable)
 			continue;
 
+		/*
+		 * If this expression is not sortable, we cannot construct a PathKey
+		 * to represent it. Give up.
+		 *
+		 * In principle, we could still use it as distribution key, but we'd
+		 * need a different representation for it. For now, though, we don't
+		 * bother. A datatype without ordering operators is a rare thing in
+		 * practice.
+		 */
+		if (sortcl->sortop == InvalidOid)
+			continue;
+
 		expr = (Expr *) get_sortgroupclause_expr(sortcl, tlist);
 
 		pathkey = make_pathkey_from_sortop(root,

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -2031,9 +2031,10 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 			qry->targetList != NIL)
 		{
 			/*
-			 * MPP-15040
-			 * turn distinct clause into grouping clause to make both sort-based
-			 * and hash-based grouping implementations viable plan options
+			 * GPDB: We convert the DISTINCT to an equivalent GROUP BY, when
+			 * possible, because the planner can generate smarter plans for
+			 * GROUP BY. In particular, the "pre-unique" optimization has not
+			 * been implemented for DISTINCT.
 			 */
 			qry->distinctClause = transformDistinctToGroupBy(pstate,
 															 &qry->targetList,

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -2893,19 +2893,10 @@ transformDistinctToGroupBy(ParseState *pstate, List **targetlist,
 		{
 			TargetEntry *tle = (TargetEntry *) lfirst(lc);
 			if (!tle->resjunk)
-			{
-				SortBy sortby;
-
-				sortby.type = T_SortBy;
-				sortby.sortby_dir = SORTBY_DEFAULT;
-				sortby.sortby_nulls = SORTBY_NULLS_DEFAULT;
-				sortby.useOp = NIL;
-				sortby.location = -1;
-				sortby.node = (Node *) tle->expr;
-				group_clause_list = addTargetToSortList(pstate, tle,
-														group_clause_list, *targetlist,
-														&sortby, true);
-			}
+				group_clause_list = addTargetToGroupList(pstate, tle,
+														 group_clause_list, *targetlist,
+														 true,
+														 exprLocation((Node *) tle));
 		}
 	}
 

--- a/src/test/regress/expected/gpdist.out
+++ b/src/test/regress/expected/gpdist.out
@@ -714,24 +714,42 @@ select * from a full join b on (a.i=b.i) full join c on (b.i=c.i);
 --
 create table xidtab (x xid) distributed by (x);
 insert into xidtab select g::text::xid from generate_series(1,5) g;
+insert into xidtab values ('1'); -- insert a duplicate
 select * from xidtab a, xidtab b, xidtab c where a.x=b.x and b.x = c.x;
  x | x | x 
 ---+---+---
- 1 | 1 | 1
+ 5 | 5 | 5
  2 | 2 | 2
  3 | 3 | 3
  4 | 4 | 4
- 5 | 5 | 5
-(5 rows)
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+(12 rows)
 
 select * from xidtab group by x;
  x 
 ---
+ 5
+ 1
  2
  4
  3
- 1
+(5 rows)
+
+select distinct x from xidtab;
+ x 
+---
  5
+ 1
+ 2
+ 4
+ 3
 (5 rows)
 
 -- Simple sanity tests for gp_dist_random()

--- a/src/test/regress/expected/gpdist_optimizer.out
+++ b/src/test/regress/expected/gpdist_optimizer.out
@@ -724,21 +724,39 @@ select * from a full join b on (a.i=b.i) full join c on (b.i=c.i);
 --
 create table xidtab (x xid) distributed by (x);
 insert into xidtab select g::text::xid from generate_series(1,5) g;
+insert into xidtab values ('1'); -- insert a duplicate
 select * from xidtab a, xidtab b, xidtab c where a.x=b.x and b.x = c.x;
  x | x | x 
 ---+---+---
- 1 | 1 | 1
+ 5 | 5 | 5
  2 | 2 | 2
  3 | 3 | 3
  4 | 4 | 4
- 5 | 5 | 5
-(5 rows)
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+ 1 | 1 | 1
+(12 rows)
 
 select * from xidtab group by x;
  x 
 ---
- 1
  5
+ 1
+ 2
+ 4
+ 3
+(5 rows)
+
+select distinct x from xidtab;
+ x 
+---
+ 5
+ 1
  2
  4
  3

--- a/src/test/regress/sql/gpdist.sql
+++ b/src/test/regress/sql/gpdist.sql
@@ -519,8 +519,10 @@ select * from a full join b on (a.i=b.i) full join c on (b.i=c.i);
 --
 create table xidtab (x xid) distributed by (x);
 insert into xidtab select g::text::xid from generate_series(1,5) g;
+insert into xidtab values ('1'); -- insert a duplicate
 select * from xidtab a, xidtab b, xidtab c where a.x=b.x and b.x = c.x;
 select * from xidtab group by x;
+select distinct x from xidtab;
 
 -- Simple sanity tests for gp_dist_random()
 CREATE TEMP TABLE gp_dist_random_table (a int);


### PR DESCRIPTION
Without this patch:

    select distinct x from xidtab;
    ERROR:  could not identify an ordering operator for type xid
    LINE 1: select distinct x from xidtab;
                            ^
    HINT:  Use an explicit ordering operator or modify the query.

There were two similar but distinct issues:

1. transformDistinctToGroupBy() called addTargetToSortList(), even though
   the expression might not have ordering operators. There's another
   function, addTargetToGroupList(), for that. Use that.

2. make_distribution_exprs_for_groupclause() tried to create a PathKey on
   the expression, even if it didn't have ordering operators.

This came up when working on the v12 merge. A new test was added to
upstream, 'hash_func', which contained a query like this involving
'relacl' datatype. But it's a pre-existing issue.

Fixes https://github.com/greenplum-db/gpdb/issues/9855
