### PR TITLE
docs WIP - add some python3 info?

### DIFF
--- a/gpdb-doc/dita/analytics/pl_container.xml
+++ b/gpdb-doc/dita/analytics/pl_container.xml
@@ -533,10 +533,6 @@ postgres=# select dummyR();
       <p>Control and configure Docker with systemd <xref
           href="https://docs.docker.com/engine/admin/systemd/" format="html" scope="external"
           >https://docs.docker.com/engine/admin/systemd/</xref></p>
-      <p>Changes to Python <xref href="https://docs.python.org/3/whatsnew/index.html" format="html"
-          scope="external">What’s New in Python</xref></p>
-      <p>Porting from Python 2 to 3 <xref href="https://docs.python.org/3/howto/pyporting.html"
-          format="html" scope="external">Porting Python 2 Code to Python 3</xref></p>
       </body>
   </topic>
 

--- a/gpdb-doc/dita/analytics/pl_container_using.xml
+++ b/gpdb-doc/dita/analytics/pl_container_using.xml
@@ -426,6 +426,83 @@ $$ LANGUAGE plcontainer;</codeblock></p>
                         >https://www.postgresql.org/docs/9.4/plpython-database.htm</xref>. </p>
             
         </section>
+        <section id="topic_plc_py3">
+            <title>About PL/Container Running PL/Python with Python 3 </title>
+            <p>If you want to use PL/Container to run the same function body in both Python2 and Python3, you must create 2 different user-defined functions.</p>
+            <p>Useful references:</p>
+            <ul>
+              <li>Changes to Python - <xref href="https://docs.python.org/3/whatsnew/3.0.html"
+                format="html" scope="external">What’s New in Python 3</xref></li>
+              <li>Porting from Python 2 to 3 - <xref href="https://docs.python.org/3/howto/pyporting.html"
+          format="html" scope="external">Porting Python 2 Code to Python 3</xref></li>
+            </ul>
+          <sectiondiv id="topic_datatype_map">
+            <b>Data Type Mapping</b>
+            <table id="datatype_mapping">
+              <tgroup cols="2">
+                <colspec colnum="1" colname="col1" colwidth="240pt"/>
+                <colspec colnum="2" colname="col2" colwidth="240pt"/>
+                <thead>
+                  <row>
+                    <entry colname="col2">Greenplum Primitive Type</entry>
+                    <entry colname="col1">Python 3 Type</entry>
+                  </row>
+                </thead>
+                <tbody>
+                  <row>
+                    <entry colname="col1">boolean</entry>
+                    <entry colname="col2">bool<sup>1</sup></entry>
+                  </row>
+                  <row>
+                    <entry colname="col1">bytea</entry>
+                    <entry colname="col2">bytes</entry>
+                  </row>
+                  <row>
+                    <entry colname="col1">smallint, bigint, oid</entry>
+                    <entry colname="col2">int</entry>
+                  </row>
+                  <row>
+                    <entry colname="col1">real, double</entry>
+                    <entry colname="col2">float</entry>
+                  </row>
+                  <row>
+                    <entry colname="col1">numeric</entry>
+                    <entry colname="col2">decimal</entry>
+                  </row>
+                  <row>
+                    <entry colname="col1"><i>other primitive types</i></entry>
+                    <entry colname="col2">string</entry>
+                  </row>
+                  <row>
+                    <entry colname="col1">SQL null value</entry>
+                    <entry colname="col2">None</entry>
+                  </row>
+                </tbody>
+              </tgroup>
+            </table>
+            <p><sup>1</sup>&nbsp;When the UDF return type is <codeph>boolean</codeph>, the
+               Greenplum Database evaluates the return value for truth according to
+               Python rules. That is, <codeph>0</codeph> and empty string are
+               <codeph>false</codeph>, but notably <codeph>'f'</codeph> is
+               <codeph>true</codeph>.</p>
+            <p>Example:</p>
+            <codeblock>testdb=# CREATE OR REPLACE FUNCTION pybool_func(a int) RETURNS boolean AS $$
+# container: plc_python3_shared
+    if (a > 0):
+        return True
+    else:
+        return False
+$$ LANGUAGE plcontainer;
+testdb=# select pybool_func(-1);
+
+ pybool_func
+-------------
+ f
+(1 row)
+</codeblock>
+          </sectiondiv>
+        </section>
+            
         <section id="topic_lqz_t3q_dw">
             <title>About PL/Container Running PL/R</title>
             

--- a/gpdb-doc/dita/analytics/pl_container_using.xml
+++ b/gpdb-doc/dita/analytics/pl_container_using.xml
@@ -215,9 +215,11 @@ plcontainer runtime-replace -r r_run1 -i pivotaldata/plcontainer_r_shared:devel 
                     <li>Executing the SAVEPOINT command with <codeph>plpy.execute()</codeph> is not
                         supported.</li>
                     <li>The DO command is not supported.</li>
-                    <li>See .OUT parameters are not supported.The Python dict type cannot be
-                        returned from a PL/Python UDF. </li>
-                    <li>When returning the Python dict type from a UDF, you can convert the dict
+                    <li>Container flow control is not supported.</li>
+                    <li>Triggers are not supported.</li>
+                    <li>OUT parameters are not supported.</li>
+                    <li>The Python dict type cannot be returned from a PL/Python UDF.
+                      When returning the Python dict type from a UDF, you can convert the dict
                         type to a Greenplum Database user-defined data type (UDT).</li>
                 </ul>
             </section>
@@ -427,80 +429,21 @@ $$ LANGUAGE plcontainer;</codeblock></p>
             
         </section>
         <section id="topic_plc_py3">
-            <title>About PL/Container Running PL/Python with Python 3 </title>
-            <p>If you want to use PL/Container to run the same function body in both Python2 and Python3, you must create 2 different user-defined functions.</p>
-            <p>Useful references:</p>
-            <ul>
-              <li>Changes to Python - <xref href="https://docs.python.org/3/whatsnew/3.0.html"
-                format="html" scope="external">What’s New in Python 3</xref></li>
-              <li>Porting from Python 2 to 3 - <xref href="https://docs.python.org/3/howto/pyporting.html"
-          format="html" scope="external">Porting Python 2 Code to Python 3</xref></li>
+          <title>About PL/Container Running PL/Python with Python 3 </title>
+          <p>PL/Container for Greenplum Database 5 supports Python version 3.6+.
+            PL/Container for Greenplum Database 6 supports Python 3.7+.</p>
+          <p>If you want to use PL/Container to run the same function body in
+            both Python2 and Python3, you must create 2 different user-defined
+            functions.</p>
+          <p>Keep in mind that UDFs that you created for Python 2 may not run in
+            PL/Container with Python 3. The following Python references may be
+            useful:</p>
+          <ul>
+            <li>Changes to Python - <xref href="https://docs.python.org/3/whatsnew/3.0.html"
+              format="html" scope="external">What’s New in Python 3</xref></li>
+            <li>Porting from Python 2 to 3 - <xref href="https://docs.python.org/3/howto/pyporting.html"
+              format="html" scope="external">Porting Python 2 Code to Python 3</xref></li>
             </ul>
-          <sectiondiv id="topic_datatype_map">
-            <b>Data Type Mapping</b>
-            <table id="datatype_mapping">
-              <tgroup cols="2">
-                <colspec colnum="1" colname="col1" colwidth="240pt"/>
-                <colspec colnum="2" colname="col2" colwidth="240pt"/>
-                <thead>
-                  <row>
-                    <entry colname="col2">Greenplum Primitive Type</entry>
-                    <entry colname="col1">Python 3 Type</entry>
-                  </row>
-                </thead>
-                <tbody>
-                  <row>
-                    <entry colname="col1">boolean</entry>
-                    <entry colname="col2">bool<sup>1</sup></entry>
-                  </row>
-                  <row>
-                    <entry colname="col1">bytea</entry>
-                    <entry colname="col2">bytes</entry>
-                  </row>
-                  <row>
-                    <entry colname="col1">smallint, bigint, oid</entry>
-                    <entry colname="col2">int</entry>
-                  </row>
-                  <row>
-                    <entry colname="col1">real, double</entry>
-                    <entry colname="col2">float</entry>
-                  </row>
-                  <row>
-                    <entry colname="col1">numeric</entry>
-                    <entry colname="col2">decimal</entry>
-                  </row>
-                  <row>
-                    <entry colname="col1"><i>other primitive types</i></entry>
-                    <entry colname="col2">string</entry>
-                  </row>
-                  <row>
-                    <entry colname="col1">SQL null value</entry>
-                    <entry colname="col2">None</entry>
-                  </row>
-                </tbody>
-              </tgroup>
-            </table>
-            <p><sup>1</sup>&nbsp;When the UDF return type is <codeph>boolean</codeph>, the
-               Greenplum Database evaluates the return value for truth according to
-               Python rules. That is, <codeph>0</codeph> and empty string are
-               <codeph>false</codeph>, but notably <codeph>'f'</codeph> is
-               <codeph>true</codeph>.</p>
-            <p>Example:</p>
-            <codeblock>testdb=# CREATE OR REPLACE FUNCTION pybool_func(a int) RETURNS boolean AS $$
-# container: plc_python3_shared
-    if (a > 0):
-        return True
-    else:
-        return False
-$$ LANGUAGE plcontainer;
-testdb=# select pybool_func(-1);
-
- pybool_func
--------------
- f
-(1 row)
-</codeblock>
-          </sectiondiv>
         </section>
             
         <section id="topic_lqz_t3q_dw">

--- a/gpdb-doc/dita/analytics/pl_container_using.xml
+++ b/gpdb-doc/dita/analytics/pl_container_using.xml
@@ -212,15 +212,16 @@ plcontainer runtime-replace -r r_run1 -i pivotaldata/plcontainer_r_shared:devel 
                             <codeph>status()</codeph> are not supported.</li>
                     <li>The PL/Python function <codeph>plpy.SPIError()</codeph> is not
                         supported.</li>
-                    <li>Executing the SAVEPOINT command with <codeph>plpy.execute()</codeph> is not
-                        supported.</li>
-                    <li>The DO command is not supported.</li>
+                    <li>Executing the <codeph>SAVEPOINT</codeph> command with
+                        <codeph>plpy.execute()</codeph> is not supported.</li>
+                    <li>The <codeph>DO</codeph> command is not supported.</li>
                     <li>Container flow control is not supported.</li>
                     <li>Triggers are not supported.</li>
-                    <li>OUT parameters are not supported.</li>
-                    <li>The Python dict type cannot be returned from a PL/Python UDF.
-                      When returning the Python dict type from a UDF, you can convert the dict
-                        type to a Greenplum Database user-defined data type (UDT).</li>
+                    <li><codeph>OUT</codeph> parameters are not supported.</li>
+                    <li>The Python <codeph>dict</codeph> type cannot be returned from
+                      a PL/Python UDF.  When returning the Python <codeph>dict</codeph>
+                      type from a UDF, you can convert the <codeph>dict</codeph> type
+                      to a Greenplum Database user-defined data type (UDT).</li>
                 </ul>
             </section>
             

--- a/gpdb-doc/dita/analytics/pl_python.xml
+++ b/gpdb-doc/dita/analytics/pl_python.xml
@@ -102,6 +102,75 @@
       <p>PL/Python translates Python's <codeph>None</codeph> into the SQL
         <codeph>null</codeph> value</p>
     </body>
+    <topic id="topic_datatypemap" xml:lang="en">
+      <title id="pw2137121113">Data Type Mapping</title>
+      <body>
+        <p>The Greenplum to Python data type mapping follows.</p>
+        <table id="datatype_mapping">
+          <tgroup cols="2">
+            <colspec colnum="1" colname="col1" colwidth="240pt"/>
+            <colspec colnum="2" colname="col2" colwidth="240pt"/>
+            <thead>
+              <row>
+                <entry colname="col2">Greenplum Primitive Type</entry>
+                <entry colname="col1">Python Data Type</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry colname="col1">boolean<sup>1</sup></entry>
+                <entry colname="col2">bool</entry>
+              </row>
+              <row>
+                <entry colname="col1">bytea</entry>
+                <entry colname="col2">bytes</entry>
+              </row>
+              <row>
+                <entry colname="col1">smallint, bigint, oid</entry>
+                <entry colname="col2">int</entry>
+              </row>
+              <row>
+                <entry colname="col1">real, double</entry>
+                <entry colname="col2">float</entry>
+              </row>
+              <row>
+                <entry colname="col1">numeric</entry>
+                <entry colname="col2">decimal</entry>
+              </row>
+              <row>
+                <entry colname="col1"><i>other primitive types</i></entry>
+                <entry colname="col2">string</entry>
+              </row>
+              <row>
+                <entry colname="col1">SQL null value</entry>
+                <entry colname="col2">None</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+        <p><sup>1</sup> When the UDF return type is <codeph>boolean</codeph>, the
+          Greenplum Database evaluates the return value for truth according to
+          Python rules. That is, <codeph>0</codeph> and empty string are
+          <codeph>false</codeph>, but notably <codeph>'f'</codeph> is
+          <codeph>true</codeph>.</p>
+        <p>Example:</p>
+        <codeblock>CREATE OR REPLACE FUNCTION pybool_func(a int) RETURNS boolean AS $$
+# container: plc_python3_shared
+    if (a > 0):
+        return True
+    else:
+        return False
+$$ LANGUAGE plcontainer;
+
+SELECT pybool_func(-1);
+
+ pybool_func
+-------------
+ f
+(1 row)
+</codeblock>
+      </body>
+    </topic>
     <topic id="topic1113" xml:lang="en">
       <title id="pw2137121113">Arrays and Lists</title>
       <body>

--- a/gpdb-doc/dita/analytics/pl_python.xml
+++ b/gpdb-doc/dita/analytics/pl_python.xml
@@ -99,6 +99,8 @@
         arguments are also passed as ordinary variables to the Python script. The result is returned
         from the PL/Python function with <codeph>return</codeph> statement, or
           <codeph>yield</codeph> statement in case of a result-set statement. </p>
+      <p>PL/Python translates Python's <codeph>None</codeph> into the SQL
+        <codeph>null</codeph> value</p>
     </body>
     <topic id="topic1113" xml:lang="en">
       <title id="pw2137121113">Arrays and Lists</title>

--- a/gpdb-doc/dita/analytics/pl_python.xml
+++ b/gpdb-doc/dita/analytics/pl_python.xml
@@ -257,6 +257,34 @@ SELECT * FROM composite_type_as_list();
       </body>
     </topic>
 
+    <topic id="topic_setresult" xml:lang="en">
+      <title>Set-Returning Functions</title>
+      <body>
+        <p>A Python function can return a set of scalar or composite types from any
+          sequence type (for example: tuple, list, set).</p>
+        <p>In the following example, you create a composite type and a Python function
+          that returns a <codeph>SETOF</codeph> of the composite type:</p>
+        <codeblock>CREATE TYPE greeting AS (
+  how text,
+  who text
+);
+
+CREATE FUNCTION greet (how text)
+  RETURNS SETOF greeting
+AS $$
+  # return tuple containing lists as composite types
+  # all other combinations work also
+  return ( {"how": how, "who": "World"}, {"how": how, "who": "Greenplum"} )
+$$ LANGUAGE plpythonu;
+
+select greet('hello');
+       greet
+-------------------
+ (hello,World)
+ (hello,Greenplum)
+(2 rows)</codeblock>
+      </body>
+    </topic>
     <topic id="topic8" xml:lang="en">
       <title>Executing and Preparing SQL Queries </title>
       <body>


### PR DESCRIPTION
some python3 doc info (from https://github.com/greenplum-db/plcontainer/blob/5X_STABLE/python3_udf.md)
- this is a WIP PR; it is not clear to me what on this page is python3-specific besides needing to specify the python3 runtime in the UDF.  i might be missing something, but it seems that some of the content should go on the pl/python page?
- is the data type mapping identified in this document for python3 only?  or is it also the mapping for python2?  if applies to both, need to move the table to the pl/python page.
- the wiki of unsupported features (https://github.com/greenplum-db/plcontainer/wiki/PLContainer-Unsupported-Features) - are these specific to pl/container running with python3?  or are these for both python3 and python2?  will need to add a new or update the existing limitations section based on this answer.
- the functions on the page - are any of these python3-specific?  i can run all of them using the stock pl/pythonu installed with greenplum.
- is the info on the page specific to pl/container for greenplum 5?  or is it also applicable to pl/container in greenplum 6?
- the pl/python page already includes similar examples for some of the UDFs on the page; todo:  add the SETOF example