### PR TITLE
Change random_page_access default value to 4

### DIFF
--- a/contrib/auto_explain/expected/auto_explain.out
+++ b/contrib/auto_explain/expected/auto_explain.out
@@ -29,10 +29,10 @@ SELECT relname FROM pg_class WHERE relname='pg_class';
 LOG:  statement: SELECT relname FROM pg_class WHERE relname='pg_class';
 LOG:  duration: 0.173 ms  plan:
 Query Text: SELECT relname FROM pg_class WHERE relname='pg_class';
-Seq Scan on pg_class  (cost=0.00..12.46 rows=1 width=64) (actual rows=1 loops=1)
-  Filter: (relname = 'pg_class'::name)
-  Rows Removed by Filter: 438
-  (slice0)    Executor memory: 32K bytes.
+Index Only Scan using pg_class_relname_nsp_index on pg_class  (cost=0.15..4.17 rows=1 width=64) (actual rows=1 loops=1)
+  Index Cond: (relname = 'pg_class'::name)
+  Heap Fetches: 0
+  (slice0)    Executor memory: 105K bytes.
 Memory used:  128000kB
  relname  
 ----------

--- a/contrib/auto_explain/expected/auto_explain_optimizer.out
+++ b/contrib/auto_explain/expected/auto_explain_optimizer.out
@@ -29,10 +29,10 @@ SELECT relname FROM pg_class WHERE relname='pg_class';
 LOG:  statement: SELECT relname FROM pg_class WHERE relname='pg_class';
 LOG:  duration: 0.112 ms  plan:
 Query Text: SELECT relname FROM pg_class WHERE relname='pg_class';
-Seq Scan on pg_class  (cost=0.00..12.46 rows=1 width=64) (actual rows=1 loops=1)
-  Filter: (relname = 'pg_class'::name)
-  Rows Removed by Filter: 438
-  (slice0)    Executor memory: 32K bytes.
+Index Only Scan using pg_class_relname_nsp_index on pg_class  (cost=0.15..4.17 rows=1 width=64) (actual rows=1 loops=1)
+  Index Cond: (relname = 'pg_class'::name)
+  Heap Fetches: 0
+  (slice0)    Executor memory: 105K bytes.
 Memory used:  128000kB
  relname  
 ----------

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -3924,7 +3924,7 @@ compute_scalar_stats(VacAttrStatsP stats,
 		 * The rows are not necessarily in the order that our sampling
 		 * query returned them, for an append-only table.
 		 */
-		if (values_cnt > 1 && stats->relstorage == RELSTORAGE_HEAP)
+		if (values_cnt > 1)
 		{
 			MemoryContext old_context;
 			float4	   *corrs;

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -3919,11 +3919,6 @@ compute_scalar_stats(VacAttrStatsP stats,
 		}
 
 		/* Generate a correlation entry if there are multiple values */
-		/*
-		 * GPDB: Don't calculate correlation for AO-tables, however.
-		 * The rows are not necessarily in the order that our sampling
-		 * query returned them, for an append-only table.
-		 */
 		if (values_cnt > 1)
 		{
 			MemoryContext old_context;

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -309,7 +309,7 @@ max_prepared_transactions = 250		# can be 0 or more
 # - Planner Cost Constants -
 
 #seq_page_cost = 1.0			# measured on an arbitrary scale
-#random_page_cost = 100			# same scale as above
+#random_page_cost = 4			# same scale as above
 
 #cpu_tuple_cost = 0.01			# same scale as above
 #cpu_index_tuple_cost = 0.005		# same scale as above

--- a/src/include/optimizer/cost.h
+++ b/src/include/optimizer/cost.h
@@ -24,7 +24,7 @@
 /* NB: cost-estimation code should use the variables, not these constants! */
 /* If you change these, update backend/utils/misc/postgresql.sample.conf */
 #define DEFAULT_SEQ_PAGE_COST  1.0
-#define DEFAULT_RANDOM_PAGE_COST  100.0
+#define DEFAULT_RANDOM_PAGE_COST  4.0
 #define DEFAULT_CPU_TUPLE_COST	0.01
 #define DEFAULT_CPU_INDEX_TUPLE_COST 0.005
 #define DEFAULT_CPU_OPERATOR_COST  0.0025

--- a/src/test/regress/expected/bitmapops.out
+++ b/src/test/regress/expected/bitmapops.out
@@ -1,10 +1,4 @@
 -- Test bitmap AND and OR
--- Currently greenplum sets random_page_cost as 100 while postgres sets it as 4.
--- This makes some BitmapOps cases are not tested as expected, so I'm
--- temporarily settting random_page_cost as 4 to test those functionalities.
--- Also bump up the statistics target, so that the plans are more stable,
--- and add explain tests to make sure BitmapOps are tested.
-SET random_page_cost  = 4;
 SET default_statistics_target=1000;
 -- Generate enough data that we can test the lossy bitmaps.
 -- There's 55 tuples per page in the table. 53 is just

--- a/src/test/regress/expected/bitmapops_optimizer.out
+++ b/src/test/regress/expected/bitmapops_optimizer.out
@@ -1,10 +1,4 @@
 -- Test bitmap AND and OR
--- Currently greenplum sets random_page_cost as 100 while postgres sets it as 4.
--- This makes some BitmapOps cases are not tested as expected, so I'm
--- temporarily settting random_page_cost as 4 to test those functionalities.
--- Also bump up the statistics target, so that the plans are more stable,
--- and add explain tests to make sure BitmapOps are tested.
-SET random_page_cost  = 4;
 SET default_statistics_target=1000;
 -- Generate enough data that we can test the lossy bitmaps.
 -- There's 55 tuples per page in the table. 53 is just

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -85,6 +85,7 @@ INSERT INTO radix_text_tbl
 INSERT INTO radix_text_tbl VALUES ('P0123456789abcde');
 INSERT INTO radix_text_tbl VALUES ('P0123456789abcdefF');
 CREATE INDEX sp_radix_ind ON radix_text_tbl USING spgist (t);
+SET optimizer_enable_tablescan = OFF;
 --
 -- Test GiST and SP-GiST indexes
 --
@@ -404,7 +405,6 @@ SELECT circle_center(f1), round(radius(f1)) as radius FROM gcircle_tbl ORDER BY 
 
 -- Now check the results from plain indexscan
 SET enable_seqscan = OFF;
-SET optimizer_enable_tablescan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = OFF;
 EXPLAIN (COSTS OFF)
@@ -1994,7 +1994,6 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~>~  'Worth                         
 (1 row)
 
 RESET enable_seqscan;
-RESET optimizer_enable_tablescan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 --
@@ -2003,7 +2002,6 @@ RESET enable_bitmapscan;
 -- Note: GIN currently supports only bitmap scans, not plain indexscans
 --
 SET enable_seqscan = OFF;
-SET optimizer_enable_tablescan = OFF;
 SET enable_indexscan = OFF;
 SET enable_bitmapscan = ON;
 CREATE INDEX intarrayidx ON array_index_op_test USING gin (i);
@@ -2540,7 +2538,6 @@ SELECT * FROM array_op_test WHERE i <@ '{NULL}' ORDER BY seqno;
 (1 row)
 
 RESET enable_seqscan;
-RESET optimizer_enable_tablescan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 --
@@ -2868,7 +2865,6 @@ CREATE TABLE onek_with_null AS SELECT unique1, unique2 FROM onek DISTRIBUTED BY 
 INSERT INTO onek_with_null (unique1,unique2) VALUES (NULL, -1), (NULL, NULL);
 CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2,unique1);
 SET enable_seqscan = OFF;
-SET optimizer_enable_tablescan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = ON;
 SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL;
@@ -3078,7 +3074,6 @@ SELECT unique1, unique2 FROM onek_with_null WHERE unique2 < 999
 (2 rows)
 
 RESET enable_seqscan;
-RESET optimizer_enable_tablescan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 DROP TABLE onek_with_null;
@@ -3086,7 +3081,6 @@ DROP TABLE onek_with_null;
 -- Check bitmap index path planning
 --
 SET enable_seqscan = OFF;
-SET optimizer_enable_tablescan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = ON;
 EXPLAIN (COSTS OFF)
@@ -3222,11 +3216,9 @@ ORDER BY thousand;
 (2 rows)
 
 RESET enable_seqscan;
-RESET optimizer_enable_tablescan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 SET enable_indexonlyscan = OFF;
-SET random_page_cost = 4; -- prefer index san.
 explain (costs off)
 SELECT thousand, tenthous FROM tenk1
 WHERE thousand < 2 AND tenthous IN (1001,3000)
@@ -3251,7 +3243,6 @@ ORDER BY thousand;
         1 |     1001
 (2 rows)
 
-RESET random_page_cost;
 RESET enable_indexonlyscan;
 RESET enable_indexscan;
 --
@@ -3345,3 +3336,4 @@ DROP ROLE regress_reindexuser;
 SET client_min_messages TO 'warning';
 DROP SCHEMA schema_to_reindex CASCADE;
 RESET client_min_messages;
+RESET optimizer_enable_tablescan;

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -3281,8 +3281,8 @@ explain (costs off)
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on tenk1
-         Filter: (((thousand = 1) AND (tenthous = 1001)) OR NULL::boolean)
+   ->  Index Scan using tenk1_thous_tenthous on tenk1
+         Index Cond: ((thousand = 1) AND (tenthous = 1001))
  Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
 (4 rows)
 

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -85,6 +85,7 @@ INSERT INTO radix_text_tbl
 INSERT INTO radix_text_tbl VALUES ('P0123456789abcde');
 INSERT INTO radix_text_tbl VALUES ('P0123456789abcdefF');
 CREATE INDEX sp_radix_ind ON radix_text_tbl USING spgist (t);
+SET optimizer_enable_tablescan = OFF;
 --
 -- Test GiST and SP-GiST indexes
 --
@@ -404,7 +405,6 @@ SELECT circle_center(f1), round(radius(f1)) as radius FROM gcircle_tbl ORDER BY 
 
 -- Now check the results from plain indexscan
 SET enable_seqscan = OFF;
-SET optimizer_enable_tablescan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = OFF;
 EXPLAIN (COSTS OFF)
@@ -2015,7 +2015,6 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~>~  'Worth                         
 (1 row)
 
 RESET enable_seqscan;
-RESET optimizer_enable_tablescan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 --
@@ -2024,7 +2023,6 @@ RESET enable_bitmapscan;
 -- Note: GIN currently supports only bitmap scans, not plain indexscans
 --
 SET enable_seqscan = OFF;
-SET optimizer_enable_tablescan = OFF;
 SET enable_indexscan = OFF;
 SET enable_bitmapscan = ON;
 CREATE INDEX intarrayidx ON array_index_op_test USING gin (i);
@@ -2561,7 +2559,6 @@ SELECT * FROM array_op_test WHERE i <@ '{NULL}' ORDER BY seqno;
 (1 row)
 
 RESET enable_seqscan;
-RESET optimizer_enable_tablescan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 --
@@ -2901,7 +2898,6 @@ CREATE TABLE onek_with_null AS SELECT unique1, unique2 FROM onek DISTRIBUTED BY 
 INSERT INTO onek_with_null (unique1,unique2) VALUES (NULL, -1), (NULL, NULL);
 CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2,unique1);
 SET enable_seqscan = OFF;
-SET optimizer_enable_tablescan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = ON;
 SELECT count(*) FROM onek_with_null WHERE unique1 IS NULL;
@@ -3111,7 +3107,6 @@ SELECT unique1, unique2 FROM onek_with_null WHERE unique2 < 999
 (2 rows)
 
 RESET enable_seqscan;
-RESET optimizer_enable_tablescan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 DROP TABLE onek_with_null;
@@ -3119,7 +3114,6 @@ DROP TABLE onek_with_null;
 -- Check bitmap index path planning
 --
 SET enable_seqscan = OFF;
-SET optimizer_enable_tablescan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = ON;
 EXPLAIN (COSTS OFF)
@@ -3249,11 +3243,9 @@ ORDER BY thousand;
 (2 rows)
 
 RESET enable_seqscan;
-RESET optimizer_enable_tablescan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 SET enable_indexonlyscan = OFF;
-SET random_page_cost = 4; -- prefer index san.
 explain (costs off)
 SELECT thousand, tenthous FROM tenk1
 WHERE thousand < 2 AND tenthous IN (1001,3000)
@@ -3279,7 +3271,6 @@ ORDER BY thousand;
         1 |     1001
 (2 rows)
 
-RESET random_page_cost;
 RESET enable_indexonlyscan;
 RESET enable_indexscan;
 --
@@ -3374,3 +3365,4 @@ DROP ROLE regress_reindexuser;
 SET client_min_messages TO 'warning';
 DROP SCHEMA schema_to_reindex CASCADE;
 RESET client_min_messages;
+RESET optimizer_enable_tablescan;

--- a/src/test/regress/expected/equivclass.out
+++ b/src/test/regress/expected/equivclass.out
@@ -260,27 +260,33 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss1
   where ss1.x = ec1.f1 and ec1.ff = 42::int8 and ec1.ff = ec1.f1;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: (((ss0.ff + 1)) = ec1.f1)
          ->  Append
                ->  Subquery Scan on ss0
                      ->  Append
-                           ->  Seq Scan on ec1 ec1_1
-                                 Filter: (((ff + 2) + 1) = '42'::bigint)
-                           ->  Seq Scan on ec1 ec1_2
-                                 Filter: (((ff + 3) + 1) = '42'::bigint)
-               ->  Seq Scan on ec1 ec1_3
-                     Filter: ((ff + 4) = '42'::bigint)
+                           ->  Bitmap Heap Scan on ec1 ec1_1
+                                 Recheck Cond: (((ff + 2) + 1) = '42'::bigint)
+                                 ->  Bitmap Index Scan on ec1_expr2
+                                       Index Cond: (((ff + 2) + 1) = '42'::bigint)
+                           ->  Bitmap Heap Scan on ec1 ec1_2
+                                 Recheck Cond: (((ff + 3) + 1) = '42'::bigint)
+                                 ->  Bitmap Index Scan on ec1_expr3
+                                       Index Cond: (((ff + 3) + 1) = '42'::bigint)
+               ->  Bitmap Heap Scan on ec1 ec1_3
+                     Recheck Cond: ((ff + 4) = '42'::bigint)
+                     ->  Bitmap Index Scan on ec1_expr4
+                           Index Cond: ((ff + 4) = '42'::bigint)
          ->  Materialize
                ->  Broadcast Motion 1:3  (slice2; segments: 1)
                      ->  Index Scan using ec1_pkey on ec1
                            Index Cond: ((ff = '42'::bigint) AND (ff = '42'::bigint))
                            Filter: (ff = f1)
  Optimizer: Postgres query optimizer
-(18 rows)
+(24 rows)
 
 explain (costs off)
   select * from ec1,

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -2348,7 +2348,6 @@ reset enable_hashjoin;
 -- a different check for handling of redundant sort keys in merge joins
 --
 set enable_mergejoin = true;
-set random_page_cost = 4;
 explain (costs off)
 select count(*) from
   (select * from tenk1 x order by x.thousand, x.twothousand, x.fivethous) x
@@ -2386,7 +2385,6 @@ select count(*) from
 (1 row)
 
 reset enable_mergejoin;
-reset random_page_cost;
 --
 -- Clean up
 --
@@ -3169,7 +3167,6 @@ where thousand = (q1 + q2);
 -- test ability to generate a suitable plan for a star-schema query
 --
 set enable_nestloop to true;
-set random_page_cost to 4;
 explain (costs off)
 select * from
   tenk1, int8_tbl a, int8_tbl b
@@ -3193,7 +3190,6 @@ where thousand = a.q1 and tenthous = b.q1 and a.q2 = 1 and b.q2 = 2;
 (14 rows)
 
 reset enable_nestloop;
-reset random_page_cost;
 --
 -- test a corner case in which we shouldn't apply the star-schema optimization
 --

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -3119,22 +3119,27 @@ select * from
   int4(sin(1)) q1,
   int4(sin(0)) q2
 where q1 = thousand or q2 = thousand;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Nested Loop
-         Join Filter: ((q1.q1 = tenk1.thousand) OR (q2.q2 = tenk1.thousand))
+   ->  Hash Join
+         Hash Cond: (tenk1.twothousand = int4_tbl.f1)
          ->  Nested Loop
-               ->  Hash Join
-                     Hash Cond: (tenk1.twothousand = int4_tbl.f1)
-                     ->  Seq Scan on tenk1
-                     ->  Hash
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                 ->  Seq Scan on int4_tbl
-               ->  Function Scan on q1
-         ->  Function Scan on q2
+               ->  Function Scan on q2
+               ->  Nested Loop
+                     ->  Function Scan on q1
+                     ->  Bitmap Heap Scan on tenk1
+                           Recheck Cond: ((q1.q1 = thousand) OR (q2.q2 = thousand))
+                           ->  BitmapOr
+                                 ->  Bitmap Index Scan on tenk1_thous_tenthous
+                                       Index Cond: (q1.q1 = thousand)
+                                 ->  Bitmap Index Scan on tenk1_thous_tenthous
+                                       Index Cond: (q2.q2 = thousand)
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on int4_tbl
  Optimizer: Postgres query optimizer
-(13 rows)
+(18 rows)
 
 explain (costs off)
 select * from
@@ -3275,14 +3280,24 @@ select * from tenk1 a join tenk1 b on
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: (((a.unique1 = 1) AND (b.unique1 = 2)) OR ((a.unique2 = 3) AND (b.hundred = 4)))
-         ->  Seq Scan on tenk1 b
-               Filter: ((unique1 = 2) OR (hundred = 4))
+         ->  Bitmap Heap Scan on tenk1 b
+               Recheck Cond: ((unique1 = 2) OR (hundred = 4))
+               ->  BitmapOr
+                     ->  Bitmap Index Scan on tenk1_unique1
+                           Index Cond: (unique1 = 2)
+                     ->  Bitmap Index Scan on tenk1_hundred
+                           Index Cond: (hundred = 4)
          ->  Materialize
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Seq Scan on tenk1 a
-                           Filter: ((unique1 = 1) OR (unique2 = 3))
+                     ->  Bitmap Heap Scan on tenk1 a
+                           Recheck Cond: ((unique1 = 1) OR (unique2 = 3))
+                           ->  BitmapOr
+                                 ->  Bitmap Index Scan on tenk1_unique1
+                                       Index Cond: (unique1 = 1)
+                                 ->  Bitmap Index Scan on tenk1_unique2
+                                       Index Cond: (unique2 = 3)
  Optimizer: Postgres query optimizer
-(10 rows)
+(20 rows)
 
 explain (costs off)
 select * from tenk1 a join tenk1 b on
@@ -3296,10 +3311,15 @@ select * from tenk1 a join tenk1 b on
                Filter: ((unique1 = 2) OR (ten = 4))
          ->  Materialize
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Seq Scan on tenk1 a
-                           Filter: ((unique1 = 1) OR (unique2 = 3))
+                     ->  Bitmap Heap Scan on tenk1 a
+                           Recheck Cond: ((unique1 = 1) OR (unique2 = 3))
+                           ->  BitmapOr
+                                 ->  Bitmap Index Scan on tenk1_unique1
+                                       Index Cond: (unique1 = 1)
+                                 ->  Bitmap Index Scan on tenk1_unique2
+                                       Index Cond: (unique2 = 3)
  Optimizer: Postgres query optimizer
-(10 rows)
+(15 rows)
 
 explain (costs off)
 select * from tenk1 a join tenk1 b on
@@ -3310,14 +3330,26 @@ select * from tenk1 a join tenk1 b on
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: (((a.unique1 = 1) AND (b.unique1 = 2)) OR (((a.unique2 = 3) OR (a.unique2 = 7)) AND (b.hundred = 4)))
-         ->  Seq Scan on tenk1 b
-               Filter: ((unique1 = 2) OR (hundred = 4))
+         ->  Bitmap Heap Scan on tenk1 b
+               Recheck Cond: ((unique1 = 2) OR (hundred = 4))
+               ->  BitmapOr
+                     ->  Bitmap Index Scan on tenk1_unique1
+                           Index Cond: (unique1 = 2)
+                     ->  Bitmap Index Scan on tenk1_hundred
+                           Index Cond: (hundred = 4)
          ->  Materialize
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Seq Scan on tenk1 a
-                           Filter: ((unique1 = 1) OR (unique2 = 3) OR (unique2 = 7))
+                     ->  Bitmap Heap Scan on tenk1 a
+                           Recheck Cond: ((unique1 = 1) OR (unique2 = 3) OR (unique2 = 7))
+                           ->  BitmapOr
+                                 ->  Bitmap Index Scan on tenk1_unique1
+                                       Index Cond: (unique1 = 1)
+                                 ->  Bitmap Index Scan on tenk1_unique2
+                                       Index Cond: (unique2 = 3)
+                                 ->  Bitmap Index Scan on tenk1_unique2
+                                       Index Cond: (unique2 = 7)
  Optimizer: Postgres query optimizer
-(10 rows)
+(22 rows)
 
 --
 -- test placement of movable quals in a parameterized join tree
@@ -3615,14 +3647,16 @@ select a.unique1, b.unique1, c.unique1, coalesce(b.twothousand, a.twothousand)
                      Hash Key: b.thousand
                      ->  Seq Scan on tenk1 b
                ->  Hash
-                     ->  Seq Scan on tenk1 a
-                           Filter: (unique2 < 10)
+                     ->  Bitmap Heap Scan on tenk1 a
+                           Recheck Cond: (unique2 < 10)
+                           ->  Bitmap Index Scan on tenk1_unique2
+                                 Index Cond: (unique2 < 10)
          ->  Hash
                ->  Broadcast Motion 3:3  (slice3; segments: 3)
                      ->  Index Scan using tenk1_unique2 on tenk1 c
                            Index Cond: (unique2 = 44)
  Optimizer: Postgres query optimizer
-(17 rows)
+(19 rows)
 
 select a.unique1, b.unique1, c.unique1, coalesce(b.twothousand, a.twothousand)
   from tenk1 a left join tenk1 b on b.thousand = a.unique1                        left join tenk1 c on c.unique2 = coalesce(b.twothousand, a.twothousand)

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -2352,7 +2352,6 @@ reset enable_hashjoin;
 -- a different check for handling of redundant sort keys in merge joins
 --
 set enable_mergejoin = true;
-set random_page_cost = 4;
 explain (costs off)
 select count(*) from
   (select * from tenk1 x order by x.thousand, x.twothousand, x.fivethous) x
@@ -2387,7 +2386,6 @@ select count(*) from
 (1 row)
 
 reset enable_mergejoin;
-reset random_page_cost;
 --
 -- Clean up
 --
@@ -3189,7 +3187,6 @@ where thousand = (q1 + q2);
 -- test ability to generate a suitable plan for a star-schema query
 --
 set enable_nestloop to true;
-set random_page_cost to 4;
 explain (costs off)
 select * from
   tenk1, int8_tbl a, int8_tbl b
@@ -3214,7 +3211,6 @@ where thousand = a.q1 and tenthous = b.q1 and a.q2 = 1 and b.q2 = 2;
 (15 rows)
 
 reset enable_nestloop;
-reset random_page_cost;
 --
 -- test a corner case in which we shouldn't apply the star-schema optimization
 --

--- a/src/test/regress/expected/limit.out
+++ b/src/test/regress/expected/limit.out
@@ -146,15 +146,10 @@ select unique1, unique2, nextval('testseq')
          Merge Key: unique2
          ->  Limit
                Output: unique1, unique2, (nextval('testseq'::regclass))
-               ->  Result
+               ->  Index Scan using tenk1_unique2 on public.tenk1
                      Output: unique1, unique2, nextval('testseq'::regclass)
-                     ->  Sort
-                           Output: unique1, unique2
-                           Sort Key: tenk1.unique2
-                           ->  Seq Scan on public.tenk1
-                                 Output: unique1, unique2
  Optimizer: Postgres query optimizer
-(15 rows)
+(10 rows)
 
 -- In gpdb, our sequence can only promise monotonicity due to MPP structure
 -- The follow case does not make sence for us.
@@ -176,8 +171,8 @@ select unique1, unique2, nextval('testseq')
 explain (verbose, costs off)
 select unique1, unique2, generate_series(1,10)
   from tenk1 order by unique2 limit 7;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Limit
    Output: unique1, unique2, (generate_series(1, 10))
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -187,13 +182,10 @@ select unique1, unique2, generate_series(1,10)
                Output: unique1, unique2, (generate_series(1, 10))
                ->  Result
                      Output: unique1, unique2, generate_series(1, 10)
-                     ->  Sort
+                     ->  Index Scan using tenk1_unique2 on public.tenk1
                            Output: unique1, unique2
-                           Sort Key: tenk1.unique2
-                           ->  Seq Scan on public.tenk1
-                                 Output: unique1, unique2
  Optimizer: Postgres query optimizer
-(15 rows)
+(12 rows)
 
 select unique1, unique2, generate_series(1,10)
   from tenk1 order by unique2 limit 7;

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -1923,35 +1923,32 @@ SELECT * FROM pt_lt_tab WHERE col4 is False ORDER BY col2,col3 LIMIT 5;
 (5 rows)
 
 EXPLAIN SELECT * FROM pt_lt_tab WHERE col4 is False ORDER BY col2,col3 LIMIT 5;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=32014.75..32014.87 rows=5 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=32014.75..32014.87 rows=5 width=8)
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=1300.29..1300.40 rows=5 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1300.29..1300.40 rows=5 width=8)
          Merge Key: pt_lt_tab_1_prt_part1.col2, pt_lt_tab_1_prt_part1.col3
-         ->  Limit  (cost=32014.75..32014.77 rows=2 width=8)
-               ->  Sort  (cost=32014.75..32014.83 rows=11 width=8)
+         ->  Limit  (cost=1300.29..1300.30 rows=2 width=8)
+               ->  Sort  (cost=1300.28..1300.36 rows=11 width=8)
                      Sort Key: pt_lt_tab_1_prt_part1.col2, pt_lt_tab_1_prt_part1.col3
-                     ->  Append  (cost=0.14..32014.22 rows=11 width=8)
-                           ->  Index Scan using pt_lt_tab_1_prt_part1_col4_idx on pt_lt_tab_1_prt_part1  (cost=0.14..1002.14 rows=1 width=8)
+                     ->  Append  (cost=0.14..1299.75 rows=11 width=8)
+                           ->  Index Scan using pt_lt_tab_1_prt_part1_col4_idx on pt_lt_tab_1_prt_part1  (cost=0.14..40.23 rows=1 width=8)
                                  Index Cond: (col4 = false)
                                  Filter: (col4 IS FALSE)
-                           ->  Index Scan using pt_lt_tab_1_prt_part2_col4_idx on pt_lt_tab_1_prt_part2  (cost=0.14..1002.14 rows=1 width=8)
+                           ->  Index Scan using pt_lt_tab_1_prt_part2_col4_idx on pt_lt_tab_1_prt_part2  (cost=0.14..40.23 rows=1 width=8)
                                  Index Cond: (col4 = false)
                                  Filter: (col4 IS FALSE)
-                           ->  Bitmap Heap Scan on pt_lt_tab_1_prt_part3  (cost=10000.21..10003.31 rows=4 width=8)
+                           ->  Index Scan using pt_lt_tab_1_prt_part3_col4_idx on pt_lt_tab_1_prt_part3  (cost=0.14..406.43 rows=4 width=8)
+                                 Index Cond: (col4 = false)
                                  Filter: (col4 IS FALSE)
-                                 ->  Bitmap Index Scan on pt_lt_tab_1_prt_part3_col4_idx  (cost=0.00..10000.21 rows=4 width=0)
-                                       Index Cond: (col4 = false)
-                           ->  Bitmap Heap Scan on pt_lt_tab_1_prt_part4  (cost=10000.21..10003.31 rows=4 width=8)
+                           ->  Index Scan using pt_lt_tab_1_prt_part4_col4_idx on pt_lt_tab_1_prt_part4  (cost=0.14..406.43 rows=4 width=8)
+                                 Index Cond: (col4 = false)
                                  Filter: (col4 IS FALSE)
-                                 ->  Bitmap Index Scan on pt_lt_tab_1_prt_part4_col4_idx  (cost=0.00..10000.21 rows=4 width=0)
-                                       Index Cond: (col4 = false)
-                           ->  Bitmap Heap Scan on pt_lt_tab_1_prt_part5  (cost=10000.21..10003.31 rows=4 width=8)
+                           ->  Index Scan using pt_lt_tab_1_prt_part5_col4_idx on pt_lt_tab_1_prt_part5  (cost=0.14..406.43 rows=4 width=8)
+                                 Index Cond: (col4 = false)
                                  Filter: (col4 IS FALSE)
-                                 ->  Bitmap Index Scan on pt_lt_tab_1_prt_part5_col4_idx  (cost=0.00..10000.21 rows=4 width=0)
-                                       Index Cond: (col4 = false)
  Optimizer: Postgres query optimizer
-(26 rows)
+(23 rows)
 
 SELECT * FROM pt_lt_tab WHERE col4 = False ORDER BY col2,col3 LIMIT 5;
  col2 | col3 | col4 
@@ -1964,35 +1961,32 @@ SELECT * FROM pt_lt_tab WHERE col4 = False ORDER BY col2,col3 LIMIT 5;
 (5 rows)
 
 EXPLAIN SELECT * FROM pt_lt_tab WHERE col4 = False ORDER BY col2,col3 LIMIT 5;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=32014.75..32014.87 rows=5 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=32014.75..32014.87 rows=5 width=8)
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=1300.29..1300.40 rows=5 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1300.29..1300.40 rows=5 width=8)
          Merge Key: pt_lt_tab_1_prt_part1.col2, pt_lt_tab_1_prt_part1.col3
-         ->  Limit  (cost=32014.75..32014.77 rows=2 width=8)
-               ->  Sort  (cost=32014.75..32014.83 rows=11 width=8)
+         ->  Limit  (cost=1300.29..1300.30 rows=2 width=8)
+               ->  Sort  (cost=1300.28..1300.36 rows=11 width=8)
                      Sort Key: pt_lt_tab_1_prt_part1.col2, pt_lt_tab_1_prt_part1.col3
-                     ->  Append  (cost=0.14..32014.22 rows=11 width=8)
-                           ->  Index Scan using pt_lt_tab_1_prt_part1_col4_idx on pt_lt_tab_1_prt_part1  (cost=0.14..1002.14 rows=1 width=8)
+                     ->  Append  (cost=0.14..1299.75 rows=11 width=8)
+                           ->  Index Scan using pt_lt_tab_1_prt_part1_col4_idx on pt_lt_tab_1_prt_part1  (cost=0.14..40.23 rows=1 width=8)
                                  Index Cond: (col4 = false)
                                  Filter: (NOT col4)
-                           ->  Index Scan using pt_lt_tab_1_prt_part2_col4_idx on pt_lt_tab_1_prt_part2  (cost=0.14..1002.14 rows=1 width=8)
+                           ->  Index Scan using pt_lt_tab_1_prt_part2_col4_idx on pt_lt_tab_1_prt_part2  (cost=0.14..40.23 rows=1 width=8)
                                  Index Cond: (col4 = false)
                                  Filter: (NOT col4)
-                           ->  Bitmap Heap Scan on pt_lt_tab_1_prt_part3  (cost=10000.21..10003.31 rows=4 width=8)
+                           ->  Index Scan using pt_lt_tab_1_prt_part3_col4_idx on pt_lt_tab_1_prt_part3  (cost=0.14..406.43 rows=4 width=8)
+                                 Index Cond: (col4 = false)
                                  Filter: (NOT col4)
-                                 ->  Bitmap Index Scan on pt_lt_tab_1_prt_part3_col4_idx  (cost=0.00..10000.21 rows=4 width=0)
-                                       Index Cond: (col4 = false)
-                           ->  Bitmap Heap Scan on pt_lt_tab_1_prt_part4  (cost=10000.21..10003.31 rows=4 width=8)
+                           ->  Index Scan using pt_lt_tab_1_prt_part4_col4_idx on pt_lt_tab_1_prt_part4  (cost=0.14..406.43 rows=4 width=8)
+                                 Index Cond: (col4 = false)
                                  Filter: (NOT col4)
-                                 ->  Bitmap Index Scan on pt_lt_tab_1_prt_part4_col4_idx  (cost=0.00..10000.21 rows=4 width=0)
-                                       Index Cond: (col4 = false)
-                           ->  Bitmap Heap Scan on pt_lt_tab_1_prt_part5  (cost=10000.21..10003.31 rows=4 width=8)
+                           ->  Index Scan using pt_lt_tab_1_prt_part5_col4_idx on pt_lt_tab_1_prt_part5  (cost=0.14..406.43 rows=4 width=8)
+                                 Index Cond: (col4 = false)
                                  Filter: (NOT col4)
-                                 ->  Bitmap Index Scan on pt_lt_tab_1_prt_part5_col4_idx  (cost=0.00..10000.21 rows=4 width=0)
-                                       Index Cond: (col4 = false)
  Optimizer: Postgres query optimizer
-(26 rows)
+(23 rows)
 
 SELECT * FROM pt_lt_tab WHERE col2 > 41 ORDER BY col2,col3 LIMIT 5;
  col2 | col3 | col4 

--- a/src/test/regress/expected/plancache.out
+++ b/src/test/regress/expected/plancache.out
@@ -262,9 +262,7 @@ NOTICE:  3
 
 -- Test plan_cache_mode
 create table test_mode (a int);
--- GPDB:setting the number of rows slightly higher to get a plan with
--- Index Only Scan (similar to upstream)
-insert into test_mode select 1 from generate_series(1,15000) union all select 2;
+insert into test_mode select 1 from generate_series(1,1000) union all select 2;
 create index on test_mode (a);
 analyze test_mode;
 prepare test_mode_pp (int) as select count(*) from test_mode where a = $1;
@@ -297,31 +295,31 @@ set plan_cache_mode to auto;
 execute test_mode_pp(1); -- 1x
  count 
 -------
- 15000
+  1000
 (1 row)
 
 execute test_mode_pp(1); -- 2x
  count 
 -------
- 15000
+  1000
 (1 row)
 
 execute test_mode_pp(1); -- 3x
  count 
 -------
- 15000
+  1000
 (1 row)
 
 execute test_mode_pp(1); -- 4x
  count 
 -------
- 15000
+  1000
 (1 row)
 
 execute test_mode_pp(1); -- 5x
  count 
 -------
- 15000
+  1000
 (1 row)
 
 -- we should now get a really bad plan

--- a/src/test/regress/expected/plancache_optimizer.out
+++ b/src/test/regress/expected/plancache_optimizer.out
@@ -262,9 +262,7 @@ NOTICE:  3
 
 -- Test plan_cache_mode
 create table test_mode (a int);
--- GPDB:setting the number of rows slightly higher to get a plan with
--- Index Only Scan (similar to upstream)
-insert into test_mode select 1 from generate_series(1,15000) union all select 2;
+insert into test_mode select 1 from generate_series(1,1000) union all select 2;
 create index on test_mode (a);
 analyze test_mode;
 prepare test_mode_pp (int) as select count(*) from test_mode where a = $1;
@@ -297,31 +295,31 @@ set plan_cache_mode to auto;
 execute test_mode_pp(1); -- 1x
  count 
 -------
- 15000
+  1000
 (1 row)
 
 execute test_mode_pp(1); -- 2x
  count 
 -------
- 15000
+  1000
 (1 row)
 
 execute test_mode_pp(1); -- 3x
  count 
 -------
- 15000
+  1000
 (1 row)
 
 execute test_mode_pp(1); -- 4x
  count 
 -------
- 15000
+  1000
 (1 row)
 
 execute test_mode_pp(1); -- 5x
  count 
 -------
- 15000
+  1000
 (1 row)
 
 -- we should now get a really bad plan

--- a/src/test/regress/expected/portals.out
+++ b/src/test/regress/expected/portals.out
@@ -995,13 +995,15 @@ COMMIT;
 BEGIN;
 EXPLAIN (costs off)
 DECLARE c1 CURSOR FOR SELECT stringu1 FROM onek WHERE stringu1 = 'DZAAAA';
-                 QUERY PLAN                  
----------------------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on onek
-         Filter: (stringu1 = 'DZAAAA'::name)
+   ->  Bitmap Heap Scan on onek
+         Recheck Cond: (stringu1 = 'DZAAAA'::name)
+         ->  Bitmap Index Scan on onek_stringu1
+               Index Cond: (stringu1 = 'DZAAAA'::name)
  Optimizer: Postgres query optimizer
-(4 rows)
+(6 rows)
 
 DECLARE c1 CURSOR FOR SELECT stringu1 FROM onek WHERE stringu1 = 'DZAAAA';
 FETCH FROM c1;

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -229,19 +229,18 @@ EXPLAIN (COSTS OFF) SELECT * FROM atest12v x, atest12v y WHERE x.a = y.b;
 -- And this one.
 EXPLAIN (COSTS OFF) SELECT * FROM atest12 x, atest12 y
   WHERE x.a = y.b and abs(y.a) <<< 5;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Hash Join
-         Hash Cond: (x.a = y.b)
-         ->  Seq Scan on atest12 x
-         ->  Hash
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: y.b
-                     ->  Seq Scan on atest12 y
-                           Filter: (abs(a) <<< 5)
+   ->  Nested Loop
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: y.b
+               ->  Seq Scan on atest12 y
+                     Filter: (abs(a) <<< 5)
+         ->  Index Scan using atest12_a_idx on atest12 x
+               Index Cond: (a = y.b)
  Optimizer: Postgres query optimizer
-(10 rows)
+(9 rows)
 
 reset enable_nestloop;
 -- Check if regress_user2 can break security.

--- a/src/test/regress/expected/rowtypes.out
+++ b/src/test/regress/expected/rowtypes.out
@@ -616,14 +616,6 @@ select row_to_json(ss) from
  {"x":4567890123456789,"y":-4567890123456789}
 (5 rows)
 
--- GPDB: Make the plan same as PG's to make further merge and testing easy.
--- PG plan is index only scan, while GP plan is seq scan without the guc
--- settings below. That is because:
--- 1) Default large (different as PG's) random_page_cost makes planner incline to seq scan.
--- 2) Low vis fraction estimation (pg_class.relallvisible) on GP causes higher
---    index only scan cost so bitmap index scan outperforms index only scan.
-set random_page_cost = 4;
-set enable_bitmapscan = off;
 explain (costs off)
 select row_to_json(q) from
   (select thousand, tenthous from tenk1
@@ -664,9 +656,6 @@ select row_to_json(q) from
  {"a":42,"b":1042}
 (2 rows)
 
--- GPDB: restore to the default or previously set values.
-reset random_page_cost;
-reset enable_bitmapscan;
 create temp table tt1 as select * from int8_tbl order by 1 limit 2;
 create temp table tt2 () inherits(tt1);
 insert into tt2 values(0,0);

--- a/src/test/regress/expected/select.out
+++ b/src/test/regress/expected/select.out
@@ -736,8 +736,6 @@ SELECT * FROM foo ORDER BY f1 DESC NULLS LAST;
 --
 -- Test planning of some cases with partial indexes
 --
--- change cost to match the upstream default, so that you get similar plans.
-set random_page_cost=4;
 -- partial index is usable
 explain (costs off)
 select * from onek2 where unique2 = 11 and stringu1 = 'ATAAAA';

--- a/src/test/regress/expected/select_optimizer.out
+++ b/src/test/regress/expected/select_optimizer.out
@@ -739,8 +739,6 @@ SELECT * FROM foo ORDER BY f1 DESC NULLS LAST;
 --
 -- Test planning of some cases with partial indexes
 --
--- change cost to match the upstream default, so that you get similar plans.
-set random_page_cost=4;
 -- partial index is usable
 explain (costs off)
 select * from onek2 where unique2 = 11 and stringu1 = 'ATAAAA';

--- a/src/test/regress/sql/bitmapops.sql
+++ b/src/test/regress/sql/bitmapops.sql
@@ -1,11 +1,5 @@
 -- Test bitmap AND and OR
 
--- Currently greenplum sets random_page_cost as 100 while postgres sets it as 4.
--- This makes some BitmapOps cases are not tested as expected, so I'm
--- temporarily settting random_page_cost as 4 to test those functionalities.
--- Also bump up the statistics target, so that the plans are more stable,
--- and add explain tests to make sure BitmapOps are tested.
-SET random_page_cost  = 4;
 SET default_statistics_target=1000;
 
 

--- a/src/test/regress/sql/create_index.sql
+++ b/src/test/regress/sql/create_index.sql
@@ -124,6 +124,7 @@ INSERT INTO radix_text_tbl VALUES ('P0123456789abcdefF');
 
 CREATE INDEX sp_radix_ind ON radix_text_tbl USING spgist (t);
 
+SET optimizer_enable_tablescan = OFF;
 --
 -- Test GiST and SP-GiST indexes
 --
@@ -230,7 +231,6 @@ SELECT circle_center(f1), round(radius(f1)) as radius FROM gcircle_tbl ORDER BY 
 
 -- Now check the results from plain indexscan
 SET enable_seqscan = OFF;
-SET optimizer_enable_tablescan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = OFF;
 
@@ -580,7 +580,6 @@ SELECT count(*) FROM radix_text_tbl WHERE t ~>~  'Worth                         
 SELECT count(*) FROM radix_text_tbl WHERE t ~>~  'Worth                         St  ';
 
 RESET enable_seqscan;
-RESET optimizer_enable_tablescan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 
@@ -591,7 +590,6 @@ RESET enable_bitmapscan;
 --
 
 SET enable_seqscan = OFF;
-SET optimizer_enable_tablescan = OFF;
 SET enable_indexscan = OFF;
 SET enable_bitmapscan = ON;
 
@@ -652,7 +650,6 @@ SELECT * FROM array_op_test WHERE i = '{NULL}' ORDER BY seqno;
 SELECT * FROM array_op_test WHERE i <@ '{NULL}' ORDER BY seqno;
 
 RESET enable_seqscan;
-RESET optimizer_enable_tablescan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 
@@ -875,7 +872,6 @@ INSERT INTO onek_with_null (unique1,unique2) VALUES (NULL, -1), (NULL, NULL);
 CREATE UNIQUE INDEX onek_nulltest ON onek_with_null (unique2,unique1);
 
 SET enable_seqscan = OFF;
-SET optimizer_enable_tablescan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = ON;
 
@@ -944,7 +940,6 @@ SELECT unique1, unique2 FROM onek_with_null WHERE unique2 < 999
   ORDER BY unique2 DESC LIMIT 2;
 
 RESET enable_seqscan;
-RESET optimizer_enable_tablescan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 
@@ -955,7 +950,6 @@ DROP TABLE onek_with_null;
 --
 
 SET enable_seqscan = OFF;
-SET optimizer_enable_tablescan = OFF;
 SET enable_indexscan = ON;
 SET enable_bitmapscan = ON;
 
@@ -1011,12 +1005,10 @@ WHERE thousand < 2 AND tenthous IN (1001,3000)
 ORDER BY thousand;
 
 RESET enable_seqscan;
-RESET optimizer_enable_tablescan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 
 SET enable_indexonlyscan = OFF;
-SET random_page_cost = 4; -- prefer index san.
 
 explain (costs off)
 SELECT thousand, tenthous FROM tenk1
@@ -1027,7 +1019,6 @@ SELECT thousand, tenthous FROM tenk1
 WHERE thousand < 2 AND tenthous IN (1001,3000)
 ORDER BY thousand;
 
-RESET random_page_cost;
 RESET enable_indexonlyscan;
 RESET enable_indexscan;
 
@@ -1099,3 +1090,5 @@ DROP ROLE regress_reindexuser;
 SET client_min_messages TO 'warning';
 DROP SCHEMA schema_to_reindex CASCADE;
 RESET client_min_messages;
+
+RESET optimizer_enable_tablescan;

--- a/src/test/regress/sql/join.sql
+++ b/src/test/regress/sql/join.sql
@@ -437,7 +437,6 @@ reset enable_hashjoin;
 -- a different check for handling of redundant sort keys in merge joins
 --
 set enable_mergejoin = true;
-set random_page_cost = 4;
 explain (costs off)
 select count(*) from
   (select * from tenk1 x order by x.thousand, x.twothousand, x.fivethous) x
@@ -451,7 +450,6 @@ select count(*) from
   (select * from tenk1 y order by y.unique2) y
   on x.thousand = y.unique2 and x.twothousand = y.hundred and x.fivethous = y.unique2;
 reset enable_mergejoin;
-reset random_page_cost;
 
 
 --
@@ -931,14 +929,12 @@ where thousand = (q1 + q2);
 --
 
 set enable_nestloop to true;
-set random_page_cost to 4;
 explain (costs off)
 select * from
   tenk1, int8_tbl a, int8_tbl b
 where thousand = a.q1 and tenthous = b.q1 and a.q2 = 1 and b.q2 = 2;
 
 reset enable_nestloop;
-reset random_page_cost;
 --
 -- test a corner case in which we shouldn't apply the star-schema optimization
 --

--- a/src/test/regress/sql/plancache.sql
+++ b/src/test/regress/sql/plancache.sql
@@ -167,9 +167,7 @@ select cachebug();
 -- Test plan_cache_mode
 
 create table test_mode (a int);
--- GPDB:setting the number of rows slightly higher to get a plan with
--- Index Only Scan (similar to upstream)
-insert into test_mode select 1 from generate_series(1,15000) union all select 2;
+insert into test_mode select 1 from generate_series(1,1000) union all select 2;
 create index on test_mode (a);
 analyze test_mode;
 

--- a/src/test/regress/sql/regex.sql
+++ b/src/test/regress/sql/regex.sql
@@ -63,13 +63,17 @@ select 'zyy' ~ '(?<![xy])yy+';
 -- Test conversion of regex patterns to indexable conditions
 -- start_ignore
 -- GPDB_93_MERGE_FIXME: the statistics and/or cost estimation code
--- in GPDB, combined with the much higher default random_page_cost
--- setting than PostgreSQL's, means that the planner chooses a seq scan
+-- in GPDB, means that the planner chooses a seq scan
 -- rather than an index scan for these. Force index scans, so that
 -- the test tests what it's supposed to test. But we should investigate
 -- why exactly the cost estimates are so different. There should be no
 -- difference in the true cost of scans on catalog tables - they're not
 -- even distributed.
+-- 
+-- After random_page_cost diminish, this guc still can not rid of.
+-- Our index scan selectivity result have tiny different with upstream,
+-- so that in a small table, e.g. pg_proc, planner will pick seq or bitmap
+-- scan instead.
 set enable_seqscan=off;
 set enable_bitmapscan=off;
 -- end_ignore

--- a/src/test/regress/sql/rowtypes.sql
+++ b/src/test/regress/sql/rowtypes.sql
@@ -268,14 +268,6 @@ select row_to_json(ss) from
 select row_to_json(ss) from
   (select q1 as a, q2 as b from int8_tbl offset 0) as ss(x,y);
 
--- GPDB: Make the plan same as PG's to make further merge and testing easy.
--- PG plan is index only scan, while GP plan is seq scan without the guc
--- settings below. That is because:
--- 1) Default large (different as PG's) random_page_cost makes planner incline to seq scan.
--- 2) Low vis fraction estimation (pg_class.relallvisible) on GP causes higher
---    index only scan cost so bitmap index scan outperforms index only scan.
-set random_page_cost = 4;
-set enable_bitmapscan = off;
 explain (costs off)
 select row_to_json(q) from
   (select thousand, tenthous from tenk1
@@ -289,9 +281,6 @@ select row_to_json(q) from
 select row_to_json(q) from
   (select thousand as x, tenthous as y from tenk1
    where thousand = 42 and tenthous < 2000 offset 0) q(a,b);
--- GPDB: restore to the default or previously set values.
-reset random_page_cost;
-reset enable_bitmapscan;
 
 create temp table tt1 as select * from int8_tbl order by 1 limit 2;
 create temp table tt2 () inherits(tt1);

--- a/src/test/regress/sql/select.sql
+++ b/src/test/regress/sql/select.sql
@@ -190,10 +190,6 @@ SELECT * FROM foo ORDER BY f1 DESC NULLS LAST;
 --
 -- Test planning of some cases with partial indexes
 --
-
--- change cost to match the upstream default, so that you get similar plans.
-set random_page_cost=4;
-
 -- partial index is usable
 explain (costs off)
 select * from onek2 where unique2 = 11 and stringu1 = 'ATAAAA';


### PR DESCRIPTION
In upstream,  `random_page_access` default value is always 4. For some unknown reason, we bump up to 100, which impacts bitmap index, index, and index-only scan cost different. After some performance tests in ao and aoco table, diminishment of the value also can leverage these table scans plan.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
