### PR TITLE
[6X BACKPORT]Avoid truncate error message in cdb_tidy_message (#9827)

### DIFF
--- a/gpcontrib/gpmapreduce/output/mapred.source
+++ b/gpcontrib/gpmapreduce/output/mapred.source
@@ -505,13 +505,11 @@ SELECT mapreduce('@abs_srcdir@/yml/perlerror.yml') ORDER BY 1;
 mapreduce
 ---------------------
 STDERR> ERROR:  syntax error at line 18, near "[]"
-STDERR> DETAIL:  
 STDERR> syntax error at line 20, near ";
 STDERR>  }"
 STDERR> CONTEXT:  compilation of PL/Perl function "mapreduce_1977_grep_map"
 STDERR> Error: Object creation Failure
 STDERR> ERROR:  syntax error at line 28, near "[]"
-STDERR> DETAIL:  
 STDERR> syntax error at line 29, near ";
 STDERR>  }"
 STDERR> CONTEXT:  compilation of PL/Perl function "mapreduce_1992_grep_map"

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -1822,13 +1822,13 @@ EmitErrorReport(void)
 	CHECK_STACK_DEPTH();
 	oldcontext = MemoryContextSwitchTo(edata->assoc_context);
 
-	/* CDB: Tidy up the message */
-	/*
-	 * TODO Why do we want to do this?  it seems pointless
-	 * and makes the error messages harder to read.
+	/* 
+	 * CDB: Tidy up the message sent to client
+	 *
+	 * Strip trailing whitespace.
+	 * Append file name and line numebr.
 	 */
-	if (edata->output_to_server ||
-		edata->output_to_client)
+	if (edata->output_to_client)
 		cdb_tidy_message(edata);
 
 	/*
@@ -2645,11 +2645,17 @@ cdb_strip_trailing_whitespace(char **buf)
 	}
 }							   /* cdb_strip_trailing_whitespace */
 
+/*
+ * cdb_tidy_message is a gpdb specific error message postprocessing function.
+ *
+ * It supplies useful error information for debug which upstream is missing:
+ * 1. append the filename and line number for internal error.
+ * 2. truncate the trailing whitespace for edata
+ */
 void
 cdb_tidy_message(ErrorData *edata)
 {
 	char	   *bp;
-	char	   *cp;
 	char	   *ep;
 	char	   *tp;
 	int			m, n;
@@ -2670,49 +2676,6 @@ cdb_tidy_message(ErrorData *edata)
 	}
 	else
 		ep = bp = "";
-
-	/*
-	 * If more than one line, move lines after the first to errdetail.
-	 * Make an exception for LOG messages because statement logging would
-	 * be uglified.  Skip DEBUG messages too, 'cause users don't see 'em.
-	 */
-	if (edata->elevel > LOG &&
-		0 != (cp = strchr(bp, '\n')))
-	{
-		char   *dp = cp;
-
-		/* If just one extra line, strip its leading '\n' and whitespace. */
-		if (!strchr(dp+1, '\n'))
-		{
-			while (*dp <= ' ' &&
-				   *dp > '\0')
-				dp++;
-		}
-
-		/* Insert in front of detail message. */
-		if (!edata->detail)
-			edata->detail = pstrdup(dp);
-		else
-		{
-			m = ep - dp;
-			n = strlen(edata->detail) + 1;
-			tp = palloc(m + 1 + n);
-			memcpy(tp, dp, m);
-			tp[m] = '\n';
-			memcpy(tp + m + 1, edata->detail, n);
-
-			pfree(edata->detail);
-			edata->detail = tp;
-		}
-
-		/* Drop from main message. */
-		ep = cp;
-		while (bp < ep &&
-			   ep[-1] <= ' ' &&
-			   ep[-1] > '\0')
-			ep--;
-		*ep = '\0';
-	}
 
 	/*
 	 * If internal error, append the filename and line number.

--- a/src/pl/plperl/expected/plperl.out
+++ b/src/pl/plperl/expected/plperl.out
@@ -638,7 +638,7 @@ CONTEXT:  PL/Perl anonymous code block
 -- compile-time error: "Unable to load blib.pm into plperl"
 DO $$ use blib; $$ LANGUAGE plperl;
 ERROR:  Unable to load blib.pm into plperl at line 1.
-DETAIL:  BEGIN failed--compilation aborted at line 1.
+BEGIN failed--compilation aborted at line 1.
 CONTEXT:  PL/Perl anonymous code block
 -- check that we can "use" a module that has already been loaded
 -- runtime error: "Can't use string ("foo") as a SCALAR ref while "strict refs" in use

--- a/src/pl/plperl/expected/plperl_elog.out
+++ b/src/pl/plperl/expected/plperl_elog.out
@@ -37,7 +37,7 @@ create or replace function uses_global() returns text language plperl as $$
 
 $$;
 ERROR:  Global symbol "$global" requires explicit package name at line 3.
-DETAIL:  Global symbol "$other_global" requires explicit package name at line 4.
+Global symbol "$other_global" requires explicit package name at line 4.
 CONTEXT:  compilation of PL/Perl function "uses_global"
 select uses_global();
 ERROR:  function uses_global() does not exist

--- a/src/pl/plperl/expected/plperl_elog_1.out
+++ b/src/pl/plperl/expected/plperl_elog_1.out
@@ -37,7 +37,7 @@ create or replace function uses_global() returns text language plperl as $$
 
 $$;
 ERROR:  Global symbol "$global" requires explicit package name (did you forget to declare "my $global"?) at line 3.
-DETAIL:  Global symbol "$other_global" requires explicit package name (did you forget to declare "my $other_global"?) at line 4.
+Global symbol "$other_global" requires explicit package name (did you forget to declare "my $other_global"?) at line 4.
 CONTEXT:  compilation of PL/Perl function "uses_global"
 select uses_global();
 ERROR:  function uses_global() does not exist

--- a/src/pl/plperl/expected/plperl_plperlu.out
+++ b/src/pl/plperl/expected/plperl_plperlu.out
@@ -73,7 +73,7 @@ AS $$
 use Errno;
 $$;
 ERROR:  Unable to load Errno.pm into plperl at line 2.
-DETAIL:  BEGIN failed--compilation aborted at line 2.
+BEGIN failed--compilation aborted at line 2.
 CONTEXT:  compilation of PL/Perl function "use_plperl"
 -- make sure our overloaded require op gets restored/set correctly
 select use_plperlu();
@@ -87,5 +87,5 @@ AS $$
 use Errno;
 $$;
 ERROR:  Unable to load Errno.pm into plperl at line 2.
-DETAIL:  BEGIN failed--compilation aborted at line 2.
+BEGIN failed--compilation aborted at line 2.
 CONTEXT:  compilation of PL/Perl function "use_plperl"

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -235,7 +235,6 @@ ALTER
 (1 row)
 12<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=25361: server closed the connection unexpectedly
-DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 13: SELECT count(*) from QE_panic_test_table;

--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -140,7 +140,6 @@ END
 --            update cdb_component_dbs, following query should fail
 2:END;
 ERROR:  Error on receive from seg1 127.0.0.1:7003 pid=2406: server closed the connection unexpectedly
-DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 -- session 3: in transaction and has a cursor, cann't update
@@ -151,7 +150,6 @@ DETAIL:
 (0 rows)
 3:END;
 ERROR:  Error on receive from seg1 127.0.0.1:7003 pid=2417: server closed the connection unexpectedly
-DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 -- session 4: not in transaction but has temp table, cann't update
@@ -159,7 +157,6 @@ DETAIL:
 --            is reset
 4:select * from tmp4;
 ERROR:  Error on receive from seg1 slice1 127.0.0.1:7003 pid=2432: server closed the connection unexpectedly
-DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 4:select * from tmp4;
@@ -170,7 +167,6 @@ LINE 1: select * from tmp4;
 --            following query should fail
 5:select * from tmp51;
 ERROR:  Error on receive from seg1 slice1 127.0.0.1:7003 pid=2441: server closed the connection unexpectedly
-DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 5:ROLLBACK TO SAVEPOINT s1;

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -122,12 +122,10 @@ END
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.0.1:25432 pid=21988)
 1<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29474: server closed the connection unexpectedly
-DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 2<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29462: server closed the connection unexpectedly
-DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
@@ -624,7 +622,6 @@ CHECKPOINT
 (1 row)
 4<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29553: server closed the connection unexpectedly
-DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 -- Shows entries for new files added to pg_aocsseg table. These are

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -103,12 +103,10 @@ UPDATE 10
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.0.1:25432 pid=21369)
 1<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=24819: server closed the connection unexpectedly
-DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 2<:  <... completed>
 ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=24830: server closed the connection unexpectedly
-DETAIL:  
 	This probably means the server terminated abnormally
 	before or while processing the request.
 

--- a/src/test/regress/expected/plpgsql.out
+++ b/src/test/regress/expected/plpgsql.out
@@ -5408,13 +5408,11 @@ NOTICE:  calling down into outer_func()
 NOTICE:  calling down into inner_func()
 CONTEXT:  PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 4 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 7 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
@@ -5436,13 +5434,11 @@ NOTICE:  calling down into outer_func()
 NOTICE:  calling down into inner_func()
 CONTEXT:  PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 4 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 7 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
@@ -5510,13 +5506,11 @@ NOTICE:  calling down into outer_func()
 NOTICE:  calling down into inner_func()
 CONTEXT:  PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 10 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 15 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
@@ -5538,13 +5532,11 @@ NOTICE:  calling down into outer_func()
 NOTICE:  calling down into inner_func()
 CONTEXT:  PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 10 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 15 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment

--- a/src/test/regress/expected/plpgsql_optimizer.out
+++ b/src/test/regress/expected/plpgsql_optimizer.out
@@ -5386,13 +5386,11 @@ NOTICE:  calling down into outer_func()
 NOTICE:  calling down into inner_func()
 CONTEXT:  PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 4 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 7 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
@@ -5414,13 +5412,11 @@ NOTICE:  calling down into outer_func()
 NOTICE:  calling down into inner_func()
 CONTEXT:  PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 4 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 7 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
@@ -5488,13 +5484,11 @@ NOTICE:  calling down into outer_func()
 NOTICE:  calling down into inner_func()
 CONTEXT:  PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 10 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 15 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
@@ -5516,13 +5510,11 @@ NOTICE:  calling down into outer_func()
 NOTICE:  calling down into inner_func()
 CONTEXT:  PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 10 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment
 NOTICE:  ***PL/pgSQL function inner_func(integer) line 15 at GET DIAGNOSTICS
-DETAIL:  
 PL/pgSQL function outer_func(integer) line 6 at assignment
 PL/pgSQL function outer_outer_func(integer) line 6 at assignment***
 CONTEXT:  PL/pgSQL function outer_func(integer) line 6 at assignment

--- a/src/test/regress/expected/xml.out
+++ b/src/test/regress/expected/xml.out
@@ -985,7 +985,6 @@ CONTEXT:  SQL function "xpath" statement 1
 -- throw an error, only a warning.
 SELECT xpath('/*', '<relativens xmlns=''relative''/>');
 WARNING:  line 1: xmlns: URI relative is not absolute
-DETAIL:  
 <relativens xmlns='relative'/>
                             ^
 CONTEXT:  SQL function "xpath" statement 1

--- a/src/test/regress/expected/xml_2.out
+++ b/src/test/regress/expected/xml_2.out
@@ -967,7 +967,6 @@ CONTEXT:  SQL function "xpath" statement 1
 -- throw an error, only a warning.
 SELECT xpath('/*', '<relativens xmlns=''relative''/>');
 WARNING:  line 1: xmlns: URI relative is not absolute
-DETAIL:  
 <relativens xmlns='relative'/>
                             ^
 CONTEXT:  SQL function "xpath" statement 1


### PR DESCRIPTION
cdb_tidy_message is gpdb specific function. It will truncate the
error message to just keep the first line and copy other lines to
error details.
For JDBC drivers, they follow the Postgres's error message and only
keep error message in JDBC getWarnings function. It makes JDBC
dirver cannot print the full error message of gpdb.
It's better to follow postgres error format.

(cherry picked from commit 0d0c33bfbed9028b5b247a0d04014852136da919)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
