### PR TITLE
Reconsider direct dispatch when Result node's contains gp_execution_s…

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1908,6 +1908,14 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 					subpath,
 					subpath->pathtarget,
 					list_make1(restrict_info));
+
+				/*
+				 * We use the skill of Result plannode with one time filter
+				 * gp_execution_segment() = <segid> here, so we should update
+				 * direct dispatch info when creating plan.
+				 */
+				((ProjectionPath *) subpath)->direct_dispath_contentIds = list_make1_int(gp_session_id % numsegments);
+
 				CdbPathLocus_MakeStrewn(&(subpath->locus),
 				                        numsegments);
 			}

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -1604,6 +1604,12 @@ typedef struct ProjectionPath
 	bool		dummypp;		/* true if no separate Result is needed */
 
 	List	   *cdb_restrict_clauses;
+
+	/*
+	 * CDB: projection with qual gp_execution_segment() = <segid>,
+	 * for such case we should consider update directdispatch info.
+	 */
+	List	   *direct_dispath_contentIds;
 } ProjectionPath;
 
 /*

--- a/src/test/regress/expected/qp_union_intersect.out
+++ b/src/test/regress/expected/qp_union_intersect.out
@@ -1858,6 +1858,44 @@ select * from t_test_append_hash;
   4 |  5 |  6
 (11 rows)
 
+-- Test value scan union all with a distributed table that direct dispatch
+-- value scan's locus is general, so it will use Result plan node with
+-- resconstantqual to be gp_execution_segment() = <some segid> to turn
+-- general locus to partitioned locus to avoid gather partitioned locus
+-- table to singleQE. When the subplan of partitioned table's scan can
+-- use direct dispatch, previously, the result plan does not handle
+-- direct dispatch correctly. This case cannot test plan, this is because
+-- gp_execution_segment() = <some segid> the filter segid is randomly picked.
+-- So the result plan's direct dispatch info is also random. We print the plan
+-- and ignore it for better debugging info if error happens.
+-- See github issue https://github.com/greenplum-db/gpdb/issues/9874 for details.
+create table t_github_issue_9874 (a int) distributed by (a);
+-- start_ignore
+explain (costs off)
+select 1
+union all
+select * from t_github_issue_9874 where a = 1;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Append
+         ->  Result
+               One-Time Filter: (gp_execution_segment() = 0)
+               ->  Result
+         ->  Seq Scan on t_github_issue_9874
+               Filter: (a = 1)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+-- end_ignore
+select 1
+union all
+select * from t_github_issue_9874 where a = 1;
+ ?column? 
+----------
+        1
+(1 row)
+
 --
 -- Test for creation of MergeAppend paths.
 --

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -1875,6 +1875,42 @@ select * from t_test_append_hash;
   4 |  5 |  6
 (11 rows)
 
+-- Test value scan union all with a distributed table that direct dispatch
+-- value scan's locus is general, so it will use Result plan node with
+-- resconstantqual to be gp_execution_segment() = <some segid> to turn
+-- general locus to partitioned locus to avoid gather partitioned locus
+-- table to singleQE. When the subplan of partitioned table's scan can
+-- use direct dispatch, previously, the result plan does not handle
+-- direct dispatch correctly. This case cannot test plan, this is because
+-- gp_execution_segment() = <some segid> the filter segid is randomly picked.
+-- So the result plan's direct dispatch info is also random. We print the plan
+-- and ignore it for better debugging info if error happens.
+-- See github issue https://github.com/greenplum-db/gpdb/issues/9874 for details.
+create table t_github_issue_9874 (a int) distributed by (a);
+-- start_ignore
+explain (costs off)
+select 1
+union all
+select * from t_github_issue_9874 where a = 1;
+                   QUERY PLAN                   
+------------------------------------------------
+ Append
+   ->  Result
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         ->  Seq Scan on t_github_issue_9874
+               Filter: (a = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+-- end_ignore
+select 1
+union all
+select * from t_github_issue_9874 where a = 1;
+ ?column? 
+----------
+        1
+(1 row)
+
 --
 -- Test for creation of MergeAppend paths.
 --


### PR DESCRIPTION
…egment() = <segid>.

Greenplum may use the skill that setting Result plan's resconstantqual to
be an expression of gp_execution_segment() = <segid>. This skill is used
in to turn a general locus path to partitioned locus path in the function
set_append_path_locus. When using this skill, we should re-consider direct
dispatch info at the function of create_projection_plan to handle it correctly.

This commit fixes github issue: https://github.com/greenplum-db/gpdb/issues/9874.
For more details, refer to the issue.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
