### PR TITLE
Add a threshold for creating eageragg alternative

### DIFF
--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -426,6 +426,8 @@ COptTasks::CreateOptimizerConfig
 	ULONG join_order_threshold = (ULONG) optimizer_join_order_threshold;
 	ULONG broadcast_threshold = (ULONG) optimizer_penalize_broadcast_threshold;
 	ULONG push_group_by_below_setop_threshold = (ULONG) optimizer_push_group_by_below_setop_threshold;
+	DOUBLE eageragg_threshold = (DOUBLE) optimizer_eageragg_threshold;
+
 
 	return GPOS_NEW(mp) COptimizerConfig
 						(
@@ -442,7 +444,8 @@ COptTasks::CreateOptimizerConfig
 								broadcast_threshold,
 								false, /* don't create Assert nodes for constraints, we'll
 								      * enforce them ourselves in the executor */
-								push_group_by_below_setop_threshold
+								push_group_by_below_setop_threshold,
+								eageragg_threshold
 								),
 						GPOS_NEW(mp) CWindowOids(OID(F_WINDOW_ROW_NUMBER), OID(F_WINDOW_RANK))
 						);

--- a/src/backend/gporca/data/dxl/minidump/EagerAggEmptyInput.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggEmptyInput.mdp
@@ -328,7 +328,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="320">
+    <dxl:Plan Id="0" SpaceSize="120">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000677" Rows="1.000000" Width="12"/>
@@ -366,7 +366,7 @@
             </dxl:ProjElem>
             <dxl:ProjElem ColId="20" Alias="min">
               <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Final">
-                <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
               </dxl:AggFunc>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -382,8 +382,8 @@
               <dxl:ProjElem ColId="11" Alias="g2">
                 <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
@@ -404,8 +404,8 @@
                 <dxl:ProjElem ColId="11" Alias="g2">
                   <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                  <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                  <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -429,8 +429,8 @@
                   <dxl:ProjElem ColId="11" Alias="g2">
                     <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                    <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                    <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
@@ -444,7 +444,7 @@
                     <dxl:GroupingColumn ColId="11"/>
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+                    <dxl:ProjElem ColId="21" Alias="ColRef_0021">
                       <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Partial">
                         <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                       </dxl:AggFunc>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
@@ -324,10 +324,10 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="96">
+    <dxl:Plan Id="0" SpaceSize="24">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000604" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000599" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="g1">
@@ -344,7 +344,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000559" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000555" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="1"/>
@@ -358,25 +358,25 @@
               <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="20" Alias="max">
-              <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final">
-                <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
+              <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal">
+                <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
               </dxl:AggFunc>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000553" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000548" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="g1">
                 <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="s1">
+                <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
               <dxl:ProjElem ColId="11" Alias="g2">
                 <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
@@ -388,17 +388,17 @@
             <dxl:LimitOffset/>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000553" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000548" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="g1">
                   <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="s1">
+                  <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="11" Alias="g2">
                   <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                  <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -411,14 +411,14 @@
               </dxl:HashCondList>
               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="g1">
                     <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                    <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="2" Alias="s1">
+                    <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
@@ -428,95 +428,42 @@
                     <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
-                <dxl:Result>
+                <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="g1">
                       <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                      <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="2" Alias="s1">
+                      <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="1"/>
-                    </dxl:GroupingColumns>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                        <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial">
-                          <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
-                        </dxl:AggFunc>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="g1">
-                        <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Sort SortDiscardDuplicates="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="1" Alias="g1">
-                          <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="s1">
-                          <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      </dxl:SortingColumnList>
-                      <dxl:LimitCount/>
-                      <dxl:LimitOffset/>
-                      <dxl:TableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="1" Alias="g1">
-                            <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="2" Alias="s1">
-                            <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:OpExpr OperatorName="%" OperatorMdid="0.530.1.0" OperatorType="0.23.1.0">
-                              <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                            </dxl:OpExpr>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                          </dxl:Comparison>
-                        </dxl:Filter>
-                        <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="foo">
-                          <dxl:Columns>
-                            <dxl:Column ColId="0" Attno="1" ColName="j1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="1" Attno="2" ColName="g1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="2" Attno="3" ColName="s1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:Sort>
-                  </dxl:Aggregate>
-                </dxl:Result>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:OpExpr OperatorName="%" OperatorMdid="0.530.1.0" OperatorType="0.23.1.0">
+                        <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                      </dxl:OpExpr>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="foo">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="j1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="1" Attno="2" ColName="g1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="2" Attno="3" ColName="s1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
               </dxl:RedistributeMotion>
               <dxl:TableScan>
                 <dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggMax.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggMax.mdp
@@ -327,7 +327,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="320">
+    <dxl:Plan Id="0" SpaceSize="120">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000677" Rows="1.000000" Width="12"/>
@@ -365,7 +365,7 @@
             </dxl:ProjElem>
             <dxl:ProjElem ColId="20" Alias="max">
               <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final">
-                <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
               </dxl:AggFunc>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -381,8 +381,8 @@
               <dxl:ProjElem ColId="11" Alias="g2">
                 <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
@@ -403,8 +403,8 @@
                 <dxl:ProjElem ColId="11" Alias="g2">
                   <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                  <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                  <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -428,8 +428,8 @@
                   <dxl:ProjElem ColId="11" Alias="g2">
                     <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                    <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                    <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
@@ -443,7 +443,7 @@
                     <dxl:GroupingColumn ColId="11"/>
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+                    <dxl:ProjElem ColId="21" Alias="ColRef_0021">
                       <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial">
                         <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
                       </dxl:AggFunc>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggSubquery.mdp
@@ -373,10 +373,10 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11640">
+    <dxl:Plan Id="0" SpaceSize="4448">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324463.236868" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324463.145074" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="g1">
@@ -393,7 +393,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324463.236808" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324463.145015" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="1"/>
@@ -407,25 +407,25 @@
               <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="30" Alias="sum">
-              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final">
-                <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
+              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal">
+                <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
               </dxl:AggFunc>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324463.236789" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324463.145000" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="g1">
                 <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="s1">
+                <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
               <dxl:ProjElem ColId="11" Alias="g2">
                 <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="33" Alias="ColRef_0033">
-                <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
@@ -437,17 +437,17 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324463.236789" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324463.145000" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="g1">
                   <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="s1">
+                  <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="11" Alias="g2">
                   <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="33" Alias="ColRef_0033">
-                  <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -462,17 +462,17 @@
               </dxl:HashExprList>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324463.236764" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324463.144981" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="g1">
                     <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="s1">
+                    <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="11" Alias="g2">
                     <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="33" Alias="ColRef_0033">
-                    <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
@@ -483,165 +483,45 @@
                     <dxl:Ident ColId="10" ColName="j2" TypeMdid="0.23.1.0"/>
                   </dxl:Comparison>
                 </dxl:HashCondList>
-                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.236242" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000111" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="0"/>
-                    <dxl:GroupingColumn ColId="1"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="33" Alias="ColRef_0033">
-                      <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial">
-                        <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
-                      </dxl:AggFunc>
-                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="0" Alias="j1">
                       <dxl:Ident ColId="0" ColName="j1" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="1" Alias="g1">
                       <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="s1">
+                      <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:Sort SortDiscardDuplicates="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324032.236221" Rows="1.000000" Width="12"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="j1">
-                        <dxl:Ident ColId="0" ColName="j1" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="g1">
-                        <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="s1">
-                        <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList>
-                      <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                    </dxl:SortingColumnList>
-                    <dxl:LimitCount/>
-                    <dxl:LimitOffset/>
-                    <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324032.236221" Rows="1.000000" Width="12"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="0" Alias="j1">
-                          <dxl:Ident ColId="0" ColName="j1" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1" Alias="g1">
-                          <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="s1">
-                          <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:JoinFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:JoinFilter>
-                      <dxl:TableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000111" Rows="1.000000" Width="12"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="0" Alias="j1">
-                            <dxl:Ident ColId="0" ColName="j1" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="1" Alias="g1">
-                            <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="2" Alias="s1">
-                            <dxl:Ident ColId="2" ColName="s1" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
-                            <dxl:Ident ColId="0" ColName="j1" TypeMdid="0.23.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:Filter>
-                        <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="foo">
-                          <dxl:Columns>
-                            <dxl:Column ColId="0" Attno="1" ColName="j1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="1" Attno="2" ColName="g1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="2" Attno="3" ColName="s1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                      <dxl:Materialize Eager="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000068" Rows="3.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList/>
-                        <dxl:Filter/>
-                        <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="3.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:Limit>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList/>
-                            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
-                              </dxl:Properties>
-                              <dxl:ProjList/>
-                              <dxl:Filter/>
-                              <dxl:SortingColumnList/>
-                              <dxl:TableScan>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="1"/>
-                                </dxl:Properties>
-                                <dxl:ProjList/>
-                                <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="0.16388.1.0" TableName="bar">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="20" Attno="1" ColName="j2" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                    <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                            </dxl:GatherMotion>
-                            <dxl:LimitCount>
-                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                            </dxl:LimitCount>
-                            <dxl:LimitOffset>
-                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                            </dxl:LimitOffset>
-                          </dxl:Limit>
-                        </dxl:BroadcastMotion>
-                      </dxl:Materialize>
-                    </dxl:NestedLoopJoin>
-                  </dxl:Sort>
-                </dxl:Aggregate>
-                <dxl:TableScan>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="0" ColName="j1" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="foo">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="j1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="1" Attno="2" ColName="g1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="2" Attno="3" ColName="s1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+                <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.144393" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="10" Alias="j2">
@@ -652,20 +532,91 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.16388.1.0" TableName="bar">
-                    <dxl:Columns>
-                      <dxl:Column ColId="10" Attno="1" ColName="j2" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="11" Attno="2" ColName="g2" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
+                  <dxl:JoinFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:JoinFilter>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="10" Alias="j2">
+                        <dxl:Ident ColId="10" ColName="j2" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="g2">
+                        <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.16388.1.0" TableName="bar">
+                      <dxl:Columns>
+                        <dxl:Column ColId="10" Attno="1" ColName="j2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="11" Attno="2" ColName="g2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                  <dxl:Materialize Eager="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000068" Rows="3.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:Filter/>
+                    <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="3.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:Limit>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList/>
+                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList/>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="1"/>
+                            </dxl:Properties>
+                            <dxl:ProjList/>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.16388.1.0" TableName="bar">
+                              <dxl:Columns>
+                                <dxl:Column ColId="20" Attno="1" ColName="j2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:GatherMotion>
+                        <dxl:LimitCount>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                        </dxl:LimitCount>
+                        <dxl:LimitOffset>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                        </dxl:LimitOffset>
+                      </dxl:Limit>
+                    </dxl:BroadcastMotion>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
               </dxl:HashJoin>
             </dxl:RedistributeMotion>
           </dxl:Sort>

--- a/src/backend/gporca/libgpopt/include/gpopt/engine/CHint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/engine/CHint.h
@@ -18,6 +18,7 @@
 #define JOIN_ORDER_DP_THRESHOLD ULONG(10)
 #define BROADCAST_THRESHOLD ULONG(10000000)
 #define PUSH_GROUP_BY_BELOW_SETOP_THRESHOLD ULONG(10)
+#define EAGERAGG_THRESHOLD DOUBLE(0.0001)
 
 
 namespace gpopt
@@ -51,6 +52,8 @@ namespace gpopt
 
 			ULONG m_ulPushGroupByBelowSetopThreshold;
 
+			CDouble m_EagerAggThreshold;
+
 			// private copy ctor
 			CHint(const CHint &);
 
@@ -65,7 +68,8 @@ namespace gpopt
 				ULONG ulJoinOrderDPLimit,
 				ULONG broadcast_threshold,
 				BOOL enforce_constraint_on_dml,
-				ULONG push_group_by_below_setop_threshold
+				ULONG push_group_by_below_setop_threshold,
+				DOUBLE eageragg_threshold
 				)
 				:
 				m_ulMinNumOfPartsToRequireSortOnInsert(min_num_of_parts_to_require_sort_on_insert),
@@ -74,7 +78,8 @@ namespace gpopt
 				m_ulJoinOrderDPLimit(ulJoinOrderDPLimit),
 				m_ulBroadcastThreshold(broadcast_threshold),
 				m_fEnforceConstraintsOnDML(enforce_constraint_on_dml),
-				m_ulPushGroupByBelowSetopThreshold(push_group_by_below_setop_threshold)
+				m_ulPushGroupByBelowSetopThreshold(push_group_by_below_setop_threshold),
+				m_EagerAggThreshold(eageragg_threshold)
 			{
 			}
 
@@ -133,6 +138,11 @@ namespace gpopt
 				return m_ulPushGroupByBelowSetopThreshold;
 			}
 
+			CDouble EagerAggThreshold() const
+			{
+				return m_EagerAggThreshold;
+			}
+
 			// generate default hint configurations, which disables sort during insert on
 			// append only row-oriented partitioned tables by default
 			static
@@ -145,7 +155,8 @@ namespace gpopt
 					JOIN_ORDER_DP_THRESHOLD, /*ulJoinOrderDPLimit*/
 					BROADCAST_THRESHOLD,	 /*broadcast_threshold*/
 					true,					 /* enforce_constraint_on_dml */
-					PUSH_GROUP_BY_BELOW_SETOP_THRESHOLD /* push_group_by_below_setop_threshold */
+					PUSH_GROUP_BY_BELOW_SETOP_THRESHOLD, /* push_group_by_below_setop_threshold */
+					EAGERAGG_THRESHOLD
 				);
 			}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/engine/CHint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/engine/CHint.h
@@ -156,7 +156,7 @@ namespace gpopt
 					BROADCAST_THRESHOLD,	 /*broadcast_threshold*/
 					true,					 /* enforce_constraint_on_dml */
 					PUSH_GROUP_BY_BELOW_SETOP_THRESHOLD, /* push_group_by_below_setop_threshold */
-					EAGERAGG_THRESHOLD
+					EAGERAGG_THRESHOLD /* eageragg threshold */
 				);
 			}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformEagerAgg.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformEagerAgg.h
@@ -89,7 +89,7 @@ namespace gpopt
 		CXformEagerAgg(const CXformEagerAgg &);
 
 		// check if transform can be applied
-		BOOL CanApplyTransform(CExpression *agg_expr) const;
+		BOOL CanApplyTransform(CMemoryPool *mp, CExpression *agg_expr) const;
 
 		// is this aggregate supported for push down?
 		BOOL CanPushAggBelowJoin(CExpression *scalar_agg_func_expr) const;

--- a/src/backend/gporca/libgpopt/src/optimizer/COptimizerConfig.cpp
+++ b/src/backend/gporca/libgpopt/src/optimizer/COptimizerConfig.cpp
@@ -173,6 +173,7 @@ COptimizerConfig::Serialize(CMemoryPool *mp, CXMLSerializer *xml_serializer, CBi
 	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenBroadcastThreshold), m_hint->UlBroadcastThreshold());
 	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenEnforceConstraintsOnDML), m_hint->FEnforceConstraintsOnDML());
 	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenPushGroupByBelowSetopThreshold), m_hint->UlPushGroupByBelowSetopThreshold());
+	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenEagerAggThreshold), m_hint->EagerAggThreshold());
 	xml_serializer->CloseElement(CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix), CDXLTokens::GetDXLTokenStr(EdxltokenHint));
 
 	// Serialize traceflags represented in bitset into stream

--- a/src/backend/gporca/libgpopt/src/xforms/CXformEagerAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformEagerAgg.cpp
@@ -22,6 +22,8 @@
 #include "gpopt/xforms/CXformEagerAgg.h"
 #include "gpopt/xforms/CXformUtils.h"
 #include "gpopt/base/CColRefSetIter.h"
+#include "gpopt/optimizer/COptimizerConfig.h"
+
 
 using namespace gpopt;
 using namespace gpmd;
@@ -93,13 +95,13 @@ CXformEagerAgg::Transform
 	GPOS_ASSERT(FPromising(pxfctxt->Pmp(), this, agg_expr));
 	GPOS_ASSERT(FCheckPattern(agg_expr));
 
+	CMemoryPool *mp = pxfctxt->Pmp();
 	/* no-op if the transform cannot be applied */
-	if (!CanApplyTransform(agg_expr))
+	if (!CanApplyTransform(mp, agg_expr))
 	{
 		return;
 	}
 
-	CMemoryPool *mp = pxfctxt->Pmp();
 	CExpression *join_expr = (*agg_expr)[0];
 	CExpression *join_outer_child_expr = (*join_expr)[0];
 	CExpression *join_inner_child_expr = (*join_expr)[1];
@@ -243,6 +245,7 @@ BOOL CXformEagerAgg::CanPushAggBelowJoin
 BOOL
 CXformEagerAgg::CanApplyTransform
 	(
+    CMemoryPool *mp,
 	CExpression *gb_agg_expr
 	)
 	const
@@ -260,6 +263,29 @@ CXformEagerAgg::CanApplyTransform
 		// child since we only support pushing down to one of children
 		return false;
 	}
+
+    if (NULL == gb_agg_expr->Pstats())
+    {
+            CExpressionHandle exprhdl(mp);
+            exprhdl.Attach(gb_agg_expr);
+            exprhdl.DeriveStats(mp, mp, NULL /*prprel*/, NULL /*pdrgpstatCtxt*/);
+    }
+
+    if (NULL == join_expr->Pstats())
+    {
+            CExpressionHandle exprhdl(mp);
+            exprhdl.Attach(join_expr);
+            exprhdl.DeriveStats(mp, mp, NULL /*prprel*/, NULL /*pdrgpstatCtxt*/);
+    }
+
+    CDouble gbrows = gb_agg_expr->Pstats()->Rows();
+    CDouble joinrows = join_expr->Pstats()->Rows();
+	COptimizerConfig *optconfig = COptCtxt::PoctxtFromTLS()->GetOptimizerConfig();
+
+    if ((gbrows / joinrows) >= optconfig->GetHint()->EagerAggThreshold())
+    {
+            return false;
+    }
 
 	const ULONG num_aggregates = agg_proj_list_expr->Arity();
 	if (num_aggregates == 0)

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperatorFactory.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperatorFactory.h
@@ -444,7 +444,9 @@ namespace gpdxl
 				CDXLMemoryManager *dxl_memory_manager,
 				const Attributes &attr,
 				Edxltoken target_attr,
-				Edxltoken target_elem
+				Edxltoken target_elem,
+				BOOL is_optional = false,
+				DOUBLE default_value = 0.0
 				);
 
 			// converts the XMLCh into ULONG. Will raise an exception if the 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -65,6 +65,7 @@ namespace gpdxl
 		EdxltokenBroadcastThreshold,
 		EdxltokenEnforceConstraintsOnDML,
 		EdxltokenPushGroupByBelowSetopThreshold,
+		EdxltokenEagerAggThreshold,
 		EdxltokenWindowOids,
 		EdxltokenOidRowNumber,
 		EdxltokenOidRank,

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -3727,15 +3727,24 @@ CDXLOperatorFactory::ExtractConvertAttrValueToDouble
 	CDXLMemoryManager *dxl_memory_manager,
 	const Attributes &attrs,
 	Edxltoken target_attr,
-	Edxltoken target_elem
+	Edxltoken target_elem,
+	BOOL is_optional,
+	DOUBLE default_value
 	)
 {
 	const XMLCh *attr_val_xml = CDXLOperatorFactory::ExtractAttrValue
 											(
 											attrs,
 											target_attr,
-											target_elem
+											target_elem,
+											is_optional
 											);
+
+	if (NULL == attr_val_xml)
+	{
+		return default_value;
+	}
+
 	return ConvertAttrValueToDouble
 			(
 			dxl_memory_manager,

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerHint.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerHint.cpp
@@ -90,6 +90,8 @@ CParseHandlerHint::StartElement
 	BOOL enforce_constraint_on_dml = CDXLOperatorFactory::ExtractConvertAttrValueToBool(m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenEnforceConstraintsOnDML, EdxltokenHint, true, true);
 	ULONG push_group_by_below_setop_threshold = CDXLOperatorFactory::ExtractConvertAttrValueToUlong(m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenPushGroupByBelowSetopThreshold, EdxltokenHint, true, PUSH_GROUP_BY_BELOW_SETOP_THRESHOLD);
 
+	CDouble eageragg_threshold = CDXLOperatorFactory::ExtractConvertAttrValueToDouble(m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenEagerAggThreshold, EdxltokenHint, true, EAGERAGG_THRESHOLD);
+
 	m_hint = GPOS_NEW(m_mp) CHint
 								(
 								min_num_of_parts_to_require_sort_on_insert,
@@ -98,7 +100,8 @@ CParseHandlerHint::StartElement
 								join_order_dp_threshold,
 								broadcast_threshold,
 								enforce_constraint_on_dml,
-								push_group_by_below_setop_threshold
+								push_group_by_below_setop_threshold,
+								eageragg_threshold.Get()
 								);
 }
 

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -87,6 +87,8 @@ CDXLTokens::Init
 			{EdxltokenBroadcastThreshold, GPOS_WSZ_LIT("BroadcastThreshold")},
 			{EdxltokenEnforceConstraintsOnDML, GPOS_WSZ_LIT("EnforceConstraintsOnDML")},
 			{EdxltokenPushGroupByBelowSetopThreshold, GPOS_WSZ_LIT("PushGroupByBelowSetopThreshold")},
+			{EdxltokenEagerAggThreshold, GPOS_WSZ_LIT("EagerAggThreshold")},
+
 			{EdxltokenWindowOids, GPOS_WSZ_LIT("WindowOids")},
 			{EdxltokenOidRowNumber, GPOS_WSZ_LIT("RowNumber")},
 			{EdxltokenOidRank, GPOS_WSZ_LIT("Rank")},

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -388,6 +388,7 @@ bool		optimizer_cte_inlining;
 bool		optimizer_enable_space_pruning;
 bool		optimizer_enable_associativity;
 bool		optimizer_enable_eageragg;
+double		optimizer_eageragg_threshold;
 bool		optimizer_enable_range_predicate_dpe;
 
 /* Analyze related GUCs for Optimizer */
@@ -4172,6 +4173,16 @@ struct config_real ConfigureNamesReal_gp[] =
 		},
 		&optimizer_sort_factor,
 		1.0, 0.0, DBL_MAX,
+		NULL, NULL, NULL
+	},
+	{
+		{"optimizer_eageragg_threshold", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Ratio of the number of rows produced by the aggregate to the number of rows produced by the join below it, If the actual value is greater than this threshold then eageragg alternative will not be created"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_eageragg_threshold,
+		0.0001, 0.0, 1.0,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4176,8 +4176,9 @@ struct config_real ConfigureNamesReal_gp[] =
 		NULL, NULL, NULL
 	},
 	{
+
 		{"optimizer_eageragg_threshold", PGC_USERSET, QUERY_TUNING_METHOD,
-			gettext_noop("Ratio of the number of rows produced by the aggregate to the number of rows produced by the join below it, If the actual value is greater than this threshold then eageragg alternative will not be created"),
+			gettext_noop("Maximum allowed ratio of the number of rows produced by the aggregate to the number of rows produced by the join below it, to consider an eageragg alternative."),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -538,6 +538,7 @@ extern int optimizer_penalize_broadcast_threshold;
 extern double optimizer_cost_threshold;
 extern double optimizer_nestloop_factor;
 extern double optimizer_sort_factor;
+extern double optimizer_eageragg_threshold;
 
 /* Optimizer hints */
 extern int optimizer_array_expansion_threshold;

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -94,7 +94,6 @@
 		"optimizer_partition_selection_log",
 		"optimizer_plan_id",
 		"optimizer_push_group_by_below_setop_threshold",
-		"optimizer_eageragg_threshold",
 		"optimizer_samples_number",
 		"parallel_setup_cost",
 		"parallel_tuple_cost",

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -94,6 +94,7 @@
 		"optimizer_partition_selection_log",
 		"optimizer_plan_id",
 		"optimizer_push_group_by_below_setop_threshold",
+		"optimizer_eageragg_threshold",
 		"optimizer_samples_number",
 		"parallel_setup_cost",
 		"parallel_tuple_cost",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -341,6 +341,7 @@
 		"optimizer_damping_factor_groupby",
 		"optimizer_damping_factor_join",
 		"optimizer_dpe_stats",
+		"optimizer_eageragg_threshold",
 		"optimizer_enable_assert_maxonerow",
 		"optimizer_enable_associativity",
 		"optimizer_enable_bitmapscan",


### PR DESCRIPTION
The eageragg alternative can sometimes end up producing a bad plan when the
ratio of the number of rows produced by the aggregate is high compared to the
number of rows produced by the join below it. This commit adds a threshold
above which the eageragg alternative will not be produced.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
