### PR TITLE
Fix possible crash in COPY FORM on QEs

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -5558,7 +5558,6 @@ retry:
 		MemoryContext oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
 
 		resultRelInfo = targetid_get_partition(frame.relid, estate, true);
-		estate->es_result_relation_info = resultRelInfo;
 		slot = reconstructPartitionTupleSlot(baseSlot, resultRelInfo);
 
 		MemoryContextSwitchTo(oldcontext);
@@ -5670,6 +5669,7 @@ retry:
 		goto retry;
 
 	ExecStoreVirtualTuple(slot);
+	estate->es_result_relation_info = resultRelInfo;
 
 	/*
 	 * Here we should compute defaults for any columns for which we didn't

--- a/src/test/regress/expected/gpcopy_dispatch.out
+++ b/src/test/regress/expected/gpcopy_dispatch.out
@@ -121,3 +121,18 @@ SELECT tableoid::regclass, count(*) FROM partdisttest GROUP BY 1;
  partdisttest_1_prt_primero | 10001
 (1 row)
 
+DROP TABLE partdisttest;
+-- Log errors on QEs
+CREATE TABLE partdisttest(id INT, t TIMESTAMP, d VARCHAR(4))
+  DISTRIBUTED BY (id)
+  PARTITION BY RANGE (t)
+  (
+    PARTITION p2020 START ('2020-01-01'::TIMESTAMP) END ('2021-01-01'::TIMESTAMP),
+    DEFAULT PARTITION extra
+  );
+NOTICE:  CREATE TABLE will create partition "partdisttest_1_prt_extra" for table "partdisttest"
+NOTICE:  CREATE TABLE will create partition "partdisttest_1_prt_p2020" for table "partdisttest"
+COPY partdisttest FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 2;
+INFO:  first field processed in the QE: 2
+NOTICE:  found 1 data formatting errors (1 or more input rows), rejected related input data
+DROP TABLE partdisttest;

--- a/src/test/regress/sql/gpcopy_dispatch.sql
+++ b/src/test/regress/sql/gpcopy_dispatch.sql
@@ -132,3 +132,20 @@ COPY (
 COPY partdisttest FROM '/tmp/ten-thousand-and-one-lines.txt';
 
 SELECT tableoid::regclass, count(*) FROM partdisttest GROUP BY 1;
+DROP TABLE partdisttest;
+
+-- Log errors on QEs
+CREATE TABLE partdisttest(id INT, t TIMESTAMP, d VARCHAR(4))
+  DISTRIBUTED BY (id)
+  PARTITION BY RANGE (t)
+  (
+    PARTITION p2020 START ('2020-01-01'::TIMESTAMP) END ('2021-01-01'::TIMESTAMP),
+    DEFAULT PARTITION extra
+  );
+
+COPY partdisttest FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 2;
+1	'2020-04-15'	abcde
+1	'2020-04-15'	abc
+\.
+
+DROP TABLE partdisttest;


### PR DESCRIPTION
Target partitions need new ResultRelInfos and override previous
estate->es_result_relation_info in NextCopyFromExecute(). The
new ResultRelInfo may leave its resultSlot as NULL. If sreh is
on, the parsing errors will be caught and loop back to parse
another row; however, the estate->es_result_relation_info was
already changed. This can cause crash.

Reproduce:

```sql
CREATE TABLE partdisttest(id INT, t TIMESTAMP, d VARCHAR(4))
DISTRIBUTED BY (id)
PARTITION BY RANGE (t)
(
  PARTITION p2020 START ('2020-01-01'::TIMESTAMP) END ('2021-01-01'::TIMESTAMP),
  DEFAULT PARTITION extra
);

COPY partdisttest FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 2;
1	'2020-04-15'	abcde
1	'2020-04-15'	abc
\.
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
