### PR TITLE
removed wrong errormsg which shows on Windows in gpload.py

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -38,14 +38,7 @@ import platform
 try:
     from pygresql import pg
 except Exception, e:
-    from struct import calcsize
-    sysWordSize = calcsize("P") * 8
-    if (platform.system()) in ['Windows', 'Microsoft'] and (sysWordSize == 64):
-        errorMsg = "gpload appears to be running in 64-bit Python under Windows.\n"
-        errorMsg = errorMsg + "Currently only 32-bit Python is supported. Please \n"
-        errorMsg = errorMsg + "reinstall a 32-bit Python interpreter.\n"
-    else:
-        errorMsg = "gpload was unable to import The PyGreSQL Python module (pg.py) - %s\n" % str(e)
+    errorMsg = "gpload was unable to import The PyGreSQL Python module (pg.py) - %s\n" % str(e)
     sys.stderr.write(str(errorMsg))
     sys.exit(2)
 


### PR DESCRIPTION
In the file gpload.bat, the requirement is 64-bit python 2.7。as shown below:
<img width="533" alt="image" src="https://user-images.githubusercontent.com/1247294/78262736-957cfe00-7533-11ea-9453-4f0211bdddca.png">

but in the file gpload.py, the requirement is 32-bit python 2.7。as shown below:
<img width="611" alt="image" src="https://user-images.githubusercontent.com/1247294/78262991-f4427780-7533-11ea-9fad-7ad04542efac.png">

Also reviewed  file gpload,  the requirement is also 64-bit python. So I removed the error msg.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
