### PR TITLE
Dont generate tablespaces information during --check

### DIFF
--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -91,7 +91,8 @@ check_and_dump_old_cluster(bool live_check, char **sequence_script_file_name)
 	/* Extract a list of databases and tables from the old cluster */
 	get_db_and_rel_infos(&old_cluster);
 
-	init_tablespaces();
+	if (!user_opts.check || is_greenplum_dispatcher_mode())
+		init_tablespaces();
 
 	get_loadable_libraries();
 

--- a/contrib/pg_upgrade/test/integration/utilities/pg-upgrade-copy.c
+++ b/contrib/pg_upgrade/test/integration/utilities/pg-upgrade-copy.c
@@ -1,7 +1,4 @@
-#include "postgres_fe.h"
-#include "greenplum/old_tablespace_file_contents.h"
-
-/* 
+/*
  * Implements
  */
 #include "pg-upgrade-copy.h"


### PR DESCRIPTION
During --check there is no need to pass the tablespaces information. No checks are performed regarding to tablespaces.
