### PR TITLE
Revert "Don't suppress unused-but-set variable warning."

### DIFF
--- a/configure
+++ b/configure
@@ -5682,6 +5682,46 @@ if test x"$pgac_cv_prog_cxx_cxxflags__fexcess_precision_standard" = x"yes"; then
 fi
 
 
+  # Silence compiler warnings about variables that are set, but otherwise
+  # unused. All of these warnings have been fixed in PostgreSQL, but there is
+  # still someGPDB added code that emit these. TODO: Fix the GPDB code and
+  # remove this.
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wno-unused-but-set-variable" >&5
+$as_echo_n "checking whether $CC supports -Wno-unused-but-set-variable... " >&6; }
+if ${pgac_cv_prog_cc_cflags__Wno_unused_but_set_variable+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CFLAGS=$CFLAGS
+CFLAGS="$pgac_save_CFLAGS -Wno-unused-but-set-variable"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  pgac_cv_prog_cc_cflags__Wno_unused_but_set_variable=yes
+else
+  pgac_cv_prog_cc_cflags__Wno_unused_but_set_variable=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$pgac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__Wno_unused_but_set_variable" >&5
+$as_echo "$pgac_cv_prog_cc_cflags__Wno_unused_but_set_variable" >&6; }
+if test x"$pgac_cv_prog_cc_cflags__Wno_unused_but_set_variable" = x"yes"; then
+  CFLAGS="$CFLAGS -Wno-unused-but-set-variable"
+fi
+
+
   # We rely on /* fallthrough */ comments to signal explicit fallthrough, but
   # some compilers (clang) don't recognize those and give spurious errors. Make
   # sure the compiler supports fallthrough comments by explicitly requesting

--- a/configure.in
+++ b/configure.in
@@ -645,6 +645,12 @@ if test "$GCC" = yes -a "$ICC" = no; then
   PGAC_PROG_CC_CFLAGS_OPT([-fexcess-precision=standard])
   PGAC_PROG_CXX_CXXFLAGS_OPT([-fexcess-precision=standard])
 
+  # Silence compiler warnings about variables that are set, but otherwise
+  # unused. All of these warnings have been fixed in PostgreSQL, but there is
+  # still someGPDB added code that emit these. TODO: Fix the GPDB code and
+  # remove this.
+  PGAC_PROG_CC_CFLAGS_OPT([-Wno-unused-but-set-variable])
+
   # We rely on /* fallthrough */ comments to signal explicit fallthrough, but
   # some compilers (clang) don't recognize those and give spurious errors. Make
   # sure the compiler supports fallthrough comments by explicitly requesting


### PR DESCRIPTION
On HEAD (commit 5cc2ea505f9b7) we're seeing a flurry of 78 warnings of
unused-but-set-variable warnings using GCC 9. We were clearly not ready
for this change. I was blindsided by my local choice of tools (Clang 10)
when I thought we were warning-free.

This reverts commit ec1f5f089ae13096f6bfa8ecd6b06e8efdbb91fa.

## Here are some reminders before you submit the pull request
- [ ] Communicate in the mailing list if needed
