### PR TITLE
Add function ExecStoreTuple for compatibility with 3rd party libraries

### DIFF
--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -384,7 +384,7 @@ extern TupleTableSlot *ExecAllocTableSlot(List **tupleTable);
 extern void ExecResetTupleTable(List *tupleTable, bool shouldFree);
 extern TupleTableSlot *MakeSingleTupleTableSlot(TupleDesc tupdesc);
 extern void ExecDropSingleTupleTableSlot(TupleTableSlot *slot);
-extern void ExecSetSlotDescriptor(TupleTableSlot *slot, TupleDesc tupdesc); 
+extern void ExecSetSlotDescriptor(TupleTableSlot *slot, TupleDesc tupdesc);
 
 extern TupleTableSlot *ExecStoreHeapTuple(HeapTuple tuple,
 			   TupleTableSlot *slot,
@@ -393,6 +393,16 @@ extern TupleTableSlot *ExecStoreHeapTuple(HeapTuple tuple,
 extern TupleTableSlot *ExecStoreMinimalTuple(MemTuple mtup,
 					  TupleTableSlot *slot,
 					  bool shouldFree);
+
+/*
+ * Some external libraries such as redis_fdw are using this API, which is
+ * changed in Greenplum. Added it back.
+ */
+static inline TupleTableSlot *ExecStoreTuple(HeapTuple tuple,
+			TupleTableSlot *slot, Buffer buffer, bool shouldFree)
+{
+	return ExecStoreHeapTuple(tuple, slot, buffer, shouldFree);
+}
 
 extern TupleTableSlot *ExecClearTuple(TupleTableSlot *slot);
 extern TupleTableSlot *ExecStoreVirtualTuple(TupleTableSlot *slot);


### PR DESCRIPTION
Unlike PostgreSQL 9/10/11, Greenplum has no API ExecStoreTuple,
thus some external libraries such as redis_fdw will not compile
against Greenplum 6. Greenplum 7 has no such issue, as PostgreSQL 12
changed ExecStoreTuple to ExecStoreHeapTuple like Greenplum.

Greenplum 6 only.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
