### PR TITLE
Fix "volatile EquivalenceClass has no sortref"

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -1470,7 +1470,7 @@ make_pathkeys_for_groupclause(PlannerInfo *root,
 			GroupClause *gc = (GroupClause *) node;
 
 			sortkey = (Expr *) get_sortgroupclause_expr(gc, tlist);
-			pathkey = make_pathkey_from_sortinfo(root, sortkey, gc->sortop, gc->nulls_first, false, 0);
+			pathkey = make_pathkey_from_sortinfo(root, sortkey, gc->sortop, gc->nulls_first, gc->tleSortGroupRef, false);
 
 			/*
 			 * Similar to SortClauses, the pathkey becomes a one-elment


### PR DESCRIPTION
make_pathkey_from_sortinfo passes the incorrect sort ref 0 to the equivalance
class and it will error out when the equivalance class has volatile function.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
