### PR TITLE
Use memchr instead of strchr inside cdbexplain_formatExtraText()

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1259,7 +1259,7 @@ cdbexplain_formatExtraText(StringInfo str,
 	/* Could be more than one line... */
 	while (cp < ep)
 	{
-		const char *nlp = strchr(cp, '\n');
+		const char *nlp = memchr(cp, '\n', ep - cp);
 		const char *dp = nlp ? nlp : ep;
 
 		/* Strip trailing whitespace. */


### PR DESCRIPTION
Earlier, we used strchr() to seek out the newline in
cdbexplain_formatExtraText(). What we didn't consider that the newline
could be located beyond notelen.

This led to issues such as the following incorrect extra text report in
EXPLAIN ANALYZE output:

```
Extra Text: (seg1)   Hash chain length 2.1 avg, 5 max, using 21 of 32
buckets; total 0 expansions.123 groups total in 32 batches; 1 overflows;
123 spill groups.
```
when the output should have been:
```
Extra Text: (seg1)   Hash chain length 2.1 avg, 5 max, using 21 of 32
buckets; total 0 expansions.
```

Co-authored-by: Jesse Zhang<jzhang@pivotal.io>