### PR TITLE
Enable reognization on partition leaf node

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4530,7 +4530,6 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 			{
 				Oid relid = RelationGetRelid(rel);
 				PartStatus ps = rel_part_status(relid);
-				List 	   *lprime;
 				DistributedBy *ldistro;
 				GpPolicy	  *policy;
 
@@ -4544,10 +4543,10 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 						case PART_STATUS_ROOT:
 							break;
 						case PART_STATUS_LEAF:
-							lprime = (List *)cmd->def;
 							Assert(PointerIsValid(cmd->def));
 							Assert(IsA(cmd->def, List));
-							ldistro = (DistributedBy *)lsecond(lprime);
+							/* The distributeby clause is the second element of cmd->def */
+							ldistro = (DistributedBy *)lsecond((List *)cmd->def);
 							if (ldistro == NULL)
 								break;
 							ldistro->numsegments = rel->rd_cdbpolicy->numsegments;
@@ -15425,8 +15424,6 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		ereport(ERROR,
 			(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 			errmsg("permission denied: \"%s\" is a system catalog", RelationGetRelationName(rel))));
-
-
 
 	Assert(PointerIsValid(node));
 	Assert(IsA(node, List));

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1412,9 +1412,43 @@ ALTER TABLE alter_table_with_unique_index SET DISTRIBUTED RANDOMLY;
 ERROR:  cannot set to DISTRIBUTED RANDOMLY because relation has unique index
 HINT:  Drop the unique index first.
 -- Enable reorg partition leaf table
-create table reorg_leaf (trans_id int, date text, amount decimal(9,2), region text) distributed by (trans_id)
-partition by range(date)
-(partition p2011 start (date '2011-01-01'::text) end (date '2012-01-01'::text),
-	partition p2012 start (date '2012-01-01'::text) end (date '2013-01-01'::text));
-alter table reorg_leaf_1_prt_p2011 set with (reorganize=true) distributed by (trans_id);
-alter table reorg_leaf_1_prt_p2011 set with (reorganize=true);
+create table reorg_leaf (a int, b int, c int) distributed by (c)
+partition by range(a)
+(partition p0 start (0) end (5),
+	partition p1 start (5) end (10));
+insert into reorg_leaf select i % 20, i, i from generate_series(0, 9) i;
+select *, gp_segment_id from reorg_leaf_1_prt_p0;
+ a | b | c | gp_segment_id 
+---+---+---+---------------
+ 2 | 2 | 2 |             0
+ 3 | 3 | 3 |             0
+ 4 | 4 | 4 |             0
+ 0 | 0 | 0 |             1
+ 1 | 1 | 1 |             1
+(5 rows)
+
+alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(b);
+ERROR:  can't set the distribution policy of "reorg_leaf_1_prt_p0"
+HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(c);
+select *, gp_segment_id from reorg_leaf_1_prt_p0;
+ a | b | c | gp_segment_id 
+---+---+---+---------------
+ 2 | 2 | 2 |             0
+ 3 | 3 | 3 |             0
+ 4 | 4 | 4 |             0
+ 0 | 0 | 0 |             1
+ 1 | 1 | 1 |             1
+(5 rows)
+
+alter table reorg_leaf_1_prt_p1 set with (reorganize=true);
+select *, gp_segment_id from reorg_leaf_1_prt_p0;
+ a | b | c | gp_segment_id 
+---+---+---+---------------
+ 2 | 2 | 2 |             0
+ 3 | 3 | 3 |             0
+ 4 | 4 | 4 |             0
+ 0 | 0 | 0 |             1
+ 1 | 1 | 1 |             1
+(5 rows)
+

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1410,4 +1410,11 @@ HINT:  Drop the primary key first
 CREATE TABLE alter_table_with_unique_index (a int unique);
 ALTER TABLE alter_table_with_unique_index SET DISTRIBUTED RANDOMLY;
 ERROR:  cannot set to DISTRIBUTED RANDOMLY because relation has unique index
-HINT:  Drop the unique index first
+HINT:  Drop the unique index first.
+-- Enable reorg partition leaf table
+create table reorg_leaf (trans_id int, date text, amount decimal(9,2), region text) distributed by (trans_id)
+partition by range(date)
+(partition p2011 start (date '2011-01-01'::text) end (date '2012-01-01'::text),
+	partition p2012 start (date '2012-01-01'::text) end (date '2013-01-01'::text));
+alter table reorg_leaf_1_prt_p2011 set with (reorganize=true) distributed by (trans_id);
+alter table reorg_leaf_1_prt_p2011 set with (reorganize=true);

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1414,9 +1414,12 @@ HINT:  Drop the unique index first.
 -- Enable reorg partition leaf table
 create table reorg_leaf (a int, b int, c int) distributed by (c)
 partition by range(a)
+subpartition by range (b)
+subpartition template
+(start(0) end (10) every (5))
 (partition p0 start (0) end (5),
 	partition p1 start (5) end (10));
-insert into reorg_leaf select i % 20, i, i from generate_series(0, 9) i;
+insert into reorg_leaf select i, i, i from generate_series(0, 9) i;
 select *, gp_segment_id from reorg_leaf_1_prt_p0;
  a | b | c | gp_segment_id 
 ---+---+---+---------------
@@ -1431,6 +1434,15 @@ alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(b);
 ERROR:  can't set the distribution policy of "reorg_leaf_1_prt_p0"
 HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
 alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(c);
+ERROR:  can't set the distribution policy of "reorg_leaf_1_prt_p0"
+HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+alter table reorg_leaf_1_prt_p0 set with (reorganize=true);
+ERROR:  can't set the distribution policy of "reorg_leaf_1_prt_p0"
+HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true) distributed by(b);
+ERROR:  can't set the distribution policy of "reorg_leaf_1_prt_p0_2_prt_1"
+HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true) distributed by(c);
 select *, gp_segment_id from reorg_leaf_1_prt_p0;
  a | b | c | gp_segment_id 
 ---+---+---+---------------
@@ -1441,7 +1453,7 @@ select *, gp_segment_id from reorg_leaf_1_prt_p0;
  1 | 1 | 1 |             1
 (5 rows)
 
-alter table reorg_leaf_1_prt_p1 set with (reorganize=true);
+alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true);
 select *, gp_segment_id from reorg_leaf_1_prt_p0;
  a | b | c | gp_segment_id 
 ---+---+---+---------------

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -430,10 +430,15 @@ CREATE TABLE alter_table_with_unique_index (a int unique);
 ALTER TABLE alter_table_with_unique_index SET DISTRIBUTED RANDOMLY;
 
 -- Enable reorg partition leaf table
-create table reorg_leaf (trans_id int, date text, amount decimal(9,2), region text) distributed by (trans_id)
-partition by range(date)
-(partition p2011 start (date '2011-01-01'::text) end (date '2012-01-01'::text),
-	partition p2012 start (date '2012-01-01'::text) end (date '2013-01-01'::text));
-alter table reorg_leaf_1_prt_p2011 set with (reorganize=true) distributed by (trans_id);
-alter table reorg_leaf_1_prt_p2011 set with (reorganize=true);
+create table reorg_leaf (a int, b int, c int) distributed by (c)
+partition by range(a)
+(partition p0 start (0) end (5),
+	partition p1 start (5) end (10));
+insert into reorg_leaf select i % 20, i, i from generate_series(0, 9) i;
+select *, gp_segment_id from reorg_leaf_1_prt_p0;
+alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(b);
+alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(c);
+select *, gp_segment_id from reorg_leaf_1_prt_p0;
+alter table reorg_leaf_1_prt_p1 set with (reorganize=true);
+select *, gp_segment_id from reorg_leaf_1_prt_p0;
 

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -432,13 +432,18 @@ ALTER TABLE alter_table_with_unique_index SET DISTRIBUTED RANDOMLY;
 -- Enable reorg partition leaf table
 create table reorg_leaf (a int, b int, c int) distributed by (c)
 partition by range(a)
+subpartition by range (b)
+subpartition template
+(start(0) end (10) every (5))
 (partition p0 start (0) end (5),
 	partition p1 start (5) end (10));
-insert into reorg_leaf select i % 20, i, i from generate_series(0, 9) i;
+insert into reorg_leaf select i, i, i from generate_series(0, 9) i;
 select *, gp_segment_id from reorg_leaf_1_prt_p0;
 alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(b);
 alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(c);
+alter table reorg_leaf_1_prt_p0 set with (reorganize=true);
+alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true) distributed by(b);
+alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true) distributed by(c);
 select *, gp_segment_id from reorg_leaf_1_prt_p0;
-alter table reorg_leaf_1_prt_p1 set with (reorganize=true);
+alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true);
 select *, gp_segment_id from reorg_leaf_1_prt_p0;
-

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -428,3 +428,12 @@ CREATE TABLE alter_table_with_primary_key (a int primary key);
 ALTER TABLE alter_table_with_primary_key SET DISTRIBUTED RANDOMLY;
 CREATE TABLE alter_table_with_unique_index (a int unique);
 ALTER TABLE alter_table_with_unique_index SET DISTRIBUTED RANDOMLY;
+
+-- Enable reorg partition leaf table
+create table reorg_leaf (trans_id int, date text, amount decimal(9,2), region text) distributed by (trans_id)
+partition by range(date)
+(partition p2011 start (date '2011-01-01'::text) end (date '2012-01-01'::text),
+	partition p2012 start (date '2012-01-01'::text) end (date '2013-01-01'::text));
+alter table reorg_leaf_1_prt_p2011 set with (reorganize=true) distributed by (trans_id);
+alter table reorg_leaf_1_prt_p2011 set with (reorganize=true);
+


### PR DESCRIPTION
We are not allowed to modify the distribution of partition leaf table
after gpdb6. Because the distibution of root table and leaf table must
be same. But if only reorg on the partition leaf table, it will not
cause this problem. So we enable reorg when the distibution was not be
changed.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
