### PR TITLE
Fix plan when segmentgeneral union all general locus.

### DIFF
--- a/src/test/regress/expected/qp_union_intersect.out
+++ b/src/test/regress/expected/qp_union_intersect.out
@@ -1896,6 +1896,39 @@ select * from t_github_issue_9874 where a = 1;
         1
 (1 row)
 
+-- Test mixing a SegmentGeneral with General locus scan.
+explain (costs off)
+select a from t_test_append_rep
+union all
+select * from generate_series(100, 105);
+                  QUERY PLAN                  
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Append
+         ->  Seq Scan on t_test_append_rep
+         ->  Function Scan on generate_series
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select a from t_test_append_rep
+union all
+select * from generate_series(100, 105);
+  a  
+-----
+   5
+   6
+   7
+   8
+   9
+  10
+ 100
+ 101
+ 102
+ 103
+ 104
+ 105
+(12 rows)
+
 --
 -- Test for creation of MergeAppend paths.
 --

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -1911,6 +1911,39 @@ select * from t_github_issue_9874 where a = 1;
         1
 (1 row)
 
+-- Test mixing a SegmentGeneral with General locus scan.
+explain (costs off)
+select a from t_test_append_rep
+union all
+select * from generate_series(100, 105);
+                  QUERY PLAN                  
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Append
+         ->  Seq Scan on t_test_append_rep
+         ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select a from t_test_append_rep
+union all
+select * from generate_series(100, 105);
+  a  
+-----
+   5
+   6
+   7
+   8
+   9
+  10
+ 100
+ 101
+ 102
+ 103
+ 104
+ 105
+(12 rows)
+
 --
 -- Test for creation of MergeAppend paths.
 --

--- a/src/test/regress/sql/qp_union_intersect.sql
+++ b/src/test/regress/sql/qp_union_intersect.sql
@@ -724,6 +724,16 @@ select 1
 union all
 select * from t_github_issue_9874 where a = 1;
 
+-- Test mixing a SegmentGeneral with General locus scan.
+explain (costs off)
+select a from t_test_append_rep
+union all
+select * from generate_series(100, 105);
+
+select a from t_test_append_rep
+union all
+select * from generate_series(100, 105);
+
 --
 -- Test for creation of MergeAppend paths.
 --


### PR DESCRIPTION
Previously, planner cannot generate plan when a replicated
table union all a general locus scan. A typical case is:

  select a from t_replicate_table
  union all
  select * from generate_series(1, 10);

The root cause is in the function `set_append_path_locus`
it deduces the whole append path's locus to be segmentgeneral.
This is reasonable. However, in the function `cdbpath_create_motion_path`
it fails to handle two issues in the case:
  * segmentgeneral locus to segmentgeneral locus
  * general locus to segmentgeneral locus

And the both above locus change does not need motion in fact.

This commit fixes this by:
  1. add a check at the very begining of `cdbpath_create_motion_path`
     that if the subpath's locus is the same as target locus, just return
  2. add logic to handle general locus to segmentgeneral locus, just return

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
