### PR TITLE
Speed up stats derivation for large number of disjunction in ORCA

### DIFF
--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
@@ -206,18 +206,6 @@ namespace gpnaucrates
 				)
 				const;
 
-			// create a new histogram with updated bucket frequency
-			CHistogram *MakeHistogramUpdateFreq
-						(
-						const CBucketArray *histogram_buckets,
-						CDoubleArray *dest_bucket_freqs,
-						CDouble *num_output_rows,
-						CDouble num_null_rows,
-						CDouble num_NDV_remain,
-						CDouble num_NDV_remain_rows
-						)
-						const;
-
 		public:
 
 			// ctors


### PR DESCRIPTION
This bug is particularly evident with queries containing a large array
IN clause, e.g "a IN (1, 3, 5, ...)".

As a first step to improve optimization times for such queries, this
commit reduces unnecessary re-allocation of histogram buckets during the
merging of statistics of disjunctive predicates.

It improves the performance of the target query with 7000 elements in
the array comparison by around 50%.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
