### PR TITLE
Support 'n_mod_since_analyze' in system view pg_stat_all_tables

### DIFF
--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -496,7 +496,7 @@ SELECT
     m.n_tup_hot_upd,
     m.n_live_tup,
     m.n_dead_tup,
-    s.n_mod_since_analyze,
+    m.n_mod_since_analyze,
     s.last_vacuum,
     s.last_autovacuum,
     s.last_analyze,

--- a/src/test/regress/expected/pg_stat.out
+++ b/src/test/regress/expected/pg_stat.out
@@ -58,20 +58,20 @@ select * from pg_stat_test where a = 1;
 reset enable_seqscan;
 select
     schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd,
-    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup
+    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze
 from pg_stat_all_tables where relname = 'pg_stat_test';
- schemaname |   relname    | seq_scan | seq_tup_read | idx_scan | idx_tup_fetch | n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup 
-------------+--------------+----------+--------------+----------+---------------+-----------+-----------+-----------+---------------+------------+------------
- public     | pg_stat_test |       12 |          391 |        1 |             0 |       110 |         0 |        19 |             0 |         91 |         19
+ schemaname |   relname    | seq_scan | seq_tup_read | idx_scan | idx_tup_fetch | n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup | n_mod_since_analyze 
+------------+--------------+----------+--------------+----------+---------------+-----------+-----------+-----------+---------------+------------+------------+---------------------
+ public     | pg_stat_test |       12 |          391 |        1 |             0 |       110 |         0 |        19 |             0 |         91 |         19 |                  58
 (1 row)
 
 select
     schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd,
-    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup
+    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze
 from pg_stat_user_tables where relname = 'pg_stat_test';
- schemaname |   relname    | seq_scan | seq_tup_read | idx_scan | idx_tup_fetch | n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup 
-------------+--------------+----------+--------------+----------+---------------+-----------+-----------+-----------+---------------+------------+------------
- public     | pg_stat_test |       12 |          391 |        1 |             0 |       110 |         0 |        19 |             0 |         91 |         19
+ schemaname |   relname    | seq_scan | seq_tup_read | idx_scan | idx_tup_fetch | n_tup_ins | n_tup_upd | n_tup_del | n_tup_hot_upd | n_live_tup | n_dead_tup | n_mod_since_analyze 
+------------+--------------+----------+--------------+----------+---------------+-----------+-----------+-----------+---------------+------------+------------+---------------------
+ public     | pg_stat_test |       12 |          391 |        1 |             0 |       110 |         0 |        19 |             0 |         91 |         19 |                  58
 (1 row)
 
 select

--- a/src/test/regress/sql/pg_stat.sql
+++ b/src/test/regress/sql/pg_stat.sql
@@ -37,11 +37,11 @@ reset enable_seqscan;
 
 select
     schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd,
-    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup
+    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze
 from pg_stat_all_tables where relname = 'pg_stat_test';
 select
     schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd,
-    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup
+    n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze
 from pg_stat_user_tables where relname = 'pg_stat_test';
 select
     schemaname, relname, indexrelname, idx_scan, idx_tup_read, idx_tup_fetch


### PR DESCRIPTION
The column n_mod_since_analyze was always 0 in the past. The root cause
is that n_mod_since_analyze is generated on segments but we read it from
master. Fix the sql and read the value from segments.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
