### PR TITLE
Fix ccnt overflow in gpperfmon

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpsmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpsmon.c
@@ -105,7 +105,7 @@ struct gx_t
 typedef struct qexec_agg_hash_key_t {
 	apr_int32_t tmid;	/* transaction time */
 	apr_int32_t ssid;	/* session id */
-	apr_int16_t ccnt;	/* command count */
+	apr_int32_t ccnt;	/* command count */
 	apr_int16_t nid;	/* plan node id */
 }qexec_agg_hash_key_t;
 

--- a/gpcontrib/gp_internal_tools/gp_instrument_shmem.c
+++ b/gpcontrib/gp_internal_tools/gp_instrument_shmem.c
@@ -101,7 +101,7 @@ next_used_slot(int32 *crtIndexPtr)
  * CREATE FUNCTION gp_instrument_shmem_detail()
  *   RETURNS TABLE ( tmid int4
  *   				,ssid int4
- *   				,ccnt int2
+ *   				,ccnt int4
  *   				,segid int2
  *   				,pid int4
  *   				,nid int2
@@ -130,7 +130,7 @@ gp_instrument_shmem_detail(PG_FUNCTION_ARGS)
 
 		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "tmid", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "ssid", INT4OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "ccnt", INT2OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "ccnt", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "segid", INT2OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 5, "pid", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 6, "nid", INT2OID, -1, 0);
@@ -164,7 +164,7 @@ gp_instrument_shmem_detail(PG_FUNCTION_ARGS)
 
 		values[0] = Int32GetDatum((slot->tmid));
 		values[1] = Int32GetDatum(slot->ssid);
-		values[2] = Int16GetDatum(slot->ccnt);
+		values[2] = Int32GetDatum(slot->ccnt);
 		values[3] = Int16GetDatum(slot->segid);
 		values[4] = Int32GetDatum(slot->pid);
 		values[5] = Int16GetDatum(slot->nid);

--- a/src/include/gpmon/gpmon.h
+++ b/src/include/gpmon/gpmon.h
@@ -192,7 +192,7 @@ typedef struct gpmon_qexec_hash_key_t {
 typedef struct gpmon_qexeckey_t {
     int32 tmid;  /* transaction time */
     int32 ssid; /* session id */
-    int16 ccnt;	/* command count */
+    int32 ccnt;	/* command count */
     gpmon_qexec_hash_key_t hash_key;
 }gpmon_qexeckey_t;
 

--- a/src/test/isolation2/expected/instr_in_shmem_terminate.out
+++ b/src/test/isolation2/expected/instr_in_shmem_terminate.out
@@ -26,7 +26,7 @@ CREATE
 GRANT EXECUTE ON FUNCTION gp_instrument_shmem_detail_f() TO public;
 GRANT
 
-CREATE VIEW gp_instrument_shmem_detail AS WITH all_entries AS ( SELECT C.* FROM __gp_localid, gp_instrument_shmem_detail_f() as C ( tmid int4,ssid int4,ccnt int2,segid int2,pid int4 ,nid int2,tuplecount int8,nloops int8,ntuples int8 ) UNION ALL SELECT C.* FROM __gp_masterid, gp_instrument_shmem_detail_f() as C ( tmid int4,ssid int4,ccnt int2,segid int2,pid int4 ,nid int2,tuplecount int8,nloops int8,ntuples int8 )) SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples FROM all_entries ORDER BY segid;
+CREATE VIEW gp_instrument_shmem_detail AS WITH all_entries AS ( SELECT C.* FROM __gp_localid, gp_instrument_shmem_detail_f() as C ( tmid int4,ssid int4,ccnt int4,segid int2,pid int4 ,nid int2,tuplecount int8,nloops int8,ntuples int8 ) UNION ALL SELECT C.* FROM __gp_masterid, gp_instrument_shmem_detail_f() as C ( tmid int4,ssid int4,ccnt int4,segid int2,pid int4 ,nid int2,tuplecount int8,nloops int8,ntuples int8 )) SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples FROM all_entries ORDER BY segid;
 CREATE
 
 CREATE TABLE a (id int, c char) DISTRIBUTED BY (id);

--- a/src/test/isolation2/sql/instr_in_shmem_terminate.sql
+++ b/src/test/isolation2/sql/instr_in_shmem_terminate.sql
@@ -32,13 +32,13 @@ CREATE VIEW gp_instrument_shmem_detail AS
 WITH all_entries AS (
   SELECT C.*
     FROM __gp_localid, gp_instrument_shmem_detail_f() as C (
-      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      tmid int4,ssid int4,ccnt int4,segid int2,pid int4
       ,nid int2,tuplecount int8,nloops int8,ntuples int8
     )
   UNION ALL
   SELECT C.*
     FROM __gp_masterid, gp_instrument_shmem_detail_f() as C (
-      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      tmid int4,ssid int4,ccnt int4,segid int2,pid int4
       ,nid int2,tuplecount int8,nloops int8,ntuples int8
     ))
 SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples

--- a/src/test/regress/expected/instr_in_shmem.out
+++ b/src/test/regress/expected/instr_in_shmem.out
@@ -74,13 +74,13 @@ CREATE VIEW gp_instrument_shmem_detail AS
 WITH all_entries AS (
   SELECT C.*
     FROM __gp_localid, gp_instrument_shmem_detail_f() as C (
-      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      tmid int4,ssid int4,ccnt int4,segid int2,pid int4
       ,nid int2,tuplecount int8,nloops int8,ntuples int8
     )
   UNION ALL
   SELECT C.*
     FROM __gp_masterid, gp_instrument_shmem_detail_f() as C (
-      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      tmid int4,ssid int4,ccnt int4,segid int2,pid int4
       ,nid int2,tuplecount int8,nloops int8,ntuples int8
     ))
 SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples

--- a/src/test/regress/expected/instr_in_shmem_verify.out
+++ b/src/test/regress/expected/instr_in_shmem_verify.out
@@ -31,13 +31,13 @@ CREATE VIEW gp_instrument_shmem_detail AS
 WITH all_entries AS (
   SELECT C.*
     FROM __gp_localid, gp_instrument_shmem_detail_f() as C (
-      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      tmid int4,ssid int4,ccnt int4,segid int2,pid int4
       ,nid int2,tuplecount int8,nloops int8,ntuples int8
     )
   UNION ALL
   SELECT C.*
     FROM __gp_masterid, gp_instrument_shmem_detail_f() as C (
-      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      tmid int4,ssid int4,ccnt int4,segid int2,pid int4
       ,nid int2,tuplecount int8,nloops int8,ntuples int8
     ))
 SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples

--- a/src/test/regress/sql/instr_in_shmem.sql
+++ b/src/test/regress/sql/instr_in_shmem.sql
@@ -62,13 +62,13 @@ CREATE VIEW gp_instrument_shmem_detail AS
 WITH all_entries AS (
   SELECT C.*
     FROM __gp_localid, gp_instrument_shmem_detail_f() as C (
-      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      tmid int4,ssid int4,ccnt int4,segid int2,pid int4
       ,nid int2,tuplecount int8,nloops int8,ntuples int8
     )
   UNION ALL
   SELECT C.*
     FROM __gp_masterid, gp_instrument_shmem_detail_f() as C (
-      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      tmid int4,ssid int4,ccnt int4,segid int2,pid int4
       ,nid int2,tuplecount int8,nloops int8,ntuples int8
     ))
 SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples

--- a/src/test/regress/sql/instr_in_shmem_verify.sql
+++ b/src/test/regress/sql/instr_in_shmem_verify.sql
@@ -33,13 +33,13 @@ CREATE VIEW gp_instrument_shmem_detail AS
 WITH all_entries AS (
   SELECT C.*
     FROM __gp_localid, gp_instrument_shmem_detail_f() as C (
-      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      tmid int4,ssid int4,ccnt int4,segid int2,pid int4
       ,nid int2,tuplecount int8,nloops int8,ntuples int8
     )
   UNION ALL
   SELECT C.*
     FROM __gp_masterid, gp_instrument_shmem_detail_f() as C (
-      tmid int4,ssid int4,ccnt int2,segid int2,pid int4
+      tmid int4,ssid int4,ccnt int4,segid int2,pid int4
       ,nid int2,tuplecount int8,nloops int8,ntuples int8
     ))
 SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples


### PR DESCRIPTION
For some reason `gpmon_qexeckey_t` structure used `int16` for `ccnt` while all other GP code operates `int32`. This problem can cause `ccnt` overflow in `gpperfmon` packets.

This problem doesn't affect `master` branch as `gpperfmon` code have been removed from it. But it seems to affect `6X_STABLE` and `5X_STABLE` branches.