### PR TITLE
Set the libraries of gpfdist and gpmapreduce at the top level

### DIFF
--- a/configure
+++ b/configure
@@ -664,6 +664,8 @@ CURL_LIBS
 CURL_CFLAGS
 CURL_CONFIG
 have_yaml
+YAML_LIBS
+EVENT_LIBS
 apr_cppflags
 apr_cflags
 apr_link_ld_libs
@@ -11766,7 +11768,9 @@ else
   as_fn_error $? "libapr-1 is required by gpfdist" "$LINENO" 5
 fi
 
+  LIBS="$_LIBS"
 
+  _LIBS="$LIBS"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing event_add" >&5
 $as_echo_n "checking for library containing event_add... " >&6; }
 if ${ac_cv_search_event_add+:} false; then :
@@ -11825,6 +11829,8 @@ else
   as_fn_error $? "libevent is required for gpfdist" "$LINENO" 5
 fi
 
+  EVENT_LIBS=" -levent"
+
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing yaml_parser_initialize" >&5
 $as_echo_n "checking for library containing yaml_parser_initialize... " >&6; }
@@ -11879,17 +11885,19 @@ $as_echo "$ac_cv_search_yaml_parser_initialize" >&6; }
 ac_res=$ac_cv_search_yaml_parser_initialize
 if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
-  have_yaml=yes
+  have_yaml=yes; YAML_LIBS=" -lyaml"
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: libyaml is not found. disabling transformations for gpfdist." >&5
 $as_echo "$as_me: WARNING: libyaml is not found. disabling transformations for gpfdist." >&2;}
 fi
 
-  LIBS="$_LIBS"
 
+
+  LIBS="$_LIBS"
 fi
 
-if test "$enable_mapreduce" = yes; then
+if test "$enable_mapreduce" = yes ; then
+  _LIBS="$LIBS"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing yaml_parser_initialize" >&5
 $as_echo_n "checking for library containing yaml_parser_initialize... " >&6; }
 if ${ac_cv_search_yaml_parser_initialize+:} false; then :
@@ -11943,12 +11951,14 @@ $as_echo "$ac_cv_search_yaml_parser_initialize" >&6; }
 ac_res=$ac_cv_search_yaml_parser_initialize
 if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
-  have_yaml=yes
+  have_yaml=yes; YAML_LIBS=" -lyaml"
 else
   as_fn_error $? "libyaml is required for Greenplum Mapreduce" "$LINENO" 5
 fi
 
 
+
+  LIBS="$_LIBS"
 fi
 
 if test "$with_openssl" = yes ; then

--- a/configure.in
+++ b/configure.in
@@ -1486,20 +1486,28 @@ AC_DEFUN([CHECK_APR], [
   _LIBS="$LIBS"
   LIBS="$LIBS $apr_link_ld_libs"
   AC_SEARCH_LIBS(apr_getopt_long, [apr-1], [], [AC_MSG_ERROR([libapr-1 is required by gpfdist])])
+  LIBS="$_LIBS"
  ])
 
 if test "$enable_gpfdist" = yes ; then
   CHECK_APR()
+  _LIBS="$LIBS"
   AC_SEARCH_LIBS(event_add, [event], [], [AC_MSG_ERROR([libevent is required for gpfdist])])
+  EVENT_LIBS=" -levent"
+  AC_SUBST(EVENT_LIBS)
 
-  AC_SEARCH_LIBS(yaml_parser_initialize, [yaml], [have_yaml=yes], [AC_MSG_WARN([libyaml is not found. disabling transformations for gpfdist.])])
-  LIBS="$_LIBS"
+  AC_SEARCH_LIBS(yaml_parser_initialize, [yaml], [have_yaml=yes; YAML_LIBS=" -lyaml"], [AC_MSG_WARN([libyaml is not found. disabling transformations for gpfdist.])])
+  AC_SUBST(YAML_LIBS)
   AC_SUBST(have_yaml)
+  LIBS="$_LIBS"
 fi
 
-if test "$enable_mapreduce" = yes; then
-  AC_SEARCH_LIBS(yaml_parser_initialize, [yaml], [have_yaml=yes], [AC_MSG_ERROR([libyaml is required for Greenplum Mapreduce])])
+if test "$enable_mapreduce" = yes ; then
+  _LIBS="$LIBS"
+  AC_SEARCH_LIBS(yaml_parser_initialize, [yaml], [have_yaml=yes; YAML_LIBS=" -lyaml"], [AC_MSG_ERROR([libyaml is required for Greenplum Mapreduce])])
+  AC_SUBST(YAML_LIBS)
   AC_SUBST(have_yaml)
+  LIBS="$_LIBS"
 fi
 
 if test "$with_openssl" = yes ; then

--- a/gpcontrib/gpmapreduce/Makefile
+++ b/gpcontrib/gpmapreduce/Makefile
@@ -22,6 +22,8 @@ include $(top_srcdir)/src/Makefile.shlib
 
 override CPPFLAGS += -I$(SRCDIR) -I$(INCDIR) -I$(libpq_srcdir)
 
+LIBS += $(YAML_LIBS)
+
 # Disable -Wimplicit-fallthrough for this module, since it is hard to change some
 # macros using switch-case.
 # -Wimplicit-fallthrough is appended to CFLAGS, so we append it to CFLAGS as well.

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -243,8 +243,10 @@ PTHREAD_CFLAGS		= @PTHREAD_CFLAGS@
 PTHREAD_LIBS		= @PTHREAD_LIBS@
 
 have_yaml 		= @have_yaml@
+YAML_LIBS		= @YAML_LIBS@
 with_zstd 		= @with_zstd@
 with_quicklz		= @with_quicklz@
+EVENT_LIBS		= @EVENT_LIBS@
 
 
 ##########################################################################

--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -13,9 +13,6 @@ OBJS = gpfdist.o gpfdist_helper.o fstream.o gfile.o
 GPFDIST_LIBS = $(EVENT_LIBS)
 
 ifeq ($(PORTNAME),aix)
-  ifeq ($(with_libbz2),yes)
-    GPFDIST_LIBS += -lbz2
-  endif
   GPFDIST_LIBS += -lbsd
 endif
 

--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -10,7 +10,7 @@ OBJS = gpfdist.o gpfdist_helper.o fstream.o gfile.o
 # we are adding the gpfdist libraries here instead
 # of the top level, so that the backend does not
 # need to link with unnecessary libraries.
-GPFDIST_LIBS =-levent
+GPFDIST_LIBS = $(EVENT_LIBS)
 
 ifeq ($(PORTNAME),aix)
   ifeq ($(with_libbz2),yes)
@@ -21,6 +21,7 @@ endif
 
 ifeq ($(have_yaml),yes)
   OBJS += transform.o
+  LIBS += $(YAML_LIBS)
   ifneq ($(PORTNAME),win32)
     override CPPFLAGS := -DGPFXDIST $(CPPFLAGS)
   endif


### PR DESCRIPTION
Before this the top level configure only sets the have_yaml, but doesn't
add -lyaml to LIBS for gpfdist or gpmapreduce.

Let Autoconf resolve all the relevant libraries here and place them in
$XXX_LIBS variables.

Signed-off-by: Adam Lee <ali@pivotal.io>