### PR TITLE
Limit DPE stats to groups with unresolved partition selectors

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
@@ -2010,7 +2010,7 @@
     <dxl:Plan Id="0" SpaceSize="150">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324604.464841" Rows="728.177778" Width="28"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324669.231990" Rows="2560.000000" Width="28"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -2039,7 +2039,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324604.388858" Rows="728.177778" Width="28"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324668.964863" Rows="2560.000000" Width="28"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -2068,40 +2068,13 @@
           <dxl:JoinFilter/>
           <dxl:HashCondList>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.062700" Rows="9000.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="10" Alias="d">
-                <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="e">
-                <dxl:Ident ColId="11" ColName="e" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.57371.1.0" TableName="bar">
-              <dxl:Columns>
-                <dxl:Column ColId="10" Attno="1" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
-                <dxl:Column ColId="11" Attno="2" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
-                <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
           <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324172.572304" Rows="809.086420" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324236.752760" Rows="2844.444444" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -2129,7 +2102,7 @@
             </dxl:HashExprList>
             <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324172.555421" Rows="809.086420" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324236.693406" Rows="2844.444444" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -2156,7 +2129,7 @@
                     <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
                       <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                         <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" Value="AAAABzk5OQ==" LintValue="724274224"/>
+                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABzk5OQ==" LintValue="724274224"/>
                       </dxl:FuncExpr>
                     </dxl:CoerceViaIO>
                   </dxl:Comparison>
@@ -2165,7 +2138,7 @@
                     <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
                       <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                         <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" Value="AAAABzk5OQ==" LintValue="724274224"/>
+                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABzk5OQ==" LintValue="724274224"/>
                       </dxl:FuncExpr>
                     </dxl:CoerceViaIO>
                   </dxl:Comparison>
@@ -2184,7 +2157,7 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:PartEqFilters>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" Value="true"/>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
                   <dxl:Or>
@@ -2196,7 +2169,7 @@
                             <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
                               <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                                 <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" Value="AAAABzk5OQ==" LintValue="724274224"/>
+                                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABzk5OQ==" LintValue="724274224"/>
                               </dxl:FuncExpr>
                             </dxl:CoerceViaIO>
                           </dxl:Comparison>
@@ -2207,7 +2180,7 @@
                           <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
                             <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                               <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" Value="AAAABzk5OQ==" LintValue="724274224"/>
+                              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABzk5OQ==" LintValue="724274224"/>
                             </dxl:FuncExpr>
                           </dxl:CoerceViaIO>
                         </dxl:Comparison>
@@ -2219,7 +2192,7 @@
                             <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
                               <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                                 <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" Value="AAAABzk5OQ==" LintValue="724274224"/>
+                                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABzk5OQ==" LintValue="724274224"/>
                               </dxl:FuncExpr>
                             </dxl:CoerceViaIO>
                           </dxl:Comparison>
@@ -2230,7 +2203,7 @@
                           <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
                             <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                               <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" Value="AAAABzk5OQ==" LintValue="724274224"/>
+                              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABzk5OQ==" LintValue="724274224"/>
                             </dxl:FuncExpr>
                           </dxl:CoerceViaIO>
                         </dxl:Comparison>
@@ -2246,10 +2219,10 @@
                   </dxl:Or>
                 </dxl:PartFilters>
                 <dxl:ResidualFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" Value="true"/>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:ResidualFilter>
                 <dxl:PropagationExpression>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:PropagationExpression>
                 <dxl:PrintableFilter>
                   <dxl:And>
@@ -2258,7 +2231,7 @@
                       <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
                         <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                           <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" Value="AAAABzk5OQ==" LintValue="724274224"/>
+                          <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABzk5OQ==" LintValue="724274224"/>
                         </dxl:FuncExpr>
                       </dxl:CoerceViaIO>
                     </dxl:Comparison>
@@ -2267,7 +2240,7 @@
                       <dxl:CoerceViaIO TypeMdid="0.23.1.0" CoercionForm="1" Location="0">
                         <dxl:FuncExpr FuncId="0.1773.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                           <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" Value="AAAABzk5OQ==" LintValue="724274224"/>
+                          <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABzk5OQ==" LintValue="724274224"/>
                         </dxl:FuncExpr>
                       </dxl:CoerceViaIO>
                     </dxl:Comparison>
@@ -2349,6 +2322,33 @@
               </dxl:DynamicTableScan>
             </dxl:NestedLoopJoin>
           </dxl:RedistributeMotion>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.062700" Rows="9000.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="d">
+                <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="e">
+                <dxl:Ident ColId="11" ColName="e" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.57371.1.0" TableName="bar">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="2" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -3835,7 +3835,7 @@
     <dxl:Plan Id="0" SpaceSize="384806">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="30992053500.095406" Rows="19136.250000" Width="31"/>
+          <dxl:Cost StartupCost="0" TotalCost="654544318.346447" Rows="19136.250000" Width="31"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="27" Alias="year">
@@ -3855,7 +3855,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="30992053209.435371" Rows="19136.250000" Width="31"/>
+            <dxl:Cost StartupCost="0" TotalCost="654544027.686413" Rows="19136.250000" Width="31"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="27" Alias="year">
@@ -3875,7 +3875,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="30992053209.435371" Rows="19136.250000" Width="31"/>
+              <dxl:Cost StartupCost="0" TotalCost="654544027.686413" Rows="19136.250000" Width="31"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="27"/>
@@ -3905,7 +3905,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="30992051358.348701" Rows="19136.250000" Width="34"/>
+                <dxl:Cost StartupCost="0" TotalCost="654542176.599743" Rows="19136.250000" Width="34"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="year">
@@ -3942,7 +3942,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="30992051039.657051" Rows="19136.250000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="654541857.908092" Rows="19136.250000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="27" Alias="year">
@@ -3965,7 +3965,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="30992051039.657051" Rows="19136.250000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="654541857.908092" Rows="19136.250000" Width="34"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="27"/>
@@ -3995,7 +3995,7 @@
                   <dxl:Filter/>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="344652958.259605" Rows="523048916394.908081" Width="30"/>
+                      <dxl:Cost StartupCost="0" TotalCost="344652958.259605" Rows="5288759693.059181" Width="30"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="6" Alias="sales">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
@@ -828,7 +828,7 @@ FROM abuela JOIN bar ON a = c AND b BETWEEN d - 1 AND d + 4
     <dxl:Plan Id="0" SpaceSize="746">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.015628" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.015667" Rows="3.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="b">
@@ -839,7 +839,7 @@ FROM abuela JOIN bar ON a = c AND b BETWEEN d - 1 AND d + 4
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.015613" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.015623" Rows="3.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="b">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
@@ -1232,7 +1232,7 @@
     <dxl:Plan Id="0" SpaceSize="33">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9.048127" Rows="3.258390" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="10.193655" Rows="101.010101" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1255,7 +1255,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="8.009943" Rows="3.258390" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="8.009943" Rows="101.010101" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
@@ -1287,7 +1287,7 @@ select * from (select * from p1 union all select * from p2) as p, tt where p.b=t
     <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1297.088987" Rows="18148.820327" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1296.285494" Rows="10101.010101" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1307,7 +1307,7 @@ select * from (select * from p1 union all select * from p2) as p, tt where p.b=t
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1295.785176" Rows="18148.820327" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1295.559837" Rows="10101.010101" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
@@ -1352,7 +1352,7 @@
     <dxl:Plan Id="0" SpaceSize="1137">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2531098.435121" Rows="5111.442548" Width="246"/>
+          <dxl:Cost StartupCost="0" TotalCost="4005245.452411" Rows="12277684.984863" Width="246"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
@@ -1513,7 +1513,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2530483.463018" Rows="5111.442548" Width="246"/>
+            <dxl:Cost StartupCost="0" TotalCost="2530483.463018" Rows="12277684.984863" Width="246"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -3258,7 +3258,7 @@
     <dxl:Plan Id="0" SpaceSize="47573">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1151165615.915166" Rows="134868946302.331726" Width="355"/>
+          <dxl:Cost StartupCost="0" TotalCost="988941274.944215" Rows="321694266.492042" Width="355"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -3484,13 +3484,109 @@
         </dxl:JoinFilter>
         <dxl:HashCondList>
           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-            <dxl:Ident ColId="15" ColName="cs_item_sk" TypeMdid="0.23.1.0"/>
             <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="15" ColName="cs_item_sk" TypeMdid="0.23.1.0"/>
           </dxl:Comparison>
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1019057414.977869" Rows="196201417.533617" Width="339"/>
+            <dxl:Cost StartupCost="0" TotalCost="366902.000000" Rows="11740800.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="41" Alias="inv_date_sk">
+              <dxl:Ident ColId="41" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="42" Alias="inv_item_sk">
+              <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="43" Alias="inv_warehouse_sk">
+              <dxl:Ident ColId="43" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="44" Alias="inv_quantity_on_hand">
+              <dxl:Ident ColId="44" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:Sequence>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="91725.000000" Rows="11740800.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="41" Alias="inv_date_sk">
+                <dxl:Ident ColId="41" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="42" Alias="inv_item_sk">
+                <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="43" Alias="inv_warehouse_sk">
+                <dxl:Ident ColId="43" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="44" Alias="inv_quantity_on_hand">
+                <dxl:Ident ColId="44" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:PartitionSelector RelationMdid="0.810176.1.1" PartitionLevels="1" ScanId="2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:PartEqFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:PartEqFilters>
+              <dxl:PartFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:PartFilters>
+              <dxl:ResidualFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:ResidualFilter>
+              <dxl:PropagationExpression>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:PropagationExpression>
+              <dxl:PrintableFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:PrintableFilter>
+            </dxl:PartitionSelector>
+            <dxl:DynamicTableScan PartIndexId="2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="91725.000000" Rows="11740800.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="41" Alias="inv_date_sk">
+                  <dxl:Ident ColId="41" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="42" Alias="inv_item_sk">
+                  <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="43" Alias="inv_warehouse_sk">
+                  <dxl:Ident ColId="43" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="44" Alias="inv_quantity_on_hand">
+                  <dxl:Ident ColId="44" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.810176.1.1" TableName="inventory">
+                <dxl:Columns>
+                  <dxl:Column ColId="41" Attno="1" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="42" Attno="2" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="43" Attno="3" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="44" Attno="4" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="45" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="46" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="47" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="48" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="49" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="50" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="51" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:DynamicTableScan>
+          </dxl:Sequence>
+        </dxl:GatherMotion>
+        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="986658180.086433" Rows="467986.685065" Width="339"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -3699,7 +3795,7 @@
           <dxl:SortingColumnList/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="986580714.493544" Rows="196201417.533617" Width="339"/>
+              <dxl:Cost StartupCost="0" TotalCost="986580714.493544" Rows="467986.685065" Width="339"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -4721,102 +4817,6 @@
               </dxl:BroadcastMotion>
             </dxl:PartitionSelector>
           </dxl:HashJoin>
-        </dxl:GatherMotion>
-        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="366902.000000" Rows="11740800.000000" Width="16"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="41" Alias="inv_date_sk">
-              <dxl:Ident ColId="41" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="42" Alias="inv_item_sk">
-              <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="43" Alias="inv_warehouse_sk">
-              <dxl:Ident ColId="43" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="44" Alias="inv_quantity_on_hand">
-              <dxl:Ident ColId="44" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:Sequence>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="91725.000000" Rows="11740800.000000" Width="16"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="41" Alias="inv_date_sk">
-                <dxl:Ident ColId="41" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="42" Alias="inv_item_sk">
-                <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="43" Alias="inv_warehouse_sk">
-                <dxl:Ident ColId="43" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="44" Alias="inv_quantity_on_hand">
-                <dxl:Ident ColId="44" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:PartitionSelector RelationMdid="0.810176.1.1" PartitionLevels="1" ScanId="2">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList/>
-              <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PartEqFilters>
-              <dxl:PartFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PartFilters>
-              <dxl:ResidualFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:ResidualFilter>
-              <dxl:PropagationExpression>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-              </dxl:PropagationExpression>
-              <dxl:PrintableFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:PrintableFilter>
-            </dxl:PartitionSelector>
-            <dxl:DynamicTableScan PartIndexId="2">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="91725.000000" Rows="11740800.000000" Width="16"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="41" Alias="inv_date_sk">
-                  <dxl:Ident ColId="41" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="42" Alias="inv_item_sk">
-                  <dxl:Ident ColId="42" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="43" Alias="inv_warehouse_sk">
-                  <dxl:Ident ColId="43" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="44" Alias="inv_quantity_on_hand">
-                  <dxl:Ident ColId="44" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.810176.1.1" TableName="inventory">
-                <dxl:Columns>
-                  <dxl:Column ColId="41" Attno="1" ColName="inv_date_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="42" Attno="2" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="43" Attno="3" ColName="inv_warehouse_sk" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="44" Attno="4" ColName="inv_quantity_on_hand" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="45" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="46" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="47" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="48" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="49" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="50" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="51" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:DynamicTableScan>
-          </dxl:Sequence>
         </dxl:GatherMotion>
       </dxl:HashJoin>
     </dxl:Plan>

--- a/src/backend/gporca/libgpopt/src/base/CCostContext.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCostContext.cpp
@@ -146,7 +146,9 @@ CCostContext::FNeedsNewStats() const
 
 	if (!m_pdpplan->Ppim()->FContainsUnresolved())
 	{
-		// all partition selectors have been resolved at this level
+		// All partition selectors have been resolved at this level.
+		// No need to use DPE stats for the common ancestor join and
+		// nodes above it, that aren't affected by the partition selector.
 		return false;
 	}
 

--- a/src/backend/gporca/libgpopt/src/base/CCostContext.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCostContext.cpp
@@ -144,6 +144,12 @@ CCostContext::FNeedsNewStats() const
 		return false;
 	}
 
+	if (!m_pdpplan->Ppim()->FContainsUnresolved())
+	{
+		// all partition selectors have been resolved at this level
+		return false;
+	}
+
 	CEnfdPartitionPropagation *pepp = Poc()->Prpp()->Pepp();
 
 	if (GPOS_FTRACE(EopttraceDeriveStatsForDPE) &&

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
@@ -533,6 +533,9 @@ CExpressionHandle::DeriveCostContextStats()
 	{
 		// there is no need to derive stats,
 		// stats are copied from owner group
+		// (note that m_pdrgpstat may not contain the correct DPE
+		// stats of children, but it is used only for deriving the
+		// stats, which we don't need to do anymore)
 
 		return;
 	}

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
@@ -547,17 +547,26 @@ CExpressionHandle::DeriveCostContextStats()
 		CPhysicalScan *popScan = CPhysicalScan::PopConvert(m_pgexpr->Pop());
 		IStatistics *pstatsDS = popScan->PstatsDerive(m_mp, *this, m_pcc->Poc()->Prpp(), m_pcc->Poc()->Pdrgpstat());
 
-		CRefCount::SafeRelease(m_pstats);
-		m_pstats = pstatsDS;
+		if (NULL == m_pstats || m_pstats->Rows() > pstatsDS->Rows())
+		{
+			// Replace the group stats with our newly derived DPE stats
+			CRefCount::SafeRelease(m_pstats);
+			m_pstats = pstatsDS;
+		}
+		else
+		{
+			// Eliminating partitions can't possibly increase the row count. If the row
+			// count is higher, that's likely due to some heuristics in the estimation.
+			// If the row count is the same, there is no need to use DPE stats.
+			pstatsDS->Release();
+		}
 
 		return;
 	}
 
-	// release current stats since we will derive new stats
-	CRefCount::SafeRelease(m_pstats);
-	m_pstats = NULL;
+	IStatistics *costContextStats = m_pstats;
 
-	// load stats from child cost context -- these may be different from child groups stats
+	// load stats from child cost context(s) -- these may be different from child groups stats
 	CRefCount::SafeRelease(m_pdrgpstat);
 	m_pdrgpstat = NULL;
 
@@ -578,35 +587,38 @@ CExpressionHandle::DeriveCostContextStats()
 	{
 		GPOS_ASSERT(1 == m_pdrgpstat->Size());
 
-		// copy stats from first child
-		(*m_pdrgpstat)[0]->AddRef();
-		m_pstats = (*m_pdrgpstat)[0];
+		// simply pass stats from first child
+		costContextStats = (*m_pdrgpstat)[0];
+	}
+	else
+	{
+		if (m_pcc->Pdpplan()->Ppim()->FContainsUnresolved())
+		{
+			// derive stats using the best logical expression with the same children as attached physical operator
+			CGroupExpression *pgexprForStats = m_pcc->PgexprForStats();
+			GPOS_ASSERT(NULL != pgexprForStats);
 
-		return;
+			CExpressionHandle exprhdl(m_mp);
+			exprhdl.Attach(pgexprForStats);
+			exprhdl.DeriveProps(NULL /*pdpctxt*/);
+			m_pdrgpstat->AddRef();
+			exprhdl.m_pdrgpstat = m_pdrgpstat;
+			exprhdl.ComputeReqdProps(m_pcc->Poc()->GetReqdRelationalProps(), 0 /*ulOptReq*/);
+
+			GPOS_ASSERT(NULL == exprhdl.m_pstats);
+			IStatistics *stats = m_pgexpr->Pgroup()->PstatsCompute(m_pcc->Poc(), exprhdl, pgexprForStats);
+
+			GPOS_ASSERT(NULL != stats);
+			costContextStats = stats;
+		}
 	}
 
-	// derive stats using the best logical expression with the same children as attached physical operator
-	CGroupExpression *pgexprForStats = m_pcc->PgexprForStats();
-	GPOS_ASSERT(NULL != pgexprForStats);
-
-	CExpressionHandle exprhdl(m_mp);
-	exprhdl.Attach(pgexprForStats);
-	exprhdl.DeriveProps(NULL /*pdpctxt*/);
-	m_pdrgpstat->AddRef();
-	exprhdl.m_pdrgpstat = m_pdrgpstat;
-	exprhdl.ComputeReqdProps(m_pcc->Poc()->GetReqdRelationalProps(), 0 /*ulOptReq*/);
-
-	GPOS_ASSERT(NULL == exprhdl.m_pstats);
-	IStatistics *stats = m_pgexpr->Pgroup()->PstatsCompute(m_pcc->Poc(), exprhdl, pgexprForStats);
-
-	// copy stats to main handle
-	GPOS_ASSERT(NULL == m_pstats);
-	GPOS_ASSERT(NULL != stats);
-
-	stats->AddRef();
-	m_pstats = stats;
-
-	GPOS_ASSERT(m_pstats != NULL);
+	if (costContextStats != m_pstats)
+	{
+		costContextStats->AddRef();
+		CRefCount::SafeRelease(m_pstats);
+		m_pstats = costContextStats;
+	}
 }
 
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
@@ -1222,6 +1222,7 @@ CPhysicalJoin::PppsRequiredJoinChild
 		return PppsRequiredCompute(mp, exprhdl, pppsRequired, child_index, fNLJoin);
 	}
 
+	// try to find a previously generated CPartitionPropagationSpec in the cache, m_phmpp
 	CPartitionPropagationSpec *ppps = m_phmpp->Find(pppr);
 	if (NULL == ppps)
 	{


### PR DESCRIPTION
DPE stats are computed when we have a dynamic partition selector that's
applied on another child of a join. The current code continues to use
DPE stats even for the common ancestor join and nodes above it, but
those nodes aren't affected by the partition selector.

Regular Memo groups pick the best expression among several to compute
stats, which makes row count estimates more reliable. We don't have
that luxury with DPE stats, therefore they are often less reliable.

By minimizing the places where we use DPE stats, we should overall get
more reliable row count estimates with DPE stats enabled.

The fix also ignores DPE stats with row counts greater than the group
stats. Partition selectors eliminate certain partitions, therefore
it is impossible for them to increase the row count.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
