### PR TITLE
Fix release job centos6

### DIFF
--- a/concourse/pipelines/README.md
+++ b/concourse/pipelines/README.md
@@ -113,13 +113,13 @@ template) to the source repository.
 
 As an example of generating a pipeline with a targeted test subset,
 the following can be used to generate a pipeline with supporting
-builds (default: centos6 platform) and `CLI` only jobs.
+builds (default: centos7 platform) and `CLI` only jobs.
 
 The generated pipeline and helper `fly` command are intended encourage
 engineers to set the pipeline with a team-name-string (-t) and engineer
 (-u) identifiable names.
 
-NOTE: The majority of jobs are only available for the `centos6`
+NOTE: The majority of jobs are only available for the `centos7`
       platform.
 
 ```
@@ -129,7 +129,7 @@ $ ./gen_pipeline.py -t dpm -u curry -a CLI
   Generate Pipeline type: .. : dpm
   Pipeline file ............ : gpdb-dpm-curry.yml
   Template file ............ : gpdb-tpl.yml
-  OS Types ................. : ['centos6']
+  OS Types ................. : ['centos7']
   Test sections ............ : ['CLI']
   test_trigger ............. : True
 ======================================================================
@@ -148,16 +148,16 @@ fly -t gpdb-dev \
 ```
 
 Use the following to generate a pipeline with `ICW` and `CS` test jobs
-for `centos6` and `ubuntu18.04` platforms.
+for `centos7` and `ubuntu18.04` platforms.
 
 ```
-$ ./gen_pipeline.py -t cs -u durant -O {centos6,ubuntu18.04} -a {ICW,CS}
+$ ./gen_pipeline.py -t cs -u durant -O {centos7,ubuntu18.04} -a {ICW,CS}
 
 ======================================================================
   Generate Pipeline type: .. : cs
   Pipeline file ............ : gpdb-cs-durant.yml
   Template file ............ : gpdb-tpl.yml
-  OS Types ................. : ['centos6', 'ubuntu18.04']
+  OS Types ................. : ['centos7', 'ubuntu18.04']
   Test sections ............ : ['ICW', 'CS']
   test_trigger ............. : True
 ======================================================================

--- a/concourse/scripts/verify_gpdb_versions.bash
+++ b/concourse/scripts/verify_gpdb_versions.bash
@@ -25,7 +25,7 @@ yum -d0 -y install git
 GREENPLUM_INSTALL_DIR=/usr/local/greenplum-db-devel
 GPDB_SRC_SHA=$(cd gpdb_src && git rev-parse HEAD)
 
-for bin_gpdb in bin_gpdb_{centos{6,7},ubuntu18.04}; do
+for bin_gpdb in bin_gpdb_{centos7,ubuntu18.04}; do
   install_greenplum "$bin_gpdb" "${GREENPLUM_INSTALL_DIR}"
   assert_postgres_version_matches "$GPDB_SRC_SHA" "${GREENPLUM_INSTALL_DIR}"
 done


### PR DESCRIPTION
Missed a hard coded check for centos 6 in release job. This should resolve failures in release job caused by this check.