### PR TITLE
global deadlock detector process  will terminated with signal 11

### DIFF
--- a/src/backend/utils/gdd/gddfuncs.c
+++ b/src/backend/utils/gdd/gddfuncs.c
@@ -50,6 +50,7 @@ static const char *const LockTagTypeNames[] = {
 	"append-only segment file",
 	"object",
 	"resource queue",
+	"distributed xid",
 	"userlock",
 	"advisory"
 };


### PR DESCRIPTION
for is commit ID:13a1f66ffcc16a5369f02273addfb4b0a7bba033
LockTagTypeNames array in file src/backend/utils/gdd/gddfuncs.c is No synchronous modification.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
