### PR TITLE
Add missing format attributes in Orca

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,14 @@ python:
 before_install:
     - eval "${OVERRIDE_CC}"
     - eval "${OVERRIDE_CXX}"
+    # ccache 3.2 (from Ubuntu Xenial) has CCACHE_CPP2 default to off (this
+    # setting defaults to on starting from ccache 3.3). That default leads to
+    # unlegible compiler warning outputs because GCC and Clang will emit
+    # warnings using the preprocessed output...
+    - |
+      if [ "${TRAVIS_DIST}" = xenial ]; then
+        ccache --set-config run_second_cpp=true
+      fi
     - |
       if [ "${TRAVIS_COMPILER}" = clang ]; then
         case "${TRAVIS_OS_NAME}" in

--- a/configure
+++ b/configure
@@ -5294,11 +5294,6 @@ if test x"$pgac_cv_prog_cc_cflags__Wmissing_format_attribute" = x"yes"; then
   CFLAGS="$CFLAGS -Wmissing-format-attribute"
 fi
 
-  # FIXME: ORCA has a couple of printf-like functions that would result in
-  # stern warnings from the compiler for not having a "format" attribute, once
-  # we decorate them all with the "format" attribute, revert this temporary fix
-  # (I promise this is temporary)
-  NOT_THE_CXXFLAGS=""
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CXX supports -Wmissing-format-attribute" >&5
 $as_echo_n "checking whether $CXX supports -Wmissing-format-attribute... " >&6; }
 if ${pgac_cv_prog_cxx_cxxflags__Wmissing_format_attribute+:} false; then :
@@ -5343,12 +5338,9 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cxx_cxxflags__Wmissing_format_attribute" >&5
 $as_echo "$pgac_cv_prog_cxx_cxxflags__Wmissing_format_attribute" >&6; }
 if test x"$pgac_cv_prog_cxx_cxxflags__Wmissing_format_attribute" = x"yes"; then
-  NOT_THE_CXXFLAGS="${NOT_THE_CXXFLAGS} -Wmissing-format-attribute"
+  CXXFLAGS="${CXXFLAGS} -Wmissing-format-attribute"
 fi
 
-  if test -n "$NOT_THE_CXXFLAGS"; then
-    CXXFLAGS="$CXXFLAGS -Wno-missing-format-attribute"
-  fi
   # This was included in -Wall/-Wformat in older GCC versions
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wformat-security" >&5
 $as_echo_n "checking whether $CC supports -Wformat-security... " >&6; }

--- a/configure.in
+++ b/configure.in
@@ -623,15 +623,7 @@ if test "$GCC" = yes -a "$ICC" = no; then
   PGAC_PROG_CC_CFLAGS_OPT([-Wendif-labels])
   PGAC_PROG_CXX_CXXFLAGS_OPT([-Wendif-labels])
   PGAC_PROG_CC_CFLAGS_OPT([-Wmissing-format-attribute])
-  # FIXME: ORCA has a couple of printf-like functions that would result in
-  # stern warnings from the compiler for not having a "format" attribute, once
-  # we decorate them all with the "format" attribute, revert this temporary fix
-  # (I promise this is temporary)
-  NOT_THE_CXXFLAGS=""
-  PGAC_PROG_CXX_VAR_OPT(NOT_THE_CXXFLAGS, [-Wmissing-format-attribute])
-  if test -n "$NOT_THE_CXXFLAGS"; then
-    CXXFLAGS="$CXXFLAGS -Wno-missing-format-attribute"
-  fi
+  PGAC_PROG_CXX_CXXFLAGS_OPT([-Wmissing-format-attribute])
   # This was included in -Wall/-Wformat in older GCC versions
   PGAC_PROG_CC_CFLAGS_OPT([-Wformat-security])
   PGAC_PROG_CXX_CXXFLAGS_OPT([-Wformat-security])

--- a/src/backend/gporca/libgpos/include/gpos/attributes.h
+++ b/src/backend/gporca/libgpos/include/gpos/attributes.h
@@ -1,0 +1,13 @@
+#ifndef GPOS_attributes_H
+#define GPOS_attributes_H
+
+#ifdef USE_CMAKE
+#define GPOS_FORMAT_ARCHETYPE printf
+#else
+#include "pg_config.h"
+#define GPOS_FORMAT_ARCHETYPE PG_PRINTF_ATTRIBUTE
+#endif
+
+#define GPOS_ATTRIBUTE_PRINTF(f, a) __attribute__((format(GPOS_FORMAT_ARCHETYPE, f, a)))
+
+#endif // !GPOS_attributes_H

--- a/src/backend/gporca/libgpos/include/gpos/common/clibwrapper.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/clibwrapper.h
@@ -19,6 +19,7 @@
 
 #include <unistd.h>
 #include "gpos/types.h"
+#include "gpos/attributes.h"
 #include "gpos/common/clibtypes.h"
 
 namespace gpos
@@ -92,7 +93,7 @@ namespace gpos
 		INT Vswprintf(WCHAR *wcstr, SIZE_T max_len, const WCHAR * format, VA_LIST vaArgs);
 
 		// format string
-		INT Vsnprintf(CHAR *src, SIZE_T size, const CHAR *format, VA_LIST vaArgs);
+		INT Vsnprintf(CHAR *src, SIZE_T size, const CHAR *format, VA_LIST vaArgs) GPOS_ATTRIBUTE_PRINTF(3, 0);
 
 		// return string describing error number
 		void Strerror_r(INT errnum, CHAR *buf, SIZE_T buf_len);

--- a/src/backend/gporca/libgpos/include/gpos/string/CStringStatic.h
+++ b/src/backend/gporca/libgpos/include/gpos/string/CStringStatic.h
@@ -12,6 +12,7 @@
 #define GPOS_CStringStatic_H
 
 #include "gpos/base.h"
+#include "gpos/attributes.h"
 #include "gpos/common/clibwrapper.h"
 
 #define GPOS_SZ_LENGTH(x) gpos::clib::Strlen(x)
@@ -100,10 +101,10 @@ namespace gpos
 			void AppendBuffer(const CHAR *buf);
 
 			// appends a formatted string
-			void AppendFormat(const CHAR *format, ...);
+			void AppendFormat(const CHAR *format, ...) GPOS_ATTRIBUTE_PRINTF(2, 3);
 
 			// appends a formatted string based on passed va list
-			void AppendFormatVA(const CHAR *format, VA_LIST va_args);
+			void AppendFormatVA(const CHAR *format, VA_LIST va_args) GPOS_ATTRIBUTE_PRINTF(2, 0);
 
 			// appends wide character string
 			void AppendConvert(const WCHAR *wc_str);

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/io/CFileTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/io/CFileTest.cpp
@@ -271,19 +271,18 @@ CFileTest::Unittest_MkTmpFile
 	GPOS_ASSERT(NULL != szTmpDir);
 	GPOS_ASSERT(NULL != szTmpFile);
 
-	CStringStatic strTmpDir(szTmpDir, GPOS_FILE_NAME_BUF_SIZE);
-	CStringStatic strTmpFile(szTmpFile, GPOS_FILE_NAME_BUF_SIZE);
-
-	const CHAR szDir[GPOS_FILE_NAME_BUF_SIZE] = "/tmp/CFileTest.XXXXXX";
-	const CHAR szFile[GPOS_FILE_NAME_BUF_SIZE] = "/CFileTest_file.txt";
+	CHAR szDir[] = "/tmp/CFileTest.XXXXXX";
+	const CHAR szFile[] = "/CFileTest_file.txt";
 
 	// create unique temporary directory name under /tmp
-	strTmpDir.AppendFormat(szDir);
-	ioutils::CreateTempDir(szTmpDir);
+	ioutils::CreateTempDir(szDir);
+
+	// copy the temporary directory name into szTmpDir
+	CStringStatic strTmpDir(szTmpDir, GPOS_FILE_NAME_BUF_SIZE, szDir);
+	CStringStatic strTmpFile(szTmpFile, GPOS_FILE_NAME_BUF_SIZE);
 
 	// unique temporary file name
-	strTmpFile.AppendFormat(szTmpDir);
-	strTmpFile.AppendFormat(szFile);
+	strTmpFile.AppendFormat("%s%s", szDir, szFile);
 
 }
 


### PR DESCRIPTION
Add `__format__` decorations for printf format checking to all ORCA functions that were missing them (uncovered by reverting commit 942448b).

When we build the ORCA test suite with CMake, we don't get to use Greenplum's configure infrastructure that determines the best format archetype (gnu_printf if available). ~For simplicity, just hardcode "printf", it's virtually universally supported.~ Add some CMake smarts to mimic what `configure` would do.

As part of this patch set, we also fix a problem the newly added attribute reveals. See each commit message for detail.