### PR TITLE
Fix a unit test failure on ARM

### DIFF
--- a/src/test/unit/mock/mocker.py
+++ b/src/test/unit/mock/mocker.py
@@ -189,6 +189,10 @@ class FuncSignature(object):
         return argtype[-1] == '*'
 
     def is_variadic(self, arg):
+        # This returns true only for "...", not for va_list type arg.
+        # Otherwise, in format_args() the va_list type of arg would get
+        # generated as '...', so the function's definition would conflict with
+        # the function prototype which is declared using the 'va_list' type.
         return arg == FuncSignature.Variadic
 
     def parse_args(self, arg_string):
@@ -199,7 +203,8 @@ class FuncSignature(object):
 
         for (i, arg) in enumerate(arg_string.split(',')):
             arg = arg.strip()
-            # TODO: needs work
+            # TODO: needs work. Also, if arg is va_list, we don't treat it as
+            # variadic. Check comments in is_variadic().
             if arg == '...':
                 args.append(FuncSignature.Variadic)
                 continue
@@ -245,6 +250,10 @@ class FuncSignature(object):
             if self.is_variadic(arg):
                 continue
             argtype = arg[0]
+            # 'va_list' needs to be explicitly checked because is_variadic()
+            # returns true only for '...', not for va_list.
+            if argtype == 'va_list':
+                continue
             argname = arg[1]
             ref = '&' if special.ByValStructs.has(argtype) else ''
             argname = subscript.sub('', argname)


### PR DESCRIPTION
While generating the check_expected() function calls, the mocker.py
script does not consider functions that have arguments with
non-integral types like typedefs of structures. Due to this, a
function appendPQExpBufferVA() which has va_list argument, causes
compilation error "aggregate value used where an integer was expected"
in src/test/unit/mock/backend/libpq/pqexpbuffer_mock.c
since the check_expected() is called for the va_list argument as well.
This is because in the check_expected() definition, the arg is cast to
an integral type such as long, which is illegal if the arg type is a
structure.

Now, this error shows up on ARM, but not on x86.
The probable explanation is : va_list is defined as a typedef of
__builtin_va_list, and __builtin_va_list is internally defined
by gcc compiler, rather than a typedef statement in one of the gcc
header files. So we cannot know what __builtin_va_list is defined as,
but since it shows up only on ARM, it must be defined to some
structure on ARM, and to some integral type such as int or long, on
x86.

I also verified by compiling a sample program that just does a
cast from va_list to int. It gives the same compilation error on ARM,
but compiles successfully on x86. At both places, I used the same gcc-7
version.

Fix is to handle va_list as a special case and skip check_expected()
call for variadic functions that use va_list rather than "..."
notation. An ideal and bigger fix should have been to handle function
arguments of structure types, but it's better to do that as a
separate item, since it needs more thought, and a solution is not
known as of now.

Author: Amit Khandekar

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
