### PR TITLE
**6X Backport** CI: Don't compile gpdb with a login shell

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -l
+#!/bin/bash
 set -exo pipefail
 
 GREENPLUM_INSTALL_DIR=/usr/local/greenplum-db-devel


### PR DESCRIPTION
_**Note:**_ This is a 6X backport of https://github.com/greenplum-db/gpdb/pull/9859 and a clean cherry pick of commit 52ef538b8c544b5c3

[Test Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-6X_fix_sles_compile_gpdb)

On login shells SLES replaces PATH with a fixed known PATH. This was causing compilation to fail by removing gcc from the PATH. Previously, gcc was being set in /root/.bashrc, but that was removed in favor of setting it with docker ENV.

This removes invoking compile_gpdb.bash with a login shell to retain the PATH containing gcc on SLES.

(cherry picked from commit 52ef538b8c544b5c3f8043033a941ed8af643b71)
