### PR TITLE
Orca clean up post-merge

### DIFF
--- a/src/backend/gporca/gporca.mk
+++ b/src/backend/gporca/gporca.mk
@@ -4,5 +4,6 @@ override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
 # Do not omit frame pointer. Even with RELEASE builds, it is used for
 # backtracing.
-override CPPFLAGS := -Werror -Wextra -Wpedantic -Wno-variadic-macros -fno-omit-frame-pointer $(CPPFLAGS)
-override CPPFLAGS := -std=gnu++98 $(CPPFLAGS)
+override CXXFLAGS := -Werror -Wextra -Wpedantic -Wno-variadic-macros -fno-omit-frame-pointer $(CXXFLAGS)
+# FIXME: this really should be done in autoconf
+override CXXFLAGS := -std=gnu++98 $(CXXFLAGS)

--- a/src/backend/gporca/libgpopt/src/engine/Makefile
+++ b/src/backend/gporca/libgpopt/src/engine/Makefile
@@ -4,7 +4,7 @@
 # src/backend/gporca/libgpopt/src/engine/Makefile
 #
 
-subdir = src/backend/gporca/libgpopt/src/engine/
+subdir = src/backend/gporca/libgpopt/src/engine
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 

--- a/src/backend/gporca/libgpopt/src/eval/Makefile
+++ b/src/backend/gporca/libgpopt/src/eval/Makefile
@@ -4,7 +4,7 @@
 # src/backend/gporca/libgpopt/src/eval/Makefile
 #
 
-subdir = src/backend/gporca/libgpopt/src/eval/
+subdir = src/backend/gporca/libgpopt/src/eval
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 

--- a/src/backend/gporca/libgpopt/src/mdcache/Makefile
+++ b/src/backend/gporca/libgpopt/src/mdcache/Makefile
@@ -4,7 +4,7 @@
 # src/backend/gporca/libgpopt/src/mdcache/Makefile
 #
 
-subdir = src/backend/gporca/libgpopt/src/mdcache/
+subdir = src/backend/gporca/libgpopt/src/mdcache
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 

--- a/src/backend/gporca/libgpopt/src/search/Makefile
+++ b/src/backend/gporca/libgpopt/src/search/Makefile
@@ -4,7 +4,7 @@
 # src/backend/gporca/libgpopt/src/search/Makefile
 #
 
-subdir = src/backend/gporca/libgpopt/src/search/
+subdir = src/backend/gporca/libgpopt/src/search
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 

--- a/src/backend/gporca/libgpopt/src/translate/Makefile
+++ b/src/backend/gporca/libgpopt/src/translate/Makefile
@@ -4,7 +4,7 @@
 # src/backend/gporca/libgpopt/src/translate/Makefile
 #
 
-subdir = src/backend/gporca/libgpopt/src/translate/
+subdir = src/backend/gporca/libgpopt/src/translate
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 

--- a/src/backend/gporca/libgpopt/src/xforms/Makefile
+++ b/src/backend/gporca/libgpopt/src/xforms/Makefile
@@ -4,7 +4,7 @@
 # src/backend/gporca/libgpopt/src/xforms/Makefile
 #
 
-subdir = src/backend/gporca/libgpopt/src/xforms/
+subdir = src/backend/gporca/libgpopt/src/xforms
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 

--- a/src/backend/gporca/libgpos/src/common/Makefile
+++ b/src/backend/gporca/libgpos/src/common/Makefile
@@ -8,13 +8,7 @@ subdir = src/backend/gporca/libgpos/src/common
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpos/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpopt/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
-# FIXME: Would be better to include gporca.mk, but hitting a warning
-override CPPFLAGS := -Wno-variadic-macros -fno-omit-frame-pointer $(CPPFLAGS)
-override CPPFLAGS := -std=gnu++98 $(CPPFLAGS)
+include $(top_builddir)/src/backend/gporca/gporca.mk
 
 OBJS        = CAutoTimer.o \
               CBitSet.o \

--- a/src/backend/gporca/libnaucrates/src/base/Makefile
+++ b/src/backend/gporca/libnaucrates/src/base/Makefile
@@ -4,7 +4,7 @@
 # src/backend/gporca/libnaucrates/src/base/Makefile
 #
 
-subdir = src/backend/gporca/libnaucrates/src/base/
+subdir = src/backend/gporca/libnaucrates/src/base
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 

--- a/src/backend/gporca/libnaucrates/src/md/Makefile
+++ b/src/backend/gporca/libnaucrates/src/md/Makefile
@@ -4,7 +4,7 @@
 # src/backend/gporca/libnaucrates/src/md/Makefile
 #
 
-subdir = src/backend/gporca/libnaucrates/src/md/
+subdir = src/backend/gporca/libnaucrates/src/md
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 

--- a/src/test/fsync/Makefile
+++ b/src/test/fsync/Makefile
@@ -4,7 +4,7 @@ PG_CONFIG=pg_config
 REGRESS = setup bgwriter_checkpoint
 REGRESS_OPTS = --load-extension=gp_inject_fault
 
-subdir = src/test/fsync/
+subdir = src/test/fsync
 top_builddir = ../../..
 
 include $(top_builddir)/src/Makefile.global

--- a/src/test/heap_checksum/Makefile
+++ b/src/test/heap_checksum/Makefile
@@ -4,7 +4,7 @@ PG_CONFIG=pg_config
 REGRESS = setup heap_checksum_corruption
 REGRESS_OPTS = --init-file=../regress/init_file --load-extension=gp_inject_fault
 
-subdir = src/test/heap_checksum/
+subdir = src/test/heap_checksum
 top_builddir = ../../..
 
 include $(top_builddir)/src/Makefile.global

--- a/src/test/walrep/Makefile
+++ b/src/test/walrep/Makefile
@@ -1,7 +1,7 @@
 MODULES=gplibpq
 PG_CONFIG=pg_config
 
-subdir = src/test/walrep/
+subdir = src/test/walrep
 top_builddir = ../../..
 
 include $(top_builddir)/src/Makefile.global


### PR DESCRIPTION
## Assorted small cleanups after merging ORCA into tree

See commit messages for details.
The one change I need to get in the most is "Use CXXFLAGS instead of CPPFLAGS for -std and -W* ."

## Out-of-scope
- extract most `CXXFLAGS` into configure
- separate `-Wpedantic` so translator is not busted if it includes `gporca.mk`