### PR TITLE
5X: Fix the nowait issue(#8539)

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -1033,7 +1033,7 @@ try_relation_open(Oid relationId, LOCKMODE lockmode, bool noWait)
  * for distributed tables.
  */
 Relation
-CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
+CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool *lockUpgraded)
 {
     LOCKMODE    lockmode = reqmode;
 	Relation    rel;
@@ -1060,7 +1060,7 @@ CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
 	 */
 	if (lockmode == RowExclusiveLock)
 	{
-		rel = try_heap_open(relid, NoLock, noWait);
+		rel = try_heap_open(relid, NoLock, false);
 		if (!rel)
 			return NULL;
 		
@@ -1074,7 +1074,7 @@ CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
 		relation_close(rel, NoLock);
     }
 
-	rel = try_heap_open(relid, lockmode, noWait);
+	rel = try_heap_open(relid, lockmode, false);
 	if (!RelationIsValid(rel))
 		return NULL;
 
@@ -1103,11 +1103,11 @@ CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
  * an error or a valid opened relation returned.
  */
 Relation
-CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
+CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool *lockUpgraded)
 {
 	Relation rel;
 
-	rel = CdbTryOpenRelation(relid, reqmode, noWait, lockUpgraded);
+	rel = CdbTryOpenRelation(relid, reqmode, lockUpgraded);
 
 	if (!RelationIsValid(rel))
 	{
@@ -1128,15 +1128,14 @@ CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, bool *lockUpgraded)
  * an error or a valid opened relation returned.
  */
 Relation
-CdbOpenRelationRv(const RangeVar *relation, LOCKMODE reqmode, bool noWait, 
-				  bool *lockUpgraded)
+CdbOpenRelationRv(const RangeVar *relation, LOCKMODE reqmode, bool *lockUpgraded)
 {
 	Oid			relid;
 	Relation	rel;
 
 	/* Look up the appropriate relation using namespace search */
 	relid = RangeVarGetRelid(relation, false);
-	rel = CdbTryOpenRelation(relid, reqmode, noWait, lockUpgraded);
+	rel = CdbTryOpenRelation(relid, reqmode, lockUpgraded);
 
 	if (!RelationIsValid(rel))
 	{

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1453,10 +1453,7 @@ InitializeResultRelations(PlannedStmt *plannedstmt, EState *estate, CmdType oper
 			resultRelationOid = getrelid(resultRelationIndex, rangeTable);
 			if (operation == CMD_UPDATE || operation == CMD_DELETE)
 			{
-				resultRelation = CdbOpenRelation(resultRelationOid,
-													 lockmode,
-													 false, /* noWait */
-													 NULL); /* lockUpgraded */
+				resultRelation = CdbOpenRelation(resultRelationOid, lockmode, NULL);
 			}
 			else
 			{
@@ -1805,7 +1802,7 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 
         /* CDB: On QD, lock whole table in S or X mode, if distributed. */
 		lockmode = rc->forUpdate ? RowExclusiveLock : RowShareLock;
-		relation = CdbOpenRelation(relid, lockmode, rc->noWait, &lockUpgraded);
+		relation = CdbOpenRelation(relid, lockmode, &lockUpgraded);
 		if (lockUpgraded)
 		{
             heap_close(relation, NoLock);

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -772,9 +772,7 @@ setTargetTable(ParseState *pstate, RangeVar *relation,
 	}
 	else
 	{
-    	pstate->p_target_relation = CdbOpenRelationRv(relation, 
-													  RowExclusiveLock, 
-													  false, NULL);
+		pstate->p_target_relation = CdbOpenRelationRv(relation, RowExclusiveLock, NULL);
 	}
 	cancel_parser_errposition_callback(&pcbstate);
 	

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -746,13 +746,13 @@ buildScalarFunctionAlias(Node *funcexpr, char *funcname,
  */
 static Relation
 parserOpenTable(ParseState *pstate, const RangeVar *relation,
-				int lockmode, bool nowait, bool *lockUpgraded)
+				int lockmode, bool *lockUpgraded)
 {
 	Relation rel = NULL;
 	
 	PG_TRY();
 	{
-		rel = CdbOpenRelationRv(relation, lockmode, nowait, NULL);
+		rel = CdbOpenRelationRv(relation, lockmode, NULL);
 	}
 	PG_CATCH();
 	{
@@ -794,7 +794,6 @@ addRangeTableEntry(ParseState *pstate,
 	RangeTblEntry *rte = makeNode(RangeTblEntry);
 	char	   *refname = alias ? alias->aliasname : relation->relname;
 	LOCKMODE	lockmode = AccessShareLock;
-	bool		nowait = false;
 	LockingClause *locking;
 	Relation	rel;
 	ParseCallbackState pcbstate;
@@ -808,10 +807,9 @@ addRangeTableEntry(ParseState *pstate,
 	if (locking)
 	{
 		lockmode = locking->forUpdate ? RowExclusiveLock : RowShareLock;
-		nowait	 = locking->noWait;
 	}
 	setup_parser_errposition_callback(&pcbstate, pstate, relation->location);
-	rel = parserOpenTable(pstate, relation, lockmode, nowait, NULL);
+	rel = parserOpenTable(pstate, relation, lockmode, NULL);
 	cancel_parser_errposition_callback(&pcbstate);
 
 	/*

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -160,7 +160,7 @@ AcquireRewriteLocks(Query *parsetree)
 				/* Take a lock either using CDB lock promotion or not */
 				if (needLockUpgrade)
 				{
-					rel = CdbOpenRelation(rte->relid, lockmode, false, NULL);
+					rel = CdbOpenRelation(rte->relid, lockmode, NULL);
 				}
 				else
 				{

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -219,12 +219,9 @@ extern Relation try_heap_open(Oid relationId, LOCKMODE lockmode, bool noWait);
 #define heap_close(r,l)  relation_close(r,l)
 
 /* CDB */
-extern Relation CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, 
-								bool *lockUpgraded);
-extern Relation CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool noWait, 
-								   bool *lockUpgraded);
-extern Relation CdbOpenRelationRv(const RangeVar *relation, LOCKMODE reqmode, 
-								  bool noWait, bool *lockUpgraded);
+extern Relation CdbOpenRelation(Oid relid, LOCKMODE reqmode, bool *lockUpgraded);
+extern Relation CdbTryOpenRelation(Oid relid, LOCKMODE reqmode, bool *lockUpgraded);
+extern Relation CdbOpenRelationRv(const RangeVar *relation, LOCKMODE reqmode, bool *lockUpgraded);
 
 
 extern HeapScanDesc heap_beginscan(Relation relation, Snapshot snapshot,

--- a/src/test/isolation2/expected/select_for_update.out
+++ b/src/test/isolation2/expected/select_for_update.out
@@ -1,0 +1,52 @@
+DROP TABLE IF EXISTS t;
+DROP
+
+CREATE TABLE t (c1 int, c2 int);
+CREATE
+ INSERT INTO t values (1,1), (2,2), (3,3), (4,4);
+INSERT 4
+
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+
+1: SELECT c2 FROM t WHERE c1 = 3 FOR UPDATE;
+c2
+--
+3 
+(1 row)
+2&: UPDATE t SET c2 = 999 where c1 = 3;  <waiting ...>
+
+1: END;
+END
+
+2<:  <... completed>
+UPDATE 1
+2: END;
+END
+
+1: BEGIN;
+BEGIN
+1: SELECT c2 FROM t WHERE c1 < 3 FOR SHARE;
+c2
+--
+1 
+2 
+(2 rows)
+2&: SELECT c2 FROM t WHERE c1 >= 3 FOR UPDATE NOWAIT;  <waiting ...>
+
+1: END;
+END
+2<:  <... completed>
+c2 
+---
+4  
+999
+(2 rows)
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+DROP TABLE t;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -22,6 +22,7 @@ test: resync_xlog_hints
 test: invalidated_toast_index
 test: dml_on_root_locks_all_parts
 test: dynamic_index_scan
+test: select_for_update
 
 # Tests on Append-Optimized tables (row-oriented).
 test: uao/alter_while_vacuum_row

--- a/src/test/isolation2/sql/select_for_update.sql
+++ b/src/test/isolation2/sql/select_for_update.sql
@@ -1,0 +1,28 @@
+DROP TABLE IF EXISTS t;
+
+CREATE TABLE t (c1 int, c2 int);
+ 
+INSERT INTO t values (1,1), (2,2), (3,3), (4,4);
+
+1: BEGIN;
+2: BEGIN;
+
+1: SELECT c2 FROM t WHERE c1 = 3 FOR UPDATE;
+2&: UPDATE t SET c2 = 999 where c1 = 3;
+
+1: END;
+
+2<:
+2: END;
+
+1: BEGIN;
+1: SELECT c2 FROM t WHERE c1 < 3 FOR SHARE;
+2&: SELECT c2 FROM t WHERE c1 >= 3 FOR UPDATE NOWAIT;
+
+1: END;
+2<:
+
+1q:
+2q:
+
+DROP TABLE t;


### PR DESCRIPTION
This is a backport of PR(https://github.com/greenplum-db/gpdb/pull/9726)
for 5X_STABLE. NOWAIT only affects how SELCT locks rows as they are
obtained from the table. They are used by the execution. So, the SELECT
statement with locking clause will wait for the table lock if it
can't hold the table lock.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
