### PR TITLE
WIP: Build ORCA with C++14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,8 @@ matrix:
             homebrew:
               packages:
                 - ccache
+          before_install:
+            - PATH=/usr/local/opt/ccache/libexec:$PATH
         #
         # Configuration variations
         # ----------------------------------------------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,8 @@ matrix:
         - os: osx
           compiler: clang
           osx_image: xcode11
-          env: T=macos
+          env:
+            - T=macos C="--with-includes=$(brew --prefix xerces-c)/include --with-libs=$(brew --prefix xerces-c)/lib"
           addons:
             homebrew:
               packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
             - gcc-8
             - libxml2
             - libxml2-dev
+            - libxerces-c-dev
             - libevent-dev
             - libperl-dev
             - g++-8
@@ -73,6 +74,7 @@ matrix:
             homebrew:
               packages:
                 - ccache
+                - xerces-c
           before_install:
             - PATH=/usr/local/opt/ccache/libexec:$PATH
         #
@@ -144,7 +146,7 @@ script:
             --enable-debug-extensions \
             --with-perl \
             --with-python \
-            --disable-orca \
+            --enable-orca \
             --with-openssl \
             --with-ldap \
             --with-libcurl \
@@ -188,7 +190,7 @@ script:
             --prefix=${TRAVIS_BUILD_DIR}/gpsql \
             --with-perl \
             --with-python \
-            --disable-orca \
+            --enable-orca \
             --enable-orafce \
             --disable-gpfdist \
             --disable-pxf \

--- a/.travis.yml
+++ b/.travis.yml
@@ -191,7 +191,7 @@ script:
             --prefix=${TRAVIS_BUILD_DIR}/gpsql \
             --with-perl \
             --with-python \
-            --enable-orca \
+            --disable-orca \
             --enable-orafce \
             --disable-gpfdist \
             --disable-pxf \

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,10 @@ matrix:
                   packages:
                       - *common_packages
                       - clang-7
+          before_install:
+            - sudo ln -sv ../../bin/ccache /usr/lib/ccache/clang-7
+            - sudo ln -sv ../../bin/ccache /usr/lib/ccache/clang++-7
+
         # macOS, XCode11
         - os: osx
           compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,7 +155,7 @@ script:
             --enable-mapreduce \
             --enable-orafce \
             $C
-        make -s install
+        travis_wait make -s -j2 install
         source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
         make -s unittest-check
         make -C gpAux/gpdemo cluster
@@ -198,7 +198,7 @@ script:
             --disable-gpcloud \
             --without-zstd \
             $C
-        make -s install
+        travis_wait 45 make -s install
         source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
         make -s unittest-check
       fi

--- a/src/backend/gporca/CMakeLists.txt
+++ b/src/backend/gporca/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 project(gpopt_master LANGUAGES CXX C)
 
-set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_STANDARD 14)
 
 # Default to shared libraries.
 option(BUILD_SHARED_LIBS "build shared libraries" ON)

--- a/src/backend/gporca/gporca.mk
+++ b/src/backend/gporca/gporca.mk
@@ -6,4 +6,4 @@ override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(
 # backtracing.
 override CXXFLAGS := -Werror -Wextra -Wpedantic -Wno-variadic-macros -fno-omit-frame-pointer $(CXXFLAGS)
 # FIXME: this really should be done in autoconf
-override CXXFLAGS := -std=gnu++98 $(CXXFLAGS)
+override CXXFLAGS := -std=gnu++14 $(CXXFLAGS)

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -331,8 +331,7 @@ namespace gpopt
 
 				SGroupAndExpression() : m_group_info(NULL), m_expr_index(gpos::ulong_max) {}
 				SGroupAndExpression(SGroupInfo *g, ULONG ix) : m_group_info(g), m_expr_index(ix) {}
-				SGroupAndExpression(const SGroupAndExpression &other) : m_group_info(other.m_group_info),
-																		  m_expr_index(other.m_expr_index) {}
+				SGroupAndExpression(const SGroupAndExpression &other) = default;
 				SExpressionInfo *GetExprInfo() const { return (*m_group_info->m_best_expr_info_array)[m_expr_index]; }
 				BOOL IsValid() { return NULL != m_group_info && gpos::ulong_max != m_expr_index; }
 				BOOL operator == (const SGroupAndExpression &other) const

--- a/src/backend/gporca/libgpos/include/gpos/common/CAutoP.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CAutoP.h
@@ -40,11 +40,10 @@ namespace gpos
 			// actual element to point to
 			T *m_object;
 						
-			// hidden copy ctor
 			CAutoP<T>
 				(
 				const CAutoP&
-				);
+				) = delete;
 
 		public:
 		

--- a/src/backend/gporca/libgpos/include/gpos/common/CAutoRg.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CAutoRg.h
@@ -36,8 +36,7 @@ namespace gpos
 			// actual element to point to
 			T *m_object_array;
 						
-			// hidden copy ctor
-			CAutoRg<T>(const CAutoRg&);
+			CAutoRg<T>(const CAutoRg&) = delete;
 
 		public:
 		

--- a/src/backend/gporca/libgpos/include/gpos/common/CDouble.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CDouble.h
@@ -111,14 +111,6 @@ namespace gpos
 				return m_d;
 			}
 
-			// assignment
-			inline CDouble& operator=(const CDouble &right)
-            {
-                this->m_d = right.m_d;
-
-                return (*this);
-            }
-
 			// arithmetic operators
 			friend CDouble operator + (const CDouble &left, const CDouble &right)
             {

--- a/src/backend/gporca/libgpos/include/gpos/common/CLink.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CLink.h
@@ -19,8 +19,7 @@ namespace gpos
 
 		private:
 
-			// no copy constructor
-			SLink(const SLink&);
+			SLink(const SLink&) = delete;
 
 		public:
 

--- a/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
@@ -63,8 +63,9 @@ namespace gpos
 				m_refs(1)
 			{}
 
+			// FIXME: should mark this noexcept in non-assert builds
 			// dtor
-			virtual ~CRefCount()
+			virtual ~CRefCount() noexcept(false)
 			{
 				// enforce strict ref-counting unless we're in a pending exception,
 				// e.g., a ctor has thrown

--- a/src/backend/gporca/libgpos/include/gpos/common/clibwrapper.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/clibwrapper.h
@@ -91,8 +91,9 @@ namespace gpos
 		// format wide character output conversion
 		INT Vswprintf(WCHAR *wcstr, SIZE_T max_len, const WCHAR * format, VA_LIST vaArgs);
 
+		// FIXME: use a more portable attribute a la pg_attribute_printf
 		// format string
-		INT Vsnprintf(CHAR *src, SIZE_T size, const CHAR *format, VA_LIST vaArgs);
+		INT Vsnprintf(CHAR *src, SIZE_T size, const CHAR *format, VA_LIST vaArgs) __attribute__((format(printf, 3, 0)));
 
 		// return string describing error number
 		void Strerror_r(INT errnum, CHAR *buf, SIZE_T buf_len);

--- a/src/backend/gporca/libgpos/include/gpos/memory/CAutoMemoryPool.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CAutoMemoryPool.h
@@ -68,8 +68,9 @@ namespace gpos
 				ELeakCheck leak_check_type = ElcExc
 				);
 
+			// FIXME: should mark this noexcept in non-assert builds
 			// dtor
-			~CAutoMemoryPool();
+			~CAutoMemoryPool() noexcept(false);
 
 			// accessor
 			CMemoryPool *Pmp() const

--- a/src/backend/gporca/libgpos/include/gpos/string/CStringStatic.h
+++ b/src/backend/gporca/libgpos/include/gpos/string/CStringStatic.h
@@ -99,11 +99,12 @@ namespace gpos
 			// appends the contents of a buffer to the current string
 			void AppendBuffer(const CHAR *buf);
 
+			// FIXME: use a more portable attribute a la pg_attribute_printf
 			// appends a formatted string
-			void AppendFormat(const CHAR *format, ...);
+			void AppendFormat(const CHAR *format, ...) __attribute__((format(printf, 2, 0)));
 
 			// appends a formatted string based on passed va list
-			void AppendFormatVA(const CHAR *format, VA_LIST va_args);
+			void AppendFormatVA(const CHAR *format, VA_LIST va_args) __attribute__((format(printf, 2, 0)));
 
 			// appends wide character string
 			void AppendConvert(const WCHAR *wc_str);

--- a/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CSyncHashtableTest.h
+++ b/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CSyncHashtableTest.h
@@ -160,6 +160,8 @@ namespace gpos
 						m_ulKey = elem.m_ulKey;
 					}
 
+					SElem& operator = (const SElem&) = default;
+
 #ifdef GPOS_DEBUG
 					static
 					BOOL IsValid

--- a/src/backend/gporca/libgpos/src/memory/CAutoMemoryPool.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CAutoMemoryPool.cpp
@@ -79,7 +79,7 @@ CAutoMemoryPool::Detach()
 //		(2) no checking while pending exception indicated and no pending exception
 //
 //---------------------------------------------------------------------------
-CAutoMemoryPool::~CAutoMemoryPool()
+CAutoMemoryPool::~CAutoMemoryPool() noexcept(false)
 {
 	if (NULL == m_mp)
 	{

--- a/src/backend/gporca/server/src/unittest/dxl/CParseHandlerCostModelTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/CParseHandlerCostModelTest.cpp
@@ -45,7 +45,7 @@ namespace
 		private:
 			CAutoMemoryPool m_amp;
 			gpos::CAutoP<CDXLMemoryManager> m_apmm;
-			std::auto_ptr<SAX2XMLReader> m_apxmlreader;
+			std::unique_ptr<SAX2XMLReader> m_apxmlreader;
 			gpos::CAutoP<CParseHandlerManager> m_apphm;
 			gpos::CAutoP<CParseHandlerCostModel> m_apphCostModel;
 


### PR DESCRIPTION
This patch makes the minimal changes to build ORCA with C++14. This
should address the grievance that ORCA cannot build with the default
Xerces headers from Debian. I've kept the CMake build system in sync
with the main Makefile. I've also made sure that all ORCA tests pass.

### Out Of Scope
What's _not_ included in this patch, but would be nice to have soon:

1. Those noexept(false) seem excessive, we should benefit from
conditionally marking more code "noexcept" at least in production.

2. Detecting whether Xerces was generated (either by autoconf or CMake)
with a compiler that's effectively running post-C++11

3. Clean up the Makefiles and move the std= flag into autoconf.

4. Work around a GCC 9 bug that crashes the loading of minidumps (I've
tested with GCC 6 to 8)

[resolves #9923]

## Here are some reminders before you submit the pull request
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Add checks (most likely in configure) to guard against Xerces that's built with C++98
- [ ] Pass Clang 10 and GCC 8 -Werror
- [ ] Enable Travis CI
- [x] Review a PR in return to support the community
