### PR TITLE
Properly mark null return from combine functions

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -1352,7 +1352,7 @@ spill_hash_table(AggState *aggstate)
 	/* Book keeping. */
 	hashtable->is_spilling = true;
 
-	Assert(hashtable->nbuckets > spill_set->num_spill_files);
+	Assert(hashtable->nbuckets >= spill_set->num_spill_files);
 
 	/*
 	 * Write each spill file. Write the last spill file first, since it will

--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -49,6 +49,7 @@ struct BatchFileInfo
 	int64 total_bytes;
 	int64 ntuples;
 	BufFile *wfile;
+	bool suspended;
 };
 
 /*
@@ -1153,6 +1154,7 @@ getSpillFile(workfile_set *work_set, SpillSet *set, int file_no, int *p_alloc_si
 		/* Initialize to NULL in case the create function below throws an exception */
 		spill_file->file_info->wfile = NULL; 
 		spill_file->file_info->wfile = BufFileCreateTempInSet(work_set, false /* interXact */);
+		spill_file->file_info->suspended = false;
 		BufFilePledgeSequential(spill_file->file_info->wfile);	/* allow compression */
 
 		elog(HHA_MSG_LVL, "HashAgg: create %d level batch file %d",
@@ -1185,7 +1187,9 @@ suspendSpillFiles(SpillSet *spill_set)
 		if (spill_file->file_info &&
 			spill_file->file_info->wfile != NULL)
 		{
+			Assert(spill_file->file_info->suspended == false);
 			BufFileSuspend(spill_file->file_info->wfile);
+			spill_file->file_info->suspended = true;
 
 			freed_size += FREEABLE_BATCHFILE_METADATA;
 
@@ -1224,7 +1228,8 @@ closeSpillFile(AggState *aggstate, SpillSet *spill_set, int file_no)
 		BufFileClose(spill_file->file_info->wfile);
 		spill_file->file_info->wfile = NULL;
 		freedspace += (BATCHFILE_METADATA - sizeof(BatchFileInfo));
-		
+		if (spill_file->file_info->suspended)
+			freedspace -= FREEABLE_BATCHFILE_METADATA;
 	}
 	if (spill_file->file_info)
 	{
@@ -1862,7 +1867,9 @@ agg_hash_reload(AggState *aggstate)
 
 	if (spill_file->file_info->wfile != NULL)
 	{
+		Assert(spill_file->file_info->suspended);
 		BufFileResume(spill_file->file_info->wfile);
+		spill_file->file_info->suspended = false;
 		hashtable->mem_for_metadata  += FREEABLE_BATCHFILE_METADATA;
 	}
 

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -3728,7 +3728,11 @@ numeric_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (NumericAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)
@@ -3819,7 +3823,11 @@ numeric_avg_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (NumericAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)
@@ -4335,7 +4343,11 @@ numeric_poly_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (PolyNumAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)
@@ -4576,7 +4588,11 @@ int8_avg_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (PolyNumAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)

--- a/src/test/regress/expected/gp_hashagg.out
+++ b/src/test/regress/expected/gp_hashagg.out
@@ -122,3 +122,154 @@ select nohash_int from hashagg_test2 group by nohash_int;
  9
 (10 rows)
 
+reset enable_sort;
+-- We had a bug in the following combine functions where if the combine function
+-- returned a NULL, it didn't set fcinfo->isnull = true. This led to a segfault
+-- when we would spill in the final stage of a two-stage agg inside the serial
+-- function.
+CREATE TABLE test_combinefn_null (a int8, b int, c char(32000));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO test_combinefn_null SELECT i, (i | 7), i::text FROM generate_series(1, 1024) i;
+ANALYZE test_combinefn_null;
+SET statement_mem='2MB';
+-- Test int8_avg_combine()
+SELECT $$
+SELECT
+sum(a) FILTER (WHERE false)
+FROM test_combinefn_null
+GROUP BY b
+HAVING max(c) = '31'
+$$ AS qry \gset
+EXPLAIN (COSTS OFF, VERBOSE) :qry;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(a) FILTER (WHERE false)), b
+   ->  Finalize HashAggregate
+         Output: sum(a) FILTER (WHERE false), b
+         Group Key: test_combinefn_null.b
+         Filter: (max(test_combinefn_null.c) = '31'::bpchar)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: b, (PARTIAL sum(a) FILTER (WHERE false)), (PARTIAL max(c))
+               Hash Key: b
+               ->  Partial HashAggregate
+                     Output: b, PARTIAL sum(a) FILTER (WHERE false), PARTIAL max(c)
+                     Group Key: test_combinefn_null.b
+                     ->  Seq Scan on public.test_combinefn_null
+                           Output: a, b, c
+ Optimizer: Postgres query optimizer
+ Settings: enable_indexscan=off, enable_seqscan=on
+(16 rows)
+
+:qry;
+ sum 
+-----
+    
+(1 row)
+
+-- Test numeric_poly_combine()
+SELECT $$
+SELECT
+var_pop(a::int) FILTER (WHERE false)
+FROM test_combinefn_null
+GROUP BY b
+HAVING max(c) = '31'
+$$ AS qry \gset
+EXPLAIN (COSTS OFF, VERBOSE) :qry;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (var_pop((a)::integer) FILTER (WHERE false)), b
+   ->  Finalize HashAggregate
+         Output: var_pop((a)::integer) FILTER (WHERE false), b
+         Group Key: test_combinefn_null.b
+         Filter: (max(test_combinefn_null.c) = '31'::bpchar)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: b, (PARTIAL var_pop((a)::integer) FILTER (WHERE false)), (PARTIAL max(c))
+               Hash Key: b
+               ->  Partial HashAggregate
+                     Output: b, PARTIAL var_pop((a)::integer) FILTER (WHERE false), PARTIAL max(c)
+                     Group Key: test_combinefn_null.b
+                     ->  Seq Scan on public.test_combinefn_null
+                           Output: a, b, c
+ Optimizer: Postgres query optimizer
+ Settings: enable_indexscan=off, enable_seqscan=on
+(16 rows)
+
+:qry;
+ var_pop 
+---------
+        
+(1 row)
+
+-- Test numeric_avg_combine()
+SELECT $$
+SELECT
+sum(a::numeric) FILTER (WHERE false)
+FROM test_combinefn_null
+GROUP BY b
+HAVING max(c) = '31'
+$$ AS qry \gset
+EXPLAIN (COSTS OFF, VERBOSE) :qry;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum((a)::numeric) FILTER (WHERE false)), b
+   ->  Finalize HashAggregate
+         Output: sum((a)::numeric) FILTER (WHERE false), b
+         Group Key: test_combinefn_null.b
+         Filter: (max(test_combinefn_null.c) = '31'::bpchar)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: b, (PARTIAL sum((a)::numeric) FILTER (WHERE false)), (PARTIAL max(c))
+               Hash Key: b
+               ->  Partial HashAggregate
+                     Output: b, PARTIAL sum((a)::numeric) FILTER (WHERE false), PARTIAL max(c)
+                     Group Key: test_combinefn_null.b
+                     ->  Seq Scan on public.test_combinefn_null
+                           Output: a, b, c
+ Optimizer: Postgres query optimizer
+ Settings: enable_indexscan=off, enable_seqscan=on
+(16 rows)
+
+:qry;
+ sum 
+-----
+    
+(1 row)
+
+-- Test numeric_combine()
+SELECT $$
+SELECT
+var_pop(a::numeric) FILTER (WHERE false)
+FROM test_combinefn_null
+GROUP BY b
+HAVING max(c) = '31'
+$$ AS qry \gset
+EXPLAIN (COSTS OFF, VERBOSE) :qry;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (var_pop((a)::numeric) FILTER (WHERE false)), b
+   ->  Finalize HashAggregate
+         Output: var_pop((a)::numeric) FILTER (WHERE false), b
+         Group Key: test_combinefn_null.b
+         Filter: (max(test_combinefn_null.c) = '31'::bpchar)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: b, (PARTIAL var_pop((a)::numeric) FILTER (WHERE false)), (PARTIAL max(c))
+               Hash Key: b
+               ->  Partial HashAggregate
+                     Output: b, PARTIAL var_pop((a)::numeric) FILTER (WHERE false), PARTIAL max(c)
+                     Group Key: test_combinefn_null.b
+                     ->  Seq Scan on public.test_combinefn_null
+                           Output: a, b, c
+ Optimizer: Postgres query optimizer
+ Settings: enable_indexscan=off, enable_seqscan=on
+(16 rows)
+
+:qry;
+ var_pop 
+---------
+        
+(1 row)
+


### PR DESCRIPTION
Highlights:

1) We had a bug in a few of the combine functions where if the combine
function returned a NULL, it didn't set fcinfo->isnull = true. This led
to a segfault when we would spill in the final hashagg of a two-stage
agg inside the serial function. So, properly mark NULL outputs from the
combine functions. **-- Needs backport to 6X_STABLE.**

2) While writing a repro for 1), we ran into two assertion failures, which we have fixed in two separate commits in this PR.
   i)  "Fix assert condition in spill_hash_table()" - addresses issue #9902 -- **Needs backport all the way to 4x.**
   ii) "Fix double deduction of FREEABLE_BATCHFILE_METADATA" - addresses a memory accounting issue which caused:
       ```
       FailedAssertion("!(hashtable->mem_for_metadata > 0)", File: "execHHashagg.c", Line: 2141)
       ```
   -- **Needs backport all the way to 4x.**

Originally reported by Denis Smirnov in PR: #9878 

Co-authored-by: Denis Smirnov <sd@arenadata.io>
Co-authored-by: Jesse Zhang <jzhang@pivotal.io>