### PR TITLE
Reduce flakiness of orafce dbms_pipe test

### DIFF
--- a/gpcontrib/orafce/expected/dbms_pipe_session_B.out
+++ b/gpcontrib/orafce/expected/dbms_pipe_session_B.out
@@ -4,6 +4,15 @@
                0
 (1 row)
 
+-- The subsequent receiveFrom() has a race condition with
+-- dbms_pipe_session_A::createImplicitPipe(). So, sleep an extra 2 seconds to
+-- give session_A a chance to execute first.
+SELECT pg_sleep(2) AS wait_for_session_A;
+ wait_for_session_a 
+--------------------
+ 
+(1 row)
+
 -- Receives messages sent via an implicit pipe
 SELECT receiveFrom('named_pipe');
 NOTICE:  RECEIVE 11: Message From Session A

--- a/gpcontrib/orafce/sql/dbms_pipe_session_B.sql
+++ b/gpcontrib/orafce/sql/dbms_pipe_session_B.sql
@@ -82,6 +82,11 @@ END; $$ LANGUAGE plpgsql;
 
 \set ECHO all
 
+-- The subsequent receiveFrom() has a race condition with
+-- dbms_pipe_session_A::createImplicitPipe(). So, sleep an extra 2 seconds to
+-- give session_A a chance to execute first.
+SELECT pg_sleep(2) AS wait_for_session_A;
+
 -- Receives messages sent via an implicit pipe
 SELECT receiveFrom('named_pipe');
 


### PR DESCRIPTION
The dbms_pipe_session_{A,B} tests are flaky in CI as it can so happen
that session B calls receiveFrom() before session A can even call
createImplicitPipe(). This leads to flaky test failures such as:
```patch
--- /tmp/build/e18b2f02/gpdb_src/gpcontrib/orafce/expected/dbms_pipe_session_B.out	2020-04-20 17:02:27.270832458 +0000
+++ /tmp/build/e18b2f02/gpdb_src/gpcontrib/orafce/results/dbms_pipe_session_B.out	2020-04-20 17:02:27.278832994 +0000
@@ -7,14 +7,6 @@

 -- Receives messages sent via an implicit pipe
 SELECT receiveFrom('named_pipe');
-NOTICE:  RECEIVE 11: Message From Session A
-NOTICE:  RECEIVE 12: 01-01-2013
-NOTICE:  RECEIVE 13: Tue Jan 01 09:00:00 2013 PST
-NOTICE:  RECEIVE 23: \201
-NOTICE:  RECEIVE 24: (2,rob)
-NOTICE:  RECEIVE 9: 12345
-NOTICE:  RECEIVE 9: 12345.6789
-NOTICE:  RECEIVE 9: 99999999999
  receivefrom
 -------------

@@ -152,12 +144,13 @@
 ORDER BY 1;
       name      | items | limit | private |      owner      
 ----------------+-------+-------+---------+-----------------
+ named_pipe     |     9 |    10 | f       | 
  pipe_name_3    |     1 |       | f       | 
  private_pipe_1 |     0 |    10 | t       | pipe_test_owner
  private_pipe_2 |     9 |    10 | t       | pipe_test_owner
  public_pipe_3  |     0 |    10 | f       | 
  public_pipe_4  |     0 |    10 | f       | 
-(5 rows)
+(6 rows)
```
This commit introduces an explicit sleep at the start of session B to
give session A a better chance to run.

Co-authored-by: Jesse Zhang <jzhang@pivotal.io>