### PR TITLE
Fix the bug that GPFDIST_WATCHDOG_TIMER doesn't work.

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3611,6 +3611,7 @@ int gpfdist_init(int argc, const char* const argv[])
 
 	if (wd != NULL)
 	{
+		errno = 0;
 		val = strtol(wd, &endptr, 10);
 
 		if (errno || endptr == wd || val > INT_MAX)

--- a/src/bin/gpfdist/regress/test_watchdog.sh
+++ b/src/bin/gpfdist/regress/test_watchdog.sh
@@ -2,10 +2,17 @@
 
 GPFDIST_PID=gpfdist.pid
 
-export GPFDIST_WATCHDOG_TIMER=3
+export GPFDIST_WATCHDOG_TIMER=5
 gpfdist &
 PID=$!
 
+sleep 3
+ps -p $PID
+if [ $? -ne 0 ]; then
+wait $PID
+echo "gpfdist should be running, failed"
+exit 1
+fi
 sleep 5
 ps -p $PID
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
Just like `man strtol` says:

>   the calling program should set errno to 0 before the call, and then determine if
>   an error occurred by checking whether errno has a nonzero value after the call.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
