### PR TITLE
Don't use GenericTupStore where the genericity is not needed.

### DIFF
--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -98,27 +98,27 @@ FunctionNext_guts(FunctionScanState *node)
 		/*
 		 * setup tuplestore reader for the firstly time
 		 */
-		if (!node->ts_state->matstore)
+		if (!node->ts_state)
 		{
 
 			char rwfile_prefix[100];
 			function_scan_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix));
 
-			node->ts_state->matstore = ntuplestore_create_readerwriter(rwfile_prefix, 0, false, false);
+			node->ts_state = ntuplestore_create_readerwriter(rwfile_prefix, 0, false, false);
 			/*
 			 * delete file when close tuplestore reader
 			 * tuplestore writer is created in initplan, so it needs to keep
 			 * the file even if initplan ended. 
 			 * we should let the reader to delete it when reader's job finished.
 			 */
-			ntuplestore_set_is_temp_file(node->ts_state->matstore, true);
+			ntuplestore_set_is_temp_file(node->ts_state, true);
 			
-			node->ts_pos = (NTupleStoreAccessor *) ntuplestore_create_accessor(node->ts_state->matstore, false);
-			ntuplestore_acc_seek_bof((NTupleStoreAccessor *) node->ts_pos);
+			node->ts_pos = ntuplestore_create_accessor(node->ts_state, false);
+			ntuplestore_acc_seek_bof(node->ts_pos);
 		}
 
-		ntuplestore_acc_advance((NTupleStoreAccessor *) node->ts_pos, forward ? 1 : -1);
-		gotOK = ntuplestore_acc_current_tupleslot((NTupleStoreAccessor *) node->ts_pos, scanslot);
+		ntuplestore_acc_advance(node->ts_pos, forward ? 1 : -1);
+		gotOK = ntuplestore_acc_current_tupleslot(node->ts_pos, scanslot);
 
 		if(!gotOK)
 		{
@@ -389,7 +389,7 @@ ExecInitFunctionScan(FunctionScan *node, EState *estate, int eflags)
 	scanstate->ss.ps.state = estate;
 	scanstate->eflags = eflags;
 	scanstate->resultInTupleStore = node->resultInTupleStore;
-	scanstate->ts_state = palloc0(sizeof(GenericTupStore));
+	scanstate->ts_state = NULL;
 	scanstate->ts_pos = NULL;
 	/*
 	 * are we adding an ordinality column?
@@ -682,10 +682,10 @@ ExecEndFunctionScan(FunctionScanState *node)
 	/*
 	 * destroy tuplestore reader if exists
 	 */
-	if (node->ts_state->matstore != NULL)
+	if (node->ts_state != NULL)
 	{
-		ntuplestore_destroy_accessor((NTupleStoreAccessor *) node->ts_pos);
-		ntuplestore_destroy(node->ts_state->matstore);
+		ntuplestore_destroy_accessor(node->ts_pos);
+		ntuplestore_destroy(node->ts_state);
 	}
 }
 

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -231,7 +231,8 @@ init_tuplestore_state(ShareInputScanState *node)
 		/* The materialstate->ts_state structure should have been initialized already, during init of material node */
 		MaterialState *child = (MaterialState *) local_state->childState;
 
-		node->ts_state = child->ts_state;
+		node->ts_state = palloc0(sizeof(GenericTupStore));
+		node->ts_state->matstore = child->ts_state;
 		Assert(NULL != node->ts_state->matstore);
 		node->ts_pos = (void *) ntuplestore_create_accessor(node->ts_state->matstore, false);
 		ntuplestore_acc_seek_bof((NTupleStoreAccessor *)node->ts_pos);
@@ -262,7 +263,8 @@ init_tuplestore_state(ShareInputScanState *node)
 	{
 		SortState *child = (SortState *) local_state->childState;
 
-		node->ts_state = ((SortState *) child)->tuplesortstate;
+		node->ts_state = palloc0(sizeof(GenericTupStore));
+		node->ts_state->sortstore = ((SortState *) child)->tuplesortstate;
 		Assert(NULL != node->ts_state->sortstore);
 		tuplesort_begin_pos(node->ts_state->sortstore, (TuplesortPos **)(&node->ts_pos));
 		tuplesort_rescan_pos(node->ts_state->sortstore, (TuplesortPos *)node->ts_pos);

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -41,6 +41,8 @@ struct MemTupleData;
 struct HeapScanDescData;
 struct FileScanDescData;
 struct SliceTable;
+struct NTupleStore;
+struct NTupleStoreAccessor;
 
 /* ----------------
  *	  IndexInfo information
@@ -1153,8 +1155,9 @@ typedef struct SubPlanState
 	FmgrInfo   *tab_eq_funcs;	/* equality functions for table datatype(s) */
 	FmgrInfo   *lhs_hash_funcs; /* hash functions for lefthand datatype(s) */
 	FmgrInfo   *cur_eq_funcs;	/* equality functions for LHS vs. table */
-	void	   *ts_pos;
-	GenericTupStore *ts_state;
+
+	struct NTupleStoreAccessor *ts_pos;
+	struct NTupleStore *ts_state;
 } SubPlanState;
 
 /* ----------------
@@ -2096,8 +2099,8 @@ typedef struct FunctionScanState
 
 	/* tuplestore info when function scan run as initplan */
 	bool		resultInTupleStore; /* function result stored in tuplestore */
-	void       *ts_pos;				/* accessor to the tuplestore */
-	GenericTupStore *ts_state;		/* tuple store state */
+	struct NTupleStoreAccessor *ts_pos; /* accessor to the tuplestore */
+	struct NTupleStore *ts_state;		/* tuple store state */
 } FunctionScanState;
 
 extern void function_scan_create_bufname_prefix(char *p, int size);
@@ -2470,7 +2473,7 @@ typedef struct MaterialState
 	bool		delayEagerFree;		/* is is safe to free memory used by this node,
 									 * when this node has outputted its last row? */
 
-	GenericTupStore *ts_state;	/* private state of tuplestore.c */
+	struct NTupleStore *ts_state;	/* private state of tuplestore.c */
 	void	   *ts_pos;
 	void	   *ts_markpos;
 } MaterialState;
@@ -2515,7 +2518,7 @@ typedef struct SortState
 	bool		sort_Done;		/* sort completed yet? */
 	bool		bounded_Done;	/* value of bounded we did the sort with */
 	int64		bound_Done;		/* value of bound we did the sort with */
-	GenericTupStore *tuplesortstate; /* private state of tuplesort.c */
+	void	   *tuplesortstate; /* private state of tuplesort.c */
 	bool		noduplicates;	/* true if discard duplicate rows */
 
 	bool		delayEagerFree;		/* is is safe to free memory used by this node,


### PR DESCRIPTION
Everywhere except ShareInputScanState, we're always dealing with either
a tuplestore or a tuplesort, so we don't need to use GenericTupStore.
