### PR TITLE
Backport fixes for syscache lookup error

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -2317,11 +2317,11 @@ pg_get_function_arguments(PG_FUNCTION_ARGS)
 	StringInfoData buf;
 	HeapTuple	proctup;
 
-	initStringInfo(&buf);
-
 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
 	if (!HeapTupleIsValid(proctup))
-		elog(ERROR, "cache lookup failed for function %u", funcid);
+		PG_RETURN_NULL();
+
+	initStringInfo(&buf);
 
 	(void) print_function_arguments(&buf, proctup, false, true);
 
@@ -2343,11 +2343,11 @@ pg_get_function_identity_arguments(PG_FUNCTION_ARGS)
 	StringInfoData buf;
 	HeapTuple	proctup;
 
-	initStringInfo(&buf);
-
 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
 	if (!HeapTupleIsValid(proctup))
-		elog(ERROR, "cache lookup failed for function %u", funcid);
+		PG_RETURN_NULL();
+
+	initStringInfo(&buf);
 
 	(void) print_function_arguments(&buf, proctup, false, false);
 
@@ -2368,11 +2368,11 @@ pg_get_function_result(PG_FUNCTION_ARGS)
 	StringInfoData buf;
 	HeapTuple	proctup;
 
-	initStringInfo(&buf);
-
 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
 	if (!HeapTupleIsValid(proctup))
-		elog(ERROR, "cache lookup failed for function %u", funcid);
+		PG_RETURN_NULL();
+
+	initStringInfo(&buf);
 
 	print_function_rettype(&buf, proctup);
 
@@ -2602,7 +2602,7 @@ pg_get_function_arg_default(PG_FUNCTION_ARGS)
 
 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
 	if (!HeapTupleIsValid(proctup))
-		elog(ERROR, "cache lookup failed for function %u", funcid);
+		PG_RETURN_NULL();
 
 	numargs = get_func_arg_info(proctup, &argtypes, &argnames, &argmodes);
 	if (nth_arg < 1 || nth_arg > numargs || !is_input_argument(nth_arg - 1, argmodes))

--- a/src/test/regress/expected/rules.out
+++ b/src/test/regress/expected/rules.out
@@ -2772,6 +2772,36 @@ SELECT pg_get_viewdef(0);
  
 (1 row)
 
+SELECT pg_get_function_arguments(0);
+ pg_get_function_arguments 
+---------------------------
+ 
+(1 row)
+
+SELECT pg_get_function_identity_arguments(0);
+ pg_get_function_identity_arguments 
+------------------------------------
+ 
+(1 row)
+
+SELECT pg_get_function_result(0);
+ pg_get_function_result 
+------------------------
+ 
+(1 row)
+
+SELECT pg_get_function_arg_default(0, 0);
+ pg_get_function_arg_default 
+-----------------------------
+ 
+(1 row)
+
+SELECT pg_get_function_arg_default('pg_class'::regclass, 0);
+ pg_get_function_arg_default 
+-----------------------------
+ 
+(1 row)
+
 -- test rule for select-for-update
 create table t_test_rules_select_for_update (c int) distributed randomly;
 create rule myrule as on insert to t_test_rules_select_for_update

--- a/src/test/regress/expected/rules.out
+++ b/src/test/regress/expected/rules.out
@@ -2735,6 +2735,43 @@ SELECT pg_get_functiondef('func_with_set_params()'::regprocedure);
  
 (1 row)
 
+-- tests for pg_get_*def with invalid objects
+SELECT pg_get_constraintdef(0);
+ pg_get_constraintdef 
+----------------------
+ 
+(1 row)
+
+SELECT pg_get_functiondef(0);
+ pg_get_functiondef 
+--------------------
+ 
+(1 row)
+
+SELECT pg_get_indexdef(0);
+ pg_get_indexdef 
+-----------------
+ 
+(1 row)
+
+SELECT pg_get_ruledef(0);
+ pg_get_ruledef 
+----------------
+ 
+(1 row)
+
+SELECT pg_get_triggerdef(0);
+ pg_get_triggerdef 
+-------------------
+ 
+(1 row)
+
+SELECT pg_get_viewdef(0);
+ pg_get_viewdef 
+----------------
+ 
+(1 row)
+
 -- test rule for select-for-update
 create table t_test_rules_select_for_update (c int) distributed randomly;
 create rule myrule as on insert to t_test_rules_select_for_update

--- a/src/test/regress/sql/rules.sql
+++ b/src/test/regress/sql/rules.sql
@@ -1043,6 +1043,11 @@ SELECT pg_get_indexdef(0);
 SELECT pg_get_ruledef(0);
 SELECT pg_get_triggerdef(0);
 SELECT pg_get_viewdef(0);
+SELECT pg_get_function_arguments(0);
+SELECT pg_get_function_identity_arguments(0);
+SELECT pg_get_function_result(0);
+SELECT pg_get_function_arg_default(0, 0);
+SELECT pg_get_function_arg_default('pg_class'::regclass, 0);
 
 -- test rule for select-for-update
 create table t_test_rules_select_for_update (c int) distributed randomly;

--- a/src/test/regress/sql/rules.sql
+++ b/src/test/regress/sql/rules.sql
@@ -1036,6 +1036,14 @@ CREATE FUNCTION func_with_set_params() RETURNS integer
     IMMUTABLE STRICT;
 SELECT pg_get_functiondef('func_with_set_params()'::regprocedure);
 
+-- tests for pg_get_*def with invalid objects
+SELECT pg_get_constraintdef(0);
+SELECT pg_get_functiondef(0);
+SELECT pg_get_indexdef(0);
+SELECT pg_get_ruledef(0);
+SELECT pg_get_triggerdef(0);
+SELECT pg_get_viewdef(0);
+
 -- test rule for select-for-update
 create table t_test_rules_select_for_update (c int) distributed randomly;
 create rule myrule as on insert to t_test_rules_select_for_update


### PR DESCRIPTION
This is a backport of two commits from master:
```
commit ecbc64ad31ac3993eeab0c4e61392a4cb6477b5d
Author: Robert Haas <rhaas@postgresql.org>
Date:   Fri Jul 29 12:06:18 2016 -0400

    Eliminate a few more user-visible "cache lookup failed" errors.

    Michael Paquier

    Original Postgres commit:
    https://github.com/postgres/postgres/commit/3153b1a52f8f2d1efe67306257aec15aaaf9e94c

commit 3b56fdf82169b642128996d5b2a38f21e22b948b
Author: Robert Haas <rhaas@postgresql.org>
Date:   Tue Jul 26 16:07:02 2016 -0400

    Change various deparsing functions to return NULL for invalid input.

    Previously, some functions returned various fixed strings and others
    failed with a cache lookup error.  Per discussion, standardize on
    returning NULL.  Although user-exposed "cache lookup failed" error
    messages might normally qualify for bug-fix treatment, no back-patch;
    the risk of breaking user code which is accustomed to the current
    behavior seems too high.

    Michael Paquier

    Original Postgres commit:
    https://github.com/postgres/postgres/commit/976b24fb477464907737d28cdf18e202fa3b1a5b
```

In the external utility gpbackup, this metadata query is run:
```
SELECT p.oid,
quote_ident(n.nspname) AS schema,
quote_ident(p.proname) AS name,
pg_catalog.pg_get_function_arguments(p.oid) AS arguments
FROM pg_proc p
LEFT JOIN pg_namespace n ON p.pronamespace = n.oid
```
If another concurrent user runs and commits a DROP FUNCTION before the above query is able to fetch the results of that specific dropped function from `pg_catalog.pg_get_function_arguments()`, a syscache lookup error is given and the query fails (syscache lookup uses SnapshotNow).  This can apply to other related functions too involving constraints, indexes, rules, triggers, and views.

Would it be okay to backport these two patches to 6X_STABLE and 5X_STABLE to convert the syscache lookup error for these pg_get functions into NULL returns?  I'm not too sure how applicable the commit note `no back-patch;
    the risk of breaking user code which is accustomed to the current
    behavior seems too high` is for GPDB so would like some other thoughts/opinions on this backport.