### PR TITLE
Fix pergroupstate for non-strict transition functions

### DIFF
--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -3109,7 +3109,11 @@ numeric_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (NumericAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)
@@ -3200,7 +3204,11 @@ numeric_avg_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (NumericAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)
@@ -3712,7 +3720,11 @@ numeric_poly_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (PolyNumAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)
@@ -3952,7 +3964,11 @@ int8_avg_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (PolyNumAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)

--- a/src/test/regress/expected/workfile/hashagg_spill.out
+++ b/src/test/regress/expected/workfile/hashagg_spill.out
@@ -156,6 +156,31 @@ SELECT avg(col2) col2 FROM hashagg_spill GROUP BY col1 HAVING(sum(col1)) < 0;') 
  t
 (1 row)
 
+-- Test the spilling aggregates for pergroupstate inconsistency
+create table spill_pgs1(a bigint, b bigint, c text, d bigint) distributed randomly;
+insert into spill_pgs1 select g, null::bigint, 'aaaaaa', g from generate_series(1, 500000) as g;
+insert into spill_pgs1 select g, g, 'aaaaaa', g from generate_series(1, 500000) as g;
+create index spill_pgs1_idx on spill_pgs1(a) where c = 'aaaaaa' or c = 'bbbbbb';
+create table spill_pgs2(a bigint) distributed randomly;
+insert into spill_pgs2 select generate_series(1, 500000);
+create table spill_pgs3(d bigint, f integer) distributed randomly;
+insert into spill_pgs3 select g, 1 from generate_series(300000, 1000000) as g;
+set statement_mem='2MB';
+set optimizer=off;
+select count(q.*) as num from (
+    select
+        spill_pgs1.a, spill_pgs3.f,
+        sum(spill_pgs1.b) filter (where spill_pgs1.c in ('bbbbbb'))
+    from spill_pgs1 join spill_pgs2 using(a)
+    left join spill_pgs3 using(d)
+    where spill_pgs1.c in ('aaaaaa', 'bbbbbb')
+    group by 1, 2  
+) as q;
+  num   
+--------
+ 500000
+(1 row)
+
 -- check spilling to a temp tablespace
 CREATE TABLE spill_temptblspace (a numeric) DISTRIBUTED BY (a);
 SET temp_tablespaces=pg_default;

--- a/src/test/regress/sql/workfile/hashagg_spill.sql
+++ b/src/test/regress/sql/workfile/hashagg_spill.sql
@@ -114,6 +114,27 @@ SET gp_workfile_compression = ON;
 select overflows >= 1 from hashagg_spill.num_hashagg_overflows('explain analyze
 SELECT avg(col2) col2 FROM hashagg_spill GROUP BY col1 HAVING(sum(col1)) < 0;') overflows;
 
+-- Test the spilling aggregates for pergroupstate inconsistency
+create table spill_pgs1(a bigint, b bigint, c text, d bigint) distributed randomly;
+insert into spill_pgs1 select g, null::bigint, 'aaaaaa', g from generate_series(1, 500000) as g;
+insert into spill_pgs1 select g, g, 'aaaaaa', g from generate_series(1, 500000) as g;
+create index spill_pgs1_idx on spill_pgs1(a) where c = 'aaaaaa' or c = 'bbbbbb';
+create table spill_pgs2(a bigint) distributed randomly;
+insert into spill_pgs2 select generate_series(1, 500000);
+create table spill_pgs3(d bigint, f integer) distributed randomly;
+insert into spill_pgs3 select g, 1 from generate_series(300000, 1000000) as g;
+set statement_mem='2MB';
+set optimizer=off;
+select count(q.*) as num from (
+    select
+        spill_pgs1.a, spill_pgs3.f,
+        sum(spill_pgs1.b) filter (where spill_pgs1.c in ('bbbbbb'))
+    from spill_pgs1 join spill_pgs2 using(a)
+    left join spill_pgs3 using(d)
+    where spill_pgs1.c in ('aaaaaa', 'bbbbbb')
+    group by 1, 2  
+) as q;
+
 -- check spilling to a temp tablespace
 CREATE TABLE spill_temptblspace (a numeric) DISTRIBUTED BY (a);
 SET temp_tablespaces=pg_default;


### PR DESCRIPTION
On some datasets GP fails with segfault on serialization of a HHashAgg table entries to spillfiles. This problem is caused by a `pergroupstate` inconsistency in some entries: `transValue` is `0` when `transValueIsNull` and `noTransValue` are `false`.

The reason of this inconsistency is a wrong `fcinfo->isnull` status returned by some of non-strict `*_combine` transition functions. The first part of the problem is that `*_combine` functions do not modify `fcinfo->isnull` state but can return `NULL`. The second part of it is that `fcinfo->isnull` in `invoke_agg_trans_func()` is always set `false` by default for non-strict transition functions. As a result `pergroupstate` can become inconsistent and cause segfailts.

We can get information whether a transition function returns `NULL` or not only from its internals. So this commit fixes `*_combine` functions to set `fcinfo->isnull` correctly.

An example added to workfile regression tests causes segfault on current `6X_STABLE`. I haven't tried it on `master` - it can be possible affected too (should I open another PR for that?) 