### PR TITLE
Fix GPORCA compilation error

### DIFF
--- a/src/backend/gporca/gporca.mk
+++ b/src/backend/gporca/gporca.mk
@@ -5,4 +5,4 @@ override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(
 # Do not omit frame pointer. Even with RELEASE builds, it is used for
 # backtracing.
 override CPPFLAGS := -Werror -Wextra -Wpedantic -Wno-variadic-macros -fno-omit-frame-pointer $(CPPFLAGS)
-override CPPFLAGS := -std=gnu++98 $(CPPFLAGS)
+override CPPFLAGS := -std=gnu++11 $(CPPFLAGS)


### PR DESCRIPTION
I was getting this error on my laptop:

```
ccache g++ -g3 -ggdb -Wall -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-but-set-variable -Werror=implicit-fallthrough=3 -Wno-format-truncation -Wno-stringop-truncation -g -ggdb -fprofile-arcs -ftest-coverage -O0 -Wmisleading-indentation -Wno-format-truncation -Wno-stringop-overflow -Wunused-result -std=gnu++98 -Werror -Wextra -Wpedantic -Wno-variadic-macros -fno-omit-frame-pointer -I../../../../../src/backend/gporca/libgpdbcost/include -I../../../../../src/backend/gporca/libnaucrates/include -I../../../../../src/backend/gporca/libgpopt/include -I../../../../../src/backend/gporca/libgpos/include -I../../../../../src/include -D_GNU_SOURCE -I/usr/include/libxml2  -c -o CCostModelGPDB.o CCostModelGPDB.cpp -MMD -MP -MF .deps/CCostModelGPDB.Po
In file included from /usr/include/c++/8/cstdint:35,
                 from /usr/include/xercesc/util/Xerces_autoconf_config.hpp:92,
                 from /usr/include/xercesc/util/XercesDefs.hpp:46,
                 from /usr/include/xercesc/util/XMLUniDefs.hpp:25,
                 from ../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h:21,
                 from ../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/CXMLSerializer.h:21,
                 from ../../../../../src/backend/gporca/libnaucrates/include/naucrates/md/CGPDBTypeHelper.h:17,
                 from ../../../../../src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeBoolGPDB.h:21,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/operators/CScalarConst.h:21,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h:24,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h:16,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h:22,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h:23,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h:23,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h:26,
                 from CCostModelGPDB.cpp:17:
/usr/include/c++/8/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support \
  ^~~~~
In file included from /usr/include/xercesc/util/XercesDefs.hpp:46,
                 from /usr/include/xercesc/util/XMLUniDefs.hpp:25,
                 from ../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h:21,
                 from ../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/CXMLSerializer.h:21,
                 from ../../../../../src/backend/gporca/libnaucrates/include/naucrates/md/CGPDBTypeHelper.h:17,
                 from ../../../../../src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeBoolGPDB.h:21,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/operators/CScalarConst.h:21,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h:24,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h:16,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h:22,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h:23,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h:23,
                 from ../../../../../src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h:26,
                 from CCostModelGPDB.cpp:17:
```

Asim R P reported this error first, with this fix, on the greenplum Slack.
Jesse said on the same discussion that this changes the behavior with
exception-throwing destructors:

> this patch has undesired consequences, specifically around
> exception-throwing destructors: C++11 onward by default marks
> destructors as noexcept(true) , while C++ 98 defaults to throwing

I'm not sure what that means for ORCA. But I'd like ORCA to compile.
I don't think we have any destructors that throw exceptions. At a quick
grep, I don't see any obvious examples of that, and all the tests are
passing.
