### PR TITLE
[6X backport]Fix ALTER DATABASE SET ... FROM CURRENT

### DIFF
--- a/src/backend/catalog/pg_db_role_setting.c
+++ b/src/backend/catalog/pg_db_role_setting.c
@@ -240,6 +240,8 @@ AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt *setstmt)
 			appendStringInfo(&buffer, "RESET ALL");
 		else if (valuestr == NULL)
 			appendStringInfo(&buffer, "RESET %s", quote_identifier(setstmt->name));
+		else if (setstmt->kind ==  VAR_SET_CURRENT)
+			appendStringInfo(&buffer, "SET %s TO %s", quote_identifier(setstmt->name), quote_literal_cstr(valuestr));
 		else
 		{
 			ListCell   *l;

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -115,6 +115,23 @@ DROP TABLE public."my table";
 CREATE TABLE "my table" (id integer);
 DROP TABLE "my table";
 
+-- test ALTER DATABASE SET FROM CURRENT
+SHOW search_path;
+ALTER DATABASE "dispatch test db" RESET ALL;
+\c
+SHOW search_path;
+SET search_path="my schema", public;
+SHOW search_path;
+ALTER DATABASE "dispatch test db" SET search_path FROM CURRENT;
+\c
+SHOW search_path;
+SELECT 0 as gp_segment_id, setconfig FROM gp_dist_random('pg_db_role_setting')
+WHERE setdatabase = (SELECT oid FROM pg_database WHERE datname='dispatch test db') and gp_segment_id = 0
+UNION
+SELECT -1 as gp_segment_id, setconfig FROM pg_db_role_setting
+WHERE setdatabase = (SELECT oid FROM pg_database WHERE datname='dispatch test db')
+ORDER BY gp_segment_id;
+
 -- Clean up
 \c dispatch_test_db
 DROP DATABASE "dispatch test db";

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -156,6 +156,48 @@ CREATE TABLE "my table" (id integer);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 DROP TABLE "my table";
+-- test ALTER DATABASE SET FROM CURRENT
+SHOW search_path;
+     search_path     
+---------------------
+ "my schema", public
+(1 row)
+
+ALTER DATABASE "dispatch test db" RESET ALL;
+\c
+SHOW search_path;
+  search_path   
+----------------
+ "$user",public
+(1 row)
+
+SET search_path="my schema", public;
+SHOW search_path;
+     search_path     
+---------------------
+ "my schema", public
+(1 row)
+
+ALTER DATABASE "dispatch test db" SET search_path FROM CURRENT;
+\c
+SHOW search_path;
+     search_path     
+---------------------
+ "my schema", public
+(1 row)
+
+SELECT 0 as gp_segment_id, setconfig FROM gp_dist_random('pg_db_role_setting')
+WHERE setdatabase = (SELECT oid FROM pg_database WHERE datname='dispatch test db') and gp_segment_id = 0
+UNION
+SELECT -1 as gp_segment_id, setconfig FROM pg_db_role_setting
+WHERE setdatabase = (SELECT oid FROM pg_database WHERE datname='dispatch test db')
+ORDER BY gp_segment_id;
+ gp_segment_id |                   setconfig                   
+---------------+-----------------------------------------------
+            -1 | {"search_path=\"my schema\", public"}
+             0 | {"search_path=\"\"\"my schema\"\", public\""}
+(2 rows)
+
 -- Clean up
 \c dispatch_test_db
 DROP DATABASE "dispatch test db";


### PR DESCRIPTION
ALTER DATABASE SET ... FROM CURRENT dispatches incorrect statement to the
segments. Reported in https://github.com/greenplum-db/gpdb/issues/9823

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
