### PR TITLE
Build ORCA with C++14: Take Two

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -192,7 +192,7 @@ script:
             --prefix=${TRAVIS_BUILD_DIR}/gpsql \
             --with-perl \
             --with-python \
-            --enable-orca \
+            --disable-orca \
             --enable-orafce \
             --disable-gpfdist \
             --disable-pxf \
@@ -201,7 +201,7 @@ script:
             --with-includes=$(brew --prefix xerces-c)/include \
             --with-libs=$(brew --prefix xerces-c)/lib \
             $C
-        travis_wait 40 make -s install
+        make -s install
         source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
         make -s unittest-check
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,7 +156,7 @@ script:
             --enable-mapreduce \
             --enable-orafce \
             $C
-        make -s install
+        travis_wait 40 make -s install
         source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
         make -s unittest-check
         make -C gpAux/gpdemo cluster
@@ -201,7 +201,7 @@ script:
             --with-includes=$(brew --prefix xerces-c)/include \
             --with-libs=$(brew --prefix xerces-c)/lib \
             $C
-        make -s install
+        travis_wait 40 make -s install
         source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh
         make -s unittest-check
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
             - gcc-8
             - libxml2
             - libxml2-dev
+            - libxerces-c-dev
             - libevent-dev
             - libperl-dev
             - g++-8
@@ -69,6 +70,7 @@ matrix:
             homebrew:
               packages:
                 - ccache
+                - xerces-c
         #
         # Configuration variations
         # ----------------------------------------------------------------
@@ -146,7 +148,7 @@ script:
             --enable-debug-extensions \
             --with-perl \
             --with-python \
-            --disable-orca \
+            --enable-orca \
             --with-openssl \
             --with-ldap \
             --with-libcurl \
@@ -168,7 +170,7 @@ script:
             --prefix=${TRAVIS_BUILD_DIR}/gpsql \
             --with-perl \
             --with-python \
-            --disable-orca \
+            --enable-orca \
             --with-openssl \
             --with-ldap \
             --with-libcurl \
@@ -190,12 +192,14 @@ script:
             --prefix=${TRAVIS_BUILD_DIR}/gpsql \
             --with-perl \
             --with-python \
-            --disable-orca \
+            --enable-orca \
             --enable-orafce \
             --disable-gpfdist \
             --disable-pxf \
             --disable-gpcloud \
             --without-zstd \
+            --with-includes=$(brew --prefix xerces-c)/include \
+            --with-libs=$(brew --prefix xerces-c)/lib \
             $C
         make -s install
         source ${TRAVIS_BUILD_DIR}/gpsql/greenplum_path.sh

--- a/src/backend/gporca/CMakeLists.txt
+++ b/src/backend/gporca/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 project(gpopt_master LANGUAGES CXX C)
 
-set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_STANDARD 14)
 
 # Default to shared libraries.
 option(BUILD_SHARED_LIBS "build shared libraries" ON)

--- a/src/backend/gporca/gporca.mk
+++ b/src/backend/gporca/gporca.mk
@@ -6,4 +6,4 @@ override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libgpdbcost/include $(CP
 # backtracing.
 override CXXFLAGS := -Werror -Wextra -Wpedantic -Wno-variadic-macros -fno-omit-frame-pointer $(CXXFLAGS)
 # FIXME: this really should be done in autoconf
-override CXXFLAGS := -std=gnu++98 $(CXXFLAGS)
+override CXXFLAGS := -std=gnu++14 $(CXXFLAGS)

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -331,8 +331,7 @@ namespace gpopt
 
 				SGroupAndExpression() : m_group_info(NULL), m_expr_index(gpos::ulong_max) {}
 				SGroupAndExpression(SGroupInfo *g, ULONG ix) : m_group_info(g), m_expr_index(ix) {}
-				SGroupAndExpression(const SGroupAndExpression &other) : m_group_info(other.m_group_info),
-																		  m_expr_index(other.m_expr_index) {}
+				SGroupAndExpression(const SGroupAndExpression &other) = default;
 				SExpressionInfo *GetExprInfo() const { return (*m_group_info->m_best_expr_info_array)[m_expr_index]; }
 				BOOL IsValid() { return NULL != m_group_info && gpos::ulong_max != m_expr_index; }
 				BOOL operator == (const SGroupAndExpression &other) const

--- a/src/backend/gporca/libgpos/include/gpos/common/CAutoP.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CAutoP.h
@@ -40,11 +40,10 @@ namespace gpos
 			// actual element to point to
 			T *m_object;
 						
-			// hidden copy ctor
 			CAutoP<T>
 				(
 				const CAutoP&
-				);
+				) = delete;
 
 		public:
 		

--- a/src/backend/gporca/libgpos/include/gpos/common/CAutoP.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CAutoP.h
@@ -39,14 +39,14 @@ namespace gpos
 
 			// actual element to point to
 			T *m_object;
-						
+
+		public:
+
 			CAutoP<T>
 				(
 				const CAutoP&
 				) = delete;
 
-		public:
-		
 			// ctor
 			explicit
 			CAutoP<T>()

--- a/src/backend/gporca/libgpos/include/gpos/common/CAutoRg.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CAutoRg.h
@@ -36,8 +36,7 @@ namespace gpos
 			// actual element to point to
 			T *m_object_array;
 						
-			// hidden copy ctor
-			CAutoRg<T>(const CAutoRg&);
+			CAutoRg<T>(const CAutoRg&) = delete;
 
 		public:
 		

--- a/src/backend/gporca/libgpos/include/gpos/common/CAutoRg.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CAutoRg.h
@@ -35,11 +35,11 @@ namespace gpos
 
 			// actual element to point to
 			T *m_object_array;
-						
-			CAutoRg<T>(const CAutoRg&) = delete;
 
 		public:
-		
+
+			CAutoRg<T>(const CAutoRg&) = delete;
+
 			// ctor
 			explicit
 			CAutoRg<T>()

--- a/src/backend/gporca/libgpos/include/gpos/common/CDouble.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CDouble.h
@@ -111,14 +111,6 @@ namespace gpos
 				return m_d;
 			}
 
-			// assignment
-			inline CDouble& operator=(const CDouble &right)
-            {
-                this->m_d = right.m_d;
-
-                return (*this);
-            }
-
 			// arithmetic operators
 			friend CDouble operator + (const CDouble &left, const CDouble &right)
             {

--- a/src/backend/gporca/libgpos/include/gpos/common/CLink.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CLink.h
@@ -19,8 +19,7 @@ namespace gpos
 
 		private:
 
-			// no copy constructor
-			SLink(const SLink&);
+			SLink(const SLink&) = delete;
 
 		public:
 

--- a/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
@@ -63,8 +63,9 @@ namespace gpos
 				m_refs(1)
 			{}
 
+			// FIXME: should mark this noexcept in non-assert builds
 			// dtor
-			virtual ~CRefCount()
+			virtual ~CRefCount() noexcept(false)
 			{
 				// enforce strict ref-counting unless we're in a pending exception,
 				// e.g., a ctor has thrown

--- a/src/backend/gporca/libgpos/include/gpos/memory/CAutoMemoryPool.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CAutoMemoryPool.h
@@ -68,8 +68,9 @@ namespace gpos
 				ELeakCheck leak_check_type = ElcExc
 				);
 
+			// FIXME: should mark this noexcept in non-assert builds
 			// dtor
-			~CAutoMemoryPool();
+			~CAutoMemoryPool() noexcept(false);
 
 			// accessor
 			CMemoryPool *Pmp() const

--- a/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CSyncHashtableTest.h
+++ b/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CSyncHashtableTest.h
@@ -160,6 +160,8 @@ namespace gpos
 						m_ulKey = elem.m_ulKey;
 					}
 
+					SElem& operator = (const SElem&) = default;
+
 #ifdef GPOS_DEBUG
 					static
 					BOOL IsValid

--- a/src/backend/gporca/libgpos/src/memory/CAutoMemoryPool.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CAutoMemoryPool.cpp
@@ -79,7 +79,7 @@ CAutoMemoryPool::Detach()
 //		(2) no checking while pending exception indicated and no pending exception
 //
 //---------------------------------------------------------------------------
-CAutoMemoryPool::~CAutoMemoryPool()
+CAutoMemoryPool::~CAutoMemoryPool() noexcept(false)
 {
 	if (NULL == m_mp)
 	{

--- a/src/backend/gporca/server/src/unittest/dxl/CParseHandlerCostModelTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/CParseHandlerCostModelTest.cpp
@@ -45,7 +45,7 @@ namespace
 		private:
 			CAutoMemoryPool m_amp;
 			gpos::CAutoP<CDXLMemoryManager> m_apmm;
-			std::auto_ptr<SAX2XMLReader> m_apxmlreader;
+			std::unique_ptr<SAX2XMLReader> m_apxmlreader;
 			gpos::CAutoP<CParseHandlerManager> m_apphm;
 			gpos::CAutoP<CParseHandlerCostModel> m_apphCostModel;
 


### PR DESCRIPTION
This patch makes the minimal changes to build ORCA with C++14. This
should address the grievance that ORCA cannot build with the default
Xerces C++ (3.2 or newer, which is built with GCC 8.3 in the default C++14
mode) headers from Debian. I've kept the CMake build system in sync with
the main Makefile. I've also made sure that all ORCA tests pass.

This patch set is the fleshed-out version of #9937 .

## To reviewers
1. I've split up the steps into granular commits. See each commit for details
1. I plan to squash into one commit when we finally merge. Will post a draft message when we're close to merging.
1. Should we turn on ORCA in Travis CI? I've included changes that compile Greenplum with ORCA enabled in Travis CI, which adds to the compile time and run time. I've kept those changes in separate commits so it'd be flexible to leave them out as well.

### Out of scope

What's _not_ included in this patch, but would be nice to have soon:

1. Those noexept(false) seem excessive, we should benefit from
conditionally marking more code "noexcept" at least in production.

2. Detecting whether Xerces was generated (either by autoconf or CMake)
with a compiler that's effectively running post-C++11

3. Clean up the Makefiles and move the std= flag into autoconf.

4. Work around a GCC 9.2 bug that crashes the loading of minidumps (I've
tested with GCC 6 to 10). Last I checked, the bug has been fixed in GCC
releases 10.1 and 9.3.

5. The translator is still built with "whatever". Ideally this part should synchronize with ORCA. But we can address that in a follow-up. There's also dependency on moving the compiler flags to configure...

[resolves #9923]

### TODO

- [ ] How much slower is Travis CI now that we're compiling and running with ORCA on?