### PR TITLE
Move --disable-pxf from compile_gpdb.bash to gpAux/Makefile

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -241,7 +241,6 @@ function _main() {
       ;;
     win32)
         export BLD_ARCH=win32
-        CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --disable-pxf"
         ;;
     *)
         echo "only centos, ubuntu, sles and win32 are supported TARGET_OS'es"

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -131,7 +131,6 @@ rhel7_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enabl
 linux_x86_64_CONFIGFLAGS=${ORCA_CONFIG} --with-libxml $(APR_CONFIG)
 ubuntu18.04_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enable-orafce ${ORCA_CONFIG} --with-libxml
 sles12_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enable-orafce ${ORCA_CONFIG} --with-libxml
-win32_CONFIGFLAGS=--disable-pxf
 BLD_CONFIGFLAGS=$($(BLD_ARCH)_CONFIGFLAGS)
 
 CONFIGFLAGS=$(strip $(BLD_CONFIGFLAGS) --with-pgport=$(DEFPORT) $(BLD_DEPLOYMENT_SETTING))

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -175,6 +175,11 @@ ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
 CONFIGFLAGS+= --with-openssl --with-pam --without-krb5 --with-ldap $(BLD_CURL_CONFIG)
 endif
 
+# disable pxf in windows
+ifneq "$(findstring $(BLD_ARCH), win32)" ""
+CONFIGFLAGS+= --disable-pxf
+endif
+
 # Platform-specific config flags
 aix7_ppc_64_CONFIG_ADDITIONS=LDFLAGS="-Wl,-bbigtoc -L/usr/lib/threads"
 

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -131,6 +131,7 @@ rhel7_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enabl
 linux_x86_64_CONFIGFLAGS=${ORCA_CONFIG} --with-libxml $(APR_CONFIG)
 ubuntu18.04_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enable-orafce ${ORCA_CONFIG} --with-libxml
 sles12_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enable-orafce ${ORCA_CONFIG} --with-libxml
+win32_CONFIGFLAGS=--disable-pxf
 BLD_CONFIGFLAGS=$($(BLD_ARCH)_CONFIGFLAGS)
 
 CONFIGFLAGS=$(strip $(BLD_CONFIGFLAGS) --with-pgport=$(DEFPORT) $(BLD_DEPLOYMENT_SETTING))
@@ -173,11 +174,6 @@ endif
 # ...but do include some of the authlibs on AIX
 ifneq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
 CONFIGFLAGS+= --with-openssl --with-pam --without-krb5 --with-ldap $(BLD_CURL_CONFIG)
-endif
-
-# disable pxf in windows
-ifneq "$(findstring $(BLD_ARCH), win32)" ""
-CONFIGFLAGS+= --disable-pxf
 endif
 
 # Platform-specific config flags


### PR DESCRIPTION
For gpdb release, gp-releng team wants to consolidate all configurations in one location: `gpAux/Makefile`

see this comment on PR: https://github.com/greenplum-db/gpdb/pull/9785#discussion_r397253979

Authored-by: Tingfang Bao <bbao@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
