### PR TITLE
[6X backport]Fix CTAS 'with no data' bug

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3544,6 +3544,7 @@ CopyCreateStmtFields(const CreateStmt *from, CreateStmt *newnode)
 	COPY_SCALAR_FIELD(ownerid);
 	COPY_SCALAR_FIELD(buildAoBlkdir);
 	COPY_NODE_FIELD(attr_encodings);
+	COPY_SCALAR_FIELD(isCtas);
 }
 
 static CreateStmt *

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1235,6 +1235,7 @@ _equalCreateStmt(const CreateStmt *a, const CreateStmt *b)
 	COMPARE_SCALAR_FIELD(ownerid);
 	COMPARE_SCALAR_FIELD(buildAoBlkdir);
 	COMPARE_NODE_FIELD(attr_encodings);
+	COMPARE_SCALAR_FIELD(isCtas);
 
 	return true;
 }

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -730,6 +730,7 @@ _outCreateStmt_common(StringInfo str, CreateStmt *node)
 	WRITE_OID_FIELD(ownerid);
 	WRITE_BOOL_FIELD(buildAoBlkdir);
 	WRITE_NODE_FIELD(attr_encodings);
+	WRITE_BOOL_FIELD(isCtas);
 }
 
 static void

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2591,6 +2591,7 @@ _outCreateStmtInfo(StringInfo str, const CreateStmt *node)
 	WRITE_OID_FIELD(ownerid);
 	WRITE_BOOL_FIELD(buildAoBlkdir);
 	WRITE_NODE_FIELD(attr_encodings);
+	WRITE_BOOL_FIELD(isCtas);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1073,6 +1073,7 @@ _readCreateStmt_common(CreateStmt *local_node)
 	READ_OID_FIELD(ownerid);
 	READ_BOOL_FIELD(buildAoBlkdir);
 	READ_NODE_FIELD(attr_encodings);
+	READ_BOOL_FIELD(isCtas);
 
 	/*
 	 * Some extra checks to make sure we didn't get lost

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2332,6 +2332,7 @@ _readCreateStmt(void)
 	READ_OID_FIELD(ownerid);
 	READ_BOOL_FIELD(buildAoBlkdir);
 	READ_NODE_FIELD(attr_encodings);
+	READ_BOOL_FIELD(isCtas);
 
 	READ_DONE();
 }

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -71,6 +71,7 @@
 #include "utils/syscache.h"
 
 #include "catalog/oid_dispatch.h"
+#include "catalog/pg_attribute_encoding.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbpartition.h"
 #include "cdb/cdbvars.h"
@@ -1159,6 +1160,14 @@ ProcessUtilitySlow(Node *parsetree,
 							 * one needs a secondary relation too.
 							 */
 							CommandCounterIncrement();
+
+							/* Add column encoding entries based on the WITH clauses */
+							if (cstmt->isCtas && cstmt->options)
+							{
+								Relation rel = heap_open(relOid, AccessExclusiveLock);
+								AddDefaultRelationAttributeOptions(rel, cstmt->options);
+								heap_close(rel, NoLock);
+							}
 
 							if (relKind != RELKIND_COMPOSITE_TYPE)
 							{

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1847,6 +1847,7 @@ typedef struct CreateStmt
 	Oid			ownerid;		/* OID of the role to own this. if InvalidOid, GetUserId() */
 	bool		buildAoBlkdir; /* whether to build the block directory for an AO table */
 	List	   *attr_encodings; /* attribute storage directives */
+	bool		isCtas;			/* CDB: is create table as */
 } CreateStmt;
 
 /* ----------------------

--- a/src/test/regress/expected/gpctas.out
+++ b/src/test/regress/expected/gpctas.out
@@ -151,7 +151,7 @@ CREATE TABLE ctas_dst as SELECT col1,col3,col4,col5 FROM ctas_src order by 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'col4' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- This will fail to find some of the rows, if they're distributed incorrectly.
-SELECT * FROM ctas_src, ctas_dst WHERE ctas_src.col1 = ctas_dst.col1
+SELECT * FROM ctas_src, ctas_dst WHERE ctas_src.col1 = ctas_dst.col1;
  col1 | col3 | col4 | col5 | col1 | col3 | col4 | col5 
 ------+------+------+------+------+------+------+------
     1 | a    | t    |    1 |    1 | a    | t    |    1
@@ -161,3 +161,18 @@ SELECT * FROM ctas_src, ctas_dst WHERE ctas_src.col1 = ctas_dst.col1
     5 | a    | t    |    5 |    5 | a    | t    |    5
 (5 rows)
 
+-- Github issue 9790.
+-- Previously, CTAS with no data won't handle the 'WITH' clause
+CREATE TABLE ctas_base(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE ctas_aocs WITH (appendonly=true, orientation=column) AS SELECT * FROM ctas_base WITH NO DATA;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT * FROM ctas_aocs;
+ a | b 
+---+---
+(0 rows)
+
+DROP TABLE ctas_base;
+DROP TABLE ctas_aocs;

--- a/src/test/regress/sql/gpctas.sql
+++ b/src/test/regress/sql/gpctas.sql
@@ -89,4 +89,12 @@ INSERT INTO ctas_src(col1, col3,col4,col5)
 CREATE TABLE ctas_dst as SELECT col1,col3,col4,col5 FROM ctas_src order by 1;
 
 -- This will fail to find some of the rows, if they're distributed incorrectly.
-SELECT * FROM ctas_src, ctas_dst WHERE ctas_src.col1 = ctas_dst.col1
+SELECT * FROM ctas_src, ctas_dst WHERE ctas_src.col1 = ctas_dst.col1;
+
+-- Github issue 9790.
+-- Previously, CTAS with no data won't handle the 'WITH' clause
+CREATE TABLE ctas_base(a int, b int);
+CREATE TABLE ctas_aocs WITH (appendonly=true, orientation=column) AS SELECT * FROM ctas_base WITH NO DATA;
+SELECT * FROM ctas_aocs;
+DROP TABLE ctas_base;
+DROP TABLE ctas_aocs;


### PR DESCRIPTION
As reported in issue #9790, 'CTAS with no data' statement doesn't handle WITH
clause, the options in WITH clause should be added in 'pg_attribute_encoding'.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
