### PR TITLE
5X: Fix poor performing query in analyzedb

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -851,13 +851,8 @@ def generate_timestamp():
 # SQL expression like: 'schema.table'::regclass, that can be embedded safely in an SQL string.
 # The escaping is a bit tricky here: the schema and table name need to be double-quoted, and the
 # whole string needs to be in single quotes.
-# This creates a subquery that will return a list of oids. This is necessary to prevent errors
-# in the case a table is dropped while analyzedb is running
 def get_oid_str(table_list):
-    subquery_str = "(SELECT pg_class.oid FROM pg_class, pg_namespace WHERE pg_class.relnamespace = pg_namespace.oid AND ("
-    tables = " OR ".join(map((lambda x: "(nspname = '%s' AND relname = '%s')" % (pg.escape_string(x[0]), pg.escape_string(x[1]))), table_list))
-    subquery_str = subquery_str + tables + "))"
-    return subquery_str
+    return ','.join(map((lambda x: regclass_schema_tbl(x[0], x[1])), table_list))
 
 
 def regclass_schema_tbl(schema, tbl):


### PR DESCRIPTION
This commit partially reverts commit 2ba1627ed43720ddbb81dc814ce71168ce1abbd5,
specifically the changes in `get_oid_str`, which attempted to be
resilient to tables be dropped during analyzedb. While this query worked
fine for a relatively small number of tables, when the number of
tables/partitions in the analyze set was very large (tens of thousands+),
the query would run out of stack space and fail during planning.
Additionally, in databases with many entries in pg_class, some of the
queries would require a high statement_mem or fail by going out of
memory. Overall, this form of query was not scalable.

This partial revert does not apply to 6X/master, as those use `to_regclass()`
which can return NULL instead of throwing an exception and does not hit
the above issues..

This does reintroduce the possibility that tables being dropped during a
narrow window can cause analyzedb will fail. If needed, we can query for
the oids directly before each of these queries, but that still only
narrows the window.