### PR TITLE
Don't suppress unused-but-set variable warning

### DIFF
--- a/configure
+++ b/configure
@@ -5380,46 +5380,6 @@ if test x"$pgac_cv_prog_cc_cflags__fexcess_precision_standard" = x"yes"; then
 fi
 
 
-  # Silence compiler warnings about variables that are set, but otherwise
-  # unused. All of these warnings have been fixed in PostgreSQL, but there is
-  # still someGPDB added code that emit these. TODO: Fix the GPDB code and
-  # remove this.
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wno-unused-but-set-variable" >&5
-$as_echo_n "checking whether $CC supports -Wno-unused-but-set-variable... " >&6; }
-if ${pgac_cv_prog_cc_cflags__Wno_unused_but_set_variable+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  pgac_save_CFLAGS=$CFLAGS
-CFLAGS="$pgac_save_CFLAGS -Wno-unused-but-set-variable"
-ac_save_c_werror_flag=$ac_c_werror_flag
-ac_c_werror_flag=yes
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  pgac_cv_prog_cc_cflags__Wno_unused_but_set_variable=yes
-else
-  pgac_cv_prog_cc_cflags__Wno_unused_but_set_variable=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-ac_c_werror_flag=$ac_save_c_werror_flag
-CFLAGS="$pgac_save_CFLAGS"
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__Wno_unused_but_set_variable" >&5
-$as_echo "$pgac_cv_prog_cc_cflags__Wno_unused_but_set_variable" >&6; }
-if test x"$pgac_cv_prog_cc_cflags__Wno_unused_but_set_variable" = x"yes"; then
-  CFLAGS="$CFLAGS -Wno-unused-but-set-variable"
-fi
-
-
   # We rely on /* fallthrough */ comments to signal explicit fallthrough, but
   # some compilers (clang) don't recognize those and give spurious errors. Make
   # sure the compiler supports fallthrough comments by explicitly requesting

--- a/configure.in
+++ b/configure.in
@@ -619,12 +619,6 @@ if test "$GCC" = yes -a "$ICC" = no; then
   # Disable FP optimizations that cause various errors on gcc 4.5+ or maybe 4.6+
   PGAC_PROG_CC_CFLAGS_OPT([-fexcess-precision=standard])
 
-  # Silence compiler warnings about variables that are set, but otherwise
-  # unused. All of these warnings have been fixed in PostgreSQL, but there is
-  # still someGPDB added code that emit these. TODO: Fix the GPDB code and
-  # remove this.
-  PGAC_PROG_CC_CFLAGS_OPT([-Wno-unused-but-set-variable])
-
   # We rely on /* fallthrough */ comments to signal explicit fallthrough, but
   # some compilers (clang) don't recognize those and give spurious errors. Make
   # sure the compiler supports fallthrough comments by explicitly requesting

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1681,7 +1681,7 @@ CTranslatorDXLToPlStmt::TranslateDXLMergeJoin
 			GPOS_ASSERT(gpdb::ListLength(opexpr->args) == 2);
 			Expr *leftarg = (Expr *) gpdb::ListNth(opexpr->args, 0);
 
-			Expr *rightarg = (Expr *) gpdb::ListNth(opexpr->args, 1);
+			Expr *rightarg PG_USED_FOR_ASSERTS_ONLY = (Expr *) gpdb::ListNth(opexpr->args, 1);
 			GPOS_ASSERT(gpdb::ExprCollation((Node *) leftarg) ==
 						gpdb::ExprCollation((Node*) rightarg));
 


### PR DESCRIPTION
This patch set knocks out the last "unused variable" compiler warning, and removes it from our CFLAGS in `configure`. See each commit for details.

## Here are some reminders before you submit the pull request
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
