### PR TITLE
Fix how must_gather is determined with LIMIT ALL.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2814,7 +2814,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		 * SELECT DISTINCT query as argument to a table function?
 		 */
 		!parse->isTableValueSelect &&
-		!parse->limitCount && !parse->limitOffset)
+		!limit_needed(parse))
 	{
 		must_gather = true;
 	}

--- a/src/test/regress/expected/limit_gp.out
+++ b/src/test/regress/expected/limit_gp.out
@@ -177,3 +177,27 @@ explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a
 
 drop table t_volatile_limit;
 drop table t_volatile_limit_1;
+-- Check LIMIT ALL should not be considered when gathering data to a single node
+create table t_limit_all(a int, b int) distributed by (a);
+insert into t_limit_all select i, i from generate_series(1,10)i;
+explain (costs off)
+select array(select b from t_limit_all order by b asc limit all) t;
+                    QUERY PLAN                    
+--------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 3:1  (slice1; segments: 3)
+           Merge Key: b
+           ->  Sort
+                 Sort Key: b
+                 ->  Seq Scan on t_limit_all
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select array(select b from t_limit_all order by b asc limit all) t;
+           t            
+------------------------
+ {1,2,3,4,5,6,7,8,9,10}
+(1 row)
+
+drop table t_limit_all;

--- a/src/test/regress/expected/limit_gp_optimizer.out
+++ b/src/test/regress/expected/limit_gp_optimizer.out
@@ -161,3 +161,27 @@ explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a
 
 drop table t_volatile_limit;
 drop table t_volatile_limit_1;
+-- Check LIMIT ALL should not be considered when gathering data to a single node
+create table t_limit_all(a int, b int) distributed by (a);
+insert into t_limit_all select i, i from generate_series(1,10)i;
+explain (costs off)
+select array(select b from t_limit_all order by b asc limit all) t;
+                    QUERY PLAN                    
+--------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 3:1  (slice1; segments: 3)
+           Merge Key: b
+           ->  Sort
+                 Sort Key: b
+                 ->  Seq Scan on t_limit_all
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select array(select b from t_limit_all order by b asc limit all) t;
+           t            
+------------------------
+ {1,2,3,4,5,6,7,8,9,10}
+(1 row)
+
+drop table t_limit_all;

--- a/src/test/regress/sql/limit_gp.sql
+++ b/src/test/regress/sql/limit_gp.sql
@@ -56,3 +56,13 @@ explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a
 
 drop table t_volatile_limit;
 drop table t_volatile_limit_1;
+
+-- Check LIMIT ALL should not be considered when gathering data to a single node
+create table t_limit_all(a int, b int) distributed by (a);
+insert into t_limit_all select i, i from generate_series(1,10)i;
+
+explain (costs off)
+select array(select b from t_limit_all order by b asc limit all) t;
+select array(select b from t_limit_all order by b asc limit all) t;
+
+drop table t_limit_all;


### PR DESCRIPTION
If there is ORDER BY or DISTINCT in the query, we need to bring all the
data to a single node by setting must_gather to be true. An exception is
when there's a LIMIT or OFFSET clause, which would be handled later when
inserting Limit node. Here to tell if there is any LIMIT or OFFSET
clause, we should use limit_needed, instead of checking limitCount or
limitOffset directly.

Fixes issue #9746.

Reviewed-by: Heikki Linnakangas <hlinnakangas@pivotal.io>
Reviewed-by: Ekta Khanna <ekhanna@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
