### PR TITLE
Refactor interconnect structs ChunkTransportState{Entry}

### DIFF
--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -361,7 +361,7 @@ CheckAndSendRecordCache(MotionLayerState *mlStates,
 	ChunkTransportStateEntry *pEntry = NULL;
 	MotionConn *conn;
 
-	getChunkTransportState(transportStates, motNodeID, &pEntry);
+	pEntry = getChunkTransportState(transportStates, motNodeID);
 
 	/*
 	 * for broadcast we only mark sent_record_typmod for connection 0 for
@@ -997,7 +997,7 @@ addChunkToSorter(MotionLayerState *mlStates,
 
 	chunkSorterEntry = getChunkSorterEntry(mlStates, pMNEntry, srcRoute);
 
-	getChunkTransportState(transportStates, motNodeID, &pEntry);
+	pEntry = getChunkTransportState(transportStates, motNodeID);
 	conn = pEntry->conns + srcRoute;
 
 	/* Look at the chunk's type, to figure out what to do with it. */

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -326,35 +326,13 @@ typedef struct ChunkTransportStateEntry
 	 */
 	mpp_fd_set  readSet;
 
-	/* highest file descriptor in the readSet. */
-	int			highReadSock;
-
     int         scanStart;
 
 	/* slice table entries */
 	struct ExecSlice *sendSlice;
 	struct ExecSlice *recvSlice;
 
-	/* setup info */
-	int			txfd;
-	int			txfd_family;
-	unsigned short txport;
-
-	bool		sendingEos;
-
-	/* Statistics info for this motion on the interconnect level */
-	uint64 stat_total_ack_time;
-	uint64 stat_count_acks;
-	uint64 stat_max_ack_time;
-	uint64 stat_min_ack_time;
-	uint64 stat_count_resent;
-	uint64 stat_max_resent;
-	uint64 stat_count_dropped;
-
 }	ChunkTransportStateEntry;
-
-/* ChunkTransportState array initial size */
-#define CTS_INITIAL_SIZE (10)
 
 /*
  * This structure is used to keep track of partially completed tuples,
@@ -497,21 +475,11 @@ typedef struct MotionLayerState
 
 typedef struct ChunkTransportState
 {
-	/* array of per-motion-node chunk transport state */
 	int size;
-	ChunkTransportStateEntry *states;
 
 	/* keeps track of if we've "activated" connections via SetupInterconnect(). */
 	bool		activated;
-
-	bool		aggressiveRetry;
-	
-	/* whether we've logged when network timeout happens */
-	bool		networkTimeoutIsLogged;
-
 	bool		teardownActive;
-	List		*incompleteConns;
-
 	/* slice table stuff. */
 	struct SliceTable  *sliceTable;
 	int			sliceId;
@@ -525,6 +493,7 @@ typedef struct ChunkTransportState
 	TupleChunkListItem (*RecvTupleChunkFromAny)(struct ChunkTransportState *transportStates, int16 motNodeID, int16 *srcRoute);
 	void (*doSendStopMessage)(struct ChunkTransportState *transportStates, int16 motNodeID);
 	void (*SendEos)(struct ChunkTransportState *transportStates, int motNodeID, TupleChunkListItem tcItem);
+	ChunkTransportStateEntry *(*GetChunkTransportStateEntry) (struct ChunkTransportState *transportState, int motNodeID);
 } ChunkTransportState;
 
 extern void dumpICBufferList(ICBufferList *list, const char *fname);

--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -222,26 +222,16 @@ extern void readPacket(MotionConn *conn, ChunkTransportState *transportStates);
  */
 extern void  MlPutRxBufferIFC(ChunkTransportState *transportStates, int motNodeID, int route);
 
-#define getChunkTransportState(transportState, motNodeID, ppEntry) \
-	do { \
-		Assert((transportState) != NULL);		\
-		if ((motNodeID) > 0 &&					\
-			(transportState) &&					 \
-			(motNodeID) <= (transportState)->size &&					\
-			(transportState)->states[(motNodeID)-1].motNodeId == (motNodeID) && \
-			(transportState)->states[(motNodeID)-1].valid)				\
-		{ \
-			*(ppEntry) = &(transportState)->states[(motNodeID) - 1];	\
-		} \
-		else \
-		{ \
+#define getChunkTransportState(transportState, motNodeID) \
+	({ \
+		ChunkTransportStateEntry *entry = (transportState)->GetChunkTransportStateEntry((transportState), (motNodeID)); \
+		if (!entry->valid || entry->motNodeId != (motNodeID)) \
 			ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR), \
-							errmsg("Interconnect Error: Unexpected Motion Node Id: %d (size %d). This means" \
-								   " a motion node that wasn't setup is requesting interconnect" \
-								   " resources.", (motNodeID), (transportState)->size))); \
-			/* not reached */ \
-		} \
-	} while (0)
+								errmsg("Interconnect Error: Unexpected Motion Node Id: %d (size %d). This means" \
+									   " a motion node that wasn't setup is requesting interconnect" \
+									   " resources.", (motNodeID), (transportState)->size))); \
+		entry; \
+	})
 
 #define ML_CHECK_FOR_INTERRUPTS(teardownActive) \
 		do {if (!teardownActive && InterruptPending) CHECK_FOR_INTERRUPTS(); } while (0)


### PR DESCRIPTION
We noticed that there were a lot of fields in the structs
ChunkTransportState and ChunkTransportStateEntry that were only used by
a specific interconnect type. So, we sought to specialize the structs to
fit the interconnect type, pushing interconnect-specific fields to
sub-structs.

Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>
