### PR TITLE
docs - clarify text for resource group CPU core usage in catalog tables.

### DIFF
--- a/gpdb-doc/dita/ref_guide/gp_toolkit.xml
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.xml
@@ -1697,7 +1697,7 @@
               </row>
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">cpu_usage</entry>
-                <entry colname="col2" class="- topic/entry ">A set of key, value pairs. For each
+                <entry colname="col2" class="- topic/entry ">A set of key-value pairs. For each
                   segment instance (the key), the value is the real-time, per-segment instance CPU
                   core usage by a resource group. The value is the sum of the percentages (as a
                   decimal value) of CPU cores that are used by the resource group for the segment
@@ -1715,7 +1715,7 @@
           string that identifies, for each resource group, the per-segment instance CPU core usage.
           The key is the segment id, the value is the sum of the percentages (as a decimal value) of
           the CPU cores used by the segment instance's resource group on the segment host. For
-          example, if a segment host that has 8 cores, the maximum value can be 8.00 (1.00 for 8 CPU
+          example, if a segment host has 8 cores, the maximum value can be 8.00 (1.00 for 8 CPU
           cores). The total CPU usage of all segment instances running on a host should not exceed
           the <codeph>gp_resource_group_cpu_limit</codeph>. Example <codeph>cpu_usage</codeph>
           column output:<codeblock>

--- a/gpdb-doc/dita/ref_guide/gp_toolkit.xml
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.xml
@@ -1697,8 +1697,11 @@
               </row>
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">cpu_usage</entry>
-                <entry colname="col2" class="- topic/entry ">The real-time CPU usage of the resource
-                  group on each Greenplum Database segment's host.</entry>
+                <entry colname="col2" class="- topic/entry ">A set of key, value pairs. For each
+                  segment instance (the key), the value is the real-time, per-segment instance CPU
+                  core usage by a resource group. The value is the sum of the percentages (as a
+                  decimal value) of CPU cores that are used by the resource group for the segment
+                  instance.</entry>
               </row>
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">memory_usage</entry>
@@ -1708,17 +1711,17 @@
             </tbody>
           </tgroup>
         </table>
-        <p> </p>
         <p id="json_field_info1">The <codeph>cpu_usage</codeph> field is a JSON-formatted, key:value
-          string that identifies, for each resource group, the per-segment CPU usage percentage. The
-          key is segment id, the value is the percentage of CPU usage by the resource group on the
-          segment host. The total CPU usage of all segments running on a segment host should not
-          exceed the <codeph>gp_resource_group_cpu_limit</codeph>. Example
-            <codeph>cpu_usage</codeph> column
-          output:<codeblock>
-{"-1":0.01, "0":0.31, "1":0.31}</codeblock></p>
-        <p>In this example, segment <codeph>0</codeph> and segment <codeph>1</codeph> are running on
-          the same host; their CPU usage is the same.</p>
+          string that identifies, for each resource group, the per-segment instance CPU core usage.
+          The key is the segment id, the value is the sum of the percentages (as a decimal value) of
+          the CPU cores used by the segment instance's resource group on the segment host. For
+          example, if a segment host that has 8 cores, the maximum value can be 8.00 (1.00 for 8 CPU
+          cores). The total CPU usage of all segment instances running on a host should not exceed
+          the <codeph>gp_resource_group_cpu_limit</codeph>. Example <codeph>cpu_usage</codeph>
+          column output:<codeblock>
+{"-1":0.01, "0":0.31, "1":0.31}</codeblock>In the example,
+          segment <codeph>0</codeph> and segment <codeph>1</codeph> are running on the same host;
+          their CPU usage is the same.</p>
         <p id="json_field_info2">The <codeph>memory_usage</codeph> field is also a JSON-formatted,
           key:value string. The string contents differ depending upon the type of resource group.
           For each resource group that you assign to a role (default memory auditor
@@ -1774,8 +1777,9 @@
               </row>
               <row>
                 <entry colname="col1"><codeph>cpu</codeph></entry>
-                <entry colname="col2">The real-time CPU usage of the resource group on the
-                  host.</entry>
+                <entry colname="col2">The real-time CPU core usage by the resource group on a host.
+                  The value is the sum of the percentages (as a decimal value) of the CPU cores that
+                  are used by the resource group on the host.</entry>
               </row>
               <row>
                 <entry colname="col1"> <codeph>memory_used</codeph> </entry>
@@ -1863,9 +1867,13 @@
                   segment host.</entry>
               </row>
               <row>
-                <entry colname="col1"> <codeph>cpu</codeph> </entry>
-                <entry colname="col4">The real-time CPU usage of the resource group for the
-                  segment instance on the host.</entry>
+                <entry colname="col1">
+                  <codeph>cpu</codeph>
+                </entry>
+                <entry colname="col4">The real-time, per-segment instance CPU core usage by the
+                  resource group on the host. The value is the sum of the percentages (as a decimal
+                  value) of the CPU cores that are used by the resource group for the segment
+                  instance.</entry>
               </row>
               <row>
                 <entry colname="col1"> <codeph>memory_used</codeph> </entry>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status.xml
@@ -87,7 +87,7 @@
             </entry>
             <entry colname="col2">json</entry>
             <entry colname="col3"/>
-            <entry colname="col4">A set of key value pairs. For each segment instance (the key), the
+            <entry colname="col4">A set of key-value pairs. For each segment instance (the key), the
               value is the real-time, per-segment instance CPU core usage by a resource group. The
               value is the sum of the percentages (as a decimal value) of CPU cores that are used by
               the resource group for the segment instance.</entry>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status.xml
@@ -86,8 +86,11 @@
               <codeph>cpu_usage</codeph>
             </entry>
             <entry colname="col2">json</entry>
-            <entry colname="col3"></entry>
-            <entry colname="col4">The real-time CPU usage of the resource group on each Greenplum Database segment's host.</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">A set of key value pairs. For each segment instance (the key), the
+              value is the real-time, per-segment instance CPU core usage by a resource group. The
+              value is the sum of the percentages (as a decimal value) of CPU cores that are used by
+              the resource group for the segment instance.</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_host.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_host.xml
@@ -55,9 +55,10 @@
               <codeph>cpu</codeph>
             </entry>
             <entry colname="col2">numeric</entry>
-            <entry colname="col3"></entry>
-            <entry colname="col4">The real-time CPU usage of the resource group on the
-              host.</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The real-time CPU core usage by the resource group on a host. The
+              value is the sum of the percentages (as a decimal value) of the CPU cores that are
+              used by the resource group on the host.</entry>
           </row>
           <row>
             <entry colname="col1">

--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_segment.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_resgroup_status_per_segment.xml
@@ -64,9 +64,10 @@
               <codeph>cpu</codeph>
             </entry>
             <entry colname="col2">numeric</entry>
-            <entry colname="col3"></entry>
-            <entry colname="col4">The real-time CPU usage of the resource group for the
-              segment instance on the host.</entry>
+            <entry colname="col3"/>
+            <entry colname="col4">The real-time, per-segment instance CPU core usage by the resource
+              group on the host. The value is the sum of the percentages (as a decimal value) of the
+              CPU cores that are used by the resource group for the segment instance.</entry>
           </row>
           <row>
             <entry colname="col1">


### PR DESCRIPTION

Will be backported to 6X_STABLE