### PR TITLE
Fix flaky test: refresh matview should use 2pc commit.

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -443,11 +443,6 @@ refresh_matview_datafill(DestReceiver *dest, Query *query,
 								GetActiveSnapshot(), InvalidSnapshot,
 								dest, NULL, 0);
 
-	/*
-	 * Refresh matview will write xlog and should use two phase commit.
-	 */
-	ExecutorMarkTransactionDoesWrites();
-
 	/* call ExecutorStart to prepare the plan for execution */
 	ExecutorStart(queryDesc, EXEC_FLAG_WITHOUT_OIDS);
 

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -443,6 +443,11 @@ refresh_matview_datafill(DestReceiver *dest, Query *query,
 								GetActiveSnapshot(), InvalidSnapshot,
 								dest, NULL, 0);
 
+	/*
+	 * Refresh matview will write xlog and should use two phase commit.
+	 */
+	ExecutorMarkTransactionDoesWrites();
+
 	/* call ExecutorStart to prepare the plan for execution */
 	ExecutorStart(queryDesc, EXEC_FLAG_WITHOUT_OIDS);
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1450,6 +1450,14 @@ ExecCheckXactReadOnly(PlannedStmt *plannedstmt)
 			PreventCommandIfReadOnly(CreateCommandTag((Node *) plannedstmt));
 	}
 
+	/*
+	 * Refresh matview will write xlog.
+	 */
+	if (plannedstmt->refreshClause != NULL)
+	{
+		PreventCommandIfReadOnly(CreateCommandTag((Node *) plannedstmt));
+	}
+
     rti = 0;
 	/*
 	 * Fail if write permissions are requested in parallel mode for table


### PR DESCRIPTION
We have a refresh matview with unique index check test case
CREATE TABLE mvtest_foo(a, b) AS VALUES(1, 10);
CREATE MATERIALIZED VIEW mvtest_mv AS SELECT * FROM mvtest_foo distributed by(a);
CREATE UNIQUE INDEX ON mvtest_mv(a);
INSERT INTO mvtest_foo SELECT * FROM mvtest_foo;
REFRESH MATERIALIZED VIEW mvtest_mv;

Only one segment contains tuples and will failed the unique index
check. Without 2pc, other segemnts will just commit transaction
successfully. Since one segment errors out, QD will send cancel
signal to all the segments, and if these segments have not finished
the commit process, it will report the warning:
DETAIL: The transaction has already changed locally,
it has to be replicated to standby.
Also it's risky to not use 2pc when qe write xlog.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
