### PR TITLE
CI: Don't compile gpdb with a login shell

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -l
+#!/bin/bash
 set -exo pipefail
 
 GREENPLUM_INSTALL_DIR=/usr/local/greenplum-db-devel


### PR DESCRIPTION
On login shells SLES replaces PATH with a fixed known PATH. This was causing compilation to fail by removing gcc from the PATH. Previously, gcc was being set in /root/.bashrc, but that was removed in favor of setting it with docker ENV.

This removes invoking compile_gpdb.bash with a login shell to retain the PATH containing gcc on SLES.

[Test pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-compile_gpdb) (The compile jobs are passing and the other errors seem unrelated.)