### PR TITLE
docs - add dblink connection string example with sslmode

### DIFF
--- a/gpdb-doc/dita/ref_guide/modules/dblink.xml
+++ b/gpdb-doc/dita/ref_guide/modules/dblink.xml
@@ -162,13 +162,24 @@ testdb=# <b>GRANT EXECUTE ON FUNCTION dblink_connect_u(text, text) TO test_user;
             table.<codeblock>testdb=> <b>SELECT * FROM dblink('testconn', 'SELECT * FROM testdblink') AS dbltab(id int, product text);</b></codeblock></li>
         </ol>
       </section>
+      <section id="dblink_ssl">
+        <title>Using dblink with SSL-Encrypted Connections to Greenplum</title>
+        <p>When you use <codeph>dblink</codeph> to connect to Greenplum Database
+          over an encrypted connection, you must specify the <codeph>sslmode</codeph>
+          property in the connection string. Set <codeph>sslmode</codeph> to at
+          least <codeph>require</codeph> to disallow unencrypted transfers. For example:</p>
+        <codeblock>testdb=# SELECT dblink_connect('greenplum_con_sales', 'dbname=sales host=gpmaster user=gpadmin sslmode=require');</codeblock>
+        <p>Refer to <xref href="../../security-guide/topics/Authenticate.xml#topic_fzv_wb2_jr/ssl_postgresql"
+          format="dita" scope="peer">SSL Client Authentication</xref> for
+          information about configuring Greenplum Database to use SSL.</p>
+      </section>
     </body>
   </topic>
   <topic id="topic_info">
     <title>Additional Module Documentation</title>
     <body>
-      <p>Refer to <xref href="https://www.postgresql.org/docs/9.4/dblink.html" format="html"
-        scope="external">dblink</xref> in the PostgreSQL documentation for detailed
+      <p>Refer to the <xref href="https://www.postgresql.org/docs/9.4/dblink.html" format="html"
+        scope="external">dblink</xref> PostgreSQL documentation for detailed
         information about the individual functions in this module.</p>
     </body>
   </topic>

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -546,11 +546,14 @@ Hostssl testdb all 192.168.0.0/16 cert map=gpuser
         <title>Configuring the SSL Client Connection</title>
       </section>
       <p>SSL options:<parml>
+        <plentry>
+            <pt>sslmode</pt>
+            <pd>Specifies the level of protection.<parml>
           <plentry>
             <pt>
               <codeph>require</codeph>
             </pt>
-            <pd>Only use SSL connection. If a root CA file is present, verify the certificate in the
+            <pd>Only use an SSL connection. If a root CA file is present, verify the certificate in the
               same way as if <codeph>verify-ca</codeph> was specified.</pd>
           </plentry>
           <plentry>
@@ -567,6 +570,8 @@ Hostssl testdb all 192.168.0.0/16 cert map=gpuser
             <pd>Only use an SSL connection. Verify that the server certificate is issued by a
               trusted CA and that the server host name matches that in the certificate.</pd>
           </plentry>
+         </parml></pd>
+        </plentry>
           <plentry>
             <pt>sslcert</pt>
             <pd>The file name of the client SSL certificate. The default is


### PR DESCRIPTION
in this PR:
- add an dblink connection string example with sslmode. 
- a few misc edits to related client authentication topic
