### PR TITLE
ShareInputScan refactoring, 2nd installment.

### DIFF
--- a/contrib/auto_explain/expected/auto_explain.out
+++ b/contrib/auto_explain/expected/auto_explain.out
@@ -89,6 +89,7 @@ Finalize Aggregate  (cost=35148.64..35148.65 rows=1 width=8) (actual rows=1 loop
                     ->  Seq Scan on auto_explain_test.t1  (cost=0.00..13.01 rows=334 width=0) (actual rows=340 loops=1)
                           Output: t1.a
                     ->  Materialize  (cost=0.00..68.06 rows=1001 width=0) (actual rows=1001 loops=340)
+                          work_mem: 142kB  Segments: 3  Max: 48kB (segment 0)  Workfile: (0 spilling)
                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..53.05 rows=1001 width=0) (actual rows=1001 loops=1)
                                 ->  Seq Scan on auto_explain_test.t2  (cost=0.00..13.01 rows=334 width=0) (actual rows=340 loops=1)
   (slice0)    Executor memory: 131K bytes.

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -1006,11 +1006,23 @@ void
 cdbllize_build_slice_table(PlannerInfo *root, Plan *top_plan,
 						   PlanSlice *top_slice)
 {
+	PlannerGlobal *glob = root->glob;
 	Query	   *query = root->parse;
 	build_slice_table_context cxt;
 	ListCell   *lc;
 	int			sliceIndex;
 	bool		all_root_slices;
+
+	/*
+	 * This can modify nodes, so the nodes we memorized earlier are no longer
+	 * valid. Clear this array just to be sure we don't accidentally use the
+	 * obsolete copies of the nodes later on.
+	 */
+	if (glob->share.shared_plans)
+	{
+		pfree(glob->share.shared_plans);
+		glob->share.shared_plans = NULL;
+	}
 
 	/* subplan_sliceIds array needs to exist, even in non-dispatcher mode */
 	root->glob->subplan_sliceIds = palloc(list_length(root->glob->subplans) * sizeof(int));

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1011,11 +1011,6 @@ shareinput_mutator_xslice_2(Node *node, PlannerInfo *root, bool fPop)
 				Assert(sisc->share_type == SHARE_MATERIAL);
 				sisc->share_type = SHARE_MATERIAL_XSLICE;
 			}
-			else if (IsA(childPlan, Sort))
-			{
-				Assert(sisc->share_type == SHARE_SORT);
-				sisc->share_type = SHARE_SORT_XSLICE;
-			}
 			else
 				elog(ERROR, "child of ShareInputScan is of unexpected type");
 		}
@@ -1028,11 +1023,6 @@ shareinput_mutator_xslice_2(Node *node, PlannerInfo *root, bool fPop)
 		{
 			((Material *) childPlan)->share_type = sisc->share_type;
 			((Material *) childPlan)->share_id = sisc->share_id;
-		}
-		else if (IsA(childPlan, Sort))
-		{
-			((Sort *) childPlan)->share_type = sisc->share_type;
-			((Sort *) childPlan)->share_id = sisc->share_id;
 		}
 		else
 			elog(ERROR, "child of ShareInputScan is of unexpected type");

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1144,9 +1144,6 @@ _copySort(const Sort *from)
     /* CDB */
 	COPY_SCALAR_FIELD(noduplicates);
 
-	COPY_SCALAR_FIELD(share_type);
-	COPY_SCALAR_FIELD(share_id);
-
 	return newnode;
 }
 

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1091,7 +1091,7 @@ _copyShareInputScan(const ShareInputScan *from)
 
 	/* copy node superclass fields */
 	CopyPlanFields((Plan *) from, (Plan *) newnode);
-	COPY_SCALAR_FIELD(share_type);
+	COPY_SCALAR_FIELD(cross_slice);
 	COPY_SCALAR_FIELD(share_id);
 	COPY_SCALAR_FIELD(producer_slice_id);
 	COPY_SCALAR_FIELD(this_slice_id);
@@ -1115,8 +1115,6 @@ _copyMaterial(const Material *from)
 	CopyPlanFields((const Plan *) from, (Plan *) newnode);
 	COPY_SCALAR_FIELD(cdb_strict);
 	COPY_SCALAR_FIELD(cdb_shield_child_from_rescans);
-	COPY_SCALAR_FIELD(share_type);
-	COPY_SCALAR_FIELD(share_id);
 
     return newnode;
 }

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -467,9 +467,6 @@ _outSort(StringInfo str, Sort *node)
 
     /* CDB */
     WRITE_BOOL_FIELD(noduplicates);
-
-	WRITE_ENUM_FIELD(share_type, ShareType);
-	WRITE_INT_FIELD(share_id);
 }
 
 static void

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1161,9 +1161,6 @@ _outSort(StringInfo str, const Sort *node)
 
 	/* CDB */
     WRITE_BOOL_FIELD(noduplicates);
-
-	WRITE_ENUM_FIELD(share_type, ShareType);
-	WRITE_INT_FIELD(share_id);
 }
 #endif /* COMPILING_BINARY_FUNCS */
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1112,9 +1112,6 @@ _outMaterial(StringInfo str, const Material *node)
 
 	WRITE_BOOL_FIELD(cdb_strict);
 	WRITE_BOOL_FIELD(cdb_shield_child_from_rescans);
-
-	WRITE_ENUM_FIELD(share_type, ShareType);
-	WRITE_INT_FIELD(share_id);
 }
 
 static void
@@ -1122,7 +1119,7 @@ _outShareInputScan(StringInfo str, const ShareInputScan *node)
 {
 	WRITE_NODE_TYPE("SHAREINPUTSCAN");
 
-	WRITE_ENUM_FIELD(share_type, ShareType);
+	WRITE_BOOL_FIELD(cross_slice);
 	WRITE_INT_FIELD(share_id);
 	WRITE_INT_FIELD(producer_slice_id);
 	WRITE_INT_FIELD(this_slice_id);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2620,7 +2620,7 @@ _outPlannerGlobal(StringInfo str, const PlannerGlobal *node)
 	WRITE_BOOL_FIELD(transientPlan);
 	WRITE_BOOL_FIELD(oneoffPlan);
 	WRITE_NODE_FIELD(share.motStack);
-	WRITE_NODE_FIELD(share.qdShares);
+	WRITE_BITMAPSET_FIELD(share.qdShares);
 	WRITE_BOOL_FIELD(dependsOnRole);
 	WRITE_BOOL_FIELD(parallelModeOK);
 	WRITE_BOOL_FIELD(parallelModeNeeded);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1530,7 +1530,7 @@ _readShareInputScan(void)
 {
 	READ_LOCALS(ShareInputScan);
 
-	READ_ENUM_FIELD(share_type, ShareType);
+	READ_BOOL_FIELD(cross_slice);
 	READ_INT_FIELD(share_id);
 	READ_INT_FIELD(producer_slice_id);
 	READ_INT_FIELD(this_slice_id);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -3057,9 +3057,6 @@ _readSort(void)
     /* CDB */
 	READ_BOOL_FIELD(noduplicates);
 
-	READ_ENUM_FIELD(share_type, ShareType);
-	READ_INT_FIELD(share_id);
-
 	READ_DONE();
 }
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -3032,9 +3032,6 @@ _readMaterial(void)
 	READ_BOOL_FIELD(cdb_strict);
 	READ_BOOL_FIELD(cdb_shield_child_from_rescans);
 
-	READ_ENUM_FIELD(share_type, ShareType);
-	READ_INT_FIELD(share_id);
-
 	READ_DONE();
 }
 

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -2079,12 +2079,19 @@ cost_group(Path *path, PlannerInfo *root,
 
 /* 
  * cost_shareinputscan
- * 		compute the cost of shareinputscan.  Shareinput scan scans from 
- * 		a material.  It may read disk, but should be costed less than
- *		material node.
+ * 		compute the cost of shareinputscan.
+ *
+ * A ShareInputScan stores all the tuples in a tuplestore, like a Material
+ * node. However, the materialization is done only once among all the
+ * ShareInputScans that are part of the same share. It's not clear how to
+ * correctly represent that. Our approach is that the startup cost is equal
+ * to the total cost of the underlying node, and the total cost is a bit
+ * higher, to reflect the cost of re-scanning the already-materialized
+ * result.
  */
 void 
-cost_shareinputscan(Path *path, PlannerInfo *root, Cost sharecost, double tuples, int width)
+cost_shareinputscan(Path *path, PlannerInfo *root, Cost sharecost,
+					double tuples, int width)
 {
 	double nbytes = relation_byte_size(tuples, width);
 	double npages = ceil(nbytes/BLCKSZ);

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -2080,8 +2080,8 @@ cost_group(Path *path, PlannerInfo *root,
 /* 
  * cost_shareinputscan
  * 		compute the cost of shareinputscan.  Shareinput scan scans from 
- * 		a material or sort.  It may read disk, but should be costed
- *   	less than material node.
+ * 		a material.  It may read disk, but should be costed less than
+ *		material node.
  */
 void 
 cost_shareinputscan(Path *path, PlannerInfo *root, Cost sharecost, double tuples, int width)

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6092,9 +6092,6 @@ make_sort(Plan *lefttree, int numCols,
 
 	node->noduplicates = false; /* CDB */
 
-	node->share_type = SHARE_NOTSHARED;
-	node->share_id = SHARE_ID_NOT_SHARED;
-
 	return node;
 }
 

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6650,8 +6650,6 @@ make_material(Plan *lefttree)
 	plan->righttree = NULL;
 
 	node->cdb_strict = false;
-	node->share_type = SHARE_NOTSHARED;
-	node->share_id = SHARE_ID_NOT_SHARED;
 
 	return node;
 }

--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -102,7 +102,7 @@ optimize_query(Query *parse, ParamListInfo boundParams)
 	glob->share.shared_inputs = NULL;
 	glob->share.shared_input_count = 0;
 	glob->share.motStack = NIL;
-	glob->share.qdShares = NIL;
+	glob->share.qdShares = NULL;
 	/* these will be filled in below, in the pre- and post-processing steps */
 	glob->finalrtable = NIL;
 	glob->subplans = NIL;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -335,7 +335,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	glob->share.shared_inputs = NULL;
 	glob->share.shared_input_count = 0;
 	glob->share.motStack = NIL;
-	glob->share.qdShares = NIL;
+	glob->share.qdShares = NULL;
 
 	if ((cursorOptions & CURSOR_OPT_UPDATABLE) != 0)
 		glob->simplyUpdatable = isSimplyUpdatableQuery(parse);
@@ -589,15 +589,6 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		/*
-		 * cdb_build_slice_table() can modify nodes, so the producer nodes we
-		 * memorized earlier are no longer valid. apply_shareinput_xslice()
-		 * will re-populate it, but clear it for now, just to make sure that
-		 * we don't access the obsolete copies of the nodes.
-		 */
-		if (glob->share.shared_input_count > 0)
-			memset(glob->share.shared_inputs, 0, glob->share.shared_input_count * sizeof(ApplyShareInputContextPerShare));
-
 		/*
 		 * cdb_build_slice_table() may create additional slices that may affect
 		 * share input. need to mark material nodes that are split acrossed

--- a/src/backend/optimizer/plan/planshare.c
+++ b/src/backend/optimizer/plan/planshare.c
@@ -29,9 +29,6 @@ get_plan_share_type(Plan *p)
 	if(IsA(p, Material))
 		return ((Material *) p)->share_type;
 
-	if(IsA(p, Sort))
-		return ((Sort *) p)->share_type ;
-
 	Assert(IsA(p, ShareInputScan));
 	return ((ShareInputScan *) p)->share_type;
 }
@@ -42,7 +39,7 @@ make_shareinputscan(PlannerInfo *root, Plan *inputplan)
 	ShareInputScan *sisc;
 	Path		sipath;
 
-	Assert(IsA(inputplan, Material) || IsA(inputplan, Sort));
+	Assert(IsA(inputplan, Material));
 
 	sisc = makeNode(ShareInputScan);
 
@@ -73,7 +70,7 @@ make_shareinputscan(PlannerInfo *root, Plan *inputplan)
 
 /*
  * Prepare a subplan for sharing. This creates a Materialize node,
- * or marks the existing Materialize or Sort node as shared. After
+ * or marks the existing Materialize node as shared. After
  * this, you can call share_prepared_plan() as many times as you
  * want to share this plan.
  */
@@ -96,14 +93,6 @@ prepare_plan_for_sharing(PlannerInfo *root, Plan *common)
 
 		m->share_id = SHARE_ID_NOT_ASSIGNED;
 		m->share_type = SHARE_MATERIAL;
-	}
-	else if (IsA(common, Sort))
-	{
-		Sort *s = (Sort *) common;
-
-		Assert(s->share_type == SHARE_NOTSHARED);
-		s->share_id = SHARE_ID_NOT_ASSIGNED;
-		s->share_type = SHARE_SORT;
 	}
 	else
 	{

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -868,34 +868,7 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 			break;
 
 		case T_ShareInputScan:
-			{
-				ShareInputScan *sisc = (ShareInputScan *) plan;
-				Plan *childPlan = plan->lefttree;
-
-				if (childPlan == NULL)
-				{
-					Assert(sisc->share_type != SHARE_NOTSHARED);
-					Assert(sisc->share_id >= 0 && sisc->share_id < root->glob->share.shared_input_count);
-					childPlan = root->glob->share.shared_inputs[sisc->share_id].shared_plan;
-				}
-
-#ifdef DEBUG
-				Assert(childPlan && IsA(childPlan,Material) || IsA(childPlan, Sort));
-				if (IsA(childPlan, Material))
-				{
-					Material *shared = (Material *) childPlan;
-					Assert(shared->share_type != SHARE_NOTSHARED
-						   && shared->share_id == sisc->share_id);
-				}
-				else
-				{
-					Sort *shared = (Sort *) childPlan;
-					Assert(shared->share_type != SHARE_NOTSHARED
-						   && shared->share_id == sisc->share_id);
-				}
-#endif
-				set_dummy_tlist_references(plan, rtoffset);
-			}
+			set_dummy_tlist_references(plan, rtoffset);
 			break;
 
 		case T_PartitionSelector:

--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -3048,6 +3048,9 @@ batchmemtuples(Tuplesortstate *state)
 	int64		availMemLessRefund;
 	int			memtupsize = state->memtupsize;
 
+	/* Caller error if we have no tapes */
+	Assert(state->activeTapes > 0);
+
 	/* For simplicity, assume no memtuples are actually currently counted */
 	Assert(state->memtupcount == 0);
 
@@ -3062,6 +3065,20 @@ batchmemtuples(Tuplesortstate *state)
 	availMemLessRefund = state->availMem - refund;
 
 	/*
+	 * We need to be sure that we do not cause LACKMEM to become true, else
+	 * the batch allocation size could be calculated as negative, causing
+	 * havoc.  Hence, if availMemLessRefund is negative at this point, we must
+	 * do nothing.  Moreover, if it's positive but rather small, there's
+	 * little point in proceeding because we could only increase memtuples by
+	 * a small amount, not worth the cost of the repalloc's.  We somewhat
+	 * arbitrarily set the threshold at ALLOCSET_DEFAULT_INITSIZE per tape.
+	 * (Note that this does not represent any assumption about tuple sizes.)
+	 */
+	if (availMemLessRefund <=
+		(int64) state->activeTapes * ALLOCSET_DEFAULT_INITSIZE)
+		return;
+
+	/*
 	 * To establish balanced memory use after refunding palloc overhead,
 	 * temporarily have our accounting indicate that we've allocated all
 	 * memory we're allowed to less that refund, and call grow_memtuples() to
@@ -3070,9 +3087,11 @@ batchmemtuples(Tuplesortstate *state)
 	state->growmemtuples = true;
 	USEMEM(state, availMemLessRefund);
 	(void) grow_memtuples(state);
-	/* Should not matter, but be tidy */
-	FREEMEM(state, availMemLessRefund);
 	state->growmemtuples = false;
+	/* availMem must stay accurate for spacePerTape calculation */
+	FREEMEM(state, availMemLessRefund);
+	if (LACKMEM(state))
+		elog(ERROR, "unexpected out-of-memory situation in tuplesort");
 
 #ifdef TRACE_SORT
 	if (trace_sort)

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -499,6 +499,9 @@ tuplestore_end(Tuplestorestate *state)
 			state->instrument->workmemwanted =
 				Max(state->instrument->workmemwanted, nbytes);
 		}
+
+		if (state->myfile)
+			state->instrument->workfileCreated = true;
 	}
 
 	if (state->myfile)

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -395,13 +395,6 @@ namespace gpdxl
 				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
-			// Initialize spooling information
-			void InitializeSpoolingInfo
-				(
-				Plan *plan,
-				ULONG share_id
-				);
-
 			// translate a CTE producer into a GPDB share input scan
 			Plan *TranslateDXLCTEProducerToSharedScan
 				(

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -848,19 +848,6 @@ typedef struct GenericExprState
 } GenericExprState;
 
 /* ----------------
- *         Generic tuplestore structure
- *	 used to communicate between ShareInputScan nodes,
- *	 Materialize and Sort
- *
- * ----------------
- */
-typedef union GenericTupStore
-{
-	struct NTupleStore        *matstore;     /* Used by Materialize */
-	void	   *sortstore;	/* Used by Sort */
-} GenericTupStore;
-
-/* ----------------
  *		WholeRowVarExprState node
  * ----------------
  */
@@ -2486,20 +2473,20 @@ typedef struct MaterialState
  */
 struct shareinput_local_state;
 struct shareinput_Xslice_reference;
+struct NTupleStore;
+struct NTupleStoreAccessor;
 
 typedef struct ShareInputScanState
 {
 	ScanState	ss;
 
-	/*
-	 * Depends on share_type, we should have a tuplestore_state, tuplestore_pos
-	 * or tuplesort_state, tuplesort_pos
-	 */
-	GenericTupStore *ts_state;
-	void	   *ts_pos;
+	struct NTupleStore *ts_state;
+	struct NTupleStoreAccessor *ts_pos;
 
 	struct shareinput_local_state *local_state;
 	struct shareinput_Xslice_reference *ref;
+
+	bool		isready;
 } ShareInputScanState;
 
 /* XXX Should move into buf file */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2455,14 +2455,12 @@ typedef struct MaterialState
 	ScanState	ss;				/* its first field is NodeTag */
 	int			eflags;			/* capability flags to pass to tuplestore */
 	bool		eof_underlying; /* reached end of underlying plan? */
+	Tuplestorestate *tuplestorestate;
+
 	bool		ts_destroyed;	/* called destroy tuple store? */
 
 	bool		delayEagerFree;		/* is is safe to free memory used by this node,
 									 * when this node has outputted its last row? */
-
-	struct NTupleStore *ts_state;	/* private state of tuplestore.c */
-	void	   *ts_pos;
-	void	   *ts_markpos;
 } MaterialState;
 
 /* ----------------

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1023,21 +1023,8 @@ typedef struct HashJoin
 	List	   *hashqualclauses;
 } HashJoin;
 
-/*
- * Share type of sharing a node.
- */
-typedef enum ShareType
-{
-	SHARE_NOTSHARED,
-	SHARE_MATERIAL,          	/* Sharing a material node */
-	SHARE_MATERIAL_XSLICE,		/* Sharing a material node, across slice */
-	/* Other types maybe added later, like sharing a hash */
-} ShareType;
-
 #define SHARE_ID_NOT_SHARED (-1)
 #define SHARE_ID_NOT_ASSIGNED (-2)
-
-extern ShareType get_plan_share_type (Plan *p);
 
 /* ----------------
  *		shareinputscan node
@@ -1047,7 +1034,7 @@ typedef struct ShareInputScan
 {
 	Scan 		scan;
 
-	ShareType 	share_type;
+	bool		cross_slice;
 	int 		share_id;
 
 	/*
@@ -1082,10 +1069,6 @@ typedef struct Material
 	Plan		plan;
 	bool		cdb_strict;
 	bool		cdb_shield_child_from_rescans;
-
-	/* Material can be shared */
-	ShareType 	share_type;
-	int 		share_id;
 } Material;
 
 /* ----------------

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1031,8 +1031,6 @@ typedef enum ShareType
 	SHARE_NOTSHARED,
 	SHARE_MATERIAL,          	/* Sharing a material node */
 	SHARE_MATERIAL_XSLICE,		/* Sharing a material node, across slice */
-	SHARE_SORT,					/* Sharing a sort */
-	SHARE_SORT_XSLICE			/* Sharing a sort, across slice */
 	/* Other types maybe added later, like sharing a hash */
 } ShareType;
 
@@ -1104,10 +1102,6 @@ typedef struct Sort
 	bool	   *nullsFirst;		/* NULLS FIRST/LAST directions */
     /* CDB */
 	bool		noduplicates;   /* TRUE if sort should discard duplicates */
-
-	/* Sort node can be shared */
-	ShareType 	share_type;
-	int 		share_id;
 } Sort;
 
 /* ---------------

--- a/src/include/optimizer/planshare.h
+++ b/src/include/optimizer/planshare.h
@@ -18,9 +18,6 @@
 
 #include "nodes/plannodes.h"
 
-extern List *share_plan(PlannerInfo *root, Plan *common, int numpartners);
-extern Cost cost_share_plan(Plan *common, PlannerInfo *root, int numpartners);
-
 extern Plan *prepare_plan_for_sharing(PlannerInfo *root, Plan *common);
 extern Plan *share_prepared_plan(PlannerInfo *root, Plan *common);
 

--- a/src/include/utils/tuplesort.h
+++ b/src/include/utils/tuplesort.h
@@ -75,15 +75,8 @@
 #define tuplesort_restorepos tuplesort_restorepos_pg
 
 /* these are in tuplesort_gp.h */
-#define tuplesort_begin_heap_file_readerwriter tuplesort_begin_heap_file_readerwriter_pg
 #define cdb_tuplesort_init cdb_tuplesort_init_pg
-#define tuplesort_begin_pos tuplesort_begin_pos_pg
-#define tuplesort_gettupleslot_pos tuplesort_gettupleslot_pos_pg
-#define tuplesort_flush tuplesort_flush_pg
 #define tuplesort_finalize_stats tuplesort_finalize_stats_pg
-#define tuplesort_rescan_pos tuplesort_rescan_pos_pg
-#define tuplesort_markpos_pos tuplesort_markpos_pos_pg
-#define tuplesort_restorepos_pos tuplesort_restorepos_pos_pg
 #define tuplesort_set_instrument tuplesort_set_instrument_pg
 
 #include "access/itup.h"
@@ -220,15 +213,9 @@ extern void tuplesort_restorepos(Tuplesortstate *state);
 #undef tuplesort_rescan
 #undef tuplesort_markpos
 #undef tuplesort_restorepos
-#undef tuplesort_begin_heap_file_readerwriter
 #undef cdb_tuplesort_init
-#undef tuplesort_begin_pos
-#undef tuplesort_gettupleslot_pos
 #undef tuplesort_flush
 #undef tuplesort_finalize_stats
-#undef tuplesort_rescan_pos
-#undef tuplesort_markpos_pos
-#undef tuplesort_restorepos_pos
 #undef tuplesort_set_instrument
 
 #include "tuplesort_mk.h"
@@ -507,41 +494,6 @@ switcheroo_tuplesort_restorepos(switcheroo_Tuplesortstate *state)
 		tuplesort_restorepos_pg((Tuplesortstate_pg *) state);
 }
 
-static inline switcheroo_Tuplesortstate *
-switcheroo_tuplesort_begin_heap_file_readerwriter(
-		struct ScanState * ss,
-		const char* rwfile_prefix, bool isWriter,
-		TupleDesc tupDesc,
-		int nkeys, AttrNumber *attNums,
-		Oid *sortOperators,
-		Oid *sortCollations,
-		bool *nullsFirstFlags,
-		int workMem, bool randomAccess)
-{
-	switcheroo_Tuplesortstate *state;
-
-	if (gp_enable_mk_sort)
-	{
-		state = (switcheroo_Tuplesortstate *)
-			tuplesort_begin_heap_file_readerwriter_mk(ss, rwfile_prefix, isWriter,
-													  tupDesc, nkeys, attNums,
-													  sortOperators, sortCollations,
-													  nullsFirstFlags,
-													  workMem, randomAccess);
-	}
-	else
-	{
-		state = (switcheroo_Tuplesortstate *)
-			tuplesort_begin_heap_file_readerwriter_pg(ss, rwfile_prefix, isWriter,
-													  tupDesc, nkeys, attNums,
-													  sortOperators, sortCollations,
-													  nullsFirstFlags,
-													  workMem, randomAccess);
-	}
-	state->is_mk_tuplesortstate = gp_enable_mk_sort;
-	return state;
-}
-
 static inline void
 switcheroo_cdb_tuplesort_init(switcheroo_Tuplesortstate *state, int unique,
 							  int sort_flags,
@@ -554,67 +506,12 @@ switcheroo_cdb_tuplesort_init(switcheroo_Tuplesortstate *state, int unique,
 }
 
 static inline void
-switcheroo_tuplesort_begin_pos(switcheroo_Tuplesortstate *state, TuplesortPos **pos)
-{
-	if (state->is_mk_tuplesortstate)
-		tuplesort_begin_pos_mk((Tuplesortstate_mk *) state, (TuplesortPos_mk **) pos);
-	else
-		tuplesort_begin_pos_pg((Tuplesortstate_pg *) state, pos);
-}
-
-static inline bool
-switcheroo_tuplesort_gettupleslot_pos(switcheroo_Tuplesortstate *state, TuplesortPos *pos,
-                          bool forward, TupleTableSlot *slot, Datum *abbrev, MemoryContext mcontext)
-{
-	if (state->is_mk_tuplesortstate)
-		return tuplesort_gettupleslot_pos_mk((Tuplesortstate_mk *) state, (TuplesortPos_mk *) pos, forward, slot, abbrev, mcontext);
-	else
-		return tuplesort_gettupleslot_pos_pg((Tuplesortstate_pg *) state, pos, forward, slot, abbrev, mcontext);
-}
-
-static inline void
-switcheroo_tuplesort_flush(switcheroo_Tuplesortstate *state)
-{
-	if (state->is_mk_tuplesortstate)
-		tuplesort_flush_mk((Tuplesortstate_mk *) state);
-	else
-		tuplesort_flush_pg((Tuplesortstate_pg *) state);
-}
-
-static inline void
 switcheroo_tuplesort_finalize_stats(switcheroo_Tuplesortstate *state)
 {
 	if (state->is_mk_tuplesortstate)
 		tuplesort_finalize_stats_mk((Tuplesortstate_mk *) state);
 	else
 		tuplesort_finalize_stats_pg((Tuplesortstate_pg *) state);
-}
-
-static inline void
-switcheroo_tuplesort_rescan_pos(switcheroo_Tuplesortstate *state, TuplesortPos *pos)
-{
-	if (state->is_mk_tuplesortstate)
-		tuplesort_rescan_pos_mk((Tuplesortstate_mk *) state, (TuplesortPos_mk *) pos);
-	else
-		tuplesort_rescan_pos_pg((Tuplesortstate_pg *) state, pos);
-}
-
-static inline void
-switcheroo_tuplesort_markpos_pos(switcheroo_Tuplesortstate *state, TuplesortPos *pos)
-{
-	if (state->is_mk_tuplesortstate)
-		tuplesort_markpos_pos_mk((Tuplesortstate_mk *) state, (TuplesortPos_mk *) pos);
-	else
-		tuplesort_markpos_pos_pg((Tuplesortstate_pg *) state, pos);
-}
-
-static inline void
-switcheroo_tuplesort_restorepos_pos(switcheroo_Tuplesortstate *state, TuplesortPos *pos)
-{
-	if (state->is_mk_tuplesortstate)
-		tuplesort_restorepos_pos_mk((Tuplesortstate_mk *) state, (TuplesortPos_mk *) pos);
-	else
-		tuplesort_restorepos_pos_pg((Tuplesortstate_pg *) state, pos);
 }
 
 static inline void
@@ -654,15 +551,8 @@ switcheroo_tuplesort_set_instrument(switcheroo_Tuplesortstate *state,
 #define tuplesort_restorepos switcheroo_tuplesort_restorepos
 
 /* these are in tuplesort_gp.h */
-#define tuplesort_begin_heap_file_readerwriter switcheroo_tuplesort_begin_heap_file_readerwriter
 #define cdb_tuplesort_init switcheroo_cdb_tuplesort_init
-#define tuplesort_begin_pos switcheroo_tuplesort_begin_pos
-#define tuplesort_gettupleslot_pos switcheroo_tuplesort_gettupleslot_pos
-#define tuplesort_flush switcheroo_tuplesort_flush
 #define tuplesort_finalize_stats switcheroo_tuplesort_finalize_stats
-#define tuplesort_rescan_pos switcheroo_tuplesort_rescan_pos
-#define tuplesort_markpos_pos switcheroo_tuplesort_markpos_pos
-#define tuplesort_restorepos_pos switcheroo_tuplesort_restorepos_pos
 #define tuplesort_set_instrument switcheroo_tuplesort_set_instrument
 
 #endif

--- a/src/include/utils/tuplesort_gp.h
+++ b/src/include/utils/tuplesort_gp.h
@@ -40,39 +40,14 @@ struct StringInfoData;                  /* #include "lib/stringinfo.h" */
  * TuplesortState and TuplesortPos are opaque types whose details are not known
  * outside tuplesort.c.
  */
-typedef struct TuplesortPos TuplesortPos;
 struct Tuplesortstate;
 struct ScanState;
-
-extern struct Tuplesortstate *tuplesort_begin_heap_file_readerwriter(
-		struct ScanState * ss,
-		const char* rwfile_prefix, bool isWriter,
-		TupleDesc tupDesc, 
-		int nkeys, AttrNumber *attNums,
-		Oid *sortOperators, Oid *sortCollations,
-		bool *nullsFirstFlags,
-		int workMem, bool randomAccess);
 
 extern void cdb_tuplesort_init(struct Tuplesortstate *state, int unique,
 							   int sort_flags,
 							   int64 maxdistinct);
 
-extern void tuplesort_begin_pos(struct Tuplesortstate *state, TuplesortPos **pos);
-extern bool tuplesort_gettupleslot_pos(struct Tuplesortstate *state, TuplesortPos *pos,
-                          bool forward, TupleTableSlot *slot, Datum *abbrev, MemoryContext mcontext);
-
-extern void tuplesort_flush(struct Tuplesortstate *state);
 extern void tuplesort_finalize_stats(struct Tuplesortstate *state);
-
-/*
- * These routines may only be called if randomAccess was specified 'true'.
- * Likewise, backwards scan in gettuple/getdatum is only allowed if
- * randomAccess was specified.
- */
-
-extern void tuplesort_rescan_pos(struct Tuplesortstate *state, TuplesortPos *pos);
-extern void tuplesort_markpos_pos(struct Tuplesortstate *state, TuplesortPos *pos);
-extern void tuplesort_restorepos_pos(struct Tuplesortstate *state, TuplesortPos *pos);
 
 /*
  * tuplesort_set_instrument

--- a/src/include/utils/tuplesort_mk.h
+++ b/src/include/utils/tuplesort_mk.h
@@ -45,15 +45,6 @@ extern Tuplesortstate_mk *tuplesort_begin_datum_mk(struct ScanState * ss,
 					  bool nullsFirstFlag,
 					  int workMem, bool randomAccess);
 
-extern Tuplesortstate_mk *tuplesort_begin_heap_file_readerwriter_mk(
-		struct ScanState * ss,
-		const char* rwfile_prefix, bool isWriter,
-		TupleDesc tupDesc,
-		int nkeys, AttrNumber *attNums,
-		Oid *sortOperators, Oid *sortCollations,
-		bool *nullsFirstFlags,
-		int workMem, bool randomAccess);
-
 extern void cdb_tuplesort_init_mk(Tuplesortstate_mk *state, int unique,
 							   int sort_flags,
 							   int64 maxdistinct);
@@ -67,9 +58,6 @@ extern void tuplesort_putindextuplevalues_mk(Tuplesortstate_mk *state, Relation 
 extern void tuplesort_putdatum_mk(Tuplesortstate_mk *state, Datum val, bool isNull);
 
 extern void tuplesort_performsort_mk(Tuplesortstate_mk *state);
-
-extern void tuplesort_begin_pos_mk(Tuplesortstate_mk *state, TuplesortPos_mk **pos);
-extern bool tuplesort_gettupleslot_pos_mk(Tuplesortstate_mk *state, TuplesortPos_mk *pos, bool forward, TupleTableSlot *slot, Datum *abbrev, MemoryContext mcontext);
 
 extern bool tuplesort_gettupleslot_mk(Tuplesortstate_mk *state, bool forward, TupleTableSlot *slot, Datum *abbrev);
 extern HeapTuple tuplesort_getheaptuple_mk(Tuplesortstate_mk *state, bool forward, bool *should_free);
@@ -85,11 +73,6 @@ extern void tuplesort_finalize_stats_mk(Tuplesortstate_mk *state);
 extern void tuplesort_rescan_mk(Tuplesortstate_mk *state);
 extern void tuplesort_markpos_mk(Tuplesortstate_mk *state);
 extern void tuplesort_restorepos_mk(Tuplesortstate_mk *state);
-
-extern void tuplesort_rescan_pos_mk(Tuplesortstate_mk *state, TuplesortPos_mk *pos);
-extern void tuplesort_restorepos_pos_mk(Tuplesortstate_mk *state, TuplesortPos_mk *pos);
-extern void tuplesort_markpos_pos_mk(Tuplesortstate_mk *state, TuplesortPos_mk *pos);
-
 
 extern void tuplesort_set_instrument_mk(Tuplesortstate_mk *state,
                          struct Instrumentation    *instrument,

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11249,8 +11249,8 @@ INSERT INTO onetimefilter2 SELECT i, i FROM generate_series(1,10)i;
 ANALYZE onetimefilter1;
 ANALYZE onetimefilter2;
 EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=3.43..18.61 rows=10 width=12)
    ->  Hash Join  (cost=3.43..18.41 rows=4 width=12)
          Hash Cond: (f1.b = f2.b)
@@ -11263,35 +11263,34 @@ EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilte
                      ->  Seq Scan on onetimefilter2 f2  (cost=0.00..3.10 rows=4 width=4)
          SubPlan 1
            ->  Limit  (cost=0.00..0.06 rows=1 width=4)
-                 ->  Result  (cost=0.00..0.55 rows=10 width=4)
+                 ->  Result  (cost=0.00..0.55 rows=4 width=4)
                        One-Time Filter: (f1.b = f2.b)
-                       ->  Materialize  (cost=0.00..0.45 rows=10 width=0)
+                       ->  Materialize  (cost=0.00..0.45 rows=4 width=0)
                              ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..0.40 rows=4 width=0)
                                    ->  Subquery Scan on abc  (cost=0.00..0.20 rows=4 width=0)
-                                         ->  Shared Scan (share slice:id 2:0)  (cost=6.51..6.72 rows=4 width=8)
-                                               ->  Materialize  (cost=3.23..6.51 rows=4 width=8)
-                                                     ->  Hash Join  (cost=3.23..6.46 rows=4 width=8)
-                                                           Hash Cond: (onetimefilter1.a = onetimefilter2.a)
-                                                           ->  Seq Scan on onetimefilter1  (cost=0.00..3.10 rows=4 width=8)
-                                                           ->  Hash  (cost=3.10..3.10 rows=4 width=4)
-                                                                 ->  Seq Scan on onetimefilter2  (cost=0.00..3.10 rows=4 width=4)
+                                         ->  Shared Scan (share slice:id 2:0)  (cost=6.46..6.67 rows=4 width=8)
+                                               ->  Hash Join  (cost=3.23..6.46 rows=4 width=8)
+                                                     Hash Cond: (onetimefilter1.a = onetimefilter2.a)
+                                                     ->  Seq Scan on onetimefilter1  (cost=0.00..3.10 rows=4 width=8)
+                                                     ->  Hash  (cost=3.10..3.10 rows=4 width=4)
+                                                           ->  Seq Scan on onetimefilter2  (cost=0.00..3.10 rows=4 width=4)
          SubPlan 2
-           ->  Result  (cost=0.00..0.55 rows=10 width=4)
+           ->  Result  (cost=0.00..0.55 rows=4 width=4)
                  One-Time Filter: (f1.a = 2)
                  Filter: ((f1.a)::double precision = random())
-                 ->  Materialize  (cost=0.00..0.45 rows=10 width=0)
+                 ->  Materialize  (cost=0.00..0.45 rows=4 width=0)
                        ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..0.40 rows=4 width=0)
                              ->  Subquery Scan on abc_1  (cost=0.00..0.20 rows=4 width=0)
-                                   ->  Shared Scan (share slice:id 3:0)  (cost=6.51..6.72 rows=4 width=8)
+                                   ->  Shared Scan (share slice:id 3:0)  (cost=6.46..6.67 rows=4 width=8)
          SubPlan 3
-           ->  Result  (cost=0.00..0.55 rows=10 width=4)
+           ->  Result  (cost=0.00..0.55 rows=4 width=4)
                  Filter: (abc_2.b = f1.b)
-                 ->  Materialize  (cost=0.00..0.45 rows=10 width=4)
+                 ->  Materialize  (cost=0.00..0.45 rows=4 width=4)
                        ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..0.40 rows=4 width=4)
                              ->  Subquery Scan on abc_2  (cost=0.00..0.20 rows=4 width=4)
-                                   ->  Shared Scan (share slice:id 4:0)  (cost=6.51..6.72 rows=4 width=8)
+                                   ->  Shared Scan (share slice:id 4:0)  (cost=6.46..6.67 rows=4 width=8)
  Optimizer: Postgres query optimizer
-(40 rows)
+(39 rows)
 
 WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
  ?column? | coalesce | b  

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10414,8 +10414,7 @@ ORDER BY 1 asc ;
                      ->  Result  (cost=0.00..1305.00 rows=1 width=8)
                            ->  Sequence  (cost=0.00..1305.00 rows=1 width=8)
                                  ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=1)
-                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-                                             ->  Seq Scan on my_tt_agg_opt  (cost=0.00..431.00 rows=1 width=54)
+                                       ->  Seq Scan on my_tt_agg_opt  (cost=0.00..431.00 rows=1 width=54)
                                  ->  Sequence  (cost=0.00..874.00 rows=1 width=8)
                                        ->  Partition Selector for my_tq_agg_opt_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                                              Partitions selected: 2 (out of 2)
@@ -10436,8 +10435,8 @@ ORDER BY 1 asc ;
                                                    ->  Dynamic Index Scan on my_tq_agg_opt_part my_tq_agg_opt_part_1 (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=1)
                                                          Index Cond: (ets <= share0_ref3.event_ts)
                                                          Filter: (((sym)::bpchar = share0_ref3.symbol) AND (plusone(bid_price) < share0_ref3.trade_price) AND (share0_ref3.event_ts < end_ts))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(33 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(32 rows)
 
 reset optimizer_segments;
 reset optimizer_enable_constant_expression_evaluation;
@@ -11403,12 +11402,11 @@ EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilte
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1852062876647.47 rows=11 width=12)
    ->  Sequence  (cost=0.00..1852062876647.47 rows=4 width=12)
          ->  Shared Scan (share slice:id 1:0)  (cost=0.00..862.00 rows=4 width=1)
-               ->  Materialize  (cost=0.00..862.00 rows=4 width=1)
-                     ->  Hash Join  (cost=0.00..862.00 rows=4 width=8)
-                           Hash Cond: (onetimefilter1_1.a = onetimefilter2_1.a)
-                           ->  Seq Scan on onetimefilter1 onetimefilter1_1  (cost=0.00..431.00 rows=4 width=8)
-                           ->  Hash  (cost=431.00..431.00 rows=4 width=4)
-                                 ->  Seq Scan on onetimefilter2 onetimefilter2_1  (cost=0.00..431.00 rows=4 width=4)
+               ->  Hash Join  (cost=0.00..862.00 rows=4 width=8)
+                     Hash Cond: (onetimefilter1_1.a = onetimefilter2_1.a)
+                     ->  Seq Scan on onetimefilter1 onetimefilter1_1  (cost=0.00..431.00 rows=4 width=8)
+                     ->  Hash  (cost=431.00..431.00 rows=4 width=4)
+                           ->  Seq Scan on onetimefilter2 onetimefilter2_1  (cost=0.00..431.00 rows=4 width=4)
          ->  Hash Join  (cost=0.00..862.00 rows=4 width=12)
                Hash Cond: (onetimefilter1.b = onetimefilter2.b)
                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=8)
@@ -11443,8 +11441,8 @@ EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilte
                              ->  Broadcast Motion 3:3  (slice6; segments: 3)  (cost=0.00..431.00 rows=11 width=4)
                                    ->  Result  (cost=0.00..431.00 rows=4 width=4)
                                          ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=4 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(44 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(43 rows)
 
 WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
  ?column? | coalesce | b  
@@ -12144,12 +12142,10 @@ EXPLAIN SELECT a, b FROM atab_old_hash FULL JOIN btab_old_hash ON a |=| b;
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2586.00 rows=10 width=8)
    ->  Sequence  (cost=0.00..2586.00 rows=4 width=8)
          ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-                     ->  Seq Scan on atab_old_hash  (cost=0.00..431.00 rows=1 width=34)
+               ->  Seq Scan on atab_old_hash  (cost=0.00..431.00 rows=1 width=34)
          ->  Sequence  (cost=0.00..2155.00 rows=4 width=8)
                ->  Shared Scan (share slice:id 1:1)  (cost=0.00..431.00 rows=2 width=1)
-                     ->  Materialize  (cost=0.00..431.00 rows=2 width=1)
-                           ->  Seq Scan on btab_old_hash  (cost=0.00..431.00 rows=2 width=34)
+                     ->  Seq Scan on btab_old_hash  (cost=0.00..431.00 rows=2 width=34)
                ->  Append  (cost=0.00..1724.00 rows=4 width=8)
                      ->  Hash Left Join  (cost=0.00..862.00 rows=2 width=8)
                            Hash Cond: (share0_ref2.a |=| share1_ref2.b)
@@ -12173,8 +12169,8 @@ EXPLAIN SELECT a, b FROM atab_old_hash FULL JOIN btab_old_hash ON a |=| b;
                                        Hash Key: share0_ref3.a
                                        ->  Result  (cost=0.00..431.00 rows=1 width=4)
                                              ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.95.0
-(33 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(31 rows)
 
 SELECT a, b FROM atab_old_hash FULL JOIN btab_old_hash ON a |=| b;
  a  | b  

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2221,13 +2221,11 @@ SELECT count(a1.i)
                ->  Hash Join
                      Hash Cond: (share1_ref1.i = a2.i)
                      ->  Shared Scan (share slice:id 1:1)
-                           ->  Materialize
-                                 ->  Seq Scan on foo
+                           ->  Seq Scan on foo
                      ->  Hash
                            ->  Subquery Scan on a2
                                  ->  Shared Scan (share slice:id 1:0)
-                                       ->  Materialize
-                                             ->  Seq Scan on foo foo_1
+                                       ->  Seq Scan on foo foo_1
          ->  Redistribute Motion 1:3  (slice2; segments: 1)
                Hash Key: (count(share1_ref2.i))
                ->  Finalize Aggregate
@@ -2240,7 +2238,7 @@ SELECT count(a1.i)
                                              ->  Subquery Scan on a2_1
                                                    ->  Shared Scan (share slice:id 3:0)
  Optimizer: Postgres query optimizer
-(25 rows)
+(23 rows)
 
 -- Another cross-slice ShareInputScan test. There is one producing slice,
 -- and two consumers in second slice. Make sure the Share Input Scan
@@ -2275,8 +2273,7 @@ UNION ALL
                      Hash Key: ('a'::text), cte.j
                      ->  Subquery Scan on cte
                            ->  Shared Scan (share slice:id 2:0)
-                                 ->  Materialize
-                                       ->  Seq Scan on foo
+                                 ->  Seq Scan on foo
          ->  Hash Join
                Hash Cond: (share0_ref3.i = y.i)
                ->  Shared Scan (share slice:id 1:0)
@@ -2284,13 +2281,13 @@ UNION ALL
                      ->  Subquery Scan on y
                            ->  Shared Scan (share slice:id 1:0)
          ->  Result
-               One-Time Filter: (gp_execution_segment() = 1)
+               One-Time Filter: (gp_execution_segment() = 0)
                ->  Result
                      One-Time Filter: (pg_sleep('1'::double precision) IS NOT NULL)
          ->  Subquery Scan on cte_1
                ->  Shared Scan (share slice:id 1:0)
  Optimizer: Postgres query optimizer
-(23 rows)
+(22 rows)
 
 WITH cte AS (SELECT * FROM foo)
   (SELECT DISTINCT 'a' as branch, j FROM cte)

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2217,12 +2217,10 @@ SELECT count(a1.i)
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Sequence
          ->  Shared Scan (share slice:id 1:0)
-               ->  Materialize
-                     ->  Seq Scan on foo foo_1
+               ->  Seq Scan on foo foo_1
          ->  Sequence
                ->  Shared Scan (share slice:id 1:1)
-                     ->  Materialize
-                           ->  Seq Scan on foo
+                     ->  Seq Scan on foo
                ->  Append
                      ->  Hash Join
                            Hash Cond: (share0_ref2.i = share1_ref2.i)
@@ -2238,7 +2236,7 @@ SELECT count(a1.i)
                                              ->  Hash
                                                    ->  Shared Scan (share slice:id 3:1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(24 rows)
+(22 rows)
 
 -- Another cross-slice ShareInputScan test. There is one producing slice,
 -- and two consumers in second slice. Make sure the Share Input Scan
@@ -2268,8 +2266,7 @@ UNION ALL
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Sequence
          ->  Shared Scan (share slice:id 1:0)
-               ->  Materialize
-                     ->  Seq Scan on foo
+               ->  Seq Scan on foo
          ->  Append
                ->  GroupAggregate
                      Group Key: ('a'::text), share0_ref2.j
@@ -2285,14 +2282,14 @@ UNION ALL
                      ->  Hash
                            ->  Shared Scan (share slice:id 1:0)
                ->  Result
-                     One-Time Filter: (gp_execution_segment() = 1)
+                     One-Time Filter: (gp_execution_segment() = 0)
                      ->  Result
                            Filter: (NOT (pg_sleep('1'::double precision) IS NULL))
                            ->  Result
                ->  Result
                      ->  Shared Scan (share slice:id 1:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(27 rows)
+(26 rows)
 
 WITH cte AS (SELECT * FROM foo)
   (SELECT DISTINCT 'a' as branch, j FROM cte)

--- a/src/test/regress/expected/workfile/sisc_mat_sort.out
+++ b/src/test/regress/expected/workfile/sisc_mat_sort.out
@@ -58,9 +58,8 @@ where t1.c1 = t2.c1 and t1.c3 = t2.c3;');
  is_workfile_created 
 ---------------------
                    1
-                   0
                    1
-(3 rows)
+(2 rows)
 
 select * from sisc_mat_sort.is_workfile_created('explain (analyze, verbose)
 with ctesisc as 
@@ -71,9 +70,8 @@ where t1.c1 = t2.c1 and t1.c3 = t2.c3 limit 50000;');
  is_workfile_created 
 ---------------------
                    1
-                   0
                    1
-(3 rows)
+(2 rows)
 
 set gp_enable_mk_sort=off;
 select count(*) from (with ctesisc as 
@@ -95,9 +93,8 @@ where t1.c1 = t2.c1 and t1.c3 = t2.c3;');
  is_workfile_created 
 ---------------------
                    1
-                   0
                    1
-(3 rows)
+(2 rows)
 
 select * from sisc_mat_sort.is_workfile_created('explain (analyze, verbose)
 with ctesisc as 
@@ -108,9 +105,8 @@ where t1.c1 = t2.c1 and t1.c3 = t2.c3 limit 50000;');
  is_workfile_created 
 ---------------------
                    1
-                   0
                    1
-(3 rows)
+(2 rows)
 
 drop schema sisc_mat_sort cascade;
 NOTICE:  drop cascades to 2 other objects

--- a/src/test/regress/expected/workfile/sisc_sort_spill.out
+++ b/src/test/regress/expected/workfile/sisc_sort_spill.out
@@ -57,10 +57,9 @@ select * from sisc_sort_spill.is_workfile_created('explain (analyze, verbose)
 ;');
  is_workfile_created 
 ---------------------
-                   0
                    1
                    1
-(3 rows)
+(2 rows)
 
 select * from sisc_sort_spill.is_workfile_created('explain (analyze, verbose)
   with ctesisc as (select * from testsisc order by i2)
@@ -70,10 +69,9 @@ select * from sisc_sort_spill.is_workfile_created('explain (analyze, verbose)
 limit 50000;');
  is_workfile_created 
 ---------------------
-                   0
                    1
                    1
-(3 rows)
+(2 rows)
 
 set gp_enable_mk_sort=off;
 select avg(i3) from (
@@ -95,10 +93,9 @@ select * from sisc_sort_spill.is_workfile_created('explain (analyze, verbose)
 ;');
  is_workfile_created 
 ---------------------
-                   0
                    1
                    1
-(3 rows)
+(2 rows)
 
 select * from sisc_sort_spill.is_workfile_created('explain (analyze, verbose)
   with ctesisc as (select * from testsisc order by i2)
@@ -108,10 +105,9 @@ select * from sisc_sort_spill.is_workfile_created('explain (analyze, verbose)
 limit 50000;');
  is_workfile_created 
 ---------------------
-                   0
                    1
                    1
-(3 rows)
+(2 rows)
 
 drop schema sisc_sort_spill cascade;
 NOTICE:  drop cascades to 2 other objects

--- a/src/test/regress/expected/workfile/sisc_sort_spill.out
+++ b/src/test/regress/expected/workfile/sisc_sort_spill.out
@@ -57,9 +57,10 @@ select * from sisc_sort_spill.is_workfile_created('explain (analyze, verbose)
 ;');
  is_workfile_created 
 ---------------------
+                   0
                    1
                    1
-(2 rows)
+(3 rows)
 
 select * from sisc_sort_spill.is_workfile_created('explain (analyze, verbose)
   with ctesisc as (select * from testsisc order by i2)
@@ -69,9 +70,10 @@ select * from sisc_sort_spill.is_workfile_created('explain (analyze, verbose)
 limit 50000;');
  is_workfile_created 
 ---------------------
+                   0
                    1
                    1
-(2 rows)
+(3 rows)
 
 set gp_enable_mk_sort=off;
 select avg(i3) from (
@@ -93,9 +95,10 @@ select * from sisc_sort_spill.is_workfile_created('explain (analyze, verbose)
 ;');
  is_workfile_created 
 ---------------------
+                   0
                    1
                    1
-(2 rows)
+(3 rows)
 
 select * from sisc_sort_spill.is_workfile_created('explain (analyze, verbose)
   with ctesisc as (select * from testsisc order by i2)
@@ -105,9 +108,10 @@ select * from sisc_sort_spill.is_workfile_created('explain (analyze, verbose)
 limit 50000;');
  is_workfile_created 
 ---------------------
+                   0
                    1
                    1
-(2 rows)
+(3 rows)
 
 drop schema sisc_sort_spill cascade;
 NOTICE:  drop cascades to 2 other objects


### PR DESCRIPTION
More refactoring of ShareInputScans, following up https://github.com/greenplum-db/gpdb/pull/9935.

See commit messages for details, but the highlights are:

- Remove the optimization of sharing a Sort node directly. Use a tuplestore on top of Sort, like all other nodes (see commit message for why I think that's acceptable)
- Manage the tuplestore directly in ShareInputScan, so that you don't need to have a Material node beneath it.

I'd recommend reviewing this by reading through the commit messages first, and once you get the big picture of all the changes, review the commits in chronological order.