### PR TITLE
docs - make finding upgrade & migration info easier

### DIFF
--- a/gpdb-doc/dita/install_guide/install_guide.ditamap
+++ b/gpdb-doc/dita/install_guide/install_guide.ditamap
@@ -35,8 +35,10 @@
         <topicref href="data_sci_pkgs.ditamap" format="ditamap" otherprops="pivotal"/>
         <topicref href="install_modules.xml" navtitle="Installing Additional Supplied Modules"/>
         <topicref href="localization.xml" navtitle="Configuring Localization Settings"/>
-        <topicref href="upgrading.xml"/>
-        <topicref href="migrate.xml"/>
+        <topicref href="upgrade_intro.xml" navtitle="Upgrading to Greenplum 6.x">
+          <topicref href="upgrading.xml"/>
+          <topicref href="migrate.xml"/>
+        </topicref>
         <topicref href="enable_iptables.xml" navtitle="Enabling iptables"/>
         <topicref href="apx_mgmt_utils.xml" navtitle="Installation Management Utilities"/>
         <topicref href="env_var_ref.xml" navtitle="Greenplum Environment Variables">

--- a/gpdb-doc/dita/install_guide/install_modules.xml
+++ b/gpdb-doc/dita/install_guide/install_modules.xml
@@ -28,6 +28,8 @@
                   format="dita">citext</xref></li>
               <li><xref href="../ref_guide/modules/dblink.xml" type="topic" scope="peer"
                   format="dita">dblink</xref></li>
+              <li><xref href="../ref_guide/modules/diskquota.xml" type="topic" scope="peer"
+                  format="dita">diskquota</xref></li>
               <li><xref href="../ref_guide/modules/fuzzystrmatch.xml" type="topic" scope="peer"
                   format="dita">fuzzystrmatch</xref></li>
               <li><xref href="../ref_guide/modules/gp_sparse_vector.xml" type="topic" scope="peer"

--- a/gpdb-doc/dita/install_guide/migrate.xml
+++ b/gpdb-doc/dita/install_guide/migrate.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE topic
   PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
 <topic id="topic1" xml:lang="en">
-  <title id="kh138244">Migrating Data from Greenplum 4.3 or 5</title>
+  <title id="kh138244">Migrating Data from Greenplum 4.3 or 5 to Greenplum 6</title>
   <shortdesc>You can migrate data from Greenplum Database 4.3 or 5 to Greenplum 6 using the standard
     backup and restore procedures, <codeph>gpbackup</codeph> and <codeph>gprestore</codeph><ph
       otherprops="pivotal">, or by using <codeph>gpcopy</codeph></ph>.</shortdesc>

--- a/gpdb-doc/dita/install_guide/upgrade_intro.xml
+++ b/gpdb-doc/dita/install_guide/upgrade_intro.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic_tbx_szy_kbb">
+  <title class="- topic/title ">Upgrading to Greenplum 6</title>
+  <shortdesc>This topic identifies the upgrade and <ph otherprops="pivotal">migration</ph>
+    path<ph otherprops="pivotal">s</ph> supported for the Greenplum Database
+    6.x. release.</shortdesc>
+  <body>
+    <p>Greenplum Database 6 supports upgrading from a Greenplum 6.x release to a newer
+      Greenplum 6.x release.
+      <ph otherprops="pivotal">Direct upgrade from Greenplum Database 4.3 or 5 to
+      Greenplum 6 is not supported; you must migrate the data to Greenplum 6.</ph></p>
+  </body>
+</topic>

--- a/gpdb-doc/dita/install_guide/upgrading.xml
+++ b/gpdb-doc/dita/install_guide/upgrading.xml
@@ -4,8 +4,7 @@
 <topic id="topic_tbx_szy_kbb">
   <title class="- topic/title ">Upgrading from an Earlier Greenplum 6 Release</title>
   <shortdesc>The upgrade path supported for this release is Greenplum Database 6.x to a newer
-    Greenplum Database 6.x release. <ph otherprops="pivotal">Direct upgrade from Greenplum Database
-      4 or 5 to Greenplum 6 is not supported.</ph></shortdesc>
+    Greenplum Database 6.x release.</shortdesc>
   <body class="- topic/body ">
     <note type="important">Set the Greenplum Database timezone to a value that is compatible with
       your host systems. Setting the Greenplum Database timezone prevents Greenplum Database from


### PR DESCRIPTION
attempt to make finding upgrade and migration info a bit easier by relating the two topics.

in this PR:
- add a landing page for upgrade (6->6 upgrade, 4/5->6 migration), then link off to the existing upgrade and migration pages
- nest upgrade and migration in the left subnav

the PR also includes a misc unrelated edit to include diskquota in the list of additional supplied modules that use CREATE EXTENSION for registering.