### PR TITLE
Add missing field skipData in RefreshClause serialization.

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -544,9 +544,6 @@ transientrel_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 	DR_transientrel *myState = (DR_transientrel *) self;
 	Relation	transientrel;
 
-	if (myState->skipData)
-		return;
-
 	transientrel = heap_open(myState->transientoid, NoLock);
 
 	/*
@@ -648,9 +645,6 @@ static void
 transientrel_shutdown(DestReceiver *self)
 {
 	DR_transientrel *myState = (DR_transientrel *) self;
-
-	if (myState->skipData)
-		return;
 
 	FreeBulkInsertState(myState->bistate);
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1468,6 +1468,7 @@ _outRefreshClause(StringInfo str, const RefreshClause *node)
 	WRITE_NODE_TYPE("REFRESHCLAUSE");
 
 	WRITE_BOOL_FIELD(concurrent);
+	WRITE_BOOL_FIELD(skipData);
 	WRITE_NODE_FIELD(relation);
 }
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -629,6 +629,7 @@ _readRefreshClause(void)
 	READ_LOCALS(RefreshClause);
 
 	READ_BOOL_FIELD(concurrent);
+	READ_BOOL_FIELD(skipData);
 	READ_NODE_FIELD(relation);
 
 	READ_DONE();

--- a/src/test/regress/expected/matview_ao.out
+++ b/src/test/regress/expected/matview_ao.out
@@ -34,6 +34,15 @@ REFRESH MATERIALIZED VIEW m_heap WITH NO DATA;
 SELECT * FROM m_heap;
 ERROR:  materialized view "m_heap" has not been populated
 HINT:  Use the REFRESH MATERIALIZED VIEW command.
+-- test WITH NO DATA is also dispatched to QEs
+select relispopulated from gp_dist_random('pg_class') where relname = 'm_heap';
+ relispopulated 
+----------------
+ f
+ f
+ f
+(3 rows)
+
 REFRESH MATERIALIZED VIEW m_heap;
 SELECT * FROM m_heap;
  type | totamt 

--- a/src/test/regress/sql/matview_ao.sql
+++ b/src/test/regress/sql/matview_ao.sql
@@ -16,6 +16,8 @@ REFRESH MATERIALIZED VIEW CONCURRENTLY m_heap;
 SELECT * FROM m_heap;
 REFRESH MATERIALIZED VIEW m_heap WITH NO DATA;
 SELECT * FROM m_heap;
+-- test WITH NO DATA is also dispatched to QEs
+select relispopulated from gp_dist_random('pg_class') where relname = 'm_heap';
 REFRESH MATERIALIZED VIEW m_heap;
 SELECT * FROM m_heap;
 


### PR DESCRIPTION
Co-authored-by: Jinbao Chen <jinchen@pivotal.io>

Just add the missing field in serialization, so no test is needed.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
