### PR TITLE
Eliminating alien nodes on master.

### DIFF
--- a/contrib/auto_explain/auto_explain.c
+++ b/contrib/auto_explain/auto_explain.c
@@ -245,6 +245,12 @@ explain_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		}
 	}
 
+	/* set eflag auto explain */
+	if (auto_explain_enabled())
+	{
+		eflags |= EXEC_FLAG_EXPLAIN;
+	}
+
 	if (prev_ExecutorStart)
 		prev_ExecutorStart(queryDesc, eflags);
 	else

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -585,7 +585,7 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
 
 	/* Select execution options */
 	if (es->analyze)
-		eflags = 0;				/* default run-to-completion flags */
+		eflags = EXEC_FLAG_EXPLAIN;
 	else
 		eflags = EXEC_FLAG_EXPLAIN_ONLY;
 	if (into)

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -499,6 +499,9 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 	if (estate->eliminateAliens && Gp_role == GP_ROLE_DISPATCH)
 	{
+		int subplanSliceId;
+		int i;
+
 		/* Explain or explain analyze needs ExecInitNode all the plan nodes on master */
 		if (eflags & (EXEC_FLAG_EXPLAIN_ONLY | EXEC_FLAG_EXPLAIN))
 			estate->eliminateAliens = false;
@@ -507,9 +510,17 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		if (queryDesc->portal_name || queryDesc->dest != None_Receiver)
 			estate->eliminateAliens = false;
 
-		/* Skip eliminating alien node on master if there exists subplan */
-		if (queryDesc->plannedstmt->subplans)
-			estate->eliminateAliens = false;
+		/* Skip eliminating alien node on master if there exists initplan */
+		for(i = 0; i < list_length(queryDesc->plannedstmt->subplans); i++)
+		{
+			subplanSliceId = queryDesc->plannedstmt->subplan_sliceIds[i];
+			if (queryDesc->plannedstmt->slices[subplanSliceId].parentIndex == -1)
+			{
+				/* subplan is initplan */
+				estate->eliminateAliens = false;
+				break;
+			}
+		}
 	}
 
 	/* If the interconnect has been set up; we need to catch any

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -148,6 +148,14 @@ static void EvalPlanQualStart(EPQState *epqstate, EState *parentestate,
 static PartitionNode *BuildPartitionNodeFromRoot(Oid relid);
 static void InitializeQueryPartsMetadata(PlannedStmt *plannedstmt, EState *estate);
 static void AdjustReplicatedTableCounts(EState *estate);
+static bool cdb_eliminate_alien_walker(Node *node, void *context);
+
+typedef struct EliminateAlienWalkerContext
+{
+	plan_tree_base_prefix base;
+	bool eliminateAliens;	/* safe to eliminate alien nodes */
+} EliminateAlienWalkerContext;
+
 
 /*
  * Note that GetUpdatedColumns() also exists in commands/trigger.c.  There does
@@ -494,13 +502,33 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	else
 		shouldDispatch = false;
 
-	/*
-	 * We don't eliminate aliens if we don't have an MPP plan
-	 * or we are executing on master.
-	 *
-	 * TODO: eliminate aliens even on master, if not EXPLAIN ANALYZE
-	 */
-	estate->eliminateAliens = execute_pruned_plan && estate->es_sliceTable && estate->es_sliceTable->hasMotions && !IS_QUERY_DISPATCHER();
+	/* We don't eliminate aliens if we don't have an MPP plan */
+	estate->eliminateAliens = execute_pruned_plan && estate->es_sliceTable && estate->es_sliceTable->hasMotions;
+
+	if (estate->eliminateAliens && Gp_role == GP_ROLE_DISPATCH)
+	{
+		Plan *planTree;
+		EliminateAlienWalkerContext ctx;
+
+		/* Explain or explain analyze needs ExecInitNode all the plan nodes on master */
+		if ((eflags & EXEC_FLAG_EXPLAIN_ONLY) || (eflags & EXEC_FLAG_EXPLAIN))
+			estate->eliminateAliens = false;
+
+		/* For cursor case, should not eliminate alien node on master */
+		if (queryDesc->portal_name || queryDesc->dest != None_Receiver)
+			estate->eliminateAliens = false;
+
+		/* 
+		 * cdb_eliminate_alien_walker to check whether eliminating alien
+		 * nodes should be disabled on master
+		 */
+		planTree = queryDesc->plannedstmt->planTree;
+		ctx.base.node = (Node *)queryDesc->plannedstmt;
+		ctx.eliminateAliens = true;
+		cdb_eliminate_alien_walker((Node *)planTree, &ctx);
+		if (!ctx.eliminateAliens)
+			 estate->eliminateAliens = false;;
+	}
 
 	/* If the interconnect has been set up; we need to catch any
 	 * errors to shut it down -- so we have to wrap InitPlan in a PG_TRY() block. */
@@ -4771,4 +4799,29 @@ AdjustReplicatedTableCounts(EState *estate)
 
 	if (containReplicatedTable)
 		estate->es_processed = estate->es_processed / numsegments;
+}
+
+/*
+ * Walker to check whether it is safe to eliminate alien node on master
+ * Currently we only check if there is initplan in plan node
+ */
+static bool
+cdb_eliminate_alien_walker(Node *node,
+					   void *context)
+{
+	EliminateAlienWalkerContext *ctx = (EliminateAlienWalkerContext *) context;
+
+	Assert(context);
+	if (node == NULL)
+		return false;
+
+	/* If plan contains initPlan, we should not eliminate alien node on master */
+	if (is_plan_node(node) && ((Plan *)node)->initPlan != NIL )
+	{
+		ctx->eliminateAliens = false;
+		return true;	/* found our node; no more visit */
+	}
+
+	/* Continue walking */
+	return plan_tree_walker(node, cdb_eliminate_alien_walker, ctx, true);
 }

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -321,7 +321,6 @@ format 'csv' ( quote as '"' header);
 NOTICE:  HEADER means that each one of the data files has a header row
 -- "
 select count(*) from ext_whois;
-NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
     23
@@ -331,35 +330,30 @@ create table v_w as select * from ext_whois;
 NOTICE:  HEADER means that each one of the data files has a header row
 -- sort distinct spill to disk/external sort
 select count(*) from (select * from v_w union select * from ext_whois) as foo;
-NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
     23
 (1 row)
 
 select count(*) from (select * from v_w union all select * from ext_whois) as foo;
-NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
     46
 (1 row)
 
 select count(*) from (select distinct * from ext_whois) as foo;
-NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
     23
 (1 row)
 
 select count(*) from (select * from ext_whois order by 1 limit 300000 offset 30000) as foo;
-NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
      0
 (1 row)
 
 select count(*) from (select * from ext_whois order by 1 limit 300000 offset 10) as foo;
-NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
     13
@@ -454,7 +448,6 @@ admin_postal_code,
 admin_country,
 rec_path,
 raw_record limit 10 offset 10;
-NOTICE:  HEADER means that each one of the data files has a header row
  source_lineno |   domain_name   
 ---------------+-----------------
            596 | 007dy.net
@@ -688,7 +681,6 @@ DROP EXTERNAL TABLE IF EXISTS ext_table_multi_locations;
 -- get an error for missing gpfdist
 --
 select count(*) from ext_whois;
-NOTICE:  HEADER means that each one of the data files has a header row
 ERROR:  connection with gpfdist failed for gpfdist://@hostname@:7070/whois.csv. effective url: http://127.0.0.1:7070/whois.csv. error code = 61 (Connection refused)  (seg1 slice1 @hostname@:50001 pid=64820)
 drop external table ext_whois;
 drop external table exttab1_gpfdist_start;

--- a/src/bin/gpfdist/regress/output/gpfdist2.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2.source
@@ -343,7 +343,6 @@ FORMAT 'csv'
 ;
 NOTICE:  HEADER means that each one of the data files has a header row
 SELECT count(*) FROM ext_lineitem;
-NOTICE:  HEADER means that each one of the data files has a header row
  count 
 -------
    255
@@ -717,7 +716,6 @@ FORMAT 'csv'
 ;
 NOTICE:  HEADER means that each one of the data files has a header row
 SELECT count(*) FROM ext_lineitem;
-NOTICE:  HEADER means that each one of the data files has a header row
    255
 
 DROP EXTERNAL TABLE ext_lineitem;

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -64,6 +64,8 @@ struct ChunkTransportState;             /* #include "cdb/cdbinterconnect.h" */
 #define EXEC_FLAG_WITH_OIDS		0x0020	/* force OIDs in returned tuples */
 #define EXEC_FLAG_WITHOUT_OIDS	0x0040	/* force no OIDs in returned tuples */
 #define EXEC_FLAG_WITH_NO_DATA	0x0080	/* rel scannability doesn't matter */
+/* CDB: explain flag to check if it is safe to eliminate alien node on master */
+#define EXEC_FLAG_EXPLAIN		0x0100
 
 
 /*

--- a/src/test/regress/expected/deadlock2.out
+++ b/src/test/regress/expected/deadlock2.out
@@ -92,6 +92,7 @@ set enable_nestloop to off;
 set Test_print_prefetch_joinqual = on;
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1);
+NOTICE:  prefetch join qual in slice 0 of plannode 3
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=25303)
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=25304)
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=25305)
@@ -109,6 +110,7 @@ NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:700
 -- for details.
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
+NOTICE:  prefetch join qual in slice 0 of plannode 3
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=74425)
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=74426)
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=74427)
@@ -120,6 +122,7 @@ NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:700
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
    and not exists (select 1 from t_subplan where t_subplan.c2=t_outer.c1);
+NOTICE:  prefetch join qual in slice 0 of plannode 3
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=74425)
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=74426)
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=74427)

--- a/src/test/regress/expected/deadlock2.out
+++ b/src/test/regress/expected/deadlock2.out
@@ -92,7 +92,6 @@ set enable_nestloop to off;
 set Test_print_prefetch_joinqual = on;
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1);
-NOTICE:  prefetch join qual in slice 0 of plannode 3
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=25303)
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=25304)
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=25305)
@@ -110,7 +109,6 @@ NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:700
 -- for details.
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and (t_inner.c1 is null or not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1));
-NOTICE:  prefetch join qual in slice 0 of plannode 3
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=74425)
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=74426)
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=74427)
@@ -122,7 +120,6 @@ NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:700
 select count(*) from t_inner right join t_outer on t_inner.c2=t_outer.c2
    and not exists (select 0 from t_subplan where t_subplan.c2=t_outer.c1)
    and not exists (select 1 from t_subplan where t_subplan.c2=t_outer.c1);
-NOTICE:  prefetch join qual in slice 0 of plannode 3
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg0 slice1 127.0.1.1:7002 pid=74425)
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg1 slice1 127.0.1.1:7003 pid=74426)
 NOTICE:  prefetch join qual in slice 1 of plannode 3  (seg2 slice1 127.0.1.1:7004 pid=74427)

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -285,12 +285,10 @@ select * from partlockt where i = 1;
 
 -- Known_opt_diff: MPP-20936
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |      mode       | locktype |  node  
--------------------------+-----------------+----------+--------
- partlockt               | AccessShareLock | relation | master
- partlockt_1_prt_1       | AccessShareLock | relation | master
- partlockt_1_prt_1_i_idx | AccessShareLock | relation | master
-(3 rows)
+ coalesce  |      mode       | locktype |  node  
+-----------+-----------------+----------+--------
+ partlockt | AccessShareLock | relation | master
+(1 row)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
         coalesce         |      mode       | locktype |   node    


### PR DESCRIPTION
GPDB support to eliminate alien nodes for QEs, but master still
needs to run ExecInitNode for all the plan nodes. This will
introduce unneccessary CPU cost on master.

Ideally master only needs to ExecInitNode for all node on top of the first
gather motion. Note that there are some exceptions we skip the
optimization: explain query, explain analzye query, cursor case and
initplan case.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
