### PR TITLE
Fix flaky uao_crash_compaction_row test: part two

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1833,12 +1833,6 @@ vacuum_rel(Oid relid, RangeVar *relation, int options, VacuumParams *params,
 			DDLNotSpecified,
 			"",	// databaseName
 			RelationGetRelationName(onerel)); // tableName
-
-		FaultInjector_InjectFaultIfSet(
-			"compaction_before_segmentfile_drop",
-			DDLNotSpecified,
-			"",	// databaseName
-			RelationGetRelationName(onerel)); // tableName
 	}
 #endif
 

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -2024,17 +2024,6 @@ vacuum_rel(Oid relid, RangeVar *relation, int options, VacuumParams *params,
 	PopActiveSnapshot();
 	CommitTransactionCommand();
 
-#ifdef FAULT_INJECTOR
-	if (ao_vacuum_phase == VACOPT_AO_POST_CLEANUP_PHASE)
-	{
-		FaultInjector_InjectFaultIfSet(
-			"vacuum_post_cleanup_committed",
-			DDLNotSpecified,
-			"",	// databaseName
-			""); // tableName
-	}
-#endif
-
 	if (is_appendoptimized && ao_vacuum_phase == 0)
 	{
 		/* orchestrate the AO vacuum phases */

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -46,17 +46,6 @@ CREATE
 INSERT 10
 3:DELETE FROM crash_before_cleanup_phase WHERE a < 4;
 DELETE 3
--- for crash_before_segmentfile_drop
-3:DROP TABLE IF	EXISTS crash_before_segmentfile_drop CASCADE;
-DROP
-3:CREATE TABLE crash_before_segmentfile_drop (a INT, b INT, c CHAR(20));
-CREATE
-3:CREATE INDEX crash_before_segmentfile_drop_index ON crash_before_segmentfile_drop(b);
-CREATE
-3:INSERT INTO crash_before_segmentfile_drop SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
-INSERT 10
-3:DELETE FROM crash_before_segmentfile_drop WHERE a < 4;
-DELETE 3
 -- for crash_vacuum_in_appendonly_insert
 3:DROP TABLE IF EXISTS crash_vacuum_in_appendonly_insert CASCADE;
 DROP
@@ -69,18 +58,7 @@ INSERT 10
 3:UPDATE crash_vacuum_in_appendonly_insert SET b = 2;
 UPDATE 10
 
--- suspend at intended points.
-3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 1, -1, 0, 2);
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-2&:VACUUM crash_before_segmentfile_drop;  <waiting ...>
-3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
- gp_wait_until_triggered_fault 
--------------------------------
- Success:                      
-(1 row)
+-- inject panic fault.
 3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 1, -1, 0, 2);
  gp_inject_fault 
 -----------------
@@ -119,11 +97,7 @@ END
 3:VACUUM crash_vacuum_in_appendonly_insert;
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.0.1:25432 pid=21988)
 1<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29474: server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-2<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29462: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=18463: server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
@@ -137,11 +111,6 @@ ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29462: server closed the c
 
 -- reset faults as protection incase tests failed and panic didn't happen
 1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 2);
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 2);
  gp_inject_fault 
 -----------------
  Success:        
@@ -254,105 +223,6 @@ UPDATE 1
  25 | 16 | c                    
  26 | 11 | c                    
 (11 rows)
--- for crash_before_segmentfile_drop
-1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_before_segmentfile_drop');
- segno | column_num | physical_segno | tupcount | modcount | state 
--------+------------+----------------+----------+----------+-------
- 1     | 0          | 1              | 0        | 2        | 1     
- 1     | 0          | 1              | 4        | 1        | 1     
- 1     | 0          | 1              | 5        | 2        | 2     
- 1     | 1          | 129            | 0        | 2        | 1     
- 1     | 1          | 129            | 4        | 1        | 1     
- 1     | 1          | 129            | 5        | 2        | 2     
- 1     | 2          | 257            | 0        | 2        | 1     
- 1     | 2          | 257            | 4        | 1        | 1     
- 1     | 2          | 257            | 5        | 2        | 2     
- 2     | 0          | 2              | 0        | 1        | 1     
- 2     | 0          | 2              | 3        | 1        | 1     
- 2     | 1          | 130            | 0        | 1        | 1     
- 2     | 1          | 130            | 3        | 1        | 1     
- 2     | 2          | 258            | 0        | 1        | 1     
- 2     | 2          | 258            | 3        | 1        | 1     
-(15 rows)
-1:INSERT INTO crash_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
-INSERT 2
-1:UPDATE crash_before_segmentfile_drop SET b = b+10 WHERE a=25;
-UPDATE 1
-1:SELECT * FROM crash_before_segmentfile_drop ORDER BY a,b;
- a  | b  | c                    
-----+----+----------------------
- 1  | 1  | c                    
- 4  | 1  | hello world          
- 5  | 1  | hello world          
- 6  | 1  | hello world          
- 7  | 1  | hello world          
- 8  | 1  | hello world          
- 9  | 1  | hello world          
- 10 | 1  | hello world          
- 25 | 16 | c                    
-(9 rows)
-1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_before_segmentfile_drop');
- segno | column_num | physical_segno | tupcount | modcount | state 
--------+------------+----------------+----------+----------+-------
- 1     | 0          | 1              | 1        | 3        | 1     
- 1     | 0          | 1              | 5        | 2        | 2     
- 1     | 0          | 1              | 6        | 3        | 1     
- 1     | 1          | 129            | 1        | 3        | 1     
- 1     | 1          | 129            | 5        | 2        | 2     
- 1     | 1          | 129            | 6        | 3        | 1     
- 1     | 2          | 257            | 1        | 3        | 1     
- 1     | 2          | 257            | 5        | 2        | 2     
- 1     | 2          | 257            | 6        | 3        | 1     
- 2     | 0          | 2              | 0        | 1        | 1     
- 2     | 0          | 2              | 3        | 1        | 1     
- 2     | 1          | 130            | 0        | 1        | 1     
- 2     | 1          | 130            | 3        | 1        | 1     
- 2     | 2          | 258            | 0        | 1        | 1     
- 2     | 2          | 258            | 3        | 1        | 1     
-(15 rows)
-1:VACUUM crash_before_segmentfile_drop;
-VACUUM
-1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_before_segmentfile_drop');
- segno | column_num | physical_segno | tupcount | modcount | state 
--------+------------+----------------+----------+----------+-------
- 1     | 0          | 1              | 0        | 2        | 1     
- 1     | 0          | 1              | 0        | 3        | 1     
- 1     | 0          | 1              | 1        | 3        | 1     
- 1     | 1          | 129            | 0        | 2        | 1     
- 1     | 1          | 129            | 0        | 3        | 1     
- 1     | 1          | 129            | 1        | 3        | 1     
- 1     | 2          | 257            | 0        | 2        | 1     
- 1     | 2          | 257            | 0        | 3        | 1     
- 1     | 2          | 257            | 1        | 3        | 1     
- 2     | 0          | 2              | 0        | 1        | 1     
- 2     | 0          | 2              | 3        | 1        | 1     
- 2     | 0          | 2              | 5        | 1        | 1     
- 2     | 1          | 130            | 0        | 1        | 1     
- 2     | 1          | 130            | 3        | 1        | 1     
- 2     | 1          | 130            | 5        | 1        | 1     
- 2     | 2          | 258            | 0        | 1        | 1     
- 2     | 2          | 258            | 3        | 1        | 1     
- 2     | 2          | 258            | 5        | 1        | 1     
-(18 rows)
-1:INSERT INTO crash_before_segmentfile_drop VALUES(21, 1, 'c'), (26, 1, 'c');
-INSERT 2
-1:UPDATE crash_before_segmentfile_drop SET b = b+10 WHERE a=26;
-UPDATE 1
-1:SELECT * FROM crash_before_segmentfile_drop ORDER BY a,b;
- a  | b  | c                    
-----+----+----------------------
- 1  | 1  | c                    
- 4  | 1  | hello world          
- 5  | 1  | hello world          
- 6  | 1  | hello world          
- 7  | 1  | hello world          
- 8  | 1  | hello world          
- 9  | 1  | hello world          
- 10 | 1  | hello world          
- 21 | 1  | c                    
- 25 | 16 | c                    
- 26 | 11 | c                    
-(11 rows)
 -- crash_vacuum_in_appendonly_insert
 1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert');
  segno | column_num | physical_segno | tupcount | modcount | state 
@@ -439,56 +309,21 @@ CREATE
 INSERT 10
 2:DELETE FROM crash_master_before_cleanup_phase WHERE a < 4;
 DELETE 3
--- for crash_master_before_segmentfile_drop
-2:DROP TABLE IF EXISTS crash_master_before_segmentfile_drop CASCADE;
-DROP
-2:CREATE TABLE crash_master_before_segmentfile_drop (a INT, b INT, c CHAR(20));
-CREATE
-2:CREATE INDEX crash_master_before_segmentfile_drop_index ON crash_master_before_segmentfile_drop(b);
-CREATE
-2:INSERT INTO crash_master_before_segmentfile_drop SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
-INSERT 10
-2:DELETE FROM crash_master_before_segmentfile_drop WHERE a < 4;
-DELETE 3
 
--- suspend at intended points
-2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
+-- inject panic fault
+2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'panic', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-1&:VACUUM crash_master_before_cleanup_phase;  <waiting ...>
-SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
- gp_wait_until_triggered_fault 
--------------------------------
- Success:                      
-(1 row)
-
--- wait for suspend faults to trigger and then proceed to run next
--- command which would trigger panic fault and help test
--- crash_recovery
-2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 1, -1, 0, 1);
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-2:VACUUM crash_master_before_segmentfile_drop;
-PANIC:  fault triggered, fault name:'compaction_before_segmentfile_drop' fault type:'panic'
-server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-1<:  <... completed>
+2:VACUUM crash_master_before_cleanup_phase;
+PANIC:  fault triggered, fault name:'compaction_before_cleanup_phase' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
 -- reset faults as protection incase tests failed and panic didn't happen
 4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 1);
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 1);
  gp_inject_fault 
 -----------------
  Success:        
@@ -580,105 +415,6 @@ INSERT 2
 4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=26;
 UPDATE 1
 4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
- a  | b  | c                    
-----+----+----------------------
- 1  | 1  | c                    
- 4  | 1  | hello world          
- 5  | 1  | hello world          
- 6  | 1  | hello world          
- 7  | 1  | hello world          
- 8  | 1  | hello world          
- 9  | 1  | hello world          
- 10 | 1  | hello world          
- 21 | 1  | c                    
- 25 | 16 | c                    
- 26 | 11 | c                    
-(11 rows)
--- for crash_master_before_segmentfile_drop
-4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_master_before_segmentfile_drop');
- segno | column_num | physical_segno | tupcount | modcount | state 
--------+------------+----------------+----------+----------+-------
- 1     | 0          | 1              | 1        | 2        | 2     
- 1     | 0          | 1              | 4        | 1        | 1     
- 1     | 0          | 1              | 5        | 2        | 2     
- 1     | 1          | 129            | 1        | 2        | 2     
- 1     | 1          | 129            | 4        | 1        | 1     
- 1     | 1          | 129            | 5        | 2        | 2     
- 1     | 2          | 257            | 1        | 2        | 2     
- 1     | 2          | 257            | 4        | 1        | 1     
- 1     | 2          | 257            | 5        | 2        | 2     
- 2     | 0          | 2              | 0        | 1        | 1     
- 2     | 0          | 2              | 3        | 1        | 1     
- 2     | 1          | 130            | 0        | 1        | 1     
- 2     | 1          | 130            | 3        | 1        | 1     
- 2     | 2          | 258            | 0        | 1        | 1     
- 2     | 2          | 258            | 3        | 1        | 1     
-(15 rows)
-4:INSERT INTO crash_master_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
-INSERT 2
-4:UPDATE crash_master_before_segmentfile_drop SET b = b+10 WHERE a=25;
-UPDATE 1
-4:SELECT * FROM crash_master_before_segmentfile_drop ORDER BY a,b;
- a  | b  | c                    
-----+----+----------------------
- 1  | 1  | c                    
- 4  | 1  | hello world          
- 5  | 1  | hello world          
- 6  | 1  | hello world          
- 7  | 1  | hello world          
- 8  | 1  | hello world          
- 9  | 1  | hello world          
- 10 | 1  | hello world          
- 25 | 16 | c                    
-(9 rows)
-4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_master_before_segmentfile_drop');
- segno | column_num | physical_segno | tupcount | modcount | state 
--------+------------+----------------+----------+----------+-------
- 1     | 0          | 1              | 1        | 2        | 2     
- 1     | 0          | 1              | 5        | 2        | 2     
- 1     | 0          | 1              | 6        | 3        | 1     
- 1     | 1          | 129            | 1        | 2        | 2     
- 1     | 1          | 129            | 5        | 2        | 2     
- 1     | 1          | 129            | 6        | 3        | 1     
- 1     | 2          | 257            | 1        | 2        | 2     
- 1     | 2          | 257            | 5        | 2        | 2     
- 1     | 2          | 257            | 6        | 3        | 1     
- 2     | 0          | 2              | 1        | 2        | 1     
- 2     | 0          | 2              | 3        | 1        | 1     
- 2     | 1          | 130            | 1        | 2        | 1     
- 2     | 1          | 130            | 3        | 1        | 1     
- 2     | 2          | 258            | 1        | 2        | 1     
- 2     | 2          | 258            | 3        | 1        | 1     
-(15 rows)
-4:VACUUM crash_master_before_segmentfile_drop;
-VACUUM
-4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_master_before_segmentfile_drop');
- segno | column_num | physical_segno | tupcount | modcount | state 
--------+------------+----------------+----------+----------+-------
- 1     | 0          | 1              | 0        | 2        | 1     
- 1     | 0          | 1              | 0        | 2        | 1     
- 1     | 0          | 1              | 0        | 3        | 1     
- 1     | 1          | 129            | 0        | 2        | 1     
- 1     | 1          | 129            | 0        | 2        | 1     
- 1     | 1          | 129            | 0        | 3        | 1     
- 1     | 2          | 257            | 0        | 2        | 1     
- 1     | 2          | 257            | 0        | 2        | 1     
- 1     | 2          | 257            | 0        | 3        | 1     
- 2     | 0          | 2              | 1        | 2        | 1     
- 2     | 0          | 2              | 3        | 1        | 1     
- 2     | 0          | 2              | 5        | 1        | 1     
- 2     | 1          | 130            | 1        | 2        | 1     
- 2     | 1          | 130            | 3        | 1        | 1     
- 2     | 1          | 130            | 5        | 1        | 1     
- 2     | 2          | 258            | 1        | 2        | 1     
- 2     | 2          | 258            | 3        | 1        | 1     
- 2     | 2          | 258            | 5        | 1        | 1     
-(18 rows)
-4:INSERT INTO crash_master_before_segmentfile_drop VALUES(21, 1, 'c'), (26, 1, 'c');
-INSERT 2
-4:UPDATE crash_master_before_segmentfile_drop SET b = b+10 WHERE a=26;
-UPDATE 1
-4:SELECT * FROM crash_master_before_segmentfile_drop ORDER BY a,b;
  a  | b  | c                    
 ----+----+----------------------
  1  | 1  | c                    

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -39,17 +39,6 @@ CREATE
 INSERT 10
 3:DELETE FROM crash_before_cleanup_phase WHERE a < 4;
 DELETE 3
--- for crash_before_segmentfile_drop
-3:DROP TABLE IF	EXISTS crash_before_segmentfile_drop CASCADE;
-DROP
-3:CREATE TABLE crash_before_segmentfile_drop (a INT, b INT, c CHAR(20));
-CREATE
-3:CREATE INDEX crash_before_segmentfile_drop_index ON crash_before_segmentfile_drop(b);
-CREATE
-3:INSERT INTO crash_before_segmentfile_drop SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
-INSERT 10
-3:DELETE FROM crash_before_segmentfile_drop WHERE a < 4;
-DELETE 3
 -- for crash_vacuum_in_appendonly_insert
 3:DROP TABLE IF EXISTS crash_vacuum_in_appendonly_insert CASCADE;
 DROP
@@ -75,18 +64,6 @@ UPDATE 10
  Success:                      
 (1 row)
 
-3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 1, -1, 0, 2);
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-2&:VACUUM crash_before_segmentfile_drop;  <waiting ...>
-3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
- gp_wait_until_triggered_fault 
--------------------------------
- Success:                      
-(1 row)
-
 -- we already waited for suspend faults to trigger and hence we can proceed to
 -- run next command which would trigger panic fault and help test
 -- crash_recovery
@@ -98,11 +75,7 @@ UPDATE 10
 3:VACUUM crash_vacuum_in_appendonly_insert;
 ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg0 127.0.0.1:25432 pid=21369)
 1<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=24819: server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-2<:  <... completed>
-ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=24830: server closed the connection unexpectedly
+ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=15584: server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
@@ -115,11 +88,6 @@ ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=24830: server closed the c
 
 -- reset faults as protection incase tests failed and panic didn't happen
 1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 2);
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 2);
  gp_inject_fault 
 -----------------
  Success:        
@@ -212,73 +180,6 @@ UPDATE 1
  25 | 16 | c                    
  26 | 11 | c                    
 (11 rows)
--- for crash_before_segmentfile_drop
-1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_before_segmentfile_drop');
- segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
-------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
- 0          | 1     | 248 | 5        | 1             | 248              | 2        | 3             | 2     
- 0          | 2     | 160 | 3        | 1             | 160              | 1        | 3             | 1     
- 1          | 1     | 64  | 1        | 1             | 64               | 2        | 3             | 2     
- 1          | 2     | 0   | 0        | 0             | 0                | 1        | 3             | 1     
- 2          | 1     | 200 | 4        | 1             | 200              | 1        | 3             | 1     
-(5 rows)
-1:INSERT INTO crash_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
-INSERT 2
-1:UPDATE crash_before_segmentfile_drop SET b = b+10 WHERE a=25;
-UPDATE 1
-1:SELECT * FROM crash_before_segmentfile_drop ORDER BY a,b;
- a  | b  | c                    
-----+----+----------------------
- 1  | 1  | c                    
- 4  | 1  | hello world          
- 5  | 1  | hello world          
- 6  | 1  | hello world          
- 7  | 1  | hello world          
- 8  | 1  | hello world          
- 9  | 1  | hello world          
- 10 | 1  | hello world          
- 25 | 16 | c                    
-(9 rows)
-1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_before_segmentfile_drop');
- segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
-------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
- 0          | 1     | 248 | 5        | 1             | 248              | 2        | 3             | 2     
- 0          | 2     | 160 | 3        | 1             | 160              | 1        | 3             | 1     
- 1          | 1     | 64  | 1        | 1             | 64               | 2        | 3             | 2     
- 1          | 2     | 64  | 1        | 1             | 64               | 2        | 3             | 1     
- 2          | 1     | 328 | 6        | 3             | 328              | 3        | 3             | 1     
-(5 rows)
-1:VACUUM crash_before_segmentfile_drop;
-VACUUM
-1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_before_segmentfile_drop');
- segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
-------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
- 0          | 1     | 0   | 0        | 0             | 0                | 2        | 3             | 1     
- 0          | 2     | 160 | 3        | 1             | 160              | 1        | 3             | 1     
- 1          | 1     | 0   | 0        | 0             | 0                | 2        | 3             | 1     
- 1          | 2     | 64  | 1        | 1             | 64               | 2        | 3             | 1     
- 2          | 1     | 0   | 0        | 0             | 0                | 3        | 3             | 1     
- 2          | 2     | 248 | 5        | 1             | 248              | 1        | 3             | 1     
-(6 rows)
-1:INSERT INTO crash_before_segmentfile_drop VALUES(21, 1, 'c'), (26, 1, 'c');
-INSERT 2
-1:UPDATE crash_before_segmentfile_drop SET b = b+10 WHERE a=26;
-UPDATE 1
-1:SELECT * FROM crash_before_segmentfile_drop ORDER BY a,b;
- a  | b  | c                    
-----+----+----------------------
- 1  | 1  | c                    
- 4  | 1  | hello world          
- 5  | 1  | hello world          
- 6  | 1  | hello world          
- 7  | 1  | hello world          
- 8  | 1  | hello world          
- 9  | 1  | hello world          
- 10 | 1  | hello world          
- 21 | 1  | c                    
- 25 | 16 | c                    
- 26 | 11 | c                    
-(11 rows)
 -- crash_vacuum_in_appendonly_insert
 1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_vacuum_in_appendonly_insert');
  segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
@@ -343,56 +244,21 @@ CREATE
 INSERT 10
 2:DELETE FROM crash_master_before_cleanup_phase WHERE a < 4;
 DELETE 3
--- for crash_master_before_segmentfile_drop
-2:DROP TABLE IF EXISTS crash_master_before_segmentfile_drop CASCADE;
-DROP
-2:CREATE TABLE crash_master_before_segmentfile_drop (a INT, b INT, c CHAR(20));
-CREATE
-2:CREATE INDEX crash_master_before_segmentfile_drop_index ON crash_master_before_segmentfile_drop(b);
-CREATE
-2:INSERT INTO crash_master_before_segmentfile_drop SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
-INSERT 10
-2:DELETE FROM crash_master_before_segmentfile_drop WHERE a < 4;
-DELETE 3
 
 -- suspend at intended points
-2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
+2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'panic', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-1&:VACUUM crash_master_before_cleanup_phase;  <waiting ...>
-2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 1, -1, 0, 1);
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-
--- wait for suspend faults to trigger and then proceed to run next
--- command which would trigger panic fault and help test
--- crash_recovery
-SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
- gp_wait_until_triggered_fault 
--------------------------------
- Success:                      
-(1 row)
-2:VACUUM crash_master_before_segmentfile_drop;
-PANIC:  fault triggered, fault name:'compaction_before_segmentfile_drop' fault type:'panic'
-server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-1<:  <... completed>
+2:VACUUM crash_master_before_cleanup_phase;
+PANIC:  fault triggered, fault name:'compaction_before_cleanup_phase' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
 -- reset faults as protection incase tests failed and panic didn't happen
 4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 1);
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 1);
  gp_inject_fault 
 -----------------
  Success:        
@@ -452,73 +318,6 @@ INSERT 2
 4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=26;
 UPDATE 1
 4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
- a  | b  | c                    
-----+----+----------------------
- 1  | 1  | c                    
- 4  | 1  | hello world          
- 5  | 1  | hello world          
- 6  | 1  | hello world          
- 7  | 1  | hello world          
- 8  | 1  | hello world          
- 9  | 1  | hello world          
- 10 | 1  | hello world          
- 21 | 1  | c                    
- 25 | 16 | c                    
- 26 | 11 | c                    
-(11 rows)
--- for crash_master_before_segmentfile_drop
-4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_master_before_segmentfile_drop');
- segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
-------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
- 0          | 1     | 248 | 5        | 1             | 248              | 2        | 3             | 2     
- 0          | 2     | 160 | 3        | 1             | 160              | 1        | 3             | 1     
- 1          | 1     | 64  | 1        | 1             | 64               | 2        | 3             | 2     
- 1          | 2     | 0   | 0        | 0             | 0                | 1        | 3             | 1     
- 2          | 1     | 200 | 4        | 1             | 200              | 1        | 3             | 1     
-(5 rows)
-4:INSERT INTO crash_master_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
-INSERT 2
-4:UPDATE crash_master_before_segmentfile_drop SET b = b+10 WHERE a=25;
-UPDATE 1
-4:SELECT * FROM crash_master_before_segmentfile_drop ORDER BY a,b;
- a  | b  | c                    
-----+----+----------------------
- 1  | 1  | c                    
- 4  | 1  | hello world          
- 5  | 1  | hello world          
- 6  | 1  | hello world          
- 7  | 1  | hello world          
- 8  | 1  | hello world          
- 9  | 1  | hello world          
- 10 | 1  | hello world          
- 25 | 16 | c                    
-(9 rows)
-4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_master_before_segmentfile_drop');
- segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
-------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
- 0          | 1     | 248 | 5        | 1             | 248              | 2        | 3             | 2     
- 0          | 2     | 160 | 3        | 1             | 160              | 1        | 3             | 1     
- 1          | 1     | 64  | 1        | 1             | 64               | 2        | 3             | 2     
- 1          | 2     | 64  | 1        | 1             | 64               | 2        | 3             | 1     
- 2          | 1     | 328 | 6        | 3             | 328              | 3        | 3             | 1     
-(5 rows)
-4:VACUUM crash_master_before_segmentfile_drop;
-VACUUM
-4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_master_before_segmentfile_drop');
- segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
-------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
- 0          | 1     | 0   | 0        | 0             | 0                | 2        | 3             | 1     
- 0          | 2     | 160 | 3        | 1             | 160              | 1        | 3             | 1     
- 1          | 1     | 0   | 0        | 0             | 0                | 2        | 3             | 1     
- 1          | 2     | 64  | 1        | 1             | 64               | 2        | 3             | 1     
- 2          | 1     | 0   | 0        | 0             | 0                | 3        | 3             | 1     
- 2          | 2     | 248 | 5        | 1             | 248              | 1        | 3             | 1     
-(6 rows)
-4:INSERT INTO crash_master_before_segmentfile_drop VALUES(21, 1, 'c'), (26, 1, 'c');
-INSERT 2
-4:UPDATE crash_master_before_segmentfile_drop SET b = b+10 WHERE a=26;
-UPDATE 1
-4:SELECT * FROM crash_master_before_segmentfile_drop ORDER BY a,b;
  a  | b  | c                    
 ----+----+----------------------
  1  | 1  | c                    

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -68,28 +68,11 @@ UPDATE 10
 -----------------
  Success:        
 (1 row)
-3:SELECT gp_inject_fault('vacuum_post_cleanup_committed', 'suspend', 3);
- gp_inject_fault 
------------------
- Success:        
-(1 row)
 1&:VACUUM crash_before_cleanup_phase;  <waiting ...>
 3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
-(1 row)
--- wait seg1 to finish the post-cleanup, this makes the aoseg info of seg1 stable.
-3:SELECT gp_wait_until_triggered_fault('vacuum_post_cleanup_committed', 1, 3);
- gp_wait_until_triggered_fault 
--------------------------------
- Success:                      
-(1 row)
--- reset the injection so following commands are not affected.
-3:SELECT gp_inject_fault('vacuum_post_cleanup_committed', 'reset', 3);
- gp_inject_fault 
------------------
- Success:        
 (1 row)
 
 3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 1, -1, 0, 2);
@@ -149,10 +132,24 @@ ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=24830: server closed the c
 
 -- perform post crash validation checks
 -- for crash_before_cleanup_phase
-1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_before_cleanup_phase');
+-- the compaction should be done, but the post-cleanup should not be performed,
+-- so awaiting-dropping segment file should exists in the pg_aoseg* catalog on
+-- seg0, however, the status on the seg1 is undetermined, any concurrent trans
+-- will delay the dropping of dead segment files.
+1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_before_cleanup_phase') where segment_id = 0;
  segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
 ------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
  0          | 1     | 248 | 5        | 1             | 248              | 2        | 3             | 2     
+ 0          | 2     | 160 | 3        | 1             | 160              | 1        | 3             | 1     
+(2 rows)
+-- do vacuum again, there should be no await-dropping segment files, no concurrent
+-- transactions exist this time when the VACUUM is performed.
+1:VACUUM crash_before_cleanup_phase;
+VACUUM
+1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_before_cleanup_phase');
+ segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
+------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
+ 0          | 1     | 0   | 0        | 0             | 0                | 2        | 3             | 1     
  0          | 2     | 160 | 3        | 1             | 160              | 1        | 3             | 1     
  1          | 1     | 0   | 0        | 0             | 0                | 2        | 3             | 1     
  1          | 2     | 0   | 0        | 0             | 0                | 1        | 3             | 1     
@@ -178,7 +175,7 @@ UPDATE 1
 1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_before_cleanup_phase');
  segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
 ------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
- 0          | 1     | 248 | 5        | 1             | 248              | 2        | 3             | 2     
+ 0          | 1     | 0   | 0        | 0             | 0                | 2        | 3             | 1     
  0          | 2     | 160 | 3        | 1             | 160              | 1        | 3             | 1     
  1          | 1     | 64  | 1        | 1             | 64               | 3        | 3             | 1     
  1          | 2     | 0   | 0        | 0             | 0                | 1        | 3             | 1     

--- a/src/test/isolation2/sql/uao_crash_compaction_column.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_column.sql
@@ -43,12 +43,6 @@ $$ language plpgsql;
 3:CREATE INDEX crash_before_cleanup_phase_index ON crash_before_cleanup_phase(b);
 3:INSERT INTO crash_before_cleanup_phase SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
 3:DELETE FROM crash_before_cleanup_phase WHERE a < 4;
--- for crash_before_segmentfile_drop
-3:DROP TABLE IF	EXISTS crash_before_segmentfile_drop CASCADE;
-3:CREATE TABLE crash_before_segmentfile_drop (a INT, b INT, c CHAR(20));
-3:CREATE INDEX crash_before_segmentfile_drop_index ON crash_before_segmentfile_drop(b);
-3:INSERT INTO crash_before_segmentfile_drop SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
-3:DELETE FROM crash_before_segmentfile_drop WHERE a < 4;
 -- for crash_vacuum_in_appendonly_insert
 3:DROP TABLE IF EXISTS crash_vacuum_in_appendonly_insert CASCADE;
 3:CREATE TABLE crash_vacuum_in_appendonly_insert (a INT, b INT, c CHAR(20));
@@ -56,10 +50,7 @@ $$ language plpgsql;
 3:INSERT INTO crash_vacuum_in_appendonly_insert SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
 3:UPDATE crash_vacuum_in_appendonly_insert SET b = 2;
 
--- suspend at intended points.
-3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 1, -1, 0, 2);
-2&:VACUUM crash_before_segmentfile_drop;
-3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
+-- inject panic fault.
 3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 1, -1, 0, 2);
 
 -- VACUUM on crash_before_cleanup_phase will end up skipping the drop
@@ -79,7 +70,6 @@ $$ language plpgsql;
 -- crash_recovery
 3:VACUUM crash_vacuum_in_appendonly_insert;
 1<:
-2<:
 
 -- wait for segment to complete recovering
 0U: SELECT 1;
@@ -87,7 +77,6 @@ $$ language plpgsql;
 
 -- reset faults as protection incase tests failed and panic didn't happen
 1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 2);
-1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 2);
 1:SELECT gp_inject_fault('appendonly_insert', 'reset', 2);
 
 -- perform post crash validation checks
@@ -104,17 +93,6 @@ $$ language plpgsql;
 1:INSERT INTO crash_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
 1:UPDATE crash_before_cleanup_phase SET b = b+10 WHERE a=26;
 1:SELECT * FROM crash_before_cleanup_phase ORDER BY a,b;
--- for crash_before_segmentfile_drop
-1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_before_segmentfile_drop');
-1:INSERT INTO crash_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
-1:UPDATE crash_before_segmentfile_drop SET b = b+10 WHERE a=25;
-1:SELECT * FROM crash_before_segmentfile_drop ORDER BY a,b;
-1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_before_segmentfile_drop');
-1:VACUUM crash_before_segmentfile_drop;
-1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_before_segmentfile_drop');
-1:INSERT INTO crash_before_segmentfile_drop VALUES(21, 1, 'c'), (26, 1, 'c');
-1:UPDATE crash_before_segmentfile_drop SET b = b+10 WHERE a=26;
-1:SELECT * FROM crash_before_segmentfile_drop ORDER BY a,b;
 -- crash_vacuum_in_appendonly_insert
 1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert');
 1:VACUUM crash_vacuum_in_appendonly_insert;
@@ -134,28 +112,13 @@ $$ language plpgsql;
 2:CREATE INDEX crash_master_before_cleanup_phase_index ON crash_master_before_cleanup_phase(b);
 2:INSERT INTO crash_master_before_cleanup_phase SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
 2:DELETE FROM crash_master_before_cleanup_phase WHERE a < 4;
--- for crash_master_before_segmentfile_drop
-2:DROP TABLE IF EXISTS crash_master_before_segmentfile_drop CASCADE;
-2:CREATE TABLE crash_master_before_segmentfile_drop (a INT, b INT, c CHAR(20));
-2:CREATE INDEX crash_master_before_segmentfile_drop_index ON crash_master_before_segmentfile_drop(b);
-2:INSERT INTO crash_master_before_segmentfile_drop SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
-2:DELETE FROM crash_master_before_segmentfile_drop WHERE a < 4;
 
--- suspend at intended points
-2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
-1&:VACUUM crash_master_before_cleanup_phase;
-SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
-
--- wait for suspend faults to trigger and then proceed to run next
--- command which would trigger panic fault and help test
--- crash_recovery
-2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 1, -1, 0, 1);
-2:VACUUM crash_master_before_segmentfile_drop;
-1<:
+-- inject panic fault 
+2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'panic', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
+2:VACUUM crash_master_before_cleanup_phase;
 
 -- reset faults as protection incase tests failed and panic didn't happen
 4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 1);
-4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 1);
 
 -- perform post crash validation checks
 -- for crash_master_before_cleanup_phase
@@ -169,17 +132,6 @@ SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
 4:INSERT INTO crash_master_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
 4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=26;
 4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
--- for crash_master_before_segmentfile_drop
-4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_master_before_segmentfile_drop');
-4:INSERT INTO crash_master_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
-4:UPDATE crash_master_before_segmentfile_drop SET b = b+10 WHERE a=25;
-4:SELECT * FROM crash_master_before_segmentfile_drop ORDER BY a,b;
-4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_master_before_segmentfile_drop');
-4:VACUUM crash_master_before_segmentfile_drop;
-4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_master_before_segmentfile_drop');
-4:INSERT INTO crash_master_before_segmentfile_drop VALUES(21, 1, 'c'), (26, 1, 'c');
-4:UPDATE crash_master_before_segmentfile_drop SET b = b+10 WHERE a=26;
-4:SELECT * FROM crash_master_before_segmentfile_drop ORDER BY a,b;
 
 -- Scenario for validating mirror replays fine and doesn't crash on
 -- truncate record replay even if file is missing.

--- a/src/test/isolation2/sql/uao_crash_compaction_row.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_row.sql
@@ -18,12 +18,6 @@
 3:CREATE INDEX crash_before_cleanup_phase_index ON crash_before_cleanup_phase(b);
 3:INSERT INTO crash_before_cleanup_phase SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
 3:DELETE FROM crash_before_cleanup_phase WHERE a < 4;
--- for crash_before_segmentfile_drop
-3:DROP TABLE IF	EXISTS crash_before_segmentfile_drop CASCADE;
-3:CREATE TABLE crash_before_segmentfile_drop (a INT, b INT, c CHAR(20));
-3:CREATE INDEX crash_before_segmentfile_drop_index ON crash_before_segmentfile_drop(b);
-3:INSERT INTO crash_before_segmentfile_drop SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
-3:DELETE FROM crash_before_segmentfile_drop WHERE a < 4;
 -- for crash_vacuum_in_appendonly_insert
 3:DROP TABLE IF EXISTS crash_vacuum_in_appendonly_insert CASCADE;
 3:CREATE TABLE crash_vacuum_in_appendonly_insert (a INT, b INT, c CHAR(20));
@@ -36,24 +30,18 @@
 1&:VACUUM crash_before_cleanup_phase;
 3:SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 2);
 
-3:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'suspend', '', '', 'crash_before_segmentfile_drop', 1, -1, 0, 2);
-2&:VACUUM crash_before_segmentfile_drop;
-3:SELECT gp_wait_until_triggered_fault('compaction_before_segmentfile_drop', 1, 2);
-
 -- we already waited for suspend faults to trigger and hence we can proceed to
 -- run next command which would trigger panic fault and help test
 -- crash_recovery
 3:SELECT gp_inject_fault('appendonly_insert', 'panic', '', '', 'crash_vacuum_in_appendonly_insert', 1, -1, 0, 2);
 3:VACUUM crash_vacuum_in_appendonly_insert;
 1<:
-2<:
 
 -- wait for segment to complete recovering
 0U: SELECT 1;
 
 -- reset faults as protection incase tests failed and panic didn't happen
 1:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 2);
-1:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 2);
 1:SELECT gp_inject_fault('appendonly_insert', 'reset', 2);
 
 -- perform post crash validation checks
@@ -76,17 +64,6 @@
 1:INSERT INTO crash_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
 1:UPDATE crash_before_cleanup_phase SET b = b+10 WHERE a=26;
 1:SELECT * FROM crash_before_cleanup_phase ORDER BY a,b;
--- for crash_before_segmentfile_drop
-1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_before_segmentfile_drop');
-1:INSERT INTO crash_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
-1:UPDATE crash_before_segmentfile_drop SET b = b+10 WHERE a=25;
-1:SELECT * FROM crash_before_segmentfile_drop ORDER BY a,b;
-1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_before_segmentfile_drop');
-1:VACUUM crash_before_segmentfile_drop;
-1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_before_segmentfile_drop');
-1:INSERT INTO crash_before_segmentfile_drop VALUES(21, 1, 'c'), (26, 1, 'c');
-1:UPDATE crash_before_segmentfile_drop SET b = b+10 WHERE a=26;
-1:SELECT * FROM crash_before_segmentfile_drop ORDER BY a,b;
 -- crash_vacuum_in_appendonly_insert
 1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_vacuum_in_appendonly_insert');
 1:VACUUM crash_vacuum_in_appendonly_insert;
@@ -106,28 +83,13 @@
 2:CREATE INDEX crash_master_before_cleanup_phase_index ON crash_master_before_cleanup_phase(b);
 2:INSERT INTO crash_master_before_cleanup_phase SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
 2:DELETE FROM crash_master_before_cleanup_phase WHERE a < 4;
--- for crash_master_before_segmentfile_drop
-2:DROP TABLE IF EXISTS crash_master_before_segmentfile_drop CASCADE;
-2:CREATE TABLE crash_master_before_segmentfile_drop (a INT, b INT, c CHAR(20));
-2:CREATE INDEX crash_master_before_segmentfile_drop_index ON crash_master_before_segmentfile_drop(b);
-2:INSERT INTO crash_master_before_segmentfile_drop SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
-2:DELETE FROM crash_master_before_segmentfile_drop WHERE a < 4;
 
 -- suspend at intended points
-2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'suspend', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
-1&:VACUUM crash_master_before_cleanup_phase;
-2:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'panic', '', '', 'crash_master_before_segmentfile_drop', 1, -1, 0, 1);
-
--- wait for suspend faults to trigger and then proceed to run next
--- command which would trigger panic fault and help test
--- crash_recovery
-SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
-2:VACUUM crash_master_before_segmentfile_drop;
-1<:
+2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'panic', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
+2:VACUUM crash_master_before_cleanup_phase;
 
 -- reset faults as protection incase tests failed and panic didn't happen
 4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 1);
-4:SELECT gp_inject_fault('compaction_before_segmentfile_drop', 'reset', 1);
 
 -- perform post crash validation checks
 -- for crash_master_before_cleanup_phase
@@ -141,14 +103,3 @@ SELECT gp_wait_until_triggered_fault('compaction_before_cleanup_phase', 1, 1);
 4:INSERT INTO crash_master_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
 4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=26;
 4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
--- for crash_master_before_segmentfile_drop
-4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_master_before_segmentfile_drop');
-4:INSERT INTO crash_master_before_segmentfile_drop VALUES(1, 1, 'c'), (25, 6, 'c');
-4:UPDATE crash_master_before_segmentfile_drop SET b = b+10 WHERE a=25;
-4:SELECT * FROM crash_master_before_segmentfile_drop ORDER BY a,b;
-4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_master_before_segmentfile_drop');
-4:VACUUM crash_master_before_segmentfile_drop;
-4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_master_before_segmentfile_drop');
-4:INSERT INTO crash_master_before_segmentfile_drop VALUES(21, 1, 'c'), (26, 1, 'c');
-4:UPDATE crash_master_before_segmentfile_drop SET b = b+10 WHERE a=26;
-4:SELECT * FROM crash_master_before_segmentfile_drop ORDER BY a,b;


### PR DESCRIPTION
    In commit b00916e699c1fa3d95132bdb596e077d87c79cb0, we added a new
    fault injector to wait segment 1 to finish the post cleanup and drop
    the dead ao segment files, however, the test is still flaky because
    segment 1 might delay the dropping of awaiting-drop segment files, this
    is caused by commit 5778f31124d which changed the vacuum behavor:

    "if there are concurrent transactions running, even in READ COMMITTED
    mode, and even if they don't access the table at all, VACUUM will no
    longer be able to recycle compacted segfiles. Next VACUUM will clean
    them up, after the old concurrent transactions."

    in test uao_crash_compaction_row, VACUUM has concurrent transactions.
        1&:VACUUM crash_before_cleanup_phase;
        3:SELECT gp_wait_until_triggered_fault('compaction_before....
    it makes the status of awaiting-drop aoseg files in segment 1
    undetermined.

    To resolve this, we only check the awaiting-drop/compaction aoseg files
    and compaction aoseg files in segment 0 when the first VACUUM (with
    concurrent transactions) is performed, then we do VACUUM again (without
    concurrent transactions) to verify the awaiting-drop/compaction aoseg
    files in segment 1.

    the commit b00916e699 is useless after we changed the test, so revert
    it.