### PR TITLE
Improve statistics calculation for exprs like "var = ANY (ARRAY[...])"

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2847,7 +2847,7 @@ CTranslatorRelcacheToDXL::TransformStatsToDXLBucketArray
 						num_distinct,
 						hist_freq
 						);
-		if (0 == histogram->Buckets())
+		if (0 == histogram->GetNumBuckets())
 		{
 			has_hist = false;
 		}
@@ -3053,7 +3053,7 @@ CTranslatorRelcacheToDXL::TransformHistogramToDXLBucketArray
 	)
 {
 	CDXLBucketArray *dxl_stats_bucket_array = GPOS_NEW(mp) CDXLBucketArray(mp);
-	const CBucketArray *buckets = hist->ParseDXLToBucketsArray();
+	const CBucketArray *buckets = hist->GetBuckets();
 	ULONG num_buckets = buckets->Size();
 	for (ULONG ul = 0; ul < num_buckets; ul++)
 	{

--- a/src/backend/gporca/data/dxl/minidump/ArrayCmp-IN-ManyElements.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayCmp-IN-ManyElements.mdp
@@ -1,0 +1,2755 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Expected 5500 rows (ORCA returns 5565 which is close enough for now)
+
+    create table arrycmp (a int, b int, c int);
+    insert into arrycmp select 1, i%2, i from generate_series(1, 10000) i;
+    analyze arrycmp;
+
+    explain select * from arrycmp where c in (
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+      21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+      41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+      61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+      81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+      101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120,
+      121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140,
+      141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160,
+      161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180,
+      181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200,
+      201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220,
+      221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240,
+      241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260,
+      261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280,
+      281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300,
+      301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320,
+      321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340,
+      341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360,
+      361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380,
+      381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400,
+      401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420,
+      421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440,
+      441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460,
+      461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480,
+      481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500,
+      501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520,
+      521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540,
+      541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560,
+      561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580,
+      581, 582, 583, 584, 585, 586, 587, 588, 589, 590, 591, 592, 593, 594, 595, 596, 597, 598, 599, 600,
+      601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620,
+      621, 622, 623, 624, 625, 626, 627, 628, 629, 630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640,
+      641, 642, 643, 644, 645, 646, 647, 648, 649, 650, 651, 652, 653, 654, 655, 656, 657, 658, 659, 660,
+      661, 662, 663, 664, 665, 666, 667, 668, 669, 670, 671, 672, 673, 674, 675, 676, 677, 678, 679, 680,
+      681, 682, 683, 684, 685, 686, 687, 688, 689, 690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700,
+      701, 702, 703, 704, 705, 706, 707, 708, 709, 710, 711, 712, 713, 714, 715, 716, 717, 718, 719, 720,
+      721, 722, 723, 724, 725, 726, 727, 728, 729, 730, 731, 732, 733, 734, 735, 736, 737, 738, 739, 740,
+      741, 742, 743, 744, 745, 746, 747, 748, 749, 750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760,
+      761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780,
+      781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 800,
+      801, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820,
+      821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840,
+      841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 852, 853, 854, 855, 856, 857, 858, 859, 860,
+      861, 862, 863, 864, 865, 866, 867, 868, 869, 870, 871, 872, 873, 874, 875, 876, 877, 878, 879, 880,
+      881, 882, 883, 884, 885, 886, 887, 888, 889, 890, 891, 892, 893, 894, 895, 896, 897, 898, 899, 900,
+      901, 902, 903, 904, 905, 906, 907, 908, 909, 910, 911, 912, 913, 914, 915, 916, 917, 918, 919, 920,
+      921, 922, 923, 924, 925, 926, 927, 928, 929, 930, 931, 932, 933, 934, 935, 936, 937, 938, 939, 940,
+      941, 942, 943, 944, 945, 946, 947, 948, 949, 950, 951, 952, 953, 954, 955, 956, 957, 958, 959, 960,
+      961, 962, 963, 964, 965, 966, 967, 968, 969, 970, 971, 972, 973, 974, 975, 976, 977, 978, 979, 980,
+      981, 982, 983, 984, 985, 986, 987, 988, 989, 990, 991, 992, 993, 994, 995, 996, 997, 998, 999, 1000)
+    OR b = 0;
+    ]]> </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.24579.1.0" Name="arrycmp" Rows="10000.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.24579.1.0" Name="arrycmp" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.24579.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.500000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.500000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.24579.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.24579.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9900"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Or>
+          <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+            <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
+            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="7"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="9"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="11"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="12"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="13"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="14"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="15"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="16"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="17"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="18"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="19"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="20"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="21"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="22"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="23"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="24"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="26"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="27"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="28"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="29"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="30"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="31"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="32"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="33"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="34"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="36"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="37"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="38"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="39"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="40"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="41"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="43"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="44"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="45"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="46"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="47"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="48"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="49"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="50"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="51"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="52"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="53"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="54"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="55"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="56"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="57"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="58"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="59"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="60"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="61"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="62"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="63"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="64"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="65"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="66"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="67"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="68"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="69"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="70"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="71"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="72"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="73"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="74"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="75"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="76"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="77"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="78"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="79"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="80"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="81"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="82"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="83"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="84"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="85"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="86"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="87"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="88"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="89"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="90"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="91"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="92"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="93"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="94"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="95"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="96"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="97"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="98"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="99"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="100"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="101"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="102"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="103"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="104"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="105"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="106"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="107"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="108"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="109"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="110"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="111"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="112"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="113"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="114"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="115"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="116"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="117"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="118"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="119"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="120"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="121"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="122"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="123"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="124"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="125"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="126"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="127"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="128"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="129"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="130"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="131"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="132"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="133"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="134"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="135"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="136"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="137"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="138"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="139"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="140"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="141"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="142"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="143"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="144"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="145"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="146"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="147"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="148"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="149"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="150"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="151"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="152"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="153"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="154"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="155"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="156"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="157"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="158"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="159"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="160"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="161"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="162"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="163"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="164"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="165"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="166"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="167"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="168"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="169"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="170"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="171"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="172"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="173"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="174"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="175"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="176"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="177"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="178"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="179"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="180"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="181"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="182"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="183"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="184"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="185"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="186"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="187"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="188"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="189"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="190"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="191"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="192"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="193"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="194"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="195"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="196"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="197"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="198"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="199"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="200"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="201"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="202"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="203"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="204"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="205"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="206"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="207"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="208"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="209"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="210"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="211"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="212"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="213"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="214"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="215"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="216"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="217"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="218"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="219"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="220"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="221"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="222"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="223"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="224"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="225"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="226"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="227"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="228"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="229"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="230"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="231"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="232"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="233"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="234"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="235"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="236"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="237"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="238"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="239"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="240"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="241"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="242"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="243"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="244"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="245"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="246"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="247"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="248"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="249"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="250"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="251"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="252"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="253"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="254"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="255"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="256"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="257"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="258"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="259"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="260"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="261"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="262"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="263"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="264"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="265"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="266"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="267"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="268"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="269"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="270"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="271"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="272"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="273"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="274"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="275"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="276"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="277"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="278"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="279"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="280"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="281"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="282"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="283"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="284"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="285"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="286"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="287"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="288"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="289"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="290"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="291"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="292"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="293"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="294"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="295"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="296"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="297"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="298"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="299"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="300"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="301"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="302"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="303"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="304"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="305"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="306"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="307"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="308"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="309"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="310"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="311"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="312"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="313"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="314"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="315"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="316"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="317"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="318"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="319"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="320"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="321"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="322"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="323"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="324"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="325"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="326"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="327"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="328"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="329"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="330"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="331"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="332"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="333"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="334"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="335"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="336"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="337"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="338"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="339"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="340"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="341"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="342"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="343"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="344"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="345"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="346"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="347"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="348"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="349"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="350"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="351"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="352"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="353"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="354"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="355"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="356"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="357"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="358"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="359"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="360"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="361"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="362"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="363"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="364"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="365"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="366"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="367"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="368"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="369"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="370"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="371"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="372"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="373"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="374"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="375"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="376"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="377"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="378"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="379"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="380"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="381"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="382"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="383"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="384"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="385"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="386"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="387"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="388"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="389"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="390"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="391"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="392"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="393"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="394"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="395"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="396"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="397"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="398"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="399"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="400"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="401"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="402"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="403"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="404"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="405"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="406"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="407"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="408"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="409"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="410"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="411"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="412"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="413"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="414"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="415"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="416"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="417"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="418"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="419"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="420"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="421"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="422"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="423"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="424"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="425"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="426"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="427"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="428"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="429"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="430"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="431"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="432"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="433"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="434"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="435"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="436"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="437"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="438"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="439"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="440"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="441"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="442"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="443"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="444"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="445"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="446"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="447"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="448"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="449"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="450"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="451"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="452"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="453"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="454"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="455"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="456"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="457"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="458"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="459"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="460"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="461"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="462"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="463"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="464"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="465"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="466"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="467"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="468"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="469"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="470"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="471"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="472"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="473"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="474"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="475"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="476"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="477"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="478"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="479"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="480"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="481"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="482"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="483"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="484"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="485"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="486"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="487"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="488"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="489"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="490"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="491"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="492"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="493"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="494"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="495"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="496"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="497"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="498"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="499"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="500"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="501"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="502"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="503"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="504"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="505"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="506"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="507"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="508"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="509"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="510"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="511"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="512"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="513"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="514"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="515"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="516"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="517"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="518"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="519"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="520"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="521"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="522"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="523"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="524"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="525"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="526"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="527"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="528"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="529"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="530"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="531"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="532"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="533"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="534"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="535"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="536"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="537"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="538"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="539"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="540"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="541"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="542"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="543"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="544"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="545"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="546"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="547"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="548"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="549"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="550"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="551"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="552"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="553"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="554"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="555"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="556"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="557"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="558"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="559"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="560"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="561"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="562"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="563"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="564"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="565"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="566"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="567"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="568"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="569"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="570"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="571"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="572"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="573"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="574"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="575"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="576"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="577"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="578"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="579"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="580"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="581"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="582"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="583"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="584"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="585"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="586"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="587"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="588"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="589"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="590"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="591"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="592"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="593"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="594"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="595"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="596"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="597"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="598"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="599"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="600"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="601"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="602"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="603"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="604"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="605"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="606"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="607"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="608"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="609"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="610"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="611"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="612"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="613"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="614"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="615"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="616"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="617"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="618"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="619"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="620"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="621"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="622"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="623"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="624"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="625"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="626"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="627"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="628"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="629"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="630"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="631"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="632"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="633"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="634"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="635"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="636"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="637"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="638"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="639"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="640"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="641"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="642"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="643"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="644"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="645"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="646"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="647"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="648"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="649"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="650"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="651"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="652"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="653"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="654"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="655"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="656"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="657"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="658"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="659"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="660"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="661"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="662"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="663"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="664"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="665"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="666"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="667"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="668"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="669"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="670"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="671"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="672"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="673"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="674"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="675"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="676"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="677"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="678"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="679"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="680"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="681"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="682"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="683"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="684"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="685"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="686"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="687"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="688"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="689"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="690"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="691"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="692"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="693"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="694"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="695"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="696"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="697"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="698"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="699"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="700"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="701"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="702"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="703"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="704"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="705"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="706"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="707"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="708"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="709"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="710"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="711"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="712"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="713"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="714"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="715"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="716"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="717"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="718"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="719"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="720"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="721"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="722"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="723"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="724"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="725"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="726"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="727"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="728"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="729"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="730"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="731"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="732"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="733"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="734"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="735"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="736"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="737"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="738"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="739"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="740"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="741"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="742"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="743"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="744"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="745"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="746"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="747"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="748"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="749"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="750"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="751"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="752"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="753"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="754"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="755"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="756"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="757"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="758"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="759"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="760"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="761"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="762"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="763"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="764"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="765"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="766"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="767"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="768"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="769"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="770"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="771"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="772"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="773"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="774"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="775"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="776"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="777"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="778"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="779"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="780"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="781"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="782"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="783"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="784"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="785"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="786"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="787"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="788"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="789"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="790"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="791"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="792"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="793"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="794"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="795"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="796"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="797"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="798"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="799"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="800"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="801"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="802"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="803"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="804"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="805"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="806"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="807"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="808"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="809"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="810"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="811"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="812"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="813"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="814"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="815"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="816"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="817"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="818"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="819"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="820"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="821"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="822"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="823"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="824"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="825"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="826"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="827"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="828"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="829"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="830"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="831"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="832"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="833"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="834"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="835"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="836"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="837"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="838"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="839"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="840"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="841"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="842"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="843"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="844"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="845"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="846"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="847"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="848"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="849"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="850"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="851"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="852"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="853"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="854"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="855"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="856"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="857"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="858"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="859"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="860"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="861"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="862"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="863"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="864"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="865"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="866"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="867"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="868"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="869"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="870"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="871"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="872"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="873"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="874"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="875"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="876"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="877"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="878"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="879"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="880"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="881"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="882"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="883"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="884"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="885"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="886"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="887"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="888"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="889"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="890"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="891"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="892"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="893"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="894"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="895"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="896"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="897"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="898"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="899"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="900"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="901"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="902"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="903"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="904"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="905"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="906"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="907"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="908"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="909"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="910"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="911"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="912"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="913"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="914"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="915"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="916"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="917"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="918"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="919"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="920"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="921"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="922"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="923"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="924"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="925"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="926"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="927"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="928"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="929"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="930"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="931"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="932"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="933"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="934"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="935"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="936"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="937"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="938"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="939"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="940"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="941"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="942"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="943"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="944"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="945"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="946"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="947"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="948"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="949"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="950"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="951"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="952"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="953"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="954"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="955"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="956"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="957"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="958"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="959"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="960"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="961"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="962"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="963"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="964"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="965"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="966"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="967"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="968"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="969"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="970"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="971"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="972"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="973"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="974"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="975"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="976"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="977"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="978"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="979"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="980"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="981"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="982"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="983"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="984"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="985"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="986"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="987"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="988"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="989"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="990"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="991"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="992"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="993"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="994"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="995"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="996"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="997"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="998"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="999"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1000"/>
+            </dxl:Array>
+          </dxl:ArrayComp>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+          </dxl:Comparison>
+        </dxl:Or>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.24579.1.0" TableName="arrycmp">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.586555" Rows="5564.062500" Width="12"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.337730" Rows="5564.062500" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Or>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="7"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="9"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="11"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="12"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="13"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="14"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="15"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="16"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="17"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="18"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="19"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="20"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="21"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="22"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="23"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="24"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="25"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="26"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="27"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="28"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="29"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="30"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="31"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="32"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="33"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="34"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="36"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="37"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="38"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="39"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="40"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="41"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="43"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="44"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="45"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="46"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="47"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="48"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="49"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="50"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="51"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="52"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="53"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="54"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="55"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="56"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="57"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="58"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="59"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="60"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="61"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="62"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="63"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="64"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="65"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="66"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="67"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="68"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="69"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="70"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="71"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="72"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="73"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="74"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="75"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="76"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="77"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="78"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="79"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="80"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="81"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="82"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="83"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="84"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="85"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="86"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="87"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="88"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="89"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="90"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="91"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="92"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="93"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="94"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="95"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="96"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="97"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="98"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="99"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="100"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="101"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="102"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="103"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="104"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="105"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="106"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="107"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="108"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="109"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="110"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="111"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="112"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="113"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="114"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="115"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="116"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="117"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="118"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="119"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="120"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="121"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="122"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="123"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="124"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="125"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="126"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="127"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="128"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="129"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="130"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="131"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="132"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="133"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="134"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="135"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="136"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="137"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="138"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="139"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="140"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="141"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="142"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="143"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="144"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="145"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="146"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="147"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="148"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="149"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="150"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="151"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="152"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="153"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="154"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="155"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="156"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="157"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="158"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="159"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="160"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="161"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="162"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="163"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="164"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="165"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="166"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="167"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="168"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="169"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="170"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="171"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="172"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="173"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="174"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="175"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="176"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="177"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="178"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="179"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="180"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="181"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="182"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="183"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="184"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="185"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="186"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="187"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="188"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="189"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="190"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="191"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="192"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="193"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="194"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="195"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="196"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="197"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="198"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="199"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="200"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="201"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="202"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="203"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="204"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="205"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="206"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="207"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="208"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="209"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="210"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="211"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="212"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="213"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="214"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="215"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="216"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="217"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="218"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="219"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="220"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="221"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="222"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="223"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="224"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="225"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="226"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="227"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="228"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="229"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="230"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="231"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="232"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="233"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="234"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="235"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="236"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="237"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="238"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="239"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="240"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="241"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="242"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="243"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="244"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="245"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="246"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="247"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="248"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="249"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="250"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="251"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="252"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="253"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="254"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="255"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="256"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="257"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="258"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="259"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="260"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="261"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="262"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="263"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="264"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="265"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="266"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="267"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="268"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="269"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="270"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="271"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="272"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="273"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="274"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="275"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="276"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="277"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="278"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="279"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="280"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="281"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="282"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="283"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="284"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="285"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="286"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="287"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="288"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="289"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="290"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="291"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="292"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="293"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="294"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="295"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="296"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="297"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="298"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="299"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="300"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="301"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="302"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="303"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="304"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="305"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="306"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="307"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="308"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="309"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="310"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="311"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="312"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="313"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="314"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="315"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="316"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="317"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="318"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="319"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="320"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="321"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="322"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="323"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="324"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="325"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="326"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="327"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="328"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="329"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="330"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="331"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="332"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="333"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="334"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="335"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="336"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="337"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="338"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="339"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="340"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="341"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="342"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="343"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="344"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="345"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="346"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="347"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="348"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="349"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="350"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="351"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="352"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="353"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="354"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="355"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="356"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="357"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="358"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="359"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="360"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="361"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="362"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="363"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="364"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="365"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="366"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="367"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="368"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="369"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="370"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="371"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="372"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="373"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="374"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="375"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="376"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="377"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="378"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="379"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="380"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="381"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="382"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="383"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="384"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="385"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="386"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="387"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="388"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="389"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="390"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="391"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="392"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="393"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="394"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="395"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="396"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="397"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="398"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="399"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="400"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="401"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="402"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="403"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="404"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="405"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="406"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="407"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="408"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="409"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="410"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="411"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="412"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="413"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="414"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="415"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="416"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="417"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="418"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="419"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="420"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="421"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="422"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="423"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="424"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="425"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="426"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="427"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="428"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="429"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="430"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="431"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="432"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="433"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="434"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="435"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="436"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="437"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="438"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="439"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="440"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="441"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="442"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="443"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="444"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="445"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="446"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="447"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="448"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="449"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="450"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="451"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="452"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="453"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="454"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="455"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="456"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="457"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="458"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="459"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="460"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="461"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="462"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="463"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="464"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="465"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="466"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="467"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="468"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="469"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="470"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="471"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="472"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="473"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="474"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="475"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="476"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="477"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="478"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="479"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="480"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="481"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="482"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="483"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="484"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="485"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="486"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="487"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="488"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="489"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="490"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="491"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="492"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="493"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="494"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="495"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="496"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="497"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="498"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="499"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="500"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="501"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="502"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="503"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="504"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="505"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="506"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="507"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="508"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="509"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="510"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="511"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="512"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="513"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="514"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="515"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="516"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="517"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="518"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="519"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="520"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="521"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="522"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="523"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="524"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="525"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="526"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="527"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="528"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="529"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="530"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="531"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="532"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="533"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="534"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="535"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="536"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="537"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="538"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="539"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="540"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="541"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="542"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="543"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="544"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="545"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="546"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="547"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="548"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="549"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="550"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="551"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="552"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="553"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="554"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="555"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="556"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="557"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="558"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="559"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="560"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="561"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="562"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="563"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="564"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="565"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="566"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="567"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="568"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="569"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="570"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="571"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="572"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="573"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="574"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="575"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="576"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="577"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="578"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="579"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="580"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="581"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="582"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="583"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="584"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="585"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="586"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="587"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="588"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="589"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="590"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="591"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="592"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="593"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="594"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="595"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="596"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="597"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="598"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="599"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="600"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="601"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="602"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="603"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="604"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="605"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="606"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="607"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="608"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="609"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="610"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="611"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="612"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="613"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="614"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="615"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="616"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="617"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="618"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="619"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="620"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="621"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="622"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="623"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="624"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="625"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="626"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="627"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="628"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="629"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="630"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="631"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="632"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="633"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="634"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="635"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="636"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="637"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="638"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="639"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="640"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="641"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="642"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="643"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="644"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="645"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="646"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="647"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="648"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="649"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="650"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="651"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="652"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="653"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="654"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="655"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="656"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="657"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="658"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="659"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="660"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="661"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="662"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="663"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="664"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="665"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="666"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="667"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="668"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="669"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="670"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="671"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="672"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="673"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="674"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="675"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="676"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="677"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="678"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="679"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="680"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="681"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="682"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="683"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="684"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="685"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="686"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="687"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="688"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="689"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="690"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="691"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="692"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="693"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="694"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="695"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="696"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="697"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="698"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="699"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="700"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="701"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="702"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="703"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="704"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="705"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="706"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="707"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="708"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="709"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="710"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="711"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="712"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="713"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="714"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="715"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="716"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="717"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="718"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="719"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="720"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="721"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="722"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="723"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="724"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="725"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="726"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="727"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="728"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="729"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="730"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="731"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="732"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="733"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="734"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="735"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="736"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="737"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="738"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="739"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="740"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="741"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="742"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="743"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="744"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="745"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="746"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="747"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="748"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="749"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="750"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="751"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="752"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="753"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="754"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="755"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="756"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="757"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="758"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="759"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="760"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="761"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="762"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="763"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="764"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="765"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="766"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="767"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="768"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="769"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="770"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="771"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="772"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="773"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="774"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="775"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="776"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="777"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="778"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="779"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="780"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="781"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="782"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="783"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="784"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="785"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="786"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="787"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="788"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="789"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="790"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="791"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="792"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="793"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="794"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="795"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="796"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="797"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="798"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="799"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="800"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="801"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="802"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="803"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="804"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="805"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="806"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="807"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="808"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="809"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="810"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="811"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="812"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="813"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="814"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="815"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="816"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="817"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="818"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="819"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="820"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="821"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="822"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="823"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="824"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="825"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="826"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="827"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="828"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="829"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="830"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="831"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="832"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="833"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="834"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="835"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="836"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="837"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="838"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="839"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="840"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="841"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="842"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="843"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="844"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="845"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="846"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="847"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="848"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="849"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="850"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="851"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="852"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="853"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="854"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="855"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="856"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="857"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="858"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="859"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="860"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="861"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="862"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="863"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="864"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="865"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="866"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="867"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="868"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="869"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="870"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="871"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="872"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="873"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="874"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="875"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="876"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="877"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="878"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="879"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="880"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="881"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="882"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="883"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="884"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="885"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="886"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="887"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="888"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="889"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="890"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="891"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="892"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="893"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="894"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="895"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="896"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="897"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="898"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="899"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="900"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="901"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="902"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="903"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="904"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="905"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="906"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="907"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="908"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="909"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="910"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="911"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="912"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="913"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="914"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="915"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="916"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="917"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="918"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="919"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="920"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="921"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="922"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="923"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="924"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="925"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="926"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="927"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="928"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="929"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="930"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="931"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="932"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="933"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="934"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="935"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="936"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="937"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="938"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="939"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="940"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="941"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="942"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="943"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="944"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="945"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="946"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="947"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="948"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="949"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="950"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="951"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="952"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="953"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="954"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="955"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="956"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="957"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="958"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="959"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="960"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="961"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="962"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="963"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="964"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="965"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="966"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="967"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="968"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="969"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="970"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="971"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="972"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="973"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="974"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="975"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="976"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="977"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="978"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="979"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="980"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="981"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="982"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="983"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="984"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="985"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="986"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="987"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="988"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="989"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="990"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="991"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="992"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="993"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="994"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="995"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="996"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="997"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="998"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="999"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1000"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+              </dxl:Comparison>
+            </dxl:Or>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="0.24579.1.0" TableName="arrycmp">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/FilterScalarCast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FilterScalarCast.mdp
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 CREATE TABLE foo ( a INT, b VARCHAR (20));
-INSERT INTO foo SELECT i%70, i%70 || 'abc' SELECT i FROM generate_series(1, 100000)i;
+INSERT INTO foo SELECT i%70, i%70 || 'abc' FROM generate_series(1, 100000)i;
 INSERT INTO foo VALUES (70, 'xyz');
 ANALYZE foo;
 EXPLAIN SELECT * FROM foo WHERE b IN ('xyz', 'asds');
@@ -514,7 +514,7 @@ EXPLAIN SELECT * FROM foo WHERE b IN ('xyz', 'asds');
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="432.861857" Rows="1405.718310" Width="9"/>
+          <dxl:Cost StartupCost="0" TotalCost="432.916810" Rows="2810.436620" Width="9"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -528,7 +528,7 @@ EXPLAIN SELECT * FROM foo WHERE b IN ('xyz', 'asds');
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="432.814710" Rows="1405.718310" Width="9"/>
+            <dxl:Cost StartupCost="0" TotalCost="432.822548" Rows="2810.436620" Width="9"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IN-Nulls-ArrayCmpAny.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IN-Nulls-ArrayCmpAny.mdp
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    create table foo(a int);
+    insert into foo select NULL from generate_series(1, 500)i;
+    insert into foo select 5 from generate_series(1, 50)i;
+    analyze;
+    explain select * from foo where a in (5, 10, NULL);
+
+    Should return around 50 rows (for the 50 5s in the table)
+    ]]> </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.16385.1.0" Name="foo" Rows="550.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16385.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16385.1.0.0" Name="a" Width="4.000000" NullFreq="0.909082" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.090908" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+          </dxl:Array>
+        </dxl:ArrayComp>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.015077" Rows="50.999400" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.014316" Rows="50.999400" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+              </dxl:Array>
+            </dxl:ArrayComp>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" IsNull="true"/>
+        </dxl:KeyValue>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:KeyValue>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IN.mdp
@@ -1011,7 +1011,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="16123.176758" Rows="2.000000" Width="165"/>
+          <dxl:Cost StartupCost="0" TotalCost="23860.852395" Rows="32015.655971" Width="165"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="p_partkey">
@@ -1046,7 +1046,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="16122.015625" Rows="2.000000" Width="165"/>
+            <dxl:Cost StartupCost="0" TotalCost="21280.466050" Rows="32015.655971" Width="165"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="p_partkey">

--- a/src/backend/gporca/data/dxl/statistics/ArrayCmpAny-Input-1.xml
+++ b/src/backend/gporca/data/dxl/statistics/ArrayCmpAny-Input-1.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Statistics>
+    <dxl:DerivedRelationStats Rows="2000.000000">
+      <dxl:DerivedColumnStats ColId="1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
+        <dxl:StatsBucket Frequency="0.2" DistinctValues="8.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.8" DistinctValues="2.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+      </dxl:DerivedColumnStats>
+    </dxl:DerivedRelationStats>
+  </dxl:Statistics>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/statistics/ArrayCmpAny-Output-1.xml
+++ b/src/backend/gporca/data/dxl/statistics/ArrayCmpAny-Output-1.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Statistics>
+    <dxl:DerivedRelationStats Rows="900.000000" EmptyRelation="false">
+      <dxl:DerivedColumnStats ColId="1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
+        <dxl:StatsBucket Frequency="0.111111" DistinctValues="2.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.888889" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+      </dxl:DerivedColumnStats>
+    </dxl:DerivedRelationStats>
+  </dxl:Statistics>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
@@ -1052,6 +1052,10 @@ namespace gpopt
 			static
 			INT IDatumCmp(const void *val1, const void *val2);
 
+			// compares two CPoints, useful for sorting functions
+			static
+			INT CPointCmp(const void *val1, const void *val2);
+
 			// check if the equivalance classes are disjoint
 			static
 			BOOL FEquivalanceClassesDisjoint(CMemoryPool *mp, const CColRefSetArray *pdrgpcrs);

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -4718,6 +4718,29 @@ INT CUtils::IDatumCmp
 	return 1;
 }
 
+// compares two points. Takes pointer pointer to a CPoint.
+INT CUtils::CPointCmp
+		(
+		const void *val1,
+		const void *val2
+		)
+{
+	const CPoint *p1 = *(CPoint**)(val1);
+	const CPoint *p2 = *(CPoint**)(val2);
+
+	if (p1->Equals(p2))
+	{
+		return 0;
+	}
+	else if (p1->IsLessThan(p2))
+	{
+		return -1;
+	}
+
+	GPOS_ASSERT(p1->IsGreaterThan(p2));
+	return 1;
+}
+
 // check if the equivalance classes are disjoint
 BOOL
 CUtils::FEquivalanceClassesDisjoint

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CBucket.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CBucket.h
@@ -13,6 +13,8 @@
 #define GPNAUCRATES_CBucket_H
 
 #include "gpos/base.h"
+#include "gpos/task/CTask.h"
+#include "gpos/error/CAutoTrace.h"
 #include "naucrates/statistics/CPoint.h"
 #include "naucrates/statistics/IBucket.h"
 
@@ -170,6 +172,10 @@ namespace gpnaucrates
 			// print function
 			virtual
 			IOstream &OsPrint(IOstream &os) const;
+
+#ifdef GPOS_DEBUG
+			void DbgPrint() const;
+#endif
 
 			// construct new bucket with lower bound greater than given point
 			CBucket *MakeBucketGreaterThan(CMemoryPool *mp, CPoint *point) const;

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CFilterStatsProcessor.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CFilterStatsProcessor.h
@@ -32,6 +32,7 @@ namespace gpnaucrates
 			static
 			CHistogram *MakeHistSimpleFilter
 				(
+				CMemoryPool *mp,
 				CStatsPred *pred_stats,
 												CBitSet *filter_colids,
 				CHistogram *hist_before,
@@ -67,6 +68,18 @@ namespace gpnaucrates
 				(
 				CStatsPredUnsupported *pred_stats,
 												   CBitSet *filter_colids,
+				CHistogram *hist_before,
+				CDouble *last_scale_factor,
+				ULONG *target_last_colid
+				);
+
+			// create a new histogram after applying a pred op ANY(ARRAY[...]) filter
+			static
+			CHistogram *MakeHistArrayCmpAnyFilter
+				(
+				CMemoryPool *mp,
+				CStatsPredArrayCmp *pred_stats,
+				CBitSet *filter_colids,
 				CHistogram *hist_before,
 				CDouble *last_scale_factor,
 				ULONG *target_last_colid

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
@@ -348,13 +348,13 @@ namespace gpnaucrates
 					const;
 
 			// number of buckets
-			ULONG Buckets() const
+			ULONG GetNumBuckets() const
 			{
 				return m_histogram_buckets->Size();
 			}
 
 			// buckets accessor
-			const CBucketArray *ParseDXLToBucketsArray() const
+			const CBucketArray *GetBuckets() const
 			{
 				return m_histogram_buckets;
 			}
@@ -374,6 +374,10 @@ namespace gpnaucrates
 			// print function
 			virtual
 			IOstream &OsPrint(IOstream &os) const;
+
+#ifdef GPOS_DEBUG
+			void DbgPrint() const;
+#endif
 
 			// total frequency from buckets and null fraction
 			CDouble GetFrequency() const;

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CPoint.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CPoint.h
@@ -101,6 +101,8 @@ namespace gpnaucrates
 			CPoint *MaxPoint(CPoint *point1, CPoint *point2);
 	}; // class CPoint
 
+	// array of CPoints
+	typedef CDynamicPtrArray<CPoint, CleanupRelease> CPointArray;
 }
 
 #endif // !GPNAUCRATES_CPoint_H

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
@@ -18,6 +18,7 @@
 #include "naucrates/statistics/CStatsPredDisj.h"
 #include "naucrates/statistics/CStatsPredConj.h"
 #include "naucrates/statistics/CStatsPredLike.h"
+#include "naucrates/statistics/CStatsPredArrayCmp.h"
 #include "naucrates/statistics/CStatsPredUnsupported.h"
 #include "naucrates/statistics/CUpperBoundNDVs.h"
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPred.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPred.h
@@ -33,6 +33,7 @@ namespace gpnaucrates
 			enum EStatsPredType
 			{
 				EsptPoint, // filter with literals
+				EsptArrayCmp, // filter with = ANY/ALL(ARRAY[...])
 				EsptConj, // conjunctive filter
 				EsptDisj, // disjunctive filter
 				EsptLike, // LIKE filter

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPredArrayCmp.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPredArrayCmp.h
@@ -1,0 +1,102 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//
+//	@filename:
+//		CStatsPredArrayCmp.h
+//
+//	@doc:
+//		ArrayCmp filter on statistics
+//---------------------------------------------------------------------------
+#ifndef GPNAUCRATES_CStatsPredArrayCmp_H
+#define GPNAUCRATES_CStatsPredArrayCmp_H
+
+#include "gpos/base.h"
+#include "naucrates/md/IMDType.h"
+#include "naucrates/statistics/CStatsPred.h"
+#include "naucrates/statistics/CPoint.h"
+
+// fwd declarations
+namespace gpopt
+{
+	class CColRef;
+}
+
+namespace gpnaucrates
+{
+	using namespace gpos;
+	using namespace gpmd;
+	using namespace gpopt;
+
+	class CStatsPredArrayCmp : public CStatsPred
+	{
+		private:
+
+			// private copy ctor
+			CStatsPredArrayCmp(const CStatsPredArrayCmp &);
+
+			// private assignment operator
+			CStatsPredArrayCmp& operator=(CStatsPredArrayCmp &);
+
+			// comparison type
+			CStatsPred::EStatsCmpType m_stats_cmp_type;
+
+			CPointArray *m_points;
+
+		public:
+
+			// ctor
+			CStatsPredArrayCmp
+				(
+				ULONG colid,
+				CStatsPred::EStatsCmpType stats_cmp_type,
+				CPointArray *points
+				);
+
+			// dtor
+			virtual
+			~CStatsPredArrayCmp()
+			{
+				m_points->Release();
+			}
+
+			// comparison types for stats computation
+			virtual
+			CStatsPred::EStatsCmpType GetCmpType() const
+			{
+				return m_stats_cmp_type;
+			}
+
+			// filter type id
+			virtual
+			EStatsPredType GetPredStatsType() const
+			{
+				return CStatsPred::EsptArrayCmp;
+			}
+
+			virtual
+			CPointArray *GetPoints() const
+			{
+				return m_points;
+			}
+
+			// conversion function
+			static
+			CStatsPredArrayCmp *ConvertPredStats
+				(
+				CStatsPred *pred_stats
+				)
+			{
+				GPOS_ASSERT(NULL != pred_stats);
+				GPOS_ASSERT(CStatsPred::EsptArrayCmp == pred_stats->GetPredStatsType());
+
+				return dynamic_cast<CStatsPredArrayCmp*>(pred_stats);
+			}
+
+	}; // class CStatsPredArrayCmp
+
+}
+
+#endif // !GPNAUCRATES_CStatsPredArrayCmp_H
+
+// EOF

--- a/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
@@ -246,6 +246,15 @@ CBucket::OsPrint
 	return os;
 }
 
+#ifdef GPOS_DEBUG
+void
+CBucket::DbgPrint() const
+{
+	CAutoTrace at(CTask::Self()->Pmp());
+	OsPrint(at.Os());
+}
+#endif
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CBucket::MakeBucketGreaterThan

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -188,11 +188,11 @@ CStatisticsUtils::MergeMCVHist
 	GPOS_ASSERT(NULL != histogram);
 	GPOS_ASSERT(mcv_histogram->IsWellDefined());
 	GPOS_ASSERT(histogram->IsWellDefined());
-	GPOS_ASSERT(0 < mcv_histogram->Buckets());
-	GPOS_ASSERT(0 < histogram->Buckets());
+	GPOS_ASSERT(0 < mcv_histogram->GetNumBuckets());
+	GPOS_ASSERT(0 < histogram->GetNumBuckets());
 
-	const CBucketArray *mcv_buckets = mcv_histogram->ParseDXLToBucketsArray();
-	const CBucketArray *histogram_buckets = histogram->ParseDXLToBucketsArray();
+	const CBucketArray *mcv_buckets = mcv_histogram->GetBuckets();
+	const CBucketArray *histogram_buckets = histogram->GetBuckets();
 
 	IDatum *datum = (*mcv_buckets)[0]->GetLowerBound()->GetDatum();
 

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatsPredArrayCmp.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatsPredArrayCmp.cpp
@@ -1,0 +1,39 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//
+//	@filename:
+//		CStatsPredArrayCmp.cpp
+//
+//	@doc:
+//		Implementation of statistics for ArrayCmp filter
+//---------------------------------------------------------------------------
+
+#include "naucrates/statistics/CStatsPredArrayCmp.h"
+#include "naucrates/md/CMDIdGPDB.h"
+
+#include "gpopt/base/CColRef.h"
+#include "gpopt/base/CColRefTable.h"
+
+using namespace gpnaucrates;
+using namespace gpopt;
+using namespace gpmd;
+
+
+// Ctor
+CStatsPredArrayCmp::CStatsPredArrayCmp
+	(
+	ULONG colid,
+	CStatsPred::EStatsCmpType stats_cmp_type,
+	CPointArray *points
+	)
+	:
+	CStatsPred(colid),
+	m_stats_cmp_type(stats_cmp_type),
+	m_points(points)
+{
+	GPOS_ASSERT(CStatsPred::EstatscmptEq == m_stats_cmp_type);
+}
+
+// EOF
+

--- a/src/backend/gporca/libnaucrates/src/statistics/Makefile
+++ b/src/backend/gporca/libnaucrates/src/statistics/Makefile
@@ -29,6 +29,7 @@ OBJS        = CBucket.o \
               CStatsPredDisj.o \
               CStatsPredLike.o \
               CStatsPredPoint.o \
+              CStatsPredArrayCmp.o \
               CStatsPredUnsupported.o \
               CStatsPredUtils.o \
               CUnionAllStatsProcessor.o \

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -151,7 +151,7 @@ UDA-AnyElement-1 UDA-AnyElement-2 Project-With-NonScalar-Func SixWayDPv2 Multipl
 
 CArrayCmpTest:
 ArrayConcat ArrayRef FoldedArrayCmp IN-ArrayCmp NOT-IN-ArrayCmp ArrayCmpAll UDA-AnyArray InClauseWithMCV
-CastedInClauseWithMCV FilterScalarCast;
+CastedInClauseWithMCV FilterScalarCast IN-Nulls-ArrayCmpAny ArrayCmp-IN-ManyElements;
 
 CProjectTest:
 ProjectWithConstant ProjectWithTextConstant ProjectSetFunction Equivalence-class-project-over-LOJ;

--- a/src/backend/gporca/server/include/unittest/dxl/statistics/CFilterCardinalityTest.h
+++ b/src/backend/gporca/server/include/unittest/dxl/statistics/CFilterCardinalityTest.h
@@ -140,6 +140,13 @@ namespace gpnaucrates
 			static
 			CStatsPred *PstatspredDisjOverConjMultipleIdenticalCols(CMemoryPool *mp);
 
+			static
+			CStatsPred *PstatspredArrayCmpAnySimple(CMemoryPool *mp);
+
+			static
+			CStatsPred *PstatspredArrayCmpAnyDuplicate(CMemoryPool *mp);
+
+
 			// conjunctive predicates
 			static
 			CStatsPred *PstatspredConj(CMemoryPool *mp);
@@ -192,6 +199,10 @@ namespace gpnaucrates
 			// testing select predicates
 			static
 			GPOS_RESULT EresUnittest_CStatisticsFilter();
+
+			// testing ArryCmpAny predicates
+			static
+			GPOS_RESULT EresUnittest_CStatisticsFilterArrayCmpAny();
 
 			// testing nested AND / OR predicates
 			static

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CFilterCardinalityTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CFilterCardinalityTest.cpp
@@ -68,6 +68,7 @@ CFilterCardinalityTest::EresUnittest()
 		{
 		GPOS_UNITTEST_FUNC(CFilterCardinalityTest::EresUnittest_CStatisticsBasicsFromDXLNumeric),
 		GPOS_UNITTEST_FUNC(CFilterCardinalityTest::EresUnittest_CStatisticsFilter),
+		GPOS_UNITTEST_FUNC(CFilterCardinalityTest::EresUnittest_CStatisticsFilterArrayCmpAny),
 		GPOS_UNITTEST_FUNC(CFilterCardinalityTest::EresUnittest_CStatisticsFilterConj),
 		GPOS_UNITTEST_FUNC(CFilterCardinalityTest::EresUnittest_CStatisticsFilterDisj),
 		GPOS_UNITTEST_FUNC(CFilterCardinalityTest::EresUnittest_CStatisticsNestedPred),
@@ -211,6 +212,74 @@ CFilterCardinalityTest::PstatspredNotNull
 	CStatsPredPtrArry *pdrgpstatspred = GPOS_NEW(mp) CStatsPredPtrArry(mp);
 
 	pdrgpstatspred->Append(GPOS_NEW(mp) CStatsPredPoint(1, CStatsPred::EstatscmptNEq,  CTestUtils::PpointInt4NullVal(mp)));
+
+	return GPOS_NEW(mp) CStatsPredConj(pdrgpstatspred);
+}
+
+// testing ArryCmpAny predicates
+GPOS_RESULT
+CFilterCardinalityTest::EresUnittest_CStatisticsFilterArrayCmpAny()
+{
+	SStatsFilterSTestCase rgstatsdisjtc[] =
+	{
+		{
+			"../data/dxl/statistics/ArrayCmpAny-Input-1.xml",
+			"../data/dxl/statistics/ArrayCmpAny-Output-1.xml",
+			PstatspredArrayCmpAnySimple
+		},
+		{
+			"../data/dxl/statistics/ArrayCmpAny-Input-1.xml",
+			"../data/dxl/statistics/ArrayCmpAny-Output-1.xml",
+			PstatspredArrayCmpAnyDuplicate
+		}
+	};
+
+	const ULONG ulTestCases = GPOS_ARRAY_SIZE(rgstatsdisjtc);
+
+	return EresUnittest_CStatistics(rgstatsdisjtc, ulTestCases);
+}
+
+// create a 'col IN (...)' filter without duplicates
+CStatsPred *
+CFilterCardinalityTest::PstatspredArrayCmpAnySimple
+	(
+	CMemoryPool *mp
+	)
+{
+	CStatsPredPtrArry *pdrgpstatspred = GPOS_NEW(mp) CStatsPredPtrArry(mp);
+
+	CPointArray *arr = GPOS_NEW(mp) CPointArray(mp);
+	arr->Append(CTestUtils::PpointInt4(mp, 1));
+	arr->Append(CTestUtils::PpointInt4(mp, 2));
+	arr->Append(CTestUtils::PpointInt4(mp, 15));
+
+	pdrgpstatspred->Append(GPOS_NEW(mp) CStatsPredArrayCmp(1, CStatsPred::EstatscmptEq, arr));
+
+	return GPOS_NEW(mp) CStatsPredConj(pdrgpstatspred);
+}
+
+// create a 'col IN (...)' filter with duplicates (unsorted)
+CStatsPred *
+CFilterCardinalityTest::PstatspredArrayCmpAnyDuplicate
+	(
+	CMemoryPool *mp
+	)
+{
+	CStatsPredPtrArry *pdrgpstatspred = GPOS_NEW(mp) CStatsPredPtrArry(mp);
+
+	CPointArray *arr = GPOS_NEW(mp) CPointArray(mp);
+	arr->Append(CTestUtils::PpointInt4(mp, 1));
+	arr->Append(CTestUtils::PpointInt4(mp, 1));
+	arr->Append(CTestUtils::PpointInt4(mp, 15));
+	arr->Append(CTestUtils::PpointInt4(mp, 2));
+	arr->Append(CTestUtils::PpointInt4(mp, 1));
+	arr->Append(CTestUtils::PpointInt4(mp, 1));
+	arr->Append(CTestUtils::PpointInt4(mp, 2));
+	arr->Append(CTestUtils::PpointInt4(mp, 15));
+	arr->Append(CTestUtils::PpointInt4(mp, 15));
+	arr->Append(CTestUtils::PpointInt4(mp, 15));
+
+	pdrgpstatspred->Append(GPOS_NEW(mp) CStatsPredArrayCmp(1, CStatsPred::EstatscmptEq, arr));
 
 	return GPOS_NEW(mp) CStatsPredConj(pdrgpstatspred);
 }

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CHistogramTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CHistogramTest.cpp
@@ -71,24 +71,24 @@ CHistogramTest::EresUnittest_CHistogramInt4()
 	CPoint *ppoint0 = CTestUtils::PpointInt4(mp, 9);
 	CHistogram *phist0 = histogram->MakeHistogramFilter(CStatsPred::EstatscmptG, ppoint0);
 	CCardinalityTestUtils::PrintHist(mp, "phist0", phist0);
-	GPOS_RTL_ASSERT(phist0->Buckets() == 9);
+	GPOS_RTL_ASSERT(phist0->GetNumBuckets() == 9);
 
 	CPoint *point1 = CTestUtils::PpointInt4(mp, 35);
 	CHistogram *histogram1 = histogram->MakeHistogramFilter(CStatsPred::EstatscmptL, point1);
 	CCardinalityTestUtils::PrintHist(mp, "histogram1", histogram1);
-	GPOS_RTL_ASSERT(histogram1->Buckets() == 4);
+	GPOS_RTL_ASSERT(histogram1->GetNumBuckets() == 4);
 
 	// edge case where point is equal to upper bound
 	CPoint *point2 = CTestUtils::PpointInt4(mp, 50);
 	CHistogram *histogram2 = histogram->MakeHistogramFilter(CStatsPred::EstatscmptL,point2);
 	CCardinalityTestUtils::PrintHist(mp, "histogram2", histogram2);
-	GPOS_RTL_ASSERT(histogram2->Buckets() == 5);
+	GPOS_RTL_ASSERT(histogram2->GetNumBuckets() == 5);
 
 	// equality check
 	CPoint *point3 = CTestUtils::PpointInt4(mp, 100);
 	CHistogram *phist3 = histogram->MakeHistogramFilter(CStatsPred::EstatscmptEq, point3);
 	CCardinalityTestUtils::PrintHist(mp, "phist3", phist3);
-	GPOS_RTL_ASSERT(phist3->Buckets() == 1);
+	GPOS_RTL_ASSERT(phist3->GetNumBuckets() == 1);
 
 	// normalized output after filter
 	CPoint *ppoint4 = CTestUtils::PpointInt4(mp, 100);
@@ -100,12 +100,12 @@ CHistogramTest::EresUnittest_CHistogramInt4()
 	// lasj
 	CHistogram *phist5 = histogram->MakeLASJHistogram(CStatsPred::EstatscmptEq, histogram2);
 	CCardinalityTestUtils::PrintHist(mp, "phist5", phist5);
-	GPOS_RTL_ASSERT(phist5->Buckets() == 5);
+	GPOS_RTL_ASSERT(phist5->GetNumBuckets() == 5);
 
 	// inequality check
 	CHistogram *phist6 = histogram->MakeHistogramFilter(CStatsPred::EstatscmptNEq, point2);
 	CCardinalityTestUtils::PrintHist(mp, "phist6", phist6);
-	GPOS_RTL_ASSERT(phist6->Buckets() == 10);
+	GPOS_RTL_ASSERT(phist6->GetNumBuckets() == 10);
 
 	// histogram with null fraction and remaining tuples
 	CHistogram *phist7 = PhistExampleInt4Remain(mp);
@@ -125,7 +125,7 @@ CHistogramTest::EresUnittest_CHistogramInt4()
 
 	// equality join, hitting remaining tuples
 	CHistogram *phist10 = phist7->MakeJoinHistogram(CStatsPred::EstatscmptEq, phist7);
-	GPOS_RTL_ASSERT(phist10->Buckets() == 5);
+	GPOS_RTL_ASSERT(phist10->GetNumBuckets() == 5);
 	GPOS_RTL_ASSERT(fabs((phist10->GetDistinctRemain() - 2.0).Get()) < CStatistics::Epsilon);
 	GPOS_RTL_ASSERT(fabs((phist10->GetFreqRemain() - 0.08).Get()) < CStatistics::Epsilon);
 
@@ -173,7 +173,7 @@ CHistogramTest::EresUnittest_CHistogramBool()
 	CDouble scale_factor(0.0);
 	CHistogram *histogram1 = histogram->MakeHistogramFilterNormalize(CStatsPred::EstatscmptEq, point1, &scale_factor);
 	CCardinalityTestUtils::PrintHist(mp, "histogram1", histogram1);
-	GPOS_RTL_ASSERT(histogram1->Buckets() == 1);
+	GPOS_RTL_ASSERT(histogram1->GetNumBuckets() == 1);
 
 	// clean up
 	point1->Release();

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
@@ -160,11 +160,11 @@ CJoinCardinalityTest::EresUnittest_JoinNDVRemain()
 		CDouble dNDVRemainJoin = elem.m_dNDVRemainJoin;
 		CDouble dFreqRemainJoin = elem.m_dFreqRemainJoin;
 
-		CDouble dDiffNDVJoin(fabs((dNDVBucketsJoin - CStatisticsUtils::GetNumDistinct(join_histogram->ParseDXLToBucketsArray())).Get()));
+		CDouble dDiffNDVJoin(fabs((dNDVBucketsJoin - CStatisticsUtils::GetNumDistinct(join_histogram->GetBuckets())).Get()));
 		CDouble dDiffNDVRemainJoin(fabs((dNDVRemainJoin - join_histogram->GetDistinctRemain()).Get()));
 		CDouble dDiffFreqRemainJoin(fabs((dFreqRemainJoin - join_histogram->GetFreqRemain()).Get()));
 
-		if (join_histogram->Buckets() != ulBucketsJoin || (dDiffNDVJoin > CStatistics::Epsilon)
+		if (join_histogram->GetNumBuckets() != ulBucketsJoin || (dDiffNDVJoin > CStatistics::Epsilon)
 			|| (dDiffNDVRemainJoin > CStatistics::Epsilon) || (dDiffFreqRemainJoin > CStatistics::Epsilon))
 		{
 			eres = GPOS_FAILED;


### PR DESCRIPTION
Implements an algorithm in MakeHistArrayCmpFilter() using CStatsPredArrayCmp:
1. Construct a histogram with the same bucket boundaries as present in the
   base_histogram.
   This is better than using a singleton bucket per point, because it that
   case, the frequency of each bucket is so small, it is often less than
   CStatistics::Epsilon, and may be considered as 0, leading to
   cardinality misestimation. Using the same buckets as base_histogram
   also aids in joining histogram later.
2. Compute the frequency for each bucket based on the number of points (NDV)
   present within each bucket boundary. NB: the points must be de-duplicated
   beforehand to prevent double counting.
3. Join this "dummy_histogram" with the base_histogram to determine the buckets
   from base_histogram that should be selected (using MakeJoinHistogram)
4. Compute and adjust the resultant scale factor for the filter.

Co-authored-by: Ashuka Xue <axue@pivotal.io>
Co-authored-by: Shreedhar Hardikar <shardikar@pivotal.io>