### PR TITLE
Temporarily disable resgroup_move_query test

### DIFF
--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -27,7 +27,7 @@ test: resgroup/resgroup_cpuset_empty_default
 test: resgroup/resgroup_set_memory_spill_ratio
 test: resgroup/resgroup_unlimit_memory_spill_ratio
 test: resgroup/resgroup_cancel_terminate_concurrency
-test: resgroup/resgroup_move_query
+#test: resgroup/resgroup_move_query
 
 # memory spill tests
 #test: resgroup/resgroup_memory_hashagg_spill


### PR DESCRIPTION
0816e4e35843122 added a new test resgroup_move_query but forgot to add
the sql src/test/isolation2/sql/resgroup/resgroup_move_query.sql or an
input file to generate it. Disable this for now so that resource group
tests will go green on master.