### PR TITLE
Fix getDtxCheckPointInfo to contain all committed transactions

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1897,8 +1897,8 @@ getDtxCheckPointInfo(char **result, int *result_size)
 	gxact_log_array = &gxact_checkpoint->committedGxactArray[0];
 
 	actual = 0;
-	for (i = 0; i < *shmNumCommittedGxacts; i++)
-		gxact_log_array[actual++] = shmCommittedGxactArray[i++];
+	for (; actual < *shmNumCommittedGxacts; actual++)
+		gxact_log_array[actual] = shmCommittedGxactArray[actual];
 
 	SIMPLE_FAULT_INJECTOR("checkpoint_dtx_info");
 


### PR DESCRIPTION
Half committed transactions in shmCommittedGxactArray are omitted.
The bug could cause data loss/inconsistency. If transaction T1
failed to commit prepared for some reasons, and the transaction T1
has been committed on the master and other segments, but the transaction
T1 isn't appended in the checkpoint record. So the DTX recovery
can't retrieve the transaction and run recovery-commit-prepared,
and the prepared transactions on the segment are aborted.

Co-authored-by: Gang Xiong <gxiong@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
