### PR TITLE
docs - new pxf IGNORE_MISSING_PATH option

### DIFF
--- a/gpdb-doc/markdown/pxf/hdfs_avro.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_avro.html.md.erb
@@ -119,6 +119,7 @@ The `hdfs:avro` profile supports the following \<custom-option\>s:
 | MAPKEY_DELIM | The delimiter character(s) placed between the key and value of a map entry when PXF maps an Avro complex data type to a text column. The default is the colon `:` character. (Read)|
 | RECORDKEY_DELIM | The delimiter character(s) placed between the field name and value of a record entry when PXF maps an Avro complex data type to a text column. The default is the colon `:` character. (Read)|
 | SCHEMA | The absolute path to the Avro schema file on the segment host or on HDFS, or the relative path to the schema file on the segment host. (Read and Write)|
+| IGNORE_MISSING_PATH | A Boolean value that specifies PXF's action when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 
 
 ## <a id="avro_example"></a>Example: Reading Avro Data

--- a/gpdb-doc/markdown/pxf/hdfs_avro.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_avro.html.md.erb
@@ -119,7 +119,7 @@ The `hdfs:avro` profile supports the following \<custom-option\>s:
 | MAPKEY_DELIM | The delimiter character(s) placed between the key and value of a map entry when PXF maps an Avro complex data type to a text column. The default is the colon `:` character. (Read)|
 | RECORDKEY_DELIM | The delimiter character(s) placed between the field name and value of a record entry when PXF maps an Avro complex data type to a text column. The default is the colon `:` character. (Read)|
 | SCHEMA | The absolute path to the Avro schema file on the segment host or on HDFS, or the relative path to the schema file on the segment host. (Read and Write)|
-| IGNORE_MISSING_PATH | A Boolean value that specifies PXF's action when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| IGNORE_MISSING_PATH | A Boolean value that specifies the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 
 
 ## <a id="avro_example"></a>Example: Reading Avro Data

--- a/gpdb-doc/markdown/pxf/hdfs_fileasrow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_fileasrow.html.md.erb
@@ -37,7 +37,7 @@ The keywords and values used in this [CREATE EXTERNAL TABLE](../ref_guide/sql_co
 | PROFILE    | The `PROFILE` keyword must specify `hdfs:text:multi`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
 | FILE\_AS\_ROW=true    | The required option that instructs PXF to read each file into a single table row. |
-| IGNORE_MISSING_PATH=\<boolean\> | Specify PXF's action when \<path-to-files\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-files\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | FORMAT | The `FORMAT` must specify `'CSV'`.  |
 
 **Note**: The `hdfs:text:multi` profile does not support additional format options when you specify the `FILE_AS_ROW=true` option.

--- a/gpdb-doc/markdown/pxf/hdfs_fileasrow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_fileasrow.html.md.erb
@@ -25,7 +25,7 @@ The following syntax creates a Greenplum Database readable external table that r
 ``` sql
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> text|json | LIKE <other_table> )
-  LOCATION ('pxf://<path-to-files>?PROFILE=hdfs:text:multi[&SERVER=<server_name>]&FILE_AS_ROW=true')
+  LOCATION ('pxf://<path-to-files>?PROFILE=hdfs:text:multi[&SERVER=<server_name>][&IGNORE_MISSING_PATH=<boolean>]&FILE_AS_ROW=true')
 FORMAT 'CSV');
 ```
 
@@ -37,6 +37,7 @@ The keywords and values used in this [CREATE EXTERNAL TABLE](../ref_guide/sql_co
 | PROFILE    | The `PROFILE` keyword must specify `hdfs:text:multi`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
 | FILE\_AS\_ROW=true    | The required option that instructs PXF to read each file into a single table row. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify PXF's action when \<path-to-files\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | FORMAT | The `FORMAT` must specify `'CSV'`.  |
 
 **Note**: The `hdfs:text:multi` profile does not support additional format options when you specify the `FILE_AS_ROW=true` option.

--- a/gpdb-doc/markdown/pxf/hdfs_json.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_json.html.md.erb
@@ -193,11 +193,14 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  the `hdfs:json` profile. The `CUSTOM` `FORMAT` requires that you specify `(FORMATTER='pxfwritable_import')`. |
 
 <a id="customopts"></a>
-PXF supports single- and multi- line JSON records. When you want to read multi-line JSON records, you must provide an `IDENTIFIER` \<custom-option\> and value. Use this \<custom-option\> to identify the member name of the first field in the JSON record object:
+PXF supports single- and multi- line JSON records. When you want to read multi-line JSON records, you must provide an `IDENTIFIER` \<custom-option\> and value. Use this \<custom-option\> to identify the member name of the first field in the JSON record object.
+
+The `hdfs:json` profile supports the following \<custom-option\>s:
 
 | Option Keyword  | &nbsp;&nbsp;Syntax,&nbsp;&nbsp;Example(s)&nbsp;&nbsp; | Description |
 |-------|--------------|-----------------------|
 | IDENTIFIER  | `&IDENTIFIER=<value>`<br>`&IDENTIFIER=created_at`| You must include the `IDENTIFIER` keyword and \<value\> in the `LOCATION` string only when you are accessing JSON data comprised of multi-line records. Use the \<value\> to identify the member name of the first field in the JSON record object. | 
+| IGNORE_MISSING_PATH | `&IGNORE_MISSING_PATH=<boolean>` | Specify PXF's action when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 
 
 ## <a id="jsonexample1"></a>Example: Reading a JSON File with Single Line Records

--- a/gpdb-doc/markdown/pxf/hdfs_json.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_json.html.md.erb
@@ -200,7 +200,7 @@ The `hdfs:json` profile supports the following \<custom-option\>s:
 | Option Keyword  | &nbsp;&nbsp;Syntax,&nbsp;&nbsp;Example(s)&nbsp;&nbsp; | Description |
 |-------|--------------|-----------------------|
 | IDENTIFIER  | `&IDENTIFIER=<value>`<br>`&IDENTIFIER=created_at`| You must include the `IDENTIFIER` keyword and \<value\> in the `LOCATION` string only when you are accessing JSON data comprised of multi-line records. Use the \<value\> to identify the member name of the first field in the JSON record object. | 
-| IGNORE_MISSING_PATH | `&IGNORE_MISSING_PATH=<boolean>` | Specify PXF's action when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| IGNORE_MISSING_PATH | `&IGNORE_MISSING_PATH=<boolean>` | Specify the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 
 
 ## <a id="jsonexample1"></a>Example: Reading a JSON File with Single Line Records

--- a/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
@@ -112,12 +112,18 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<path&#8209;to&#8209;hdfs&#8209;file\>    | The absolute path to the directory in the HDFS data store. |
 | PROFILE    | The `PROFILE` keyword must specify `hdfs:parquet`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
-| \<custom&#8209;option\>=\<value\>  | \<custom-option\>s are described below.|
+| \<custom&#8209;option\>  | \<custom-option\>s are described below.|
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
 | DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
 <a id="customopts"></a>
-The PXF `hdfs:parquet` profile supports encoding- and compression-related write options. You specify these write options in the `CREATE WRITABLE EXTERNAL TABLE` `LOCATION` clause. The `hdfs:parquet` profile supports the following custom options:
+The PXF `hdfs:parquet` profile supports the following read option. You specify this option in the `CREATE EXTERNAL TABLE` `LOCATION` clause:
+
+| Read Option  | Value Description |
+|-------|-------------------------------------|
+| IGNORE_MISSING_PATH | A Boolean value that specifies PXF's action when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+
+The PXF `hdfs:parquet` profile supports encoding- and compression-related write options. You specify these write options in the `CREATE WRITABLE EXTERNAL TABLE` `LOCATION` clause. The `hdfs:parquet` profile supports the following custom write options:
 
 | Write Option  | Value Description |
 |-------|-------------------------------------|

--- a/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_parquet.html.md.erb
@@ -121,7 +121,7 @@ The PXF `hdfs:parquet` profile supports the following read option. You specify t
 
 | Read Option  | Value Description |
 |-------|-------------------------------------|
-| IGNORE_MISSING_PATH | A Boolean value that specifies PXF's action when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| IGNORE_MISSING_PATH | A Boolean value that specifies the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 
 The PXF `hdfs:parquet` profile supports encoding- and compression-related write options. You specify these write options in the `CREATE WRITABLE EXTERNAL TABLE` `LOCATION` clause. The `hdfs:parquet` profile supports the following custom write options:
 

--- a/gpdb-doc/markdown/pxf/hdfs_seqfile.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_seqfile.html.md.erb
@@ -63,7 +63,9 @@ SequenceFile format data can optionally employ record or block compression. The 
 
 When you use the `hdfs:SequenceFile` profile to write SequenceFile format data, you must provide the name of the Java class to use for serializing/deserializing the binary data. This class must provide read and write methods for each data type referenced in the data schema.
 
-You specify the compression codec and Java serialization class via custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `hdfs:SequenceFile` profile supports the following custom options:
+You specify the compression codec and Java serialization class via custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause.
+
+The `hdfs:SequenceFile` profile supports the following custom options:
 
 | Option  | Value Description |
 |-------|-------------------------------------|
@@ -71,6 +73,7 @@ You specify the compression codec and Java serialization class via custom option
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 | DATA-SCHEMA    | The name of the writer serialization/deserialization class. The jar file in which this class resides must be in the PXF classpath. This option is required for the `hdfs:SequenceFile` profile and has no default value. |
 | THREAD-SAFE | Boolean value determining if a table query can run in multi-threaded mode. The default value is `TRUE`. Set this option to `FALSE` to handle all requests in a single thread for operations that are not thread-safe (for example, compression). |
+| IGNORE_MISSING_PATH | A Boolean value that specifies PXF's action when \<path-to-hdfs-dir\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 
 
 ## <a id="write_binary"></a>Reading and Writing Binary Data

--- a/gpdb-doc/markdown/pxf/hdfs_seqfile.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_seqfile.html.md.erb
@@ -73,7 +73,7 @@ The `hdfs:SequenceFile` profile supports the following custom options:
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 | DATA-SCHEMA    | The name of the writer serialization/deserialization class. The jar file in which this class resides must be in the PXF classpath. This option is required for the `hdfs:SequenceFile` profile and has no default value. |
 | THREAD-SAFE | Boolean value determining if a table query can run in multi-threaded mode. The default value is `TRUE`. Set this option to `FALSE` to handle all requests in a single thread for operations that are not thread-safe (for example, compression). |
-| IGNORE_MISSING_PATH | A Boolean value that specifies PXF's action when \<path-to-hdfs-dir\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| IGNORE_MISSING_PATH | A Boolean value that specifies the action to take when \<path-to-hdfs-dir\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 
 
 ## <a id="write_binary"></a>Reading and Writing Binary Data

--- a/gpdb-doc/markdown/pxf/hdfs_text.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_text.html.md.erb
@@ -132,7 +132,7 @@ Use the `hdfs:text:multi` profile to read plain text data with delimited single-
 ``` sql
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:text:multi[&SERVER=<server_name>]')
+LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:text:multi[&SERVER=<server_name>][&IGNORE_MISSING_PATH=<boolean>]')
 FORMAT '[TEXT|CSV]' (delimiter[=|<space>][E]'<delim_value>');
 ```
 
@@ -143,6 +143,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<path&#8209;to&#8209;hdfs&#8209;file\>    | The absolute path to the directory or file in the HDFS data store. |
 | PROFILE    | The `PROFILE` keyword must specify `hdfs:text:multi`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify PXF's action when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | FORMAT | Use `FORMAT` `'TEXT'` when \<path-to-hdfs-file\> references plain text delimited data.<br> Use `FORMAT` `'CSV'` when \<path-to-hdfs-file\> references comma-separated value data.  |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 

--- a/gpdb-doc/markdown/pxf/hdfs_text.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_text.html.md.erb
@@ -34,7 +34,7 @@ Use the `hdfs:text` profile when you read plain text delimited or .csv data wher
 ``` sql
 CREATE EXTERNAL TABLE <table_name> 
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:text[&SERVER=<server_name>]')
+LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:text[&SERVER=<server_name>][&IGNORE_MISSING_PATH=<boolean>]')
 FORMAT '[TEXT|CSV]' (delimiter[=|<space>][E]'<delim_value>');
 ```
 
@@ -45,6 +45,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<path&#8209;to&#8209;hdfs&#8209;file\>    | The absolute path to the directory or file in the HDFS data store. |
 | PROFILE    | The `PROFILE` keyword must specify `hdfs:text`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify PXF's action when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | FORMAT | Use `FORMAT` `'TEXT'` when \<path-to-hdfs-file\> references plain text delimited data.<br> Use `FORMAT` `'CSV'`  when \<path-to-hdfs-file\> references comma-separated value data.  |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 

--- a/gpdb-doc/markdown/pxf/hdfs_text.html.md.erb
+++ b/gpdb-doc/markdown/pxf/hdfs_text.html.md.erb
@@ -45,7 +45,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<path&#8209;to&#8209;hdfs&#8209;file\>    | The absolute path to the directory or file in the HDFS data store. |
 | PROFILE    | The `PROFILE` keyword must specify `hdfs:text`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
-| IGNORE_MISSING_PATH=\<boolean\> | Specify PXF's action when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | FORMAT | Use `FORMAT` `'TEXT'` when \<path-to-hdfs-file\> references plain text delimited data.<br> Use `FORMAT` `'CSV'`  when \<path-to-hdfs-file\> references comma-separated value data.  |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 
@@ -143,7 +143,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<path&#8209;to&#8209;hdfs&#8209;file\>    | The absolute path to the directory or file in the HDFS data store. |
 | PROFILE    | The `PROFILE` keyword must specify `hdfs:text:multi`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. Optional; PXF uses the `default` server if not specified. |
-| IGNORE_MISSING_PATH=\<boolean\> | Specify PXF's action when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | FORMAT | Use `FORMAT` `'TEXT'` when \<path-to-hdfs-file\> references plain text delimited data.<br> Use `FORMAT` `'CSV'` when \<path-to-hdfs-file\> references comma-separated value data.  |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 

--- a/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
@@ -40,7 +40,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<path&#8209;to&#8209;files\>    | The absolute path to the directory or files in the object store. |
 | PROFILE=\<objstore\>:text:multi    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text:multi`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
-| IGNORE_MISSING_PATH=\<boolean\> | Specify PXF's action when \<path-to-files\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-files\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | FILE\_AS\_ROW=true    | The required option that instructs PXF to read each file into a single table row. |
 | FORMAT | The `FORMAT` must specify `'CSV'`.  |
 

--- a/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_fileasrow.html.md.erb
@@ -29,7 +29,7 @@ The following syntax creates a Greenplum Database readable external table that r
 ``` sql
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> text|json | LIKE <other_table> )
-  LOCATION ('pxf://<path-to-files>?PROFILE=<objstore>:text:multi&SERVER=<server_name>&FILE_AS_ROW=true')
+  LOCATION ('pxf://<path-to-files>?PROFILE=<objstore>:text:multi&SERVER=<server_name>[&IGNORE_MISSING_PATH=<boolean>]&FILE_AS_ROW=true')
   FORMAT 'CSV');
 ```
 
@@ -40,6 +40,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<path&#8209;to&#8209;files\>    | The absolute path to the directory or files in the object store. |
 | PROFILE=\<objstore\>:text:multi    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text:multi`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify PXF's action when \<path-to-files\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | FILE\_AS\_ROW=true    | The required option that instructs PXF to read each file into a single table row. |
 | FORMAT | The `FORMAT` must specify `'CSV'`.  |
 

--- a/gpdb-doc/markdown/pxf/objstore_parquet.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_parquet.html.md.erb
@@ -65,7 +65,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<path&#8209;to&#8209;dir\>    | The absolute path to the directory in the object store. |
 | PROFILE=\<objstore\>:parquet    | The `PROFILE` keyword must identify the specific object store. For example, `s3:parquet`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
-| \<custom&#8209;option\>=\<value\> | Parquet-specific custom write options are described in the [PXF HDFS Parquet documentation](hdfs_parquet.html#customopts). |
+| \<custom&#8209;option\>=\<value\> | Parquet-specific custom options are described in the [PXF HDFS Parquet documentation](hdfs_parquet.html#customopts). |
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
 | DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 

--- a/gpdb-doc/markdown/pxf/objstore_text.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_text.html.md.erb
@@ -46,7 +46,7 @@ The following syntax creates a Greenplum Database readable external table that r
 ``` sql
 CREATE EXTERNAL TABLE <table_name> 
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:text&SERVER=<server_name>[&<custom-option>=<value>[...]]')
+LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:text&SERVER=<server_name>[&IGNORE_MISSING_PATH=<boolean>][&<custom-option>=<value>[...]]')
 FORMAT '[TEXT|CSV]' (delimiter[=|<space>][E]'<delim_value>');
 ```
 
@@ -57,6 +57,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<path&#8209;to&#8209;file\>    | The absolute path to the directory or file in the S3 object store. |
 | PROFILE=\<objstore\>:text    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify PXF's action when \<path-to-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | FORMAT | Use `FORMAT` `'TEXT'` when \<path-to-file\> references plain text delimited data.<br> Use `FORMAT` `'CSV'`  when \<path-to-file\> references comma-separated value data.  |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 
@@ -153,7 +154,7 @@ Use the `<objstore>:text:multi` profile to read plain text data with delimited s
 ``` sql
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:text:multi&SERVER=<server_name>[&<custom-option>=<value>[...]]')
+LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:text:multi&SERVER=<server_name>[&IGNORE_MISSING_PATH=<boolean>][&<custom-option>=<value>[...]]')
 FORMAT '[TEXT|CSV]' (delimiter[=|<space>][E]'<delim_value>');
 ```
 
@@ -164,6 +165,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<path&#8209;to&#8209;file\>    | The absolute path to the directory or file in the S3 data store. |
 | PROFILE=\<objstore\>:text:multi    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text:multi`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify PXF's action when \<path-to-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | FORMAT | Use `FORMAT` `'TEXT'` when \<path-to-file\> references plain text delimited data.<br> Use `FORMAT` `'CSV'` when \<path-to-file\> references comma-separated value data.  |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 

--- a/gpdb-doc/markdown/pxf/objstore_text.html.md.erb
+++ b/gpdb-doc/markdown/pxf/objstore_text.html.md.erb
@@ -57,7 +57,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<path&#8209;to&#8209;file\>    | The absolute path to the directory or file in the S3 object store. |
 | PROFILE=\<objstore\>:text    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
-| IGNORE_MISSING_PATH=\<boolean\> | Specify PXF's action when \<path-to-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | FORMAT | Use `FORMAT` `'TEXT'` when \<path-to-file\> references plain text delimited data.<br> Use `FORMAT` `'CSV'`  when \<path-to-file\> references comma-separated value data.  |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 
@@ -165,7 +165,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](../ref_guid
 | \<path&#8209;to&#8209;file\>    | The absolute path to the directory or file in the S3 data store. |
 | PROFILE=\<objstore\>:text:multi    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text:multi`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
-| IGNORE_MISSING_PATH=\<boolean\> | Specify PXF's action when \<path-to-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | FORMAT | Use `FORMAT` `'TEXT'` when \<path-to-file\> references plain text delimited data.<br> Use `FORMAT` `'CSV'` when \<path-to-file\> references comma-separated value data.  |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 

--- a/gpdb-doc/markdown/pxf/read_s3_s3select.html.md.erb
+++ b/gpdb-doc/markdown/pxf/read_s3_s3select.html.md.erb
@@ -29,6 +29,8 @@ The `S3_SELECT` external table custom option governs PXF's use of S3 Select when
 
 By default, PXF does not use S3 Select (`S3_SELECT=OFF`). You can enable PXF to always use S3 Select, or to use S3 Select only when PXF determines that it could be beneficial for performance. For example, when `S3_SELECT=AUTO`, PXF automatically uses S3 Select when a query on the external table utilizes column projection or predicate pushdown, or when the referenced CSV file has a header row.
 
+**Note**: The <code>IGNORE_MISSING_PATH</code> custom option is not available when you use a PXF external table to read CSV text and Parquet data from S3 using S3 Select.
+
 
 ## <a id="s3_select_parquet"></a>Reading Parquet Data with S3 Select
 

--- a/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
@@ -363,7 +363,7 @@ Greenplum Database supports partitioned tables, and permits exchanging a leaf ch
 
 When you read from a partitioned Greenplum table where one or more partitions is a PXF external table and there is no data backing the external table path, PXF returns an error and the query fails. This behavior is not optimal.
 
-The `IGNORE_MISSING_PATH` PXF custom option is a boolean that specifies PXF's action when the external table path is missing or invalid. The default value is `false`, PXF does not ignore a missing path and returns an error. If the external table is a partition of a Greenplum table and you want PXF to ignore a missing path error, set this option to `true`.
+The `IGNORE_MISSING_PATH` PXF custom option is a boolean that specifies PXF's action when the external table path is missing or invalid. The default value is `false`, PXF returns an error when it encounters a missing path. If the external table is a partition of a Greenplum table and you want PXF to ignore a missing path error, set this option to `true`.
 
 For example, PXF ignores missing path errors generated from the following external table:
 

--- a/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
@@ -363,7 +363,7 @@ Greenplum Database supports partitioned tables, and permits exchanging a leaf ch
 
 When you read from a partitioned Greenplum table where one or more partitions is a PXF external table and there is no data backing the external table path, PXF returns an error and the query fails. This behavior is not optimal.
 
-The `IGNORE_MISSING_PATH` PXF custom option is a boolean that specifies PXF's action when the external table path is missing or invalid. The default value is `false`, PXF returns an error when it encounters a missing path. If the external table is a partition of a Greenplum table and you want PXF to ignore a missing path error, set this option to `true`.
+The `IGNORE_MISSING_PATH` PXF custom option is a boolean that specifies the action to take when the external table path is missing or invalid. The default value is `false`, PXF returns an error when it encounters a missing path. If the external table is a partition of a Greenplum table and you want PXF to ignore a missing path error, set this option to `true`.
 
 For example, PXF ignores missing path errors generated from the following external table:
 

--- a/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
@@ -356,3 +356,22 @@ PXF fragment metadata caching is enabled by default. To turn off fragment metada
 
 5. Restart PXF on each Greenplum Database segment host as described in [Restarting PXF](cfginitstart_pxf.html#restart_pxf).
 
+
+## <a id="pxf-tblpart"></a>About PXF External Table Child Partitions
+
+Greenplum Database supports partitioned tables, and permits exchanging a leaf child partition with a PXF external table.
+
+When you read from a partitioned Greenplum table where one or more partitions is a PXF external table and there is no data backing the external table path, PXF returns an error and the query fails. This behavior is not optimal.
+
+The `IGNORE_MISSING_PATH` PXF custom option is a boolean that specifies PXF's action when the external table path is missing or invalid. The default value is `false`, PXF does not ignore a missing path and returns an error. If the external table is a partition of a Greenplum table and you want PXF to ignore a missing path error, set this option to `true`.
+
+For example, PXF ignores missing path errors generated from the following external table:
+
+``` sql
+CREATE EXTERNAL TABLE ext_part_87 (id int, some_date date)
+  LOCATION ('pxf://bucket/path/?PROFILE=s3:parquet&SERVER=s3&IGNORE_MISSING_PATH=true')
+FORMAT 'CUSTOM' (formatter = 'pxfwritable_import');
+```
+
+The `IGNORE_MISSING_PATH` custom option applies only to file-based profiles, including `*:text`, `*:parquet`, `*:avro`, `*:json`, `*:AvroSequenceFile`, and `*:SequenceFile`. This option is *not available* when the external table specifies the `HBase`, `Hive*`, or `Jdbc` profiles, or when reading from S3 using S3-Select.
+

--- a/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/troubleshooting_pxf.html.md.erb
@@ -361,9 +361,9 @@ PXF fragment metadata caching is enabled by default. To turn off fragment metada
 
 Greenplum Database supports partitioned tables, and permits exchanging a leaf child partition with a PXF external table.
 
-When you read from a partitioned Greenplum table where one or more partitions is a PXF external table and there is no data backing the external table path, PXF returns an error and the query fails. This behavior is not optimal.
+When you read from a partitioned Greenplum table where one or more partitions is a PXF external table and there is no data backing the external table path, PXF returns an error and the query fails. This default PXF behavior is not optimal in the partitioned table case; an empty child partition is valid and should not cause a query on the parent table to fail.
 
-The `IGNORE_MISSING_PATH` PXF custom option is a boolean that specifies the action to take when the external table path is missing or invalid. The default value is `false`, PXF returns an error when it encounters a missing path. If the external table is a partition of a Greenplum table and you want PXF to ignore a missing path error, set this option to `true`.
+The `IGNORE_MISSING_PATH` PXF custom option is a boolean that specifies the action to take when the external table path is missing or invalid. The default value is `false`, PXF returns an error when it encounters a missing path. If the external table is a child partition of a Greenplum table, you want PXF to ignore a missing path error, so set this option to `true`.
 
 For example, PXF ignores missing path errors generated from the following external table:
 


### PR DESCRIPTION
pxf introduces the IGNORE_MISSING_PATH option.  in this PR:
- add new section "About PXF External Table Child Partitions" to the troubleshooting page.  i added it here because it seems to me that this isn't that common of a scenario.  i could be convinced to add it elsewhere.
- this new option is available for many, but not all, of the profiles.  i added an entry for the option on the hdfs:text page, in the external table parameters table.  i can also add this option/description to the external table parameters tables of all applicable profiles.   but just wondering if we want to do this?  if the option won't typically be used, the description could introduce confusion.  interested in your thoughts.

doc review site link:  http://docs-lisa-newpxfopt.cfapps.io/7-0/pxf/troubleshooting_pxf.html#pxf-tblpart
