### PR TITLE
Fix flaky uao_crash_compaction_row test

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1825,6 +1825,7 @@ vacuum_rel(Oid relid, RangeVar *relation, int options, VacuumParams *params,
 		return false;
 	}
 
+#ifdef FAULT_INJECTOR
 	if (ao_vacuum_phase == VACOPT_AO_POST_CLEANUP_PHASE)
 	{
 		FaultInjector_InjectFaultIfSet(
@@ -1839,6 +1840,7 @@ vacuum_rel(Oid relid, RangeVar *relation, int options, VacuumParams *params,
 			"",	// databaseName
 			RelationGetRelationName(onerel)); // tableName
 	}
+#endif
 
 	/*
 	 * Silently ignore tables that are temp tables of other backends ---
@@ -2021,6 +2023,17 @@ vacuum_rel(Oid relid, RangeVar *relation, int options, VacuumParams *params,
 	 */
 	PopActiveSnapshot();
 	CommitTransactionCommand();
+
+#ifdef FAULT_INJECTOR
+	if (ao_vacuum_phase == VACOPT_AO_POST_CLEANUP_PHASE)
+	{
+		FaultInjector_InjectFaultIfSet(
+			"vacuum_post_cleanup_committed",
+			DDLNotSpecified,
+			"",	// databaseName
+			""); // tableName
+	}
+#endif
 
 	if (is_appendoptimized && ao_vacuum_phase == 0)
 	{

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -68,11 +68,28 @@ UPDATE 10
 -----------------
  Success:        
 (1 row)
+3:SELECT gp_inject_fault('vacuum_post_cleanup_committed', 'suspend', 3);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
 1&:VACUUM crash_before_cleanup_phase;  <waiting ...>
 3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
+(1 row)
+-- wait seg1 to finish the post-cleanup, this makes the aoseg info of seg1 stable.
+3:SELECT gp_wait_until_triggered_fault('vacuum_post_cleanup_committed', 1, 3);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- reset the injection so following commands are not affected.
+3:SELECT gp_inject_fault('vacuum_post_cleanup_committed', 'reset', 3);
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 
 3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 1, -1, 0, 2);

--- a/src/test/isolation2/sql/uao_crash_compaction_row.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_row.sql
@@ -33,8 +33,13 @@
 
 -- suspend at intended points.
 3:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_before_cleanup_phase', 1, -1, 0, 2);
+3:SELECT gp_inject_fault('vacuum_post_cleanup_committed', 'suspend', 3);
 1&:VACUUM crash_before_cleanup_phase;
 3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
+-- wait seg1 to finish the post-cleanup, this makes the aoseg info of seg1 stable.
+3:SELECT gp_wait_until_triggered_fault('vacuum_post_cleanup_committed', 1, 3);
+-- reset the injection so following commands are not affected.
+3:SELECT gp_inject_fault('vacuum_post_cleanup_committed', 'reset', 3);
 
 3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 1, -1, 0, 2);
 2&:VACUUM crash_before_segmentfile_drop;


### PR DESCRIPTION
This test creates an AO table and inserts data on all segments, then
it deletes some data on seg0 and seg1 and do a vacuum on the AO
table. When doing vacuum, it suspends the QE in seg0 at starting
doing the post vacuum cleanup, then crash the seg0 and finally do
the post crash validation checks using gp_toolkit.__gp_aoseg(), this
function will check all aoseg info on all segments.

The VACUUM process on seg1 is in an uncertain state, it might have
finished the post cleanup which is expected or hasn't started yet,
so the aoseg info in seg1 is uncertain too.

To resolve this, this commit added a new injector on the point all
post vacuum cleanup are committed and validate the aoseg info after
the vacuum process on seg1 reached this point.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
