### PR TITLE
6X: Fix the nowait issue(#8539)

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -1183,7 +1183,7 @@ try_relation_open(Oid relationId, LOCKMODE lockmode, bool noWait)
  * for distributed tables.
  */
 Relation
-CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
+CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool *lockUpgraded)
 {
     LOCKMODE    lockmode = reqmode;
 	Relation    rel;
@@ -1205,7 +1205,7 @@ CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
 	if (lockmode == RowExclusiveLock)
 	{
 		if (Gp_role == GP_ROLE_DISPATCH &&
-			CondUpgradeRelLock(relid, noWait))
+			CondUpgradeRelLock(relid))
 		{
 			lockmode = ExclusiveLock;
 			if (lockUpgraded != NULL)
@@ -1213,7 +1213,7 @@ CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
 		}
     }
 
-	rel = try_heap_open(relid, lockmode, noWait);
+	rel = try_heap_open(relid, lockmode, false);
 	if (!RelationIsValid(rel))
 		return NULL;
 
@@ -1244,11 +1244,11 @@ CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
  * an error or a valid opened relation returned.
  */
 Relation
-CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
+CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool *lockUpgraded)
 {
 	Relation rel;
 
-	rel = CdbTryOpenRelation(relid, reqmode, noWait, lockUpgraded);
+	rel = CdbTryOpenRelation(relid, reqmode, lockUpgraded);
 
 	if (!RelationIsValid(rel))
 	{
@@ -1277,7 +1277,7 @@ CdbOpenRelationRv(const RangeVar *relation, LOCKMODE reqmode, bool noWait,
 
 	/* Look up the appropriate relation using namespace search */
 	relid = RangeVarGetRelid(relation, NoLock, false);
-	rel = CdbTryOpenRelation(relid, reqmode, noWait, lockUpgraded);
+	rel = CdbTryOpenRelation(relid, reqmode, lockUpgraded);
 
 	if (!RelationIsValid(rel))
 	{

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1707,10 +1707,7 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 				{
 					lockmode = NoLock;
 				}
-				resultRelation = CdbOpenRelation(resultRelationOid,
-													 lockmode,
-													 false, /* noWait */
-													 NULL); /* lockUpgraded */
+				resultRelation = CdbOpenRelation(resultRelationOid, lockmode, NULL);
 			}
 			else
 			{

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -337,8 +337,7 @@ setTargetTable(ParseState *pstate, RangeVar *relation,
 	else
 	{
 
-		pstate->p_target_relation = parserOpenTable(pstate, relation, RowExclusiveLock,
-													false, NULL);
+		pstate->p_target_relation = parserOpenTable(pstate, relation, RowExclusiveLock, NULL);
 	}
 
 	/*

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -981,7 +981,7 @@ chooseScalarFunctionAlias(Node *funcexpr, char *funcname,
  */
 Relation
 parserOpenTable(ParseState *pstate, const RangeVar *relation,
-				int lockmode, bool nowait, bool *lockUpgraded)
+				int lockmode, bool *lockUpgraded)
 {
 	Relation	rel;
 	ParseCallbackState pcbstate;
@@ -996,7 +996,7 @@ parserOpenTable(ParseState *pstate, const RangeVar *relation,
 	 * is dropped by another transaction). Every time we invoke function
 	 * CdbTryOpenRelation, we should check if the return value is NULL.
 	 */
-	rel = CdbTryOpenRelation(relid, lockmode, nowait, lockUpgraded);
+	rel = CdbTryOpenRelation(relid, lockmode, lockUpgraded);
 
 	if (!RelationIsValid(rel))
 	{
@@ -1052,7 +1052,6 @@ addRangeTableEntry(ParseState *pstate,
 	RangeTblEntry *rte = makeNode(RangeTblEntry);
 	char	   *refname = alias ? alias->aliasname : relation->relname;
 	LOCKMODE	lockmode = AccessShareLock;
-	bool		nowait = false;
 	LockingClause *locking;
 	Relation	rel;
 	ParseCallbackState pcbstate;
@@ -1092,7 +1091,6 @@ addRangeTableEntry(ParseState *pstate,
 		{
 			lockmode = RowShareLock;
 		}
-		nowait = locking->noWait;
 	}
 
 	/*
@@ -1102,7 +1100,7 @@ addRangeTableEntry(ParseState *pstate,
 	 * depending on whether we're doing SELECT FOR UPDATE/SHARE.
 	 */
 	setup_parser_errposition_callback(&pcbstate, pstate, relation->location);
-	rel = parserOpenTable(pstate, relation, lockmode, nowait, NULL);
+	rel = parserOpenTable(pstate, relation, lockmode, NULL);
 	cancel_parser_errposition_callback(&pcbstate);
 	rte->relid = RelationGetRelid(rel);
 	rte->relkind = rel->rd_rel->relkind;

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -190,7 +190,7 @@ AcquireRewriteLocks(Query *parsetree,
 				/* Take a lock either using CDB lock promotion or not */
 				if (needLockUpgrade)
 				{
-					rel = CdbOpenRelation(rte->relid, lockmode, false, NULL);
+					rel = CdbOpenRelation(rte->relid, lockmode, NULL);
 				}
 				else
 				{

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -1142,7 +1142,7 @@ LockTagIsTemp(const LOCKTAG *tag)
  * we have to keep upgrading locks for AO table.
  */
 bool
-CondUpgradeRelLock(Oid relid, bool noWait)
+CondUpgradeRelLock(Oid relid)
 {
 	Relation rel;
 	bool upgrade = false;
@@ -1150,10 +1150,10 @@ CondUpgradeRelLock(Oid relid, bool noWait)
 	if (!gp_enable_global_deadlock_detector)
 		return true;
 
-	rel = try_relation_open(relid, NoLock, noWait);
+	rel = try_relation_open(relid, NoLock, false);
 
 	if (!rel)
-		elog(ERROR, "Relation open failed!");
+		return false;
 	else if (RelationIsAppendOptimized(rel))
 		upgrade = true;
 	else

--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -1561,7 +1561,7 @@ AcquireExecutorLocks(List *stmt_list, bool acquire)
 				if (rte->relid >= FirstNormalObjectId &&
 					(plannedstmt->commandType == CMD_UPDATE ||
 					 plannedstmt->commandType == CMD_DELETE) &&
-					CondUpgradeRelLock(rte->relid, false))
+					CondUpgradeRelLock(rte->relid))
 					lockmode = ExclusiveLock;
 				else
 					lockmode = RowExclusiveLock;
@@ -1651,7 +1651,7 @@ ScanQueryForLocks(Query *parsetree, bool acquire)
 					if (rte->relid >= FirstNormalObjectId &&
 						(parsetree->commandType == CMD_UPDATE ||
 						 parsetree->commandType == CMD_DELETE) &&
-						CondUpgradeRelLock(rte->relid, false))
+						CondUpgradeRelLock(rte->relid))
 						lockmode = ExclusiveLock;
 					else
 						lockmode = RowExclusiveLock;

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -107,10 +107,8 @@ extern Relation heap_openrv_extended(const RangeVar *relation,
 #define heap_close(r,l)  relation_close(r,l)
 
 /* CDB */
-extern Relation CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, 
-								bool *lockUpgraded);
-extern Relation CdbTryOpenRelation(Oid relid, LOCKMODE reqmode,
-								   bool noWait, bool *lockUpgraded);
+extern Relation CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool *lockUpgraded);
+extern Relation CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool *lockUpgraded);
 extern Relation CdbOpenRelationRv(const RangeVar *relation, LOCKMODE reqmode, 
 								  bool noWait, bool *lockUpgraded);
 

--- a/src/include/parser/parse_relation.h
+++ b/src/include/parser/parse_relation.h
@@ -45,7 +45,7 @@ extern Node *colNameToVar(ParseState *pstate, char *colname, bool localonly,
 extern void markVarForSelectPriv(ParseState *pstate, Var *var,
 					 RangeTblEntry *rte);
 extern Relation parserOpenTable(ParseState *pstate, const RangeVar *relation,
-								int lockmode, bool nowait, bool *lockUpgraded);
+					int lockmode, bool *lockUpgraded);
 extern RangeTblEntry *addRangeTableEntry(ParseState *pstate,
 				   RangeVar *relation,
 				   Alias *alias,

--- a/src/include/storage/lmgr.h
+++ b/src/include/storage/lmgr.h
@@ -107,7 +107,7 @@ extern void DescribeLockTag(StringInfo buf, const LOCKTAG *tag);
 /* Knowledge about which locktags describe temp objects */
 extern bool LockTagIsTemp(const LOCKTAG *tag);
 
-extern bool CondUpgradeRelLock(Oid relid, bool noWait);
+extern bool CondUpgradeRelLock(Oid relid);
 
 extern void GxactLockTableInsert(DistributedTransactionId xid);
 extern void GxactLockTableWait(DistributedTransactionId xid);

--- a/src/test/isolation2/expected/select_for_update.out
+++ b/src/test/isolation2/expected/select_for_update.out
@@ -26,6 +26,25 @@ UPDATE 1
 2: END;
 END
 
+1: BEGIN;
+BEGIN
+1: SELECT c2 FROM t WHERE c1 < 3 FOR SHARE;
+ c2 
+----
+ 2  
+ 1  
+(2 rows)
+2&: SELECT c2 FROM t WHERE c1 >= 3 FOR UPDATE NOWAIT;  <waiting ...>
+
+1: END;
+END
+2<:  <... completed>
+ c2  
+-----
+ 4   
+ 999 
+(2 rows)
+
 1q: ... <quitting>
 2q: ... <quitting>
 

--- a/src/test/isolation2/sql/select_for_update.sql
+++ b/src/test/isolation2/sql/select_for_update.sql
@@ -15,6 +15,13 @@ INSERT INTO t values (1,1), (2,2), (3,3), (4,4);
 2<:
 2: END;
 
+1: BEGIN;
+1: SELECT c2 FROM t WHERE c1 < 3 FOR SHARE;
+2&: SELECT c2 FROM t WHERE c1 >= 3 FOR UPDATE NOWAIT;
+
+1: END;
+2<:
+
 1q:
 2q:
 


### PR DESCRIPTION
This is a backport of PR(https://github.com/greenplum-db/gpdb/pull/9726)
for 5X_STABLE. NOWAIT only affects how SELCT locks rows as they are
obtained from the table. They are used by the execution. So, the SELECT
statement with locking clause will wait for the table lock if it
can't hold the table lock.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
