### PR TITLE
Rename BeginCopyToForExternalTable() to BeginCopyToForeignTable()

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -624,7 +624,7 @@ external_insert_init(Relation rel)
 	/* pass external table's encoding to copy's options */
 	copyFmtOpts = appendCopyEncodingOption(copyFmtOpts, extentry->encoding);
 
-	extInsertDesc->ext_pstate = BeginCopyToForExternalTable(rel, copyFmtOpts);
+	extInsertDesc->ext_pstate = BeginCopyToForeignTable(rel, copyFmtOpts);
 	InitParseState(extInsertDesc->ext_pstate,
 				   rel,
 				   true,

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -2624,16 +2624,17 @@ BeginCopyTo(Relation rel,
 }
 
 /*
- * Set up CopyState for writing to an external table.
+ * Set up CopyState for writing to a foreign or external table.
  */
 CopyState
-BeginCopyToForExternalTable(Relation extrel, List *options)
+BeginCopyToForeignTable(Relation forrel, List *options)
 {
 	CopyState	cstate;
 
-	Assert(rel_is_external_table(RelationGetRelid(extrel)));
+	Assert(rel_is_external_table(RelationGetRelid(forrel)) || RelationIsForeign(forrel));
 
-	cstate = BeginCopy(false, extrel, NULL, NULL, InvalidOid, NIL, options, NULL);
+	cstate = BeginCopy(false, forrel, NULL, NULL, InvalidOid, NIL, options, NULL);
+
 	cstate->dispatch_mode = COPY_DIRECT;
 
 	/*

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -293,7 +293,7 @@ extern CopyState BeginCopy(bool is_from, Relation rel, Node *raw_query,
 extern CopyState
 BeginCopyToOnSegment(QueryDesc *queryDesc);
 extern void EndCopyToOnSegment(CopyState cstate);
-extern CopyState BeginCopyToForExternalTable(Relation extrel, List *options);
+extern CopyState BeginCopyToForeignTable(Relation forrel, List *options);
 extern void EndCopyFrom(CopyState cstate);
 extern bool NextCopyFrom(CopyState cstate, ExprContext *econtext,
 						 Datum *values, bool *nulls, Oid *tupleOid);


### PR DESCRIPTION
External tables are slowly becoming a type of foreign tables in
Greenplum. Rename BeginCopyToForExternalTable() to
BeginCopyToForeignTable() and allow foreign relations to use this
functionality.

This commit made it to 6X_STABLE first, but we should move it here for
consistency: ref: https://github.com/greenplum-db/gpdb/commit/3041e27652bd6d849c173d978d154f6501a9d681
