### PR TITLE
[Backport 6X] Truncate AO relation correctly (#9806)

### DIFF
--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -32,13 +32,17 @@
 #include "access/appendonlytid.h"
 #include "access/appendonlywriter.h"
 #include "catalog/catalog.h"
+#include "catalog/pg_appendonly_fn.h"
 #include "cdb/cdbappendonlystorage.h"
 #include "cdb/cdbappendonlyxlog.h"
 #include "common/relpath.h"
 #include "utils/guc.h"
 
+#define SEGNO_SUFFIX_LENGTH 12
+
 static bool mdunlink_ao_perFile(const int segno, void *ctx);
 static bool copy_append_only_data_perFile(const int segno, void *ctx);
+static bool truncate_ao_perFile(const int segno, void *ctx);
 
 int
 AOSegmentFilePathNameLen(Relation rel)
@@ -210,9 +214,17 @@ TruncateAOSegmentFile(File fd, Relation rel, int32 segFileNum, int64 offset)
 	}
 }
 
-struct mdunlink_ao_callback_ctx {
+struct mdunlink_ao_callback_ctx
+{
 	char *segPath;
 	char *segpathSuffixPosition;
+};
+
+struct truncate_ao_callback_ctx
+{
+	char *segPath;
+	char *segpathSuffixPosition;
+	Relation rel;
 };
 
 void
@@ -229,7 +241,7 @@ mdunlink_ao(const char *path, ForkNumber forkNumber)
 	Assert(forkNumber == MAIN_FORKNUM);
 
 	int pathSize = strlen(path);
-	char *segPath = (char *) palloc(pathSize + 12);
+	char *segPath = (char *) palloc(pathSize + SEGNO_SUFFIX_LENGTH);
 	char *segPathSuffixPosition = segPath + pathSize;
 	struct mdunlink_ao_callback_ctx unlinkFiles = { 0 };
 
@@ -416,3 +428,71 @@ copy_append_only_data_perFile(const int segno, void *ctx)
 	return true;
 }
 
+/*
+ * ao_truncate_one_rel
+ *
+ * This routine deletes all data within the specified ao relation.
+ */
+void
+ao_truncate_one_rel(Relation rel)
+{
+	char *basepath;
+	char *segPath;
+	char *segPathSuffixPosition;
+	struct truncate_ao_callback_ctx truncateFiles = { 0 };
+	int pathSize;
+
+	/* Get base path for this relation file */
+	basepath = relpathbackend(rel->rd_node, rel->rd_backend, MAIN_FORKNUM);
+
+	pathSize = strlen(basepath);
+	segPath = (char *) palloc(pathSize + SEGNO_SUFFIX_LENGTH);
+	segPathSuffixPosition = segPath + pathSize;
+	strncpy(segPath, basepath, pathSize);
+
+	truncateFiles.segPath = segPath;
+	truncateFiles.segpathSuffixPosition = segPathSuffixPosition;
+	truncateFiles.rel = rel;
+
+	/* Truncate the actual file */
+	ao_foreach_extent_file(truncate_ao_perFile, &truncateFiles);
+
+	pfree(segPath);
+	pfree(basepath);
+}
+
+/*
+ * Truncate a specific segment file of ao relation.
+ */
+static bool
+truncate_ao_perFile(const int segno, void *ctx)
+{
+	File		fd;
+	Relation aorel;
+
+	const struct truncate_ao_callback_ctx *truncateFiles = ctx;
+
+	char *segPath = truncateFiles->segPath;
+	char *segPathSuffixPosition = truncateFiles->segpathSuffixPosition;
+	aorel = truncateFiles->rel;
+
+	sprintf(segPathSuffixPosition, ".%u", segno);
+
+	fd = OpenAOSegmentFile(aorel, segPath, segno, 0);
+
+	if (fd >= 0)
+	{
+		TruncateAOSegmentFile(fd, aorel, segno, 0);
+		CloseAOSegmentFile(fd);
+	}
+	else
+	{
+		/* 
+		 * we traverse possible segment files of AO/AOCS tables and call
+		 * truncate_ao_perFile to truncate them. It is ok that some files do not exist
+		 */
+		return false;
+	}
+
+	return true;
+}

--- a/src/include/access/aomd.h
+++ b/src/include/access/aomd.h
@@ -48,6 +48,8 @@ TruncateAOSegmentFile(File fd,
 					  int32 segmentFileNum,
 					  int64 offset);
 
+extern void ao_truncate_one_rel(Relation rel);
+
 extern void
 mdunlink_ao(const char *path, ForkNumber forkNumber);
 

--- a/src/test/regress/expected/sirv_functions.out
+++ b/src/test/regress/expected/sirv_functions.out
@@ -1419,8 +1419,8 @@ drop table if exists sirv_test13_result1;
 NOTICE:  table "sirv_test13_result1" does not exist, skipping
 drop table if exists sirv_test13_result2;
 NOTICE:  table "sirv_test13_result2" does not exist, skipping
---end_ignore
 CREATE LANGUAGE plpythonu;
+--end_ignore
 CREATE or replace FUNCTION sirv_test13_fun1 ()
   RETURNS text
 AS $$
@@ -1500,8 +1500,8 @@ NOTICE:  drop cascades to function sirv_test13_fun2(double precision,integer)
 NOTICE:  drop cascades to function sirv_test13_fun1()
 drop table if exists sirv_test14_result1;
 NOTICE:  table "sirv_test14_result1" does not exist, skipping
---end_ignore
 CREATE LANGUAGE plpythonu;
+--end_ignore
 CREATE or replace FUNCTION sirv_test14_fun1 ()
   RETURNS text
 AS $$

--- a/src/test/regress/expected/truncate_gp.out
+++ b/src/test/regress/expected/truncate_gp.out
@@ -1,0 +1,111 @@
+-- Mask out segment file name
+-- start_matchsubs
+-- m/segfile.*,/
+-- s/segfile.*,/segfile###,/
+-- end_matchsubs
+-- start_ignore
+CREATE EXTENSION plpythonu;
+-- end_ignore
+--- Fucntion which lists the table segment file size on each segment.
+CREATE OR REPLACE FUNCTION stat_table_segfile_size(datname text, tabname text)
+    RETURNS TABLE (dbid int2, relfilenode_dboid_relative_path text, size int)
+    VOLATILE LANGUAGE plpythonu
+AS
+$fn$
+import os
+db_instances = {}
+relfilenodes = {}
+
+result = plpy.execute("SELECT oid AS dboid FROM pg_database WHERE datname='%s'" % datname)
+dboid = result[0]['dboid']
+
+result = plpy.execute("SELECT relfilenode FROM gp_dist_random('pg_class') WHERE relname = '%s' ORDER BY gp_segment_id" % tabname)
+for col in range(0, result.nrows()):
+    relfilenodes[col] = str(result[col]['relfilenode'])
+
+result = plpy.execute("select dbid, datadir from gp_segment_configuration where role ='p' and content >= 0 order by dbid;")
+for col in range(0, result.nrows()):
+    db_instances[result[col]['dbid']] = result[col]['datadir']
+
+rows = []
+i = -1
+for dbid, datadir in db_instances.items():
+    relative_path_to_dboid_dir = ''
+    absolute_path_to_dboid_dir = '%s/base/%d' % (datadir, dboid)
+    i = i+1
+    try:
+        for relfilenode in os.listdir(absolute_path_to_dboid_dir):
+            relfilenode_prefix = relfilenode.split('.')[0]
+            if relfilenodes[i] != relfilenode_prefix:
+                continue
+            relfilenode_absolute_path = absolute_path_to_dboid_dir + '/' + relfilenode
+            size_relfilenode = os.stat(relfilenode_absolute_path).st_size
+            row = {
+                'relfilenode_dboid_relative_path': 'segfile:%d/%s' % (dboid, relfilenode),
+                'dbid': dbid,
+                'size': size_relfilenode
+            }
+            rows.append(row)
+    except OSError:
+        #plpy.notice("dboid dir for database %s does not exist on dbid = %d" % (datname, dbid))
+        rows.append({
+            'relfilenode_dboid_relative_path': None,
+            'dbid': dbid,
+            'size': None
+        })
+return rows
+$fn$;
+-- test truncate table and create table are in the same transaction for ao table
+begin;
+create table truncate_with_create_ao(a int, b int) with (appendoptimized = true, orientation = row) distributed by (a);
+insert into truncate_with_create_ao select i, i from generate_series(1,10)i;
+truncate truncate_with_create_ao;
+end; 
+-- the ao table segment file size after truncate should be zero
+select stat_table_segfile_size('regression', 'truncate_with_create_ao');
+   stat_table_segfile_size   
+-----------------------------
+ (2,segfile:16384/19161,0)
+ (2,segfile:16384/19161.1,0)
+ (3,segfile:16384/19161,0)
+ (3,segfile:16384/19161.1,0)
+ (4,segfile:16384/19160,0)
+ (4,segfile:16384/19160.1,0)
+(6 rows)
+
+-- test truncate table and create table are in the same transaction for aocs table
+begin;
+create table truncate_with_create_aocs(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+insert into truncate_with_create_aocs select i, i from generate_series(1,10)i;
+truncate truncate_with_create_aocs;
+end; 
+-- the aocs table segment file size after truncate should be zero
+select stat_table_segfile_size('regression', 'truncate_with_create_aocs');
+    stat_table_segfile_size    
+-------------------------------
+ (2,segfile:16384/19196,0)
+ (2,segfile:16384/19196.1,0)
+ (2,segfile:16384/19196.129,0)
+ (3,segfile:16384/19196,0)
+ (3,segfile:16384/19196.1,0)
+ (3,segfile:16384/19196.129,0)
+ (4,segfile:16384/19194,0)
+ (4,segfile:16384/19194.1,0)
+ (4,segfile:16384/19194.129,0)
+(9 rows)
+
+-- test truncate table and create table are in the same transaction for heap table
+begin;                                                                          
+create table truncate_with_create_heap(a int, b int) distributed by (a);
+insert into truncate_with_create_heap select i, i from generate_series(1,10)i;
+truncate truncate_with_create_heap;
+end;
+-- the heap table segment file size after truncate should be zero
+select stat_table_segfile_size('regression', 'truncate_with_create_heap');
+  stat_table_segfile_size  
+---------------------------
+ (2,segfile:16384/19218,0)
+ (3,segfile:16384/19217,0)
+ (4,segfile:16384/19220,0)
+(3 rows)
+

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -150,7 +150,7 @@ test: select_views portals_p2 cluster dependency guc bitmapops tsearch tsdicts f
 # NB: temp.sql does a reconnect which transiently uses 2 connections,
 # so keep this parallel group to at most 19 tests
 # ----------
-test: plancache limit plpgsql copy2 temp domain rangefuncs prepare without_oid conversion truncate alter_table alter_extension sequence polymorphism rowtypes returning with xml gp_foreign_data
+test: plancache limit plpgsql copy2 temp domain rangefuncs prepare without_oid conversion truncate truncate_gp alter_table alter_extension sequence polymorphism rowtypes returning with xml gp_foreign_data
 
 # large objects are not supported by GPDB
 # test: largeobject

--- a/src/test/regress/sql/sirv_functions.sql
+++ b/src/test/regress/sql/sirv_functions.sql
@@ -6775,9 +6775,8 @@ drop language if exists plpythonu cascade;
 drop table if exists sirv_test13_result1;
 drop table if exists sirv_test13_result2;
 
---end_ignore
-
 CREATE LANGUAGE plpythonu;
+--end_ignore
 
 CREATE or replace FUNCTION sirv_test13_fun1 ()
   RETURNS text
@@ -6863,9 +6862,8 @@ drop language if exists plpythonu cascade;
 
 drop table if exists sirv_test14_result1;
 
---end_ignore
-
 CREATE LANGUAGE plpythonu;
+--end_ignore
 
 CREATE or replace FUNCTION sirv_test14_fun1 ()
   RETURNS text

--- a/src/test/regress/sql/truncate_gp.sql
+++ b/src/test/regress/sql/truncate_gp.sql
@@ -1,0 +1,88 @@
+-- Mask out segment file name
+-- start_matchsubs
+-- m/segfile.*,/
+-- s/segfile.*,/segfile###,/
+-- end_matchsubs
+
+-- start_ignore
+CREATE EXTENSION plpythonu;
+-- end_ignore
+--- Fucntion which lists the table segment file size on each segment.
+CREATE OR REPLACE FUNCTION stat_table_segfile_size(datname text, tabname text)
+    RETURNS TABLE (dbid int2, relfilenode_dboid_relative_path text, size int)
+    VOLATILE LANGUAGE plpythonu
+AS
+$fn$
+import os
+db_instances = {}
+relfilenodes = {}
+
+result = plpy.execute("SELECT oid AS dboid FROM pg_database WHERE datname='%s'" % datname)
+dboid = result[0]['dboid']
+
+result = plpy.execute("SELECT relfilenode FROM gp_dist_random('pg_class') WHERE relname = '%s' ORDER BY gp_segment_id" % tabname)
+for col in range(0, result.nrows()):
+    relfilenodes[col] = str(result[col]['relfilenode'])
+
+result = plpy.execute("select dbid, datadir from gp_segment_configuration where role ='p' and content >= 0 order by dbid;")
+for col in range(0, result.nrows()):
+    db_instances[result[col]['dbid']] = result[col]['datadir']
+
+rows = []
+i = -1
+for dbid, datadir in db_instances.items():
+    relative_path_to_dboid_dir = ''
+    absolute_path_to_dboid_dir = '%s/base/%d' % (datadir, dboid)
+    i = i+1
+    try:
+        for relfilenode in os.listdir(absolute_path_to_dboid_dir):
+            relfilenode_prefix = relfilenode.split('.')[0]
+            if relfilenodes[i] != relfilenode_prefix:
+                continue
+            relfilenode_absolute_path = absolute_path_to_dboid_dir + '/' + relfilenode
+            size_relfilenode = os.stat(relfilenode_absolute_path).st_size
+            row = {
+                'relfilenode_dboid_relative_path': 'segfile:%d/%s' % (dboid, relfilenode),
+                'dbid': dbid,
+                'size': size_relfilenode
+            }
+            rows.append(row)
+    except OSError:
+        #plpy.notice("dboid dir for database %s does not exist on dbid = %d" % (datname, dbid))
+        rows.append({
+            'relfilenode_dboid_relative_path': None,
+            'dbid': dbid,
+            'size': None
+        })
+return rows
+$fn$;
+
+-- test truncate table and create table are in the same transaction for ao table
+begin;
+create table truncate_with_create_ao(a int, b int) with (appendoptimized = true, orientation = row) distributed by (a);
+insert into truncate_with_create_ao select i, i from generate_series(1,10)i;
+truncate truncate_with_create_ao;
+end; 
+
+-- the ao table segment file size after truncate should be zero
+select stat_table_segfile_size('regression', 'truncate_with_create_ao');
+
+-- test truncate table and create table are in the same transaction for aocs table
+begin;
+create table truncate_with_create_aocs(a int, b int) with (appendoptimized = true, orientation = column) distributed by (a);
+insert into truncate_with_create_aocs select i, i from generate_series(1,10)i;
+truncate truncate_with_create_aocs;
+end; 
+
+-- the aocs table segment file size after truncate should be zero
+select stat_table_segfile_size('regression', 'truncate_with_create_aocs');
+
+-- test truncate table and create table are in the same transaction for heap table
+begin;                                                                          
+create table truncate_with_create_heap(a int, b int) distributed by (a);
+insert into truncate_with_create_heap select i, i from generate_series(1,10)i;
+truncate truncate_with_create_heap;
+end;
+
+-- the heap table segment file size after truncate should be zero
+select stat_table_segfile_size('regression', 'truncate_with_create_heap');


### PR DESCRIPTION
In past, when create table and truncate table are in the same
transaction, Greenplum will call heap_truncate_one_rel() to truncate
the relation. But for AO tables, it has different segmenting logic,
which leads to some of segment files cannot be truncated to zero.

Using ao_truncate_one_rel to replace heap_truncate_one_rel() and
handle the segmenting by ao_foreach_extent_file().

Reviewed-by: Ashwin Agrawal <aagrawal@pivotal.io>
Reviewed-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>
(cherry picked from commit bb8d0305e17d79db7747688c783d7c13bb2939ae)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
