### PR TITLE
Revert "Remove redundant 'hasError' flag in TeardownTCPInterconnect"

### DIFF
--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -569,7 +569,8 @@ forceEosToPeers(ChunkTransportState *transportStates,
  * even if SetupInterconnect did not complete correctly.
  */
 void
-TeardownInterconnect(ChunkTransportState *transportStates, bool forceEOS)
+TeardownInterconnect(ChunkTransportState *transportStates,
+					 bool forceEOS, bool hasError)
 {
 	interconnect_handle_t *h = find_interconnect_handle(transportStates);
 
@@ -579,7 +580,7 @@ TeardownInterconnect(ChunkTransportState *transportStates, bool forceEOS)
 	}
 	else if (Gp_interconnect_type == INTERCONNECT_TYPE_TCP)
 	{
-		TeardownTCPInterconnect(transportStates, forceEOS);
+		TeardownTCPInterconnect(transportStates, forceEOS, hasError);
 	}
 
 	if (h != NULL)
@@ -825,7 +826,7 @@ cleanup_interconnect_handle(interconnect_handle_t *h)
 		destroy_interconnect_handle(h);
 		return;
 	}
-	TeardownInterconnect(h->interconnect_context, true /* force EOS */);
+	TeardownInterconnect(h->interconnect_context, true /* force EOS */, true);
 }
 
 static void

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1801,7 +1801,8 @@ SetupTCPInterconnect(EState *estate)
  * adding errors!).
  */
 void
-TeardownTCPInterconnect(ChunkTransportState *transportStates, bool forceEOS)
+TeardownTCPInterconnect(ChunkTransportState *transportStates,
+						bool forceEOS, bool hasError)
 {
 	ListCell   *cell;
 	ChunkTransportStateEntry *pEntry = NULL;
@@ -1919,7 +1920,7 @@ TeardownTCPInterconnect(ChunkTransportState *transportStates, bool forceEOS)
 
 		getChunkTransportState(transportStates, mySlice->sliceIndex, &pEntry);
 
-		if (forceEOS)
+		if (forceEOS && !hasError)
 			forceEosToPeers(transportStates, mySlice->sliceIndex);
 
 		for (i = 0; i < pEntry->numConns; i++)
@@ -2007,7 +2008,7 @@ TeardownTCPInterconnect(ChunkTransportState *transportStates, bool forceEOS)
 		 * If some errors are happening, senders can skip this step to avoid hung
 		 * issues, QD will take care of the error handling.
 		 */
-		if (!forceEOS)
+		if (!hasError)
 			waitOnOutbound(pEntry);
 
 		for (i = 0; i < pEntry->numConns; i++)

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1602,7 +1602,7 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 		 * mark the estate to "cancelUnfinished" and then try to do a
 		 * normal interconnect teardown).
 		 */
-		TeardownInterconnect(estate->interconnect_context, estate->cancelUnfinished);
+		TeardownInterconnect(estate->interconnect_context, estate->cancelUnfinished, false);
 		estate->interconnect_context = NULL;
 		estate->es_interconnect_is_setup = false;
 	}
@@ -1690,7 +1690,7 @@ void mppExecutorCleanup(QueryDesc *queryDesc)
 	/* Clean up the interconnect. */
 	if (estate->es_interconnect_is_setup)
 	{
-		TeardownInterconnect(estate->interconnect_context, true /* force EOS */);
+		TeardownInterconnect(estate->interconnect_context, true /* force EOS */, true);
 		estate->es_interconnect_is_setup = false;
 	}
 

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1280,7 +1280,8 @@ PG_TRY();
 	/* Clean up the interconnect. */
 	if (queryDesc && queryDesc->estate && queryDesc->estate->es_interconnect_is_setup)
 	{
-		TeardownInterconnect(queryDesc->estate->interconnect_context, false); /* following success on QD */
+		TeardownInterconnect(queryDesc->estate->interconnect_context,
+							 false, false); /* following success on QD */
 		queryDesc->estate->interconnect_context = NULL;
 		queryDesc->estate->es_interconnect_is_setup = false;
 	}
@@ -1342,7 +1343,8 @@ PG_CATCH();
 	 */
 	if (queryDesc && queryDesc->estate && queryDesc->estate->es_interconnect_is_setup)
 	{
-		TeardownInterconnect(queryDesc->estate->interconnect_context, true);
+		TeardownInterconnect(queryDesc->estate->interconnect_context,
+							 true, false);
 		queryDesc->estate->interconnect_context = NULL;
 		queryDesc->estate->es_interconnect_is_setup = false;
 	}

--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -117,7 +117,7 @@ extern void SetupInterconnect(struct EState *estate);
  *
  */
 extern void TeardownInterconnect(ChunkTransportState *transportStates,
-								 bool forceEOS);
+								 bool forceEOS, bool hasError);
 
 extern void WaitInterconnectQuit(void);
 
@@ -318,7 +318,7 @@ extern void WaitInterconnectQuitUDPIFC(void);
 extern void SetupTCPInterconnect(EState *estate);
 extern void SetupUDPIFCInterconnect(EState *estate);
 extern void TeardownTCPInterconnect(ChunkTransportState *transportStates,
-									bool forceEOS);
+								 bool forceEOS, bool hasError);
 extern void TeardownUDPIFCInterconnect(ChunkTransportState *transportStates,
 								 bool forceEOS);
 


### PR DESCRIPTION
It seems we're toning down errors on segments into warnings with this
commit, which led to the regression test "external_table" failure with a
diff in the expected output like this:

```patch
--- /tmp/build/e18b2f02/gpdb_src/src/test/regress/expected/external_table.out	2020-04-08 05:40:45.168312682 +0000
+++ /tmp/build/e18b2f02/gpdb_src/src/test/regress/results/external_table.out	2020-04-08 05:40:45.504312692 +0000
@@ -1125,9 +1193,11 @@
 (SELECT i, j FROM exttab_subq_1 WHERE i < 10) e2
 group by e1.j
 HAVING sum(distinct e1.i) > (SELECT max(i) FROM exttab_subq_2);
-DETAIL:  Last error was: invalid input syntax for integer: "error_1", column i
-ERROR:  segment reject limit reached, aborting operation
-CONTEXT:  External table exttab_subq_2, line 7 of file://212dcc91-13b3-49fb-5d9e-295b243b163d/tmp/build/e18b2f02/gpdb_src/src/test/regress/data/exttab_more_errors.data, column i
+NOTICE:  found 4 data formatting errors (4 or more input rows), rejected related input data
+ sum | sum | j
+-----+-----+---
+(0 rows)
+
 SELECT COUNT(*) > 0 FROM
 (
 SELECT * FROM gp_read_error_log('exttab_subq_1')


```

This reverts commit a6ae448df47660d51f74f37ed933f8f38e42b947.

Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
