### PR TITLE
Init gpmon packet for dynamic scan states

### DIFF
--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -122,6 +122,10 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 	if (node->ss.ps.instrument)
 		InstrStopNode(node->ss.ps.instrument, 1 /* nTuples */);
 
+	/* Increment gpmon packet too */
+	if (&node->ss.ps.gpmon_pkt)
+		Gpmon_Incr_Rows_Out(&node->ss.ps.gpmon_pkt);
+
 	return (Node *) bitmap;
 }
 


### PR DESCRIPTION
Dynamic scans use scan states to initialize and keep sidecar nodes. It is done bypassing `ExecInitNode` that normally does `gpmon` packet initialization. As a result `gpmon` is not initialized for all dynamic sidecar nodes that causes `bad magic 0` warnings. Here is an example to reproduce a problem (`gp_enable_gpperfmon` should be `on`):
```sql
create table t(a int, b date, c int) distributed by (a)
partition by range (b) subpartition by list (c)
subpartition template
(subpartition s1 values (1), subpartition s2 values(2))
(start ('2020-04-01') end('2020-05-01') every(interval '1 day'));
create index t_idx on t using bitmap (b);

select count(*) from t where b = '2020-04-02';

WARNING:  gpmon - bad magic 0  (seg1 slice1 10.92.6.98:6006 pid=7727)
WARNING:  gpmon - bad magic 0  (seg1 slice1 10.92.6.98:6006 pid=7727)
WARNING:  gpmon - bad magic 0  (seg1 slice1 10.92.6.98:6006 pid=7727)
WARNING:  gpmon - bad magic 0  (seg0 slice1 10.92.6.98:6005 pid=7726)
WARNING:  gpmon - bad magic 0  (seg2 slice1 10.92.6.98:6007 pid=7728)
WARNING:  gpmon - bad magic 0  (seg1 slice1 10.92.6.98:6006 pid=7727)
WARNING:  gpmon - bad magic 0  (seg0 slice1 10.92.6.98:6005 pid=7726)
WARNING:  gpmon - bad magic 0  (seg2 slice1 10.92.6.98:6007 pid=7728)
WARNING:  gpmon - bad magic 0  (seg0 slice1 10.92.6.98:6005 pid=7726)
WARNING:  gpmon - bad magic 0  (seg2 slice1 10.92.6.98:6007 pid=7728)
WARNING:  gpmon - bad magic 0  (seg0 slice1 10.92.6.98:6005 pid=7726)
WARNING:  gpmon - bad magic 0  (seg2 slice1 10.92.6.98:6007 pid=7728)
 count 
-------
     0
(1 row)
```
We should keep in mind that rows count for sidecar partition scan have to be consistent with a parent dynamic scan as they share the same plan_node_id. Otherwise partition sends zero row number while dynamic scan sends an actual value and this is confusing.

`gpperfmon` initialization code was not be moved into e.g. `ExecInitBitmapHeapScanForPartition` and other `...Init...` functions, as these are used in normal scans as well, where gpperfmon initialization should not be conducted.

There are no tests in a PR as I haven't found any existing `gpperfmon` tests in GP code.