### PR TITLE
Penalize cross products in Orca's DPv2 algorithm more accurately

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -3832,7 +3832,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="384806">
+    <dxl:Plan Id="0" SpaceSize="433164">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="654544318.346447" Rows="19136.250000" Width="31"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -73,7 +73,7 @@ namespace gpopt
 				// does the parent/child exist?
 				BOOL exists(ULONG ix) { return ix < m_topk->Size(); }
 				// cost of an entry (this class implements a Min-Heap)
-				CDouble cost(ULONG ix) { return (*m_topk)[ix]->DCost(); }
+				CDouble cost(ULONG ix) { return (*m_topk)[ix]->DCostForHeap(); }
 
 				// push node ix in the tree down into its child tree as much as needed
 				void HeapifyDown(ULONG ix)
@@ -360,6 +360,8 @@ namespace gpopt
 				// cost of the expression
 				CDouble m_cost;
 
+				CDouble m_cost_penalty;
+
 				SExpressionInfo(
 								CExpression *expr,
 								const SGroupAndExpression &left_child_expr_info,
@@ -369,7 +371,8 @@ namespace gpopt
 								   m_left_child_expr(left_child_expr_info),
 								   m_right_child_expr(right_child_expr_info),
 								   m_properties(properties),
-								   m_cost(0.0)
+								   m_cost(0.0),
+								   m_cost_penalty(0.0)
 				{
 				}
 
@@ -378,7 +381,8 @@ namespace gpopt
 								SExpressionProperties &properties
 								) : m_expr(expr),
 									m_properties(properties),
-									m_cost(0.0)
+									m_cost(0.0),
+									m_cost_penalty(0.0)
 				{
 				}
 
@@ -388,7 +392,10 @@ namespace gpopt
 				}
 
 				// cost (use -1 for greedy solutions to ensure we keep all of them)
-				CDouble DCost() { return m_properties.IsGreedy() ? -1.0 : m_cost; }
+				CDouble DCostForHeap() { return m_properties.IsGreedy() ? -1.0 : m_cost + m_cost_penalty; }
+
+				CDouble DCost() { return m_cost + m_cost_penalty; }
+
 				BOOL ChildrenAreEqual(const SExpressionInfo &other) const
 				{ return m_left_child_expr == other.m_left_child_expr && m_right_child_expr == other.m_right_child_expr; }
 			};
@@ -429,7 +436,7 @@ namespace gpopt
 					}
 
 					BOOL IsAnAtom() { return 1 == m_atoms->Size(); }
-					CDouble DCost() { return m_lowest_expr_cost; }
+					CDouble DCostForHeap() { return m_lowest_expr_cost; }
 
 				};
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -360,8 +360,6 @@ namespace gpopt
 				// cost of the expression
 				CDouble m_cost;
 
-				CDouble m_cost_penalty;
-
 				SExpressionInfo(
 								CExpression *expr,
 								const SGroupAndExpression &left_child_expr_info,
@@ -371,8 +369,7 @@ namespace gpopt
 								   m_left_child_expr(left_child_expr_info),
 								   m_right_child_expr(right_child_expr_info),
 								   m_properties(properties),
-								   m_cost(0.0),
-								   m_cost_penalty(0.0)
+								   m_cost(0.0)
 				{
 				}
 
@@ -381,8 +378,7 @@ namespace gpopt
 								SExpressionProperties &properties
 								) : m_expr(expr),
 									m_properties(properties),
-									m_cost(0.0),
-									m_cost_penalty(0.0)
+									m_cost(0.0)
 				{
 				}
 
@@ -392,9 +388,9 @@ namespace gpopt
 				}
 
 				// cost (use -1 for greedy solutions to ensure we keep all of them)
-				CDouble DCostForHeap() { return m_properties.IsGreedy() ? -1.0 : m_cost + m_cost_penalty; }
+				CDouble DCostForHeap() { return m_properties.IsGreedy() ? -1.0 : DCost(); }
 
-				CDouble DCost() { return m_cost + m_cost_penalty; }
+				CDouble DCost() { return m_cost; }
 
 				BOOL ChildrenAreEqual(const SExpressionInfo &other) const
 				{ return m_left_child_expr == other.m_left_child_expr && m_right_child_expr == other.m_right_child_expr; }
@@ -608,7 +604,7 @@ namespace gpopt
 
 			void EnumerateDP();
 			void EnumerateQuery();
-			void FindLowestCardTwoWayJoin();
+			void FindLowestCardTwoWayJoin(JoinOrderPropType prop_type);
 			void EnumerateMinCard();
 			void EnumerateGreedyAvoidXProd();
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -73,7 +73,7 @@ namespace gpopt
 				// does the parent/child exist?
 				BOOL exists(ULONG ix) { return ix < m_topk->Size(); }
 				// cost of an entry (this class implements a Min-Heap)
-				CDouble cost(ULONG ix) { return (*m_topk)[ix]->DCostForHeap(); }
+				CDouble cost(ULONG ix) { return (*m_topk)[ix]->GetCostForHeap(); }
 
 				// push node ix in the tree down into its child tree as much as needed
 				void HeapifyDown(ULONG ix)
@@ -388,9 +388,9 @@ namespace gpopt
 				}
 
 				// cost (use -1 for greedy solutions to ensure we keep all of them)
-				CDouble DCostForHeap() { return m_properties.IsGreedy() ? -1.0 : DCost(); }
+				CDouble GetCostForHeap() { return m_properties.IsGreedy() ? -1.0 : GetCost(); }
 
-				CDouble DCost() { return m_cost; }
+				CDouble GetCost() { return m_cost; }
 
 				BOOL ChildrenAreEqual(const SExpressionInfo &other) const
 				{ return m_left_child_expr == other.m_left_child_expr && m_right_child_expr == other.m_right_child_expr; }
@@ -432,7 +432,7 @@ namespace gpopt
 					}
 
 					BOOL IsAnAtom() { return 1 == m_atoms->Size(); }
-					CDouble DCostForHeap() { return m_lowest_expr_cost; }
+					CDouble GetCostForHeap() { return m_lowest_expr_cost; }
 
 				};
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -319,7 +319,7 @@ namespace gpopt
 
 				BOOL Satisfies(ULONG pt) { return pt == (m_join_order & pt); }
 				void Add(const SExpressionProperties &p) { m_join_order |= p.m_join_order; }
-				BOOL IsGreedy() { return 0 != (m_join_order & (EJoinOrderQuery + EJoinOrderMincard)); }
+				BOOL IsGreedy() { return 0 != (m_join_order & (EJoinOrderQuery + EJoinOrderMincard + EJoinOrderGreedyAvoidXProd)); }
 			};
 
 			// a simple wrapper of an SGroupInfo * plus an index into its array of SExpressionInfos

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
@@ -448,11 +448,11 @@ CJoinOrderDPv2::GetBestExprForProperties
 
 		if (IsASupersetOfProperties(expr_info->m_properties, props))
 		{
-			if (gpos::ulong_max == best_ix || expr_info->DCost() < best_cost)
+			if (gpos::ulong_max == best_ix || expr_info->GetCost() < best_cost)
 			{
 				// we found a candidate with the best cost so far that satisfies the properties
 				best_ix = ul;
-				best_cost = expr_info->DCost();
+				best_cost = expr_info->GetCost();
 			}
 		}
 	}
@@ -502,7 +502,7 @@ CJoinOrderDPv2::AddExprToGroupIfNecessary
 {
 	// compute the cost for the new expression
 	ComputeCost(new_expr_info, group_info->m_cardinality);
-	CDouble new_cost = new_expr_info->DCost();
+	CDouble new_cost = new_expr_info->GetCost();
 
 	if (group_info->m_atoms->Size() == m_ulComps)
 	{
@@ -555,8 +555,8 @@ CJoinOrderDPv2::AddExprToGroupIfNecessary
 		SExpressionInfo *expr_info = (*group_info->m_best_expr_info_array)[ul];
 		BOOL old_ge_new = IsASupersetOfProperties(expr_info->m_properties, new_expr_info->m_properties);
 		BOOL new_ge_old = IsASupersetOfProperties(new_expr_info->m_properties, expr_info->m_properties);
-		CDouble old_cost = expr_info->DCost();
-		CDouble new_cost = new_expr_info->DCost();
+		CDouble old_cost = expr_info->GetCost();
+		CDouble new_cost = new_expr_info->GetCost();
 
 		if (old_ge_new)
 		{
@@ -975,7 +975,7 @@ CJoinOrderDPv2::GreedySearchJoinOrders
 			SGroupInfo *join_group_info = LookupOrCreateGroupInfo(current_level_info, join_bitset, join_expr_info);
 
 			ComputeCost(join_expr_info, join_group_info->m_cardinality);
-			CDouble join_cost = join_expr_info->DCost();
+			CDouble join_cost = join_expr_info->GetCost();
 
 			if (NULL == best_expr_info_in_level || join_cost < best_cost_in_level)
 			{
@@ -1657,7 +1657,6 @@ CJoinOrderDPv2::OsPrint
 					os << " join ";
 					expr_info->m_right_child_expr.m_group_info->m_atoms->OsPrint(os);
 					os << std::endl;
-
 				}
 				os << "   Cost: ";
 				expr_info->m_cost.OsPrint(os);


### PR DESCRIPTION
Previously in the DPv2 transform (`exhaustive2`) while we penalized 
cross joins for the remaining joins in greedy, we did
not for the first join, which in some cases selected a cross join.
This ended up selecting a poor join order in many cases and went against
the intent of the alternative being generated, which is to minimize
cross joins. 

We also increase the cost of the default penalty from 5 to 1024, which is the value we use in the cost model during the optimization stage.

The greedy alternative also wasn't kept in the heap, so we include that now too.

These changes improved tpcds performance using dpv2 overall by ~6% compared to the existing DPv2 transform (`exhaustive`) and improved many of the regressions we saw.