### PR TITLE
(6x backport) Fix some potential bugs that not update size results.

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -419,8 +419,8 @@ InitLocks(void)
 	/* Allow for extra entries if resource locking is enabled. */
 	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled())
 	{
-		add_size(max_table_size, NRESLOCKENTS() );
-		//add_size(max_plock_table_size, NRESPROCLOCKENTS() );
+		max_table_size = add_size(max_table_size, NRESLOCKENTS() );
+		max_table_size = add_size(max_table_size, NRESPROCLOCKENTS() );
 	}
 
 	init_table_size = max_table_size / 2;
@@ -3697,14 +3697,14 @@ LockShmemSize(void)
 
 	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled())
 	{
-		add_size(max_table_size, NRESLOCKENTS() );
+		max_table_size = add_size(max_table_size, NRESLOCKENTS() );
 	}
 
 	size = add_size(size, hash_estimate_size(max_table_size, sizeof(LOCK)));
 	
 	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled())
 	{
-		add_size(max_table_size, NRESPROCLOCKENTS() );
+		max_table_size = add_size(max_table_size, NRESPROCLOCKENTS() );
 	}
 
 	/* proclock hash table */


### PR DESCRIPTION
At several places we just invoke the function add_size
but does not assign its return value to any variable.
The result is just discarded. This commit fixes this.

------------------

Cherry-pick pr (https://github.com/greenplum-db/gpdb/pull/9972) to 6X.

Pr https://github.com/greenplum-db/gpdb/pull/9972 has been reviewed and merged into master.

Will merge this when pipeline is green.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
