### PR TITLE
Fix flaky test concurrent_update

### DIFF
--- a/src/test/isolation2/expected/gdd/concurrent_update.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update.out
@@ -48,7 +48,7 @@ SET
 3&: UPDATE t_concurrent_update SET b=b+10 WHERE a=1;  <waiting ...>
 
 -- transaction 2 suspend before commit, but it will wake up transaction 3 on segment
-2: select gp_inject_fault('before_xact_end_procarray', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+2: select gp_inject_fault('before_xact_end_procarray', 'suspend', '', 'isolation2test', '', 1, 1, 0, dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
  gp_inject_fault 
 -----------------
  Success:        
@@ -63,17 +63,17 @@ SET
 3<:  <... completed>
 UPDATE 1
 3&: END;  <waiting ...>
+-- the query should not get the incorrect distributed snapshot: transaction 1 in-progress
+-- and transaction 2 finished
+1: SELECT count(*) FROM t_concurrent_update;
+ count 
+-------
+ 1     
+(1 row)
 1: select gp_inject_fault('before_xact_end_procarray', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
--- the query should not get the incorrect distributed snapshot: transaction 1 in-progress
--- and transaction 2 finished
-1: SELECT * FROM t_concurrent_update;
- a | b 
----+---
- 1 | 1 
 (1 row)
 2<:  <... completed>
 END


### PR DESCRIPTION
the test case injects a 'suspend' fault in function 'ProcArrayEndTransaction'
and it could be triggered by some other process like 'global deadlock detector'
or FTS, to fix this we specify the database name in the fault.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
