### PR TITLE
Get gpfdist's lib specification back

### DIFF
--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -20,6 +20,7 @@ ifeq ($(PORTNAME),aix)
 endif
 
 ifeq ($(have_yaml),yes)
+  GPFDIST_LIBS += -lyaml
   OBJS += transform.o
   ifneq ($(PORTNAME),win32)
     override CPPFLAGS := -DGPFXDIST $(CPPFLAGS)


### PR DESCRIPTION
Top level configure only sets the `have_yaml`, but doesn't add `-lyaml`
to LIBS. Check out this commit:

```
commit a1ecb3e3cba15c47ed8a821b78cf6c4640b0536a
Author: Marbin Tan <mtan@pivotal.io>
Date:   Wed Mar 16 09:59:02 2016 -0700

    Remove gpfdist library dependencies on the top level.

    We do not need to link all of the gpfdist libraries to
    the backend. Make sure that gpfdist is the only one who uses
    libyaml, libevent, and libapr-1 for now.
```
