### PR TITLE
Unvendor python runtime from Greenplum installation directory

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -70,8 +70,6 @@ jobs:
       resource: libquicklz-centos7
     - get: libquicklz-devel-installer
       resource: libquicklz-devel-centos7
-    - get: python-tarball
-      resource: python-centos7
 
   - put: gpdb_pr
     params:

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -523,7 +523,7 @@ resources:
   type: docker-image
   source:
     repository: pivotaldata/gpdb7-centos7-build
-    tag: latest
+    tag: devv13
 
 {% endif %}
 {% if "centos7" in os_types or "CLI" in test_sections %}
@@ -531,7 +531,7 @@ resources:
   type: docker-image
   source:
     repository: pivotaldata/gpdb7-centos7-test
-    tag: latest
+    tag: devv17
 
 {% endif %}
 
@@ -539,14 +539,14 @@ resources:
   type: docker-image
   source:
     repository: pivotaldata/gpdb7-ubuntu18.04-build
-    tag: latest
+    tag: devv11
 
 {% if "ubuntu18.04" in os_types %}
 - name: gpdb7-ubuntu18.04-test
   type: docker-image
   source:
     repository: pivotaldata/gpdb7-ubuntu18.04-test
-    tag: latest
+    tag: devv12
 
 {% endif %}
 
@@ -554,7 +554,7 @@ resources:
   type: docker-image
   source:
     repository: pivotaldata/gpdb7-sles12-build
-    tag: latest
+    tag: devv18
     username: ((docker_username))
     password: ((docker_password))
 
@@ -563,7 +563,7 @@ resources:
   type: docker-image
   source:
     repository: pivotaldata/gpdb7-sles12-test
-    tag: latest
+    tag: devv16
     username: ((docker_username))
     password: ((docker_password))
 

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -519,33 +519,6 @@ resources:
 
 {% endif %}
 {% if "centos7" in os_types %}
-- name: python-centos7
-  type: gcs
-  source:
-    bucket: ((gcs-bucket))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: gp-internal-artifacts/centos7/python-(2\.7\.12-.*).tar.gz
-
-{% endif %}
-{% if "ubuntu18.04" in os_types %}
-- name: python-ubuntu18.04
-  type: gcs
-  source:
-    bucket: ((gcs-bucket))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: gp-internal-artifacts/ubuntu18.04/python-(2\.7\.12-.*).tar.gz
-
-{% endif %}
-{% if "sles12" in os_types %}
-- name: python-sles12
-  type: gcs
-  source:
-    bucket: ((gcs-bucket))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: gp-internal-artifacts/sles12/python-(2\.7\.12-.*).tar.gz
-
-{% endif %}
-{% if "centos7" in os_types %}
 - name: gpdb7-centos7-build
   type: docker-image
   source:
@@ -869,8 +842,6 @@ jobs:
         resource: libquicklz-centos7
       - get: libquicklz-devel-installer
         resource: libquicklz-devel-centos7
-      - get: python-tarball
-        resource: python-centos7
   - task: compile_gpdb
     image: gpdb7-centos7-build
     file: gpdb_src/concourse/tasks/compile_gpdb.yml
@@ -902,8 +873,6 @@ jobs:
         - get: gpdb7-ubuntu18.04-build
         - get: libquicklz-installer
           resource: libquicklz-ubuntu18.04
-        - get: python-tarball
-          resource: python-ubuntu18.04
     - task: compile_gpdb
       image: gpdb7-ubuntu18.04-build
       file: gpdb_src/concourse/tasks/compile_gpdb.yml
@@ -937,8 +906,6 @@ jobs:
           resource: libquicklz-sles12
         - get: libquicklz-devel-installer
           resource: libquicklz-devel-sles12
-        - get: python-tarball
-          resource: python-sles12
     - task: compile_gpdb
       image: gpdb7-sles12-build
       file: gpdb_src/concourse/tasks/compile_gpdb.yml

--- a/concourse/scripts/behave_gpdb.bash
+++ b/concourse/scripts/behave_gpdb.bash
@@ -41,7 +41,6 @@ function _main() {
     # sourcing greenplum_path
     time (make_cluster)
 
-    time install_python_hacks
     time install_python_requirements_on_single_host ./gpdb_src/gpMgmt/requirements-dev.txt
 
     time gen_env

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -27,10 +27,6 @@ function setup_configure_vars() {
 }
 
 function configure() {
-  if [ -f /opt/gcc_env.sh ]; then
-    # ubuntu uses the system compiler
-    source /opt/gcc_env.sh
-  fi
   pushd gpdb_src
       # The full set of configure options which were used for building the
       # tree must be used here as well since the toplevel Makefile depends

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -140,23 +140,6 @@ function include_quicklz() {
   popd
 }
 
-function include_libstdcxx() {
-  if [ "${TARGET_OS}" == "centos" ] ; then
-    pushd /opt/gcc-6*/lib64
-      for libfile in libstdc++.so.*; do
-        case $libfile in
-          *.py)
-            ;; # we don't vendor libstdc++.so.*-gdb.py
-          *)
-            cp -d "$libfile" ${GREENPLUM_INSTALL_DIR}/lib
-            ;; # vendor everything else
-        esac
-      done
-    popd
-  fi
-
-}
-
 function export_gpdb() {
   TARBALL="${GPDB_ARTIFACTS_DIR}/${GPDB_BIN_FILENAME}"
   local server_version
@@ -265,7 +248,6 @@ function _main() {
   fi
   include_zstd
   include_quicklz
-  include_libstdcxx
   export_gpdb
   export_gpdb_extensions
   export_gpdb_win32_ccl

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -64,11 +64,6 @@ function install_deps() {
   esac
 }
 
-function link_python() {
-  tar xf python-tarball/python-*.tar.gz -C $(pwd)/${GPDB_SRC_PATH}/gpAux/ext
-  ln -sf $(pwd)/${GPDB_SRC_PATH}/gpAux/ext/${BLD_ARCH}/python-2.7.12 /opt/python-2.7.12
-}
-
 function generate_build_number() {
   pushd ${GPDB_SRC_PATH}
     #Only if its git repro, add commit SHA as build number
@@ -237,7 +232,6 @@ function _main() {
       build_xerces
       test_orca
       install_deps
-      link_python
       ;;
     win32)
         export BLD_ARCH=win32

--- a/concourse/scripts/dumpdb.bash
+++ b/concourse/scripts/dumpdb.bash
@@ -3,7 +3,6 @@ set -e
 set -u
 
 source /usr/local/greenplum-db-devel/greenplum_path.sh
-source /opt/gcc_env.sh
 source ./gpdb_src/gpAux/gpdemo/gpdemo-env.sh
 
 gpstart -a

--- a/concourse/scripts/gpMgmt_check_gpdb.bash
+++ b/concourse/scripts/gpMgmt_check_gpdb.bash
@@ -21,6 +21,7 @@ function gen_env(){
 		source /usr/local/greenplum-db-devel/greenplum_path.sh
 		source /opt/gcc_env.sh
 		source \${base_path}/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+
 		cd \${base_path}/gpdb_src/gpMgmt/bin
 		make check
 		# show results into concourse
@@ -42,7 +43,6 @@ function _main() {
     setup_gpadmin_user
     (make_cluster)
 
-    install_python_hacks
     install_python_requirements_on_single_host ./gpdb_src/gpMgmt/requirements-dev.txt
 
     gen_env

--- a/concourse/scripts/gpMgmt_check_gpdb.bash
+++ b/concourse/scripts/gpMgmt_check_gpdb.bash
@@ -19,7 +19,6 @@ function gen_env(){
 		}
 
 		source /usr/local/greenplum-db-devel/greenplum_path.sh
-		source /opt/gcc_env.sh
 		source \${base_path}/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
 
 		cd \${base_path}/gpdb_src/gpMgmt/bin

--- a/concourse/scripts/gpcheckcloud_tests_gpcloud.bash
+++ b/concourse/scripts/gpcheckcloud_tests_gpcloud.bash
@@ -9,7 +9,6 @@ function gen_env(){
 	cat > /home/gpadmin/run_regression_gpcheckcloud.sh <<-EOF
 	set -exo pipefail
 
-	source /opt/gcc_env.sh
 	source /usr/local/greenplum-db-devel/greenplum_path.sh
 
 	cd "\${1}/gpdb_src/gpcontrib/gpcloud/regress"

--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -29,9 +29,6 @@ function gen_env(){
 		    exit 1
 		}
 		source /usr/local/greenplum-db-devel/greenplum_path.sh
-		if [ -f /opt/gcc_env.sh ]; then
-		    source /opt/gcc_env.sh
-		fi
 		cd "\${1}/gpdb_src"
 		source gpAux/gpdemo/gpdemo-env.sh
 		make -s ${MAKE_TEST_COMMAND}

--- a/concourse/scripts/regression_tests_gpcloud.bash
+++ b/concourse/scripts/regression_tests_gpcloud.bash
@@ -8,9 +8,6 @@ GPDB_INSTALL_DIR="/usr/local/gpdb"
 function gen_local_regression_script(){
 cat > /home/gpadmin/run_regression_test.sh <<-EOF
 set -exo pipefail
-if [ \$TARGET_OS != "ubuntu" ]; then
-source /opt/gcc_env.sh
-fi
 INSTALL_DIR=/usr/local/gpdb
 GPDB_SRC_DIR=\${1}/gpdb_src
 

--- a/concourse/scripts/run_behave_test.sh
+++ b/concourse/scripts/run_behave_test.sh
@@ -6,13 +6,16 @@ source "${CWDIR}/common.bash"
 
 BEHAVE_FLAGS=$@
 
-cat > ~/gpdb-env.sh << EOF
+cat > ~/gpdb-env.sh <<'EOF'
   source /usr/local/greenplum-db-devel/greenplum_path.sh
   export PGPORT=5432
   export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
   export PGDATABASE=gptest
 
   alias mdd='cd \$MASTER_DATA_DIRECTORY'
+  # pip installs are done using --user, so are in ~/.local/bin which
+  # is not in the default path over ssh
+  export PATH=~/.local/bin:${PATH}
 EOF
 source ~/gpdb-env.sh
 

--- a/concourse/scripts/scan_with_coverity.bash
+++ b/concourse/scripts/scan_with_coverity.bash
@@ -13,7 +13,6 @@ function prep_env_for_centos() {
   alternatives --set java "$java7_bin"
   export JAVA_HOME="${java7_bin/jre\/bin\/java/}"
   ln -sf /usr/bin/xsubpp /usr/share/perl5/ExtUtils/xsubpp
-  source /opt/gcc_env.sh
 
   export PATH=${JAVA_HOME}/bin:${PATH}
 }

--- a/concourse/scripts/scan_with_coverity.bash
+++ b/concourse/scripts/scan_with_coverity.bash
@@ -15,7 +15,6 @@ function prep_env_for_centos() {
   ln -sf /usr/bin/xsubpp /usr/share/perl5/ExtUtils/xsubpp
   source /opt/gcc_env.sh
 
-  ln -sf "$BASE_DIR"/gpdb_src/gpAux/ext/${BLD_ARCH}/python-2.7.12 /opt/python-2.7.12
   export PATH=${JAVA_HOME}/bin:${PATH}
 }
 

--- a/concourse/scripts/unit_tests_gpcloud.bash
+++ b/concourse/scripts/unit_tests_gpcloud.bash
@@ -8,7 +8,6 @@ function gen_env(){
 	cat > ~/run_unit_tests.sh <<-EOF
 	set -exo pipefail
 
-	source /opt/gcc_env.sh
 	cd "\${1}/gpdb_src/gpcontrib/gpcloud"
 	make test
 	EOF

--- a/concourse/tasks/compile_gpdb.yml
+++ b/concourse/tasks/compile_gpdb.yml
@@ -6,7 +6,6 @@ inputs:
   - name: libquicklz-installer
   - name: libquicklz-devel-installer
     optional: true
-  - name: python-tarball
 outputs:
   - name: gpdb_artifacts
 run:

--- a/concourse/tasks/run_behave_on_ccp_cluster.yml
+++ b/concourse/tasks/run_behave_on_ccp_cluster.yml
@@ -21,7 +21,6 @@ run:
     # cluster_env_files.
     ssh -t ccp-$(cat cluster_env_files/terraform/name)-0 "sudo bash -c '
         source /home/gpadmin/gpdb_src/concourse/scripts/common.bash
-        install_python_hacks
     '"
 
     # ensure cluster is stopped

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -194,7 +194,7 @@ $(GPPGDIR)/GNUmakefile : $(GPPGDIR)/configure  env.sh
 	rm -rf $(INSTLOC)
 	mkdir -p $(GPPGDIR)
 	echo "Running ./configure with CONFIGFLAGS=$(CONFIGFLAGS)\n"
-	cd $(GPPGDIR) && CC="$(strip $(BLD_CC) $(BLD_CFLAGS))"    \
+	cd $(GPPGDIR) && \
                      CFLAGS=$(INSTCFLAGS) $(BLD_CONFIG_SHELL) \
                      ./configure $(CONFIGFLAGS)               \
                          --prefix=$(INSTLOC)                  \
@@ -204,7 +204,7 @@ Debug/GNUmakefile : $(GPPGDIR)/configure  env.sh
 	rm -rf $(INSTLOC)
 	mkdir -p Debug
 	echo "Running ./configure with CONFIGFLAGS=$(CONFIGFLAGS)\n"
-	cd Debug && CC="$(strip $(BLD_CC) $(BLD_CFLAGS))"        \
+	cd Debug && \
                 CFLAGS=$(INSTCFLAGS) $(BLD_CONFIG_SHELL)     \
                 ./configure $(CONFIGFLAGS)                   \
                     --prefix=$(INSTLOC)                      \
@@ -214,7 +214,7 @@ Release/GNUmakefile : $(GPPGDIR)/configure  env.sh
 	rm -rf $(INSTLOC)
 	mkdir -p Release
 	echo "Running ./configure with CONFIGFLAGS=$(CONFIGFLAGS)\n"
-	cd Release && CC="$(strip $(BLD_CC) $(BLD_CFLAGS))"     \
+	cd Release && \
                   CFLAGS=$(INSTCFLAGS) $(BLD_CONFIG_SHELL)  \
                   ./configure $(CONFIGFLAGS)                \
                       --prefix=$(INSTLOC)                   \
@@ -318,7 +318,6 @@ endif
 env.sh:
 	echo "export BLD_ARCH=$(BLD_ARCH)" > env.sh
 	echo "export NO_M64=$(NO_M64)" >> env.sh
-	echo "export CC=\"$(strip $(BLD_CC) $(BLD_CFLAGS))\"" >> env.sh
 	echo "export PATH=$(PATH)" >> env.sh
 	echo "export $(BLD_WHERE_THE_LIBRARY_THINGS_ARE)=$($(BLD_WHERE_THE_LIBRARY_THINGS_ARE))" >> env.sh
 ifneq "$(PERL_DIR)" ""
@@ -642,15 +641,6 @@ mgmtcopy :
 libcopy=(cd $(1) && $(TAR) cf - $(2)) | (cd $(3) && $(TAR) xvf -)$(check_pipe_for_errors)
 
 copylibs : thirdparty-dist
-	# Create the python directory to flag to build scripts that python has been handled
-	mkdir -p $(INSTLOC)/ext/python
-	@if [ ! -z "$(PYTHONHOME)" ]; then \
-	    echo "Copying python, $(BLD_PYTHON_FILESET), from $(PYTHONHOME) into $(INSTLOC)/ext/python..."; \
-	    (cd $(PYTHONHOME) && $(TAR) cf - $(BLD_PYTHON_FILESET)) | (cd $(INSTLOC)/ext/python/ && $(TAR) xpf -); \
-		echo "...DONE"; \
-	else \
-	    echo "INFO: Python not found on this platform, $(BLD_ARCH), not copying it into the GPDB package."; \
-	fi
 	mkdir -p $(INSTLOC)/etc
 	mkdir -p $(INSTLOC)/include
 

--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -23,15 +23,6 @@ ifneq "$($(BLD_ARCH)_MPP_ARCH)" ""
 export MPP_ARCH=$($(BLD_ARCH)_MPP_ARCH)
 endif
 
-# take over the gcc version we use
-BLD_CC=gcc
-
-ifneq "$($(BLD_ARCH)_CC)" ""
-BLD_CC=$($(BLD_ARCH)_CC)
-export CC=$(BLD_CC)
-export CPP=$(subst gcc,cpp,$(BLD_CC))
-export CXX=$(subst gcc,g++,$(BLD_CC))
-endif
 
 ifneq "$($(BLD_ARCH)_CXX)" ""
 export CXX=$($(BLD_ARCH)_CXX)
@@ -54,36 +45,6 @@ ifneq "$(BLD_LD_LIBRARY_PATH_PREPEND)" ""
 export $(BLD_WHERE_THE_LIBRARY_THINGS_ARE):=$(BLD_LD_LIBRARY_PATH_PREPEND):$($(BLD_WHERE_THE_LIBRARY_THINGS_ARE))
 endif
 export BLD_LD_LIBRARY_PATH_FIXED=true
-
-# specify python version to use for build-time and run-time
-aix7_ppc_64_PYTHONHOME=/opt/freeware
-rhel6_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
-rhel7_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
-ubuntu18.04_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
-sles12_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
-
-ifneq "$($(BLD_ARCH)_PYTHONHOME)" ""
-export PYTHONHOME=$($(BLD_ARCH)_PYTHONHOME)
-endif
-
-export PYTHON=python
-ifneq "$(PYTHONHOME)" ""
-export PYTHON=$(PYTHONHOME)/bin/python
-aix7_ppc_64_PYTHON=$(PYTHONHOME)/bin/python2.7_64
-ifneq "$($(BLD_ARCH)_PYTHON)" ""
-export PYTHON=$($(BLD_ARCH)_PYTHON)
-endif
-endif
-
-# if PYTHONHOME was specified above, use it for the build
-ifneq "$(PYTHONHOME)" ""
-ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64)" ""
-tmpPATH=$(PYTHONHOME)/bin:$(PATH)
-export PATH:=$(tmpPATH)
-tmpLD_LIBRARY_PATH=$(PYTHONHOME)/lib:$($(BLD_WHERE_THE_LIBRARY_THINGS_ARE))
-export $(BLD_WHERE_THE_LIBRARY_THINGS_ARE):=$(tmpLD_LIBRARY_PATH)
-endif
-endif
 
 ##
 ## Control if PATH and LD_LIBRARY_PATH|DYLD_LIBRARY_PATH values are displayed.

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -80,13 +80,13 @@ pygresql:
 		unset LIBPATH; \
 		./generate-greenplum-path.sh $(prefix) > $(DESTDIR)$(prefix)/greenplum_path.sh ; \
 	fi
-	. $(DESTDIR)$(prefix)/greenplum_path.sh && unset PYTHONHOME && \
+	. $(DESTDIR)$(prefix)/greenplum_path.sh && \
 	if [ "$(BLD_ARCH)" = 'aix7_ppc_64' ]; then \
 	    unset PYTHONPATH && cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python_64 setup.py build; \
 	elif [ `uname -s` = 'OpenBSD' ]; then \
 	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC=cc python setup.py build; \
 	else \
-	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python setup.py build; \
+	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" env -u CC python setup.py build; \
 	fi
 	mkdir -p $(PYLIB_DIR)/pygresql
 	if [ `uname -s` = 'Darwin' ]; then \
@@ -122,7 +122,7 @@ lockfile:
 subprocess32:
 	@echo "--- subprocess32, Linux only"
 	@if [ `uname -s` = 'Linux' ]; then \
-		  cd $(PYLIB_SRC)/subprocess32 && CC="$(CC)" python setup.py build; \
+		  cd $(PYLIB_SRC)/subprocess32 && env -u CC python setup.py build; \
 		  cp -f $(PYLIB_SRC)/subprocess32/build/lib.*/* $(PYLIB_DIR)/;  \
 		  cp -f $(PYLIB_SRC)/subprocess32/ChangeLog $(PYLIB_DIR)/subprocess32-ChangeLog;  \
 	  fi
@@ -137,7 +137,7 @@ psutil:
 	@echo "--- psutil"
 ifeq "$(findstring $(BLD_ARCH),aix7_ppc_64 )" ""
 	cd $(PYLIB_SRC_EXT)/ && $(TAR) xzf $(PSUTIL_DIR).tar.gz
-	cd $(PYLIB_SRC_EXT)/$(PSUTIL_DIR)/ && CC="$(CC)" python setup.py build
+	cd $(PYLIB_SRC_EXT)/$(PSUTIL_DIR)/ && env -u CC python setup.py build
 	cp -r $(PYLIB_SRC_EXT)/$(PSUTIL_DIR)/build/lib.*/psutil $(PYLIB_DIR)
 endif
 

--- a/gpMgmt/bin/README.md
+++ b/gpMgmt/bin/README.md
@@ -1,24 +1,23 @@
+# For Developers
+
+To install the libraries necessary for running scripts or testing, a system python of 2.7 must be available, the version of gcc and g++ used to compile python must be available.
+On most distributions, python will compiled with the same gcc and g++ verion available from the base packages "gcc" and "gcc-c++".
+
+The command `python -VV` will show the compiler used to compile the version of python being used.
+A `make` in from gpMgmt will install the proper libraries provided a gcc and gcc-c++ are present.
+
+To run any of these python scripts, necessary libraries must be installed, and PYTHONPATH must be modified to use the libraries in this path.
+
+```
+PYTHONPATH="\$GPHOME/lib/python:${PYTHONPATH}"
+```
+
+This will be set automatically with a `source $GPHOME/greenplum_path.sh`
 
 
-=-=-=-=-=-=-=-=-=-=-=- PYTHON =-=-=-=-=-=-=-=-=-=-=-=
+## Python Version
 
-For Developers
-==============
-
-If you'd like to run the python scripts directly from this 
-directory you will need to modify your PYTHONPATH variable to add the "ext" 
-directory.  so something like:
-
-	export PYTHONPATH=~/dev/cdb2/gpMgmt/bin/ext
-
-should do the trick.
-
-
-Python Version
---------------
-
-* The current utilities bundle python 2.5.1.  We are planning on moving 
-  forward to 2.6.1 in the near future.
+System python 2.7 is currently required.
 
 
 Where Things Go
@@ -158,8 +157,7 @@ util/ssh_session.py  - SSH and SCP related utility functions brought in from gpm
                        that are used by gpssh, gpscp and gpssh-exkeys
 
 
-Testing Management Scripts
---------------------------
+## Testing Management Scripts (unit tests)
 
 This directory contains the unit tests for the management scripts. These tests
 require the following Python modules to be installed: mock and pygresql.
@@ -184,3 +182,22 @@ run all of the unit tests.
 "python -m unittest discover --verbose -s gppylib -p 'test_unit*.py'" will run only the unit
 tests that do not require a running cluster.
 
+## Testing Management Scripts (behave tests)
+
+Behave tests require a running Greenplum cluster, and additional python libraries for testing, available to gpadmin.
+
+Thus, you can install these additional python libraries using any of the following methods:
+
+1. As root user, to be available globally:
+
+```
+sudo pip install -r gpMgmt/requirements-dev.txt
+```
+
+2. As gpadmin user, to be available only to gpadmin user, but overriding any overlapping libraries with the specific verions in this requirements file:
+
+```
+pip install --user -r gpMgmt/requirements-dev.txt
+```
+
+3. As gpadmin, using a virtual env - see additional documentation on using a virtual env on python.org

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -40,20 +40,9 @@ if [ -h \${GPHOME}/../greenplum-db ]; then
 fi
 EOF
 
-cat <<EOF
-#setup PYTHONHOME
-if [ -x \$GPHOME/ext/python/bin/python ]; then
-    PYTHONHOME="\$GPHOME/ext/python"
-    export PYTHONHOME
-fi
-EOF
 
 #setup PYTHONPATH
-if [ "x${PYTHONPATH}" == "x" ]; then
-    PYTHONPATH="\$GPHOME/lib/python"
-else
-    PYTHONPATH="\$GPHOME/lib/python:${PYTHONPATH}"
-fi
+PYTHONPATH="\$GPHOME/lib/python:${PYTHONPATH}"
 cat <<EOF
 PYTHONPATH=${PYTHONPATH}
 EOF
@@ -61,10 +50,6 @@ EOF
 GP_BIN_PATH=\$GPHOME/bin
 GP_LIB_PATH=\$GPHOME/lib
 
-if [ -n "$PYTHONHOME" ]; then
-    GP_BIN_PATH=${GP_BIN_PATH}:\$PYTHONHOME/bin
-    GP_LIB_PATH=${GP_LIB_PATH}:\$PYTHONHOME/lib
-fi
 cat <<EOF
 PATH=${GP_BIN_PATH}:\$PATH
 EOF


### PR DESCRIPTION
Currently, Greenplum is built with a vendored python in $GPHOME/lib/python, which is then set to be the PYTHONHOME environment value after sourcing `greenplum_path.sh` 

This PR removes the requirement to vendor python in this directory, and by extension, unsets the PYTHONHOME environment variable.

This has several implications to the build and installation process.

With regards to building:
- previously, our vendored python provided the python headers necessary to compile pl/python. Now, these headers must be provided by python-devel (in RHEL or Suse environments) or python-dev (in Debian-based systems) to compile Greenplum.
- The python libraries that we ship, which include pygresql and psutil, should be compiled with system gcc - the same gcc version which compiled python that they are running against. Therefore, while a developer may be compiling greenplum with a higher gcc version, a system gcc needs to be installed in order to build the vendored python libraries and complete building Greenplum.
> PL/python is still built with the compiler which builds Greenplum.

With regards to running:
- A system python 2.7 is now required to run greenplum. This is not an issue on any current officially supported platform (Ubuntu 18.04, SLES 12, or RHEL/Centos 7) as they ship with a compatible python. However, some systems like Ubuntu 20.04 will need to install a legacy python 2 for the time being in order to run the utilities.

The scope of this PR is two commits:
1. Unvendoring python, which is largely done in the Makefiles, especially gpAux Makefile, and some related unsetting of PYTHONHOME and adjusting the PYTHONPATH. 
2. CI improvements to make both Unvendoring python possible and toolchain improvements to make it easier, which includes using a "system provided" gcc and g++ instead of one built from source. The PR in gp-image-baking to make these changes is here: https://github.com/pivotal/gp-image-baking/pull/76

Once the gp-image-backing PR is merged, the "use dev images" commit will be dropped, using "latest" images in gpdb7 master.

The completed .rpm or .deb in the build process will also need to specify a python version as a required dependency. 