### PR TITLE
(6x backport) Fix plan when segmentgeneral union all general locus.

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -104,6 +104,13 @@ cdbpath_create_motion_path(PlannerInfo *root,
 	numsegments = CdbPathLocus_CommonSegments(subpath->locus, locus);
 	Assert(numsegments > 0);
 
+	/*
+	 * Motion is to change path's locus, if target locus is the
+	 * same as the subpath's, there is no need to add motion.
+	 */
+	if (cdbpathlocus_equal(subpath->locus, locus))
+		return subpath;
+
 	/* Moving subpath output to a single executor process (qDisp or qExec)? */
 	if (CdbPathLocus_IsBottleneck(locus))
 	{
@@ -269,9 +276,13 @@ cdbpath_create_motion_path(PlannerInfo *root,
 	/* If subplan uses no tables, it can run on qDisp or a singleton qExec. */
 	else if (CdbPathLocus_IsGeneral(subpath->locus))
 	{
-		/* No motion needed if general-->general or general-->replicated. */
+		/*
+		 * No motion needed if general-->general or general-->replicated or
+		 * general-->segmentGeneral
+		 */
 		if (CdbPathLocus_IsGeneral(locus) ||
-			CdbPathLocus_IsReplicated(locus))
+			CdbPathLocus_IsReplicated(locus) ||
+			CdbPathLocus_IsSegmentGeneral(locus))
 		{
 			subpath->locus.numsegments = numsegments;
 			return subpath;

--- a/src/test/regress/expected/qp_union_intersect.out
+++ b/src/test/regress/expected/qp_union_intersect.out
@@ -1744,6 +1744,41 @@ select g from generate_series(1,2) g;
    2
 (7 rows)
 
+-- Test mixing a SegmentGeneral with General locus scan.
+create table t_test_append_rep(a int, b int, c int) distributed replicated;
+insert into t_test_append_rep select i, i+1, i+2 from generate_series(5, 10)i;
+explain (costs off)
+select a from t_test_append_rep
+union all
+select * from generate_series(100, 105);
+                  QUERY PLAN                  
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Append
+         ->  Seq Scan on t_test_append_rep
+         ->  Function Scan on generate_series
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select a from t_test_append_rep
+union all
+select * from generate_series(100, 105);
+  a  
+-----
+   5
+   6
+   7
+   8
+   9
+  10
+ 100
+ 101
+ 102
+ 103
+ 104
+ 105
+(12 rows)
+
 --
 -- Test for creation of MergeAppend paths.
 --

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -1764,6 +1764,41 @@ select g from generate_series(1,2) g;
   99
 (7 rows)
 
+-- Test mixing a SegmentGeneral with General locus scan.
+create table t_test_append_rep(a int, b int, c int) distributed replicated;
+insert into t_test_append_rep select i, i+1, i+2 from generate_series(5, 10)i;
+explain (costs off)
+select a from t_test_append_rep
+union all
+select * from generate_series(100, 105);
+                  QUERY PLAN                  
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Append
+         ->  Seq Scan on t_test_append_rep
+         ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select a from t_test_append_rep
+union all
+select * from generate_series(100, 105);
+  a  
+-----
+   5
+   6
+   7
+   8
+   9
+  10
+ 100
+ 101
+ 102
+ 103
+ 104
+ 105
+(12 rows)
+
 --
 -- Test for creation of MergeAppend paths.
 --

--- a/src/test/regress/sql/qp_union_intersect.sql
+++ b/src/test/regress/sql/qp_union_intersect.sql
@@ -654,6 +654,19 @@ select a from dml_union_r where a > 95
 union all
 select g from generate_series(1,2) g;
 
+-- Test mixing a SegmentGeneral with General locus scan.
+create table t_test_append_rep(a int, b int, c int) distributed replicated;
+insert into t_test_append_rep select i, i+1, i+2 from generate_series(5, 10)i;
+
+explain (costs off)
+select a from t_test_append_rep
+union all
+select * from generate_series(100, 105);
+
+select a from t_test_append_rep
+union all
+select * from generate_series(100, 105);
+
 --
 -- Test for creation of MergeAppend paths.
 --


### PR DESCRIPTION
Previously, planner cannot generate plan when a replicated
table union all a general locus scan. A typical case is:

  select a from t_replicate_table
  union all
  select * from generate_series(1, 10);

The root cause is in the function `set_append_path_locus`
it deduces the whole append path's locus to be segmentgeneral.
This is reasonable. However, in the function `cdbpath_create_motion_path`
it fails to handle two issues in the case:
  * segmentgeneral locus to segmentgeneral locus
  * general locus to segmentgeneral locus
And the both above locus change does not need motion in fact.

This commit fixes this by:
  1. add a check at the very begining of `cdbpath_create_motion_path`
     that if the subpath's locus is the same as target locus, just return
  2. add logic to handle general locus to segmentgeneral locus, just return

-----------------------------

The pr is cherry-picked from master's pr ( https://github.com/greenplum-db/gpdb/pull/9947 ) to 6X.
The pr 9947 for master has been reviewed and merged already.

Without this pr, 6x will encounter  Assert fail for the test case in this pr. This is a bug fix that need backport to 6x.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
