### PR TITLE
docs - updates for PostGIS 2.5.4

### DIFF
--- a/gpdb-doc/dita/analytics/postGIS.xml
+++ b/gpdb-doc/dita/analytics/postGIS.xml
@@ -184,7 +184,7 @@ export POSTGIS_GDAL_ENABLED_DRIVERS=DISABLE_ALL</codeblock>
         <p>Run the <codeph>postgis_manager.sh</codeph> script specifying the database, a schema name
           (if necessary), and with the <codeph>uninstall</codeph> option to remove PostGIS and
           PostGIS Raster. You specify the schema if you specified a schema when you installed
-          PostGIS.<codeblock>postgis_manager.sh &lt;dbname> [&lt;schema_name>] uninstall </codeblock></p>
+          PostGIS.<codeblock>postgis_manager.sh &lt;dbname> [&lt;schema_name>] uninstall</codeblock></p>
         <p>This example removes PostGIS and PostGIS Raster support from the database
             <codeph>mydatabase</codeph> that was installed in the default
           schema.<codeblock>postgis_manager.sh mydatabase uninstall</codeblock></p>

--- a/gpdb-doc/dita/analytics/postGIS.xml
+++ b/gpdb-doc/dita/analytics/postGIS.xml
@@ -108,7 +108,7 @@
       <body>
         <p>Run the <codeph>postgis_manager.sh</codeph> script specifying the database, an optional
           schema, and the <codeph>install</codeph> option to install PostGIS and PostGIS Raster. If
-          you do not specify a schema, the script installs PostGIS installs in the default
+          you do not specify a schema, the script installs PostGIS in the default
           schema.<codeblock>postgis_manager.sh &lt;dbname> [&lt;schema_name>] install </codeblock></p>
         <p>This example installs PostGIS and PostGIS Raster objects in the database
             <codeph>mydatabase</codeph> in the default
@@ -187,7 +187,7 @@ export POSTGIS_GDAL_ENABLED_DRIVERS=DISABLE_ALL</codeblock>
           PostGIS.<codeblock>postgis_manager.sh &lt;dbname> [&lt;schema_name>] uninstall </codeblock></p>
         <p>This example removes PostGIS and PostGIS Raster support from the database
             <codeph>mydatabase</codeph> that was installed in the default
-          schema.<codeblock><codeph>postgis_manager.sh</codeph> mydatabase uninstall</codeblock></p>
+          schema.<codeblock>postgis_manager.sh mydatabase uninstall</codeblock></p>
         <p>The script runs both the PostGIS SQL scripts that remove PostGIS and PostGIS Raster from
           a database: <codeph>uninstall_rtpostgis.sql</codeph> and
             <codeph>uninstall_postgis.sql</codeph>.</p>

--- a/gpdb-doc/dita/analytics/postGIS.xml
+++ b/gpdb-doc/dita/analytics/postGIS.xml
@@ -52,13 +52,13 @@
       <title id="ij168742">Greenplum PostGIS Extension</title>
       <body>
         <p><ph otherprops="pivotal">The Greenplum Database PostGIS extension package is available
-            from <xref href="https://network.pivotal.io/products/pivotal-gpdb" scope="external" format="html">Pivotal
-              Network</xref>. </ph>You can install the package using the Greenplum Package Manager
-            (<codeph>gppkg</codeph>). For details, see <codeph>gppkg</codeph> in the <cite>Greenplum
-            Database Utility Guide</cite>.</p>
+            from <xref href="https://network.pivotal.io/products/pivotal-gpdb" scope="external"
+              format="html">VMware Tanzu Network</xref>. </ph>You can install the package using the
+          Greenplum Package Manager (<codeph>gppkg</codeph>). For details, see
+            <codeph>gppkg</codeph> in the <cite>Greenplum Database Utility Guide</cite>.</p>
         <p>Greenplum Database supports the PostGIS extension with these component versions.<ul
             id="ul_csh_q3z_d1b">
-            <li>PostGIS 2.1.5</li>
+            <li>PostGIS 2.5.4</li>
             <li>Proj 4.8.0 </li>
             <li>Geos 3.4.2</li>
             <li>GDAL 1.11.1</li>
@@ -66,18 +66,15 @@
             <li>Expat 2.1.0</li>
           </ul></p>
         <p otherprops="pivotal">For the information about supported extension packages and software
-          versions see the <cite>Greenplum Database Release Notes</cite>.</p>
-        <p>Major enhancements and changes in PostGIS 2.1.5 from 2.0.3 include new PostGIS Raster
-          functions. For a list of new and enhanced functions in PostGIS 2.1, see the PostGIS
-          documentation <xref
-            href="http://postgis.net/docs/manual-2.1/PostGIS_Special_Functions_Index.html#NewFunctions_2_1"
-            format="html" scope="external">PostGIS Functions new or enhanced in 2.1</xref>.</p>
-        <p>For a list of breaking changes in PostGIS 2.1, see <xref
-            href="http://postgis.net/docs/manual-2.1/PostGIS_Special_Functions_Index.html#ChangedFunctions_2_1"
-            format="html" scope="external">PostGIS functions breaking changes in 2.1</xref>.</p>
-        <p>For a comprehensive list of PostGIS changes in PostGIS 2.1.5 and earlier, see PostGIS 2.1
-          Appendix A <xref href="http://postgis.net/docs/manual-2.1/release_notes.html#idm34802"
-            format="html" scope="external">Release 2.1.5</xref>.</p>
+          versions, see the <cite>Greenplum Database Release Notes</cite>.</p>
+        <p>There have been significant changes in PostGIS 2.5.4 compared with the previously
+          supported version of 2.1.5. For a list of new and enhanced functions in PostGIS 2.5, see
+          the PostGIS documentation <xref
+            href="http://postgis.net/docs/manual-2.5/PostGIS_Special_Functions_Index.html#NewFunctions_2_5"
+            format="html" scope="external">PostGIS Functions new or enhanced in 2.5</xref>.</p>
+        <p>For a comprehensive list of PostGIS changes in PostGIS 2.5.4 and earlier, see PostGIS 2.5
+          Appendix A <xref href="http://postgis.net/docs/manual-2.5/release_notes.html"
+            format="html" scope="external">Release 2.5.4</xref>.</p>
       </body>
       <topic id="topic4" xml:lang="en">
         <title>Greenplum Database PostGIS Limitations</title>
@@ -87,7 +84,6 @@
             <li id="ij169095">Topology</li>
             <li id="ij166819">A small number of user defined functions and aggregates</li>
             <li id="ij166822">PostGIS long transaction support</li>
-            <li id="ij169588">Geometry and geography type modifier</li>
           </ul>
           <p>For information about Greenplum Database PostGIS support, see <xref
               href="#postgis_support" format="dita"/>.</p>
@@ -101,7 +97,7 @@
       <p>The Greenplum Database PostGIS extension contains the <codeph>postgis_manager.sh</codeph>
         script that installs or removes both the PostGIS and PostGIS Raster features in a database.
         After the PostGIS extension package is installed, the script is in
-          <codeph>$GPHOME/share/postgresql/contrib/postgis-2.1/</codeph>. The
+          <codeph>$GPHOME/share/postgresql/contrib/postgis-2.5/</codeph>. The
           <codeph>postgis_manager.sh</codeph> script runs SQL scripts that install or remove PostGIS
         and PostGIS Raster from a database.</p>
       <p>For information about the PostGIS and PostGIS Raster SQL scripts, and required PostGIS
@@ -110,16 +106,19 @@
     <topic id="topic_ln5_xcl_r1b">
       <title>Enabling PostGIS Support</title>
       <body>
-        <p>Run the <codeph>postgis_manager.sh</codeph> script specifying the database and with the
-            <codeph>install</codeph> option to install PostGIS and PostGIS Raster. This example
-          installs PostGIS and PostGIS Raster objects in the database
-          <codeph>mydatabase</codeph>.<codeblock><codeph>postgis_manager.sh</codeph> mydatabase install</codeblock></p>
+        <p>Run the <codeph>postgis_manager.sh</codeph> script specifying the database, an optional
+          schema, and the <codeph>install</codeph> option to install PostGIS and PostGIS Raster. If
+          you do not specify a schema, the script installs PostGIS installs in the default
+          schema.<codeblock>postgis_manager.sh &lt;dbname> [&lt;schema_name>] install </codeblock></p>
+        <p>This example installs PostGIS and PostGIS Raster objects in the database
+            <codeph>mydatabase</codeph> in the default
+          schema.<codeblock>postgis_manager.sh mydatabase install</codeblock></p>
         <p>The script runs all the PostGIS SQL scripts that enable PostGIS in a database:
             <codeph>install/postgis.sql</codeph>, <codeph>install/rtpostgis.sql</codeph>
           <codeph>install/spatial_ref_sys.sql</codeph>,
             <codeph>install/postgis_comments.sql</codeph>, and
             <codeph>install/raster_comments.sql</codeph>.</p>
-        <p dir="ltr">The postGIS package installation adds these lines to the
+        <p>The postGIS package installation adds these lines to the
             <codeph>greenplum_path.sh</codeph> file for PostGIS Raster support. </p>
         <codeblock>export GDAL_DATA=$GPHOME/share/gdal
 export POSTGIS_ENABLE_OUTDB_RASTERS=0
@@ -134,6 +133,12 @@ export POSTGIS_GDAL_ENABLED_DRIVERS=DISABLE_ALL</codeblock>
           enable raster drivers by setting the value of the
             <codeph>POSTGIS_GDAL_ENABLED_DRIVERS</codeph> environment variable in the
             <codeph>greenplum_path.sh</codeph> file on all Greenplum Database hosts.</p>
+        <p>Alternatively, you can do it at the session level by setting
+            <codeph>postgis.gdal_enabled_drivers</codeph>. For a Greenplum Database session, this
+          example <codeph>SET</codeph> command enables three GDAL raster
+          drivers.<codeblock>SET postgis.gdal_enabled_drivers TO 'GTiff PNG JPEG';</codeblock></p>
+        <p>This <codeph>SET</codeph> command sets the enabled drivers to the default for a session.
+          <codeblock>SET postgis.gdal_enabled_drivers = default;</codeblock></p>
         <p>To see the list of supported GDAL raster drivers for a Greenplum Database system, run the
             <codeph>raster2pgsql</codeph> utility with the <codeph>-G</codeph> option on the
           Greenplum Database master.</p>
@@ -154,15 +159,33 @@ export POSTGIS_GDAL_ENABLED_DRIVERS=DISABLE_ALL</codeblock>
           the <codeph>ST_GDALDrivers()</codeph> function. This <codeph>SELECT</codeph> command lists
           the enabled raster drivers.</p>
         <codeblock>SELECT short_name, long_name FROM ST_GDALDrivers();</codeblock>
+        <section>
+          <title>Enabling Out-of-Database Rasters</title>
+          <p>After installing PostGIS, the default setting
+              <codeph>POSTGIS_ENABLE_OUTDB_RASTERS=0</codeph> in the
+              <codeph>greenplum_path.sh</codeph> file disables support for to out-of-database
+            rasters. To enable this feature, you can set the value to true (a non-zero value) on all
+            hosts and restart the Greenplum Database system. </p>
+          <p>You can also enable or disable this feature for a Greenplum Database session. For
+            example, this <codeph>SET</codeph> command enables the feature for the current
+            session.</p>
+          <codeblock>SET postgis.enable_outdb_rasters = true;				</codeblock>
+          <note>When the feature is enabled, the server configuration parameter
+              <codeph>postgis.gdal_enabled_drivers</codeph> determines the accessible raster
+            formats.</note>
+        </section>
       </body>
     </topic>
     <topic id="topic_bgz_vcl_r1b">
       <title>Removing PostGIS Support</title>
       <body>
-        <p>Run the <codeph>postgis_manager.sh</codeph> script specifying the database and with the
-            <codeph>uninstall</codeph> option to remove PostGIS and PostGIS Raster. This example
-          removes PostGIS and PostGIS Raster support from the database
-          <codeph>mydatabase</codeph>.<codeblock><codeph>postgis_manager.sh</codeph> mydatabase uninstall</codeblock></p>
+        <p>Run the <codeph>postgis_manager.sh</codeph> script specifying the database, a schema name
+          (if necessary), and with the <codeph>uninstall</codeph> option to remove PostGIS and
+          PostGIS Raster. You specify the schema if you specified a schema when you installed
+          PostGIS.<codeblock>postgis_manager.sh &lt;dbname> [&lt;schema_name>] uninstall </codeblock></p>
+        <p>This example removes PostGIS and PostGIS Raster support from the database
+            <codeph>mydatabase</codeph> that was installed in the default
+          schema.<codeblock><codeph>postgis_manager.sh</codeph> mydatabase uninstall</codeblock></p>
         <p>The script runs both the PostGIS SQL scripts that remove PostGIS and PostGIS Raster from
           a database: <codeph>uninstall_rtpostgis.sql</codeph> and
             <codeph>uninstall_postgis.sql</codeph>.</p>
@@ -271,11 +294,12 @@ SELECT name,ST_AsText(geopoint) FROM geotest;</codeblock>
           <li dir="ltr">summarystats </li>
           <li dir="ltr">unionarg</li>
         </ul>
-        <p>For information about PostGIS Raster data Management, queries, and applications <xref
-            href="http://postgis.net/docs/manual-2.1/using_raster_dataman.html" format="html"
-            scope="external">http://postgis.net/docs/manual-2.1/using_raster_dataman.html</xref></p>
+        <p>For information about PostGIS Raster data Management, queries, and applications, see
+            <xref href="http://postgis.net/docs/manual-2.5/using_raster_dataman.html" format="html"
+            scope="external"
+          >http://postgis.net/docs/manual-2.5/using_raster_dataman.html</xref>.</p>
         <p>For a list of PostGIS Raster data types, operators, and functions, see the <xref
-            href="http://postgis.net/docs/manual-2.1/RT_reference.html" format="html"
+            href="http://postgis.net/docs/manual-2.5/RT_reference.html" format="html"
             scope="external">PostGIS Raster reference documentation</xref>.</p>
       </body>
     </topic>
@@ -294,13 +318,9 @@ SELECT name,ST_AsText(geopoint) FROM geotest;</codeblock>
         <ul id="ul_vzc_bpb_3p">
           <li>Data types and functions related to PostGIS topology functionality, such as
               <apiname>TopoGeometry</apiname>, are not supported by Greenplum Database.</li>
-          <li> Functions that perform <codeph>ANALYZE</codeph> operations for user-defined data
-            types are not supported. For example, the <apiname>ST_Estimated_Extent</apiname>
-            function is not supported. The function requires table column statistics for user
-            defined data types that are not available with Greenplum Database.</li>
           <li>These PostGIS aggregates are not supported by Greenplum Database:<ul
               id="ul_ylg_hpb_3p">
-              <li><apiname>ST_MemCollect</apiname></li>
+              <li><apiname>ST_Collect</apiname></li>
               <li><apiname>ST_MakeLine</apiname></li>
             </ul><p>On a Greenplum Database with multiple segments, the aggregate might return
               different answers if it is called several times repeatedly.</p></li>
@@ -321,6 +341,11 @@ SELECT name,ST_AsText(geopoint) FROM geotest;</codeblock>
               the
               table:<codeblock>CREATE TABLE geometries(id INTEGER);
 SELECT AddGeometryColumn('public', 'geometries', 'geom', 0, 'LINESTRING', 2);</codeblock></p></li>
+          <li>The <codeph>_postgis_index_extent</codeph> function is not supported on Greenplum
+            Database 6 due to its dependence on spatial index operations.</li>
+          <li>The <codeph>&lt;-></codeph> operator (<codeph><varname>geometry</varname> &lt;->
+                <varname>geometry</varname></codeph>) returns the centroid/centroid distance for
+            Greenplum Database 6.</li>
         </ul>
       </body>
     </topic>
@@ -331,7 +356,7 @@ SELECT AddGeometryColumn('public', 'geometries', 'geom', 0, 'LINESTRING', 2);</c
       <p>After installing the PostGIS extension package, you enable PostGIS support for each
         database that requires its use. To enable or remove PostGIS support in your database, you
         can run SQL scripts that are supplied with the PostGIS package in
-          <codeph>$GPHOME/share/postgresql/contrib/postgis-2.1/</codeph>.<ul id="ul_xmd_xpz_r1b">
+          <codeph>$GPHOME/share/postgresql/contrib/postgis-2.5/</codeph>.<ul id="ul_xmd_xpz_r1b">
           <li><xref href="#topic_ulm_4gl_r1b" format="dita"/></li>
           <li><xref href="#topic_xp2_lgl_r1b" format="dita"/></li>
         </ul></p>
@@ -343,19 +368,19 @@ SELECT AddGeometryColumn('public', 'geometries', 'geom', 0, 'LINESTRING', 2);</c
           <codeph>rtpostgis.sql</codeph>, and <codeph>spatial_ref_sys.sql</codeph> in the database
           <codeph>mydatabase</codeph>.</p>
       <codeblock>psql -d mydatabase -f 
-  $GPHOME/share/postgresql/contrib/postgis-2.1/install/postgis.sql
+  $GPHOME/share/postgresql/contrib/postgis-2.5/install/postgis.sql
 psql -d mydatabase -f 
-  $GPHOME/share/postgresql/contrib/postgis-2.1/install/rtpostgis.sql
+  $GPHOME/share/postgresql/contrib/postgis-2.5/install/rtpostgis.sql
 psql -d mydatabase -f 
-  $GPHOME/share/postgresql/contrib/postgis-2.1/install/spatial_ref_sys.sql</codeblock>
+  $GPHOME/share/postgresql/contrib/postgis-2.5/install/spatial_ref_sys.sql</codeblock>
       <p>After running the scripts, the database is enabled with both PostGIS and PostGIS
         Raster.</p>
     </body>
     <topic id="topic_ulm_4gl_r1b">
       <title>Scripts that Enable PostGIS and PostGIS Raster Support</title>
       <body>
-        <p dir="ltr" id="docs-internal-guid-8c038020-7f9c-b023-7fae-617656ae21e7">These scripts
-          enable PostGIS, and the optional PostGIS Raster in a database.<ul id="ul_iph_ddm_d1b">
+        <p>These scripts enable PostGIS, and the optional PostGIS Raster in a database.<ul
+            id="ul_iph_ddm_d1b">
             <li><codeph>install/postgis.sql</codeph> - Load the PostGIS objects and function
               definitions.</li>
             <li><codeph>install/rtpostgis.sql</codeph> - Load the PostGIS <codeph>raster</codeph>
@@ -369,10 +394,10 @@ psql -d mydatabase -f
             <li><codeph>install/spatial_ref_sys.sql</codeph> - Populate the
                 <codeph>spatial_ref_sys</codeph> table with a complete set of EPSG coordinate system
               definition identifiers. With the definition identifiers you can perform
-                <codeph>ST_Transform()</codeph> operations on geometries.<note type="note">If you
-                have overridden standard entries and want to use those overrides, do not load the
-                  <codeph>spatial_ref_sys.sql</codeph> file when creating the new
-              database.</note></li>
+                <codeph>ST_Transform()</codeph> operations on geometries.
+              <note type="note">If you have overridden standard entries and want to use those
+                overrides, do not load the <codeph>spatial_ref_sys.sql</codeph> file when creating
+                the new database.</note></li>
             <li><codeph>install/postgis_comments.sql</codeph> - Add comments to the PostGIS
               functions.</li>
             <li><codeph>install/raster_comments.sql</codeph> - Add comments to the PostGIS Raster
@@ -407,7 +432,7 @@ export POSTGIS_GDAL_ENABLED_DRIVERS=DISABLE_ALL</codeblock>
       <body>
         <p>To remove PostGIS support from a database, run SQL scripts that are supplied with the
           PostGIS extension package in
-            <codeph>$GPHOME/share/postgresql/contrib/postgis-2.1/</codeph>
+            <codeph>$GPHOME/share/postgresql/contrib/postgis-2.5/</codeph>
         </p>
         <note>If you installed PostGIS Raster, you must uninstall PostGIS Raster before you
           uninstall the PostGIS objects. PostGIS Raster depends on PostGIS objects. Greenplum
@@ -422,7 +447,7 @@ export POSTGIS_GDAL_ENABLED_DRIVERS=DISABLE_ALL</codeblock>
         <p>After PostGIS support has been removed from all databases in the Greenplum Database
           system, you can remove the PostGIS extension package. For example this
             <codeph>gppkg</codeph> command removes the PostGIS extension package.
-          <codeblock>gppkg -r postgis-2.1.5+pivotal.2</codeblock></p>
+          <codeblock>gppkg -r postgis-2.5.5+pivotal.1</codeblock></p>
         <p>Restart Greenplum Database after removing the package.</p>
         <codeblock>gpstop -r</codeblock>
         <p dir="ltr">Ensure that these lines for PostGIS Raster support are removed from the

--- a/gpdb-doc/dita/analytics/postGIS.xml
+++ b/gpdb-doc/dita/analytics/postGIS.xml
@@ -255,9 +255,10 @@ SELECT name,ST_AsText(geopoint) FROM geotest;</codeblock>
           <xref href="#topic_g2d_hkb_3p" format="dita"/>
         </li>
         <li>
+          <xref href="#topic_bl3_4vy_d1b" format="dita"/></li>
+        <li>
           <xref href="#topic_y5z_nkb_3p" format="dita"/>
         </li>
-        <li><xref href="#topic_bl3_4vy_d1b" format="dita"/></li>
         <li>
           <xref href="#topic_wy2_rkb_3p" format="dita"/>
         </li>

--- a/gpdb-doc/dita/analytics/postGIS.xml
+++ b/gpdb-doc/dita/analytics/postGIS.xml
@@ -48,47 +48,47 @@
       <p>For information about GDAL, see <xref href="http://www.gdal.org" format="html"
           scope="external">http://www.gdal.org</xref>. </p>
     </body>
-    <topic id="topic3" xml:lang="en">
-      <title id="ij168742">Greenplum PostGIS Extension</title>
+  </topic>
+  <topic id="topic3" xml:lang="en">
+    <title id="ij168742">Greenplum PostGIS Extension</title>
+    <body>
+      <p><ph otherprops="pivotal">The Greenplum Database PostGIS extension package is available from
+            <xref href="https://network.pivotal.io/products/pivotal-gpdb" scope="external"
+            format="html">VMware Tanzu Network</xref>. </ph>You can install the package using the
+        Greenplum Package Manager (<codeph>gppkg</codeph>). For details, see <codeph>gppkg</codeph>
+        in the <cite>Greenplum Database Utility Guide</cite>.</p>
+      <p>Greenplum Database supports the PostGIS extension with these component versions.<ul
+          id="ul_csh_q3z_d1b">
+          <li>PostGIS 2.5.4</li>
+          <li>Proj 4.8.0 </li>
+          <li>Geos 3.4.2</li>
+          <li>GDAL 1.11.1</li>
+          <li>Json 0.12</li>
+          <li>Expat 2.1.0</li>
+        </ul></p>
+      <p otherprops="pivotal">For the information about supported extension packages and software
+        versions, see the <cite>Greenplum Database Release Notes</cite>.</p>
+      <p>There have been significant changes in PostGIS 2.5.4 compared with the previously supported
+        version of 2.1.5. For a list of new and enhanced functions in PostGIS 2.5, see the PostGIS
+        documentation <xref
+          href="http://postgis.net/docs/manual-2.5/PostGIS_Special_Functions_Index.html#NewFunctions_2_5"
+          format="html" scope="external">PostGIS Functions new or enhanced in 2.5</xref>.</p>
+      <p>For a comprehensive list of PostGIS changes in PostGIS 2.5.4 and earlier, see PostGIS 2.5
+        Appendix A <xref href="http://postgis.net/docs/manual-2.5/release_notes.html" format="html"
+          scope="external">Release 2.5.4</xref>.</p>
+    </body>
+    <topic id="topic4" xml:lang="en">
+      <title>Greenplum Database PostGIS Limitations</title>
       <body>
-        <p><ph otherprops="pivotal">The Greenplum Database PostGIS extension package is available
-            from <xref href="https://network.pivotal.io/products/pivotal-gpdb" scope="external"
-              format="html">VMware Tanzu Network</xref>. </ph>You can install the package using the
-          Greenplum Package Manager (<codeph>gppkg</codeph>). For details, see
-            <codeph>gppkg</codeph> in the <cite>Greenplum Database Utility Guide</cite>.</p>
-        <p>Greenplum Database supports the PostGIS extension with these component versions.<ul
-            id="ul_csh_q3z_d1b">
-            <li>PostGIS 2.5.4</li>
-            <li>Proj 4.8.0 </li>
-            <li>Geos 3.4.2</li>
-            <li>GDAL 1.11.1</li>
-            <li>Json 0.12</li>
-            <li>Expat 2.1.0</li>
-          </ul></p>
-        <p otherprops="pivotal">For the information about supported extension packages and software
-          versions, see the <cite>Greenplum Database Release Notes</cite>.</p>
-        <p>There have been significant changes in PostGIS 2.5.4 compared with the previously
-          supported version of 2.1.5. For a list of new and enhanced functions in PostGIS 2.5, see
-          the PostGIS documentation <xref
-            href="http://postgis.net/docs/manual-2.5/PostGIS_Special_Functions_Index.html#NewFunctions_2_5"
-            format="html" scope="external">PostGIS Functions new or enhanced in 2.5</xref>.</p>
-        <p>For a comprehensive list of PostGIS changes in PostGIS 2.5.4 and earlier, see PostGIS 2.5
-          Appendix A <xref href="http://postgis.net/docs/manual-2.5/release_notes.html"
-            format="html" scope="external">Release 2.5.4</xref>.</p>
+        <p>The Greenplum Database PostGIS extension does not support the following features:</p>
+        <ul id="ul_mm2_p42_4p">
+          <li id="ij169095">Topology</li>
+          <li id="ij166819">A small number of user defined functions and aggregates</li>
+          <li id="ij166822">PostGIS long transaction support</li>
+        </ul>
+        <p>For information about Greenplum Database PostGIS support, see <xref
+            href="#postgis_support" format="dita"/>.</p>
       </body>
-      <topic id="topic4" xml:lang="en">
-        <title>Greenplum Database PostGIS Limitations</title>
-        <body>
-          <p>The Greenplum Database PostGIS extension does not support the following features:</p>
-          <ul id="ul_mm2_p42_4p">
-            <li id="ij169095">Topology</li>
-            <li id="ij166819">A small number of user defined functions and aggregates</li>
-            <li id="ij166822">PostGIS long transaction support</li>
-          </ul>
-          <p>For information about Greenplum Database PostGIS support, see <xref
-              href="#postgis_support" format="dita"/>.</p>
-        </body>
-      </topic>
     </topic>
   </topic>
   <topic id="topic_b2l_hzw_q1b">
@@ -159,21 +159,23 @@ export POSTGIS_GDAL_ENABLED_DRIVERS=DISABLE_ALL</codeblock>
           the <codeph>ST_GDALDrivers()</codeph> function. This <codeph>SELECT</codeph> command lists
           the enabled raster drivers.</p>
         <codeblock>SELECT short_name, long_name FROM ST_GDALDrivers();</codeblock>
-        <section>
-          <title>Enabling Out-of-Database Rasters</title>
-          <p>After installing PostGIS, the default setting
-              <codeph>POSTGIS_ENABLE_OUTDB_RASTERS=0</codeph> in the
-              <codeph>greenplum_path.sh</codeph> file disables support for to out-of-database
-            rasters. To enable this feature, you can set the value to true (a non-zero value) on all
-            hosts and restart the Greenplum Database system. </p>
-          <p>You can also enable or disable this feature for a Greenplum Database session. For
-            example, this <codeph>SET</codeph> command enables the feature for the current
-            session.</p>
-          <codeblock>SET postgis.enable_outdb_rasters = true;				</codeblock>
-          <note>When the feature is enabled, the server configuration parameter
-              <codeph>postgis.gdal_enabled_drivers</codeph> determines the accessible raster
-            formats.</note>
-        </section>
+      </body>
+    </topic>
+    <topic id="topic_fx2_fpx_llb">
+      <title>Enabling Out-of-Database Rasters</title>
+      <body>
+        <p>After installing PostGIS, the default setting
+            <codeph>POSTGIS_ENABLE_OUTDB_RASTERS=0</codeph> in the
+            <codeph>greenplum_path.sh</codeph> file disables support for to out-of-database rasters.
+          To enable this feature, you can set the value to true (a non-zero value) on all hosts and
+          restart the Greenplum Database system. </p>
+        <p>You can also enable or disable this feature for a Greenplum Database session. For
+          example, this <codeph>SET</codeph> command enables the feature for the current
+          session.</p>
+        <codeblock>SET postgis.enable_outdb_rasters = true;				</codeblock>
+        <note>When the feature is enabled, the server configuration parameter
+            <codeph>postgis.gdal_enabled_drivers</codeph> determines the accessible raster
+          formats.</note>
       </body>
     </topic>
     <topic id="topic_bgz_vcl_r1b">

--- a/gpdb-doc/dita/analytics/postGIS.xml
+++ b/gpdb-doc/dita/analytics/postGIS.xml
@@ -447,7 +447,7 @@ export POSTGIS_GDAL_ENABLED_DRIVERS=DISABLE_ALL</codeblock>
         <p>After PostGIS support has been removed from all databases in the Greenplum Database
           system, you can remove the PostGIS extension package. For example this
             <codeph>gppkg</codeph> command removes the PostGIS extension package.
-          <codeblock>gppkg -r postgis-2.5.5+pivotal.1</codeblock></p>
+          <codeblock>gppkg -r postgis-2.5.4+pivotal.1</codeblock></p>
         <p>Restart Greenplum Database after removing the package.</p>
         <codeblock>gpstop -r</codeblock>
         <p dir="ltr">Ensure that these lines for PostGIS Raster support are removed from the

--- a/gpdb-doc/dita/analytics/postGIS.xml
+++ b/gpdb-doc/dita/analytics/postGIS.xml
@@ -38,15 +38,15 @@
         SQL functions (such as <codeph>ST_Intersects</codeph>) operating seamlessly on vector and
         raster geospatial data. PostGIS Raster uses the GDAL (Geospatial Data Abstraction Library)
         translator library for raster geospatial data formats that presents a <xref
-          href="http://www.gdal.org/gdal_datamodel.html" format="html" scope="external">single
+          href="https://gdal.org/user/raster_data_model.html" format="html" scope="external">single
           raster abstract data model</xref> to a calling application. </p>
       <p>For information about Greenplum Database PostGIS extension support, see <xref
           href="#postgis_support" format="dita"/>.</p>
-      <p>For information about PostGIS, see <xref href="http://postgis.refractions.net/"
-          scope="external" format="html"> http://postgis.refractions.net/</xref>
+      <p>For information about PostGIS, see <xref href="https://postgis.net/" scope="external"
+          format="html">https://postgis.net/</xref>
       </p>
-      <p>For information about GDAL, see <xref href="http://www.gdal.org" format="html"
-          scope="external">http://www.gdal.org</xref>. </p>
+      <p>For information about GDAL, see <xref href="https://gdal.org/" format="html"
+          scope="external">https://gdal.org/</xref>. </p>
     </body>
   </topic>
   <topic id="topic3" xml:lang="en">
@@ -71,10 +71,10 @@
       <p>There have been significant changes in PostGIS 2.5.4 compared with the previously supported
         version of 2.1.5. For a list of new and enhanced functions in PostGIS 2.5, see the PostGIS
         documentation <xref
-          href="http://postgis.net/docs/manual-2.5/PostGIS_Special_Functions_Index.html#NewFunctions_2_5"
+          href="https://postgis.net/docs/manual-2.5/PostGIS_Special_Functions_Index.html#NewFunctions_2_5"
           format="html" scope="external">PostGIS Functions new or enhanced in 2.5</xref>.</p>
       <p>For a comprehensive list of PostGIS changes in PostGIS 2.5.4 and earlier, see PostGIS 2.5
-        Appendix A <xref href="http://postgis.net/docs/manual-2.5/release_notes.html" format="html"
+        Appendix A <xref href="https://postgis.net/docs/manual-2.5/release_notes.html" format="html"
           scope="external">Release 2.5.4</xref>.</p>
     </body>
     <topic id="topic4" xml:lang="en">
@@ -145,9 +145,9 @@ export POSTGIS_GDAL_ENABLED_DRIVERS=DISABLE_ALL</codeblock>
         <p>
           <codeblock>raster2pgsql -G </codeblock>
         </p>
-        <p>The command lists the driver long format name. The <cite>GDAL Raster Formats</cite> table
-          at <xref href="http://www.gdal.org/formats_list.html" format="html" scope="external"
-            >http://www.gdal.org/formats_list.html</xref> lists the long format names and the
+        <p>The command lists the driver long format name. The <cite>GDAL Raster</cite> table at
+            <xref href="https://gdal.org/drivers/raster/index.html" format="html" scope="external"
+            >https://gdal.org/drivers/raster/index.html</xref> lists the long format names and the
           corresponding codes that you specify as the value of the environment variable. For
           example, the code for the long name Portable Network Graphics is <codeph>PNG</codeph>.
           This example <codeph>export</codeph> line enables four GDAL raster drivers.</p>
@@ -280,7 +280,7 @@ SELECT name,ST_AsText(geopoint) FROM geotest;</codeblock>
           <li dir="ltr">geography</li>
         </ul>
         <p>For a list of PostGIS data types, operators, and functions, see the <xref
-            href="http://postgis.net/docs/manual-2.1/reference.html" format="html" scope="external"
+            href="https://postgis.net/docs/manual-2.5/reference.html" format="html" scope="external"
             >PostGIS reference documentation</xref>.</p>
       </body>
     </topic>
@@ -298,11 +298,11 @@ SELECT name,ST_AsText(geopoint) FROM geotest;</codeblock>
           <li dir="ltr">unionarg</li>
         </ul>
         <p>For information about PostGIS Raster data Management, queries, and applications, see
-            <xref href="http://postgis.net/docs/manual-2.5/using_raster_dataman.html" format="html"
+            <xref href="https://postgis.net/docs/manual-2.5/using_raster_dataman.html" format="html"
             scope="external"
-          >http://postgis.net/docs/manual-2.5/using_raster_dataman.html</xref>.</p>
+          >https://postgis.net/docs/manual-2.5/using_raster_dataman.html</xref>.</p>
         <p>For a list of PostGIS Raster data types, operators, and functions, see the <xref
-            href="http://postgis.net/docs/manual-2.5/RT_reference.html" format="html"
+            href="https://postgis.net/docs/manual-2.5/RT_reference.html" format="html"
             scope="external">PostGIS Raster reference documentation</xref>.</p>
       </body>
     </topic>


### PR DESCRIPTION
This will be backported to 6X_STABLE

-Updated version 2.1.5 -> 2.5.4
-Updated references to PostGIS topics
-Removed geometry and geography limitation
-Added enhancement for postgis_manager.sh script - support installing PostGIS in a non-default schema
-Added examples of updating postgis.enable_outdb_rasters and postgis.gdal_enabled_drivers for a GPDB session
-Remove ANALYZE limitation for user-defined data types
-Added  _postgis_index_extent function is not supported
-Added note: <-> operator returns centroid/centroid distance
-changed name of PostGIS aggregate function ST_MemCollect to ST_Collect


Link to HTML output on a temporary GPDB doc review site.
https://docs-msk-gpdb6-gis.cfapps.io/7-0/analytics/postGIS.html
