### PR TITLE
Fix system views pg_stat_*

### DIFF
--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -448,7 +448,7 @@ REVOKE EXECUTE ON FUNCTION pg_config() FROM PUBLIC;
 
 -- Statistics views
 
-CREATE VIEW pg_stat_all_tables AS
+CREATE VIEW pg_stat_all_tables_internal AS
     SELECT
             C.oid AS relid,
             N.nspname AS schemaname,
@@ -478,6 +478,72 @@ CREATE VIEW pg_stat_all_tables AS
          LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace)
     WHERE C.relkind IN ('r', 't', 'm')
     GROUP BY C.oid, N.nspname, C.relname;
+
+-- Gather data from segments on user tables, and use data on master on system tables.
+
+CREATE VIEW pg_stat_all_tables AS
+SELECT
+    s.relid,
+    s.schemaname,
+    s.relname,
+    m.seq_scan,
+    m.seq_tup_read,
+    m.idx_scan,
+    m.idx_tup_fetch,
+    m.n_tup_ins,
+    m.n_tup_upd,
+    m.n_tup_del,
+    m.n_tup_hot_upd,
+    m.n_live_tup,
+    m.n_dead_tup,
+    s.n_mod_since_analyze,
+    s.last_vacuum,
+    s.last_autovacuum,
+    s.last_analyze,
+    s.last_autoanalyze,
+    s.vacuum_count,
+    s.autovacuum_count,
+    s.analyze_count,
+    s.autoanalyze_count
+FROM
+    (SELECT
+         relid,
+         schemaname,
+         relname,
+         sum(seq_scan) as seq_scan,
+         sum(seq_tup_read) as seq_tup_read,
+         sum(idx_scan) as idx_scan,
+         sum(idx_tup_fetch) as idx_tup_fetch,
+         sum(n_tup_ins) as n_tup_ins,
+         sum(n_tup_upd) as n_tup_upd,
+         sum(n_tup_del) as n_tup_del,
+         sum(n_tup_hot_upd) as n_tup_hot_upd,
+         sum(n_live_tup) as n_live_tup,
+         sum(n_dead_tup) as n_dead_tup,
+         max(n_mod_since_analyze) as n_mod_since_analyze,
+         max(last_vacuum) as last_vacuum,
+         max(last_autovacuum) as last_autovacuum,
+         max(last_analyze) as last_analyze,
+         max(last_autoanalyze) as last_autoanalyze,
+         max(vacuum_count) as vacuum_count,
+         max(autovacuum_count) as autovacuum_count,
+         max(analyze_count) as analyze_count,
+         max(autoanalyze_count) as autoanalyze_count
+     FROM
+         gp_dist_random('pg_stat_all_tables_internal')
+     WHERE
+             relid >= 16384
+     GROUP BY relid, schemaname, relname
+
+     UNION ALL
+
+     SELECT
+         *
+     FROM
+         pg_stat_all_tables_internal
+     WHERE
+             relid < 16384) m, pg_stat_all_tables_internal s
+WHERE m.relid = s.relid;
 
 CREATE VIEW pg_stat_xact_all_tables AS
     SELECT
@@ -554,7 +620,7 @@ CREATE VIEW pg_statio_user_tables AS
     WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND
           schemaname !~ '^pg_toast';
 
-CREATE VIEW pg_stat_all_indexes AS
+CREATE VIEW pg_stat_all_indexes_internal AS
     SELECT
             C.oid AS relid,
             I.oid AS indexrelid,
@@ -569,6 +635,44 @@ CREATE VIEW pg_stat_all_indexes AS
             pg_class I ON I.oid = X.indexrelid
             LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace)
     WHERE C.relkind IN ('r', 't', 'm');
+
+-- Gather data from segments on user tables, and use data on master on system tables.
+
+CREATE VIEW pg_stat_all_indexes AS
+SELECT
+    s.relid,
+    s.indexrelid,
+    s.schemaname,
+    s.relname,
+    s.indexrelname,
+    m.idx_scan,
+    m.idx_tup_read,
+    m.idx_tup_fetch
+FROM
+    (SELECT
+         relid,
+         indexrelid,
+         schemaname,
+         relname,
+         indexrelname,
+         sum(idx_scan) as idx_scan,
+         sum(idx_tup_read) as idx_tup_read,
+         sum(idx_tup_fetch) as idx_tup_fetch
+     FROM
+         gp_dist_random('pg_stat_all_indexes_internal')
+     WHERE
+             relid >= 16384
+     GROUP BY relid, indexrelid, schemaname, relname, indexrelname
+
+     UNION ALL
+
+     SELECT
+         *
+     FROM
+         pg_stat_all_indexes_internal
+     WHERE
+             relid < 16384) m, pg_stat_all_indexes_internal s
+WHERE m.relid = s.relid;
 
 CREATE VIEW pg_stat_sys_indexes AS
     SELECT * FROM pg_stat_all_indexes

--- a/src/test/regress/expected/pg_stat.out
+++ b/src/test/regress/expected/pg_stat.out
@@ -1,0 +1,93 @@
+set optimizer to off;
+drop table  if exists pg_stat_test;
+create table pg_stat_test(a int);
+select
+    schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd,
+    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup
+from pg_stat_all_tables where relname = 'pg_stat_test';
+ schemaname |   relname    | seq_scan | seq_tup_read | idx_scan | idx_tup_fetch | n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup 
+------------+--------------+----------+--------------+----------+---------------+-----------+-----------+-----------+---------------+------------+------------
+ public     | pg_stat_test |        0 |            0 |          |               |         0 |         0 |         0 |             0 |          0 |          0
+(1 row)
+
+select
+    schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd,
+    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup
+from pg_stat_user_tables where relname = 'pg_stat_test';
+ schemaname |   relname    | seq_scan | seq_tup_read | idx_scan | idx_tup_fetch | n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup 
+------------+--------------+----------+--------------+----------+---------------+-----------+-----------+-----------+---------------+------------+------------
+ public     | pg_stat_test |        0 |            0 |          |               |         0 |         0 |         0 |             0 |          0 |          0
+(1 row)
+
+select
+    schemaname, relname, indexrelname, idx_scan, idx_tup_read, idx_tup_fetch
+from pg_stat_all_indexes where relname = 'pg_stat_test';
+ schemaname | relname | indexrelname | idx_scan | idx_tup_read | idx_tup_fetch 
+------------+---------+--------------+----------+--------------+---------------
+(0 rows)
+
+select
+    schemaname, relname, indexrelname, idx_scan, idx_tup_read, idx_tup_fetch
+from pg_stat_user_indexes where relname = 'pg_stat_test';
+ schemaname | relname | indexrelname | idx_scan | idx_tup_read | idx_tup_fetch 
+------------+---------+--------------+----------+--------------+---------------
+(0 rows)
+
+insert into pg_stat_test select * from generate_series(1, 100);
+create index pg_stat_user_table_index on pg_stat_test(a);
+select count(*) from pg_stat_test;
+ count 
+-------
+   100
+(1 row)
+
+delete from pg_stat_test where a < 10;
+update pg_stat_test set a = 1000 where a > 90;
+set enable_seqscan to off;
+select pg_sleep(10);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+select * from pg_stat_test where a = 1;
+ a 
+---
+(0 rows)
+
+reset enable_seqscan;
+select
+    schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd,
+    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup
+from pg_stat_all_tables where relname = 'pg_stat_test';
+ schemaname |   relname    | seq_scan | seq_tup_read | idx_scan | idx_tup_fetch | n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup 
+------------+--------------+----------+--------------+----------+---------------+-----------+-----------+-----------+---------------+------------+------------
+ public     | pg_stat_test |       12 |          391 |        1 |             0 |       110 |         0 |        19 |             0 |         91 |         19
+(1 row)
+
+select
+    schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd,
+    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup
+from pg_stat_user_tables where relname = 'pg_stat_test';
+ schemaname |   relname    | seq_scan | seq_tup_read | idx_scan | idx_tup_fetch | n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup 
+------------+--------------+----------+--------------+----------+---------------+-----------+-----------+-----------+---------------+------------+------------
+ public     | pg_stat_test |       12 |          391 |        1 |             0 |       110 |         0 |        19 |             0 |         91 |         19
+(1 row)
+
+select
+    schemaname, relname, indexrelname, idx_scan, idx_tup_read, idx_tup_fetch
+from pg_stat_all_indexes where relname = 'pg_stat_test';
+ schemaname |   relname    |       indexrelname       | idx_scan | idx_tup_read | idx_tup_fetch 
+------------+--------------+--------------------------+----------+--------------+---------------
+ public     | pg_stat_test | pg_stat_user_table_index |        1 |            1 |             0
+(1 row)
+
+select
+    schemaname, relname, indexrelname, idx_scan, idx_tup_read, idx_tup_fetch
+from pg_stat_user_indexes where relname = 'pg_stat_test';
+ schemaname |   relname    |       indexrelname       | idx_scan | idx_tup_read | idx_tup_fetch 
+------------+--------------+--------------------------+----------+--------------+---------------
+ public     | pg_stat_test | pg_stat_user_table_index |        1 |            1 |             0
+(1 row)
+
+reset optimizer;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -136,7 +136,7 @@ test: resource_group_gucs
 test: wrkloadadmin
 
 # expand_table tests may affect the result of 'gp_explain', keep them below that
-test: gp_toolkit_ao_funcs trig auth_constraint role portals_updatable plpgsql_cache timeseries pg_stat_last_operation pg_stat_last_shoperation gp_numeric_agg partindex_test partition_pruning runtime_stats expand_table expand_table_ao expand_table_aoco expand_table_regression
+test: gp_toolkit_ao_funcs trig auth_constraint role portals_updatable plpgsql_cache timeseries pg_stat pg_stat_last_operation pg_stat_last_shoperation gp_numeric_agg partindex_test partition_pruning runtime_stats expand_table expand_table_ao expand_table_aoco expand_table_regression
 test: rle rle_delta dsp not_out_of_shmem_exit_slots
 
 # direct dispatch tests

--- a/src/test/regress/sql/pg_stat.sql
+++ b/src/test/regress/sql/pg_stat.sql
@@ -1,0 +1,53 @@
+set optimizer to off;
+drop table  if exists pg_stat_test;
+create table pg_stat_test(a int);
+
+select
+    schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd,
+    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup
+from pg_stat_all_tables where relname = 'pg_stat_test';
+select
+    schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd,
+    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup
+from pg_stat_user_tables where relname = 'pg_stat_test';
+select
+    schemaname, relname, indexrelname, idx_scan, idx_tup_read, idx_tup_fetch
+from pg_stat_all_indexes where relname = 'pg_stat_test';
+select
+    schemaname, relname, indexrelname, idx_scan, idx_tup_read, idx_tup_fetch
+from pg_stat_user_indexes where relname = 'pg_stat_test';
+
+insert into pg_stat_test select * from generate_series(1, 100);
+
+create index pg_stat_user_table_index on pg_stat_test(a);
+
+select count(*) from pg_stat_test;
+
+delete from pg_stat_test where a < 10;
+
+update pg_stat_test set a = 1000 where a > 90;
+
+set enable_seqscan to off;
+
+select pg_sleep(10);
+
+select * from pg_stat_test where a = 1;
+
+reset enable_seqscan;
+
+select
+    schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd,
+    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup
+from pg_stat_all_tables where relname = 'pg_stat_test';
+select
+    schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd,
+    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup
+from pg_stat_user_tables where relname = 'pg_stat_test';
+select
+    schemaname, relname, indexrelname, idx_scan, idx_tup_read, idx_tup_fetch
+from pg_stat_all_indexes where relname = 'pg_stat_test';
+select
+    schemaname, relname, indexrelname, idx_scan, idx_tup_read, idx_tup_fetch
+from pg_stat_user_indexes where relname = 'pg_stat_test';
+
+reset optimizer;


### PR DESCRIPTION
In the past, these system views only counted the values on each segment,
and the master value was 0. We add some new views to gather the value from
segment to master.

Co-authored-by: Zhenghua Lyu <kainwen@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
