### PR TITLE
[6X bugfix] Fix a bug that restartpoint could remove/recycle segment files which …

### DIFF
--- a/src/include/access/twophase.h
+++ b/src/include/access/twophase.h
@@ -79,6 +79,8 @@ extern bool StandbyTransactionIdIsPrepared(TransactionId xid);
 
 extern TransactionId PrescanPreparedTransactions(TransactionId **xids_p,
 							int *nxids_p);
+extern void SetOldestPreparedTransaction(void);
+extern XLogRecPtr GetOldestPreparedTransaction(void);
 extern void StandbyRecoverPreparedTransactions(bool overwriteOK);
 extern void RecoverPreparedTransactions(void);
 

--- a/src/test/isolation2/expected/segwalrep/restartpoint_remove_xlog.out
+++ b/src/test/isolation2/expected/segwalrep/restartpoint_remove_xlog.out
@@ -1,0 +1,163 @@
+-- Test a bug that restartpoint removes xlog segment files which still
+-- has prepared but not-yet-committed/aborted transactions.
+
+include: helpers/server_helpers.sql;
+CREATE
+
+!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
+(exited with code 0)
+!\retcode gpconfig -c wal_keep_segments -v 0 --skipvalidation;
+(exited with code 0)
+-- Allow extra time for mirror promotion to complete recovery to avoid
+-- gprecoverseg BEGIN failures due to gang creation failure as some primaries
+-- are not up. Setting these increase the number of retries in gang creation in
+-- case segment is in recovery. Approximately we want to wait 30 seconds.
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
+(exited with code 0)
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
+
+create extension if not exists gp_inject_fault;
+CREATE
+
+create or replace function wait_for_replication_replay (retries int) returns bool as $$ declare i int; /* in func */ result bool; /* in func */ begin /* in func */ i := 0; /* in func */ -- Wait until the mirror (content 0) has replayed up to flush location loop /* in func */ SELECT flush_location = replay_location INTO result from gp_stat_replication where gp_segment_id = 0; /* in func */ if result then /* in func */ return true; /* in func */ end if; /* in func */ 
+if i >= retries then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ i := i + 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE
+
+
+create table t_restart (a int);
+CREATE
+
+-- generate an orphaned prepare transaction.
+select gp_inject_fault('dtm_broadcast_prepare', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- assume (2), (1) are on different segments and one tuple is on the first segment.
+-- the test finally double-check that.
+1&: insert into t_restart values(2),(1);  <waiting ...>
+select gp_wait_until_triggered_fault('dtm_broadcast_prepare', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- trigger xlog file switch on the first segment.
+-- start_ignore
+0U: select pg_switch_xlog();
+ pg_switch_xlog 
+----------------
+ 0/1C151C40     
+(1 row)
+-- end_ignore
+checkpoint;
+CHECKPOINT
+-- start_ignore
+0U: select pg_switch_xlog();
+ pg_switch_xlog 
+----------------
+ 0/20000318     
+(1 row)
+-- end_ignore
+checkpoint;
+CHECKPOINT
+
+-- wait until the restartpoints on seg0 finish so that if the bug is not fixed,
+-- the xlog segment file with the orphaned prepare transaction will be removed,
+-- and then if the mirror is promoted it will panic like this:
+-- FATAL","58P01","requested WAL segment pg_xlog/000000010000000000000003 has already been removed
+-- The call stack is: StartupXLOG()->PrescanPreparedTransactions()...
+select * from wait_for_replication_replay(5000);
+ wait_for_replication_replay 
+-----------------------------
+ t                           
+(1 row)
+
+-- shutdown primary and make sure the segment is down
+-1U: select pg_ctl((SELECT datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop', 'immediate');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+select role, preferred_role from gp_segment_configuration where content = 0;
+ role | preferred_role 
+------+----------------
+ m    | p              
+ p    | m              
+(2 rows)
+
+-- double confirm that promote succeeds.
+-- also double confirm that
+--  1. tuples (2) and (1) are located on two segments (thus we are testing 2pc with prepared transaction).
+--  2. there are tuples on the first segment (we have been testing on the first segment).
+insert into t_restart values(2),(1);
+INSERT 2
+select gp_segment_id, * from t_restart;
+ gp_segment_id | a 
+---------------+---
+ 0             | 2 
+ 1             | 1 
+(2 rows)
+
+select gp_inject_fault('dtm_broadcast_prepare', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+INSERT 2
+
+-- confirm the "orphaned" prepared trnasaction commits finally.
+select * from t_restart;
+ a 
+---
+ 2 
+ 2 
+ 1 
+ 1 
+(4 rows)
+
+-- recovery the nodes
+!\retcode gprecoverseg -a;
+(exited with code 0)
+
+-- loop while segments come in sync
+do $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select count(*) = 2 from gp_segment_configuration where content = 0 and mode = 's') then /* in func */ return; /* in func */ end if; /* in func */ perform gp_request_fts_probe_scan(); /* in func */ end loop; /* in func */ end; /* in func */ $$;
+DO
+
+!\retcode gprecoverseg -ar;
+(exited with code 0)
+
+-- loop while segments come in sync
+do $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select count(*) = 2 from gp_segment_configuration where content = 0 and mode = 's') then /* in func */ return; /* in func */ end if; /* in func */ perform gp_request_fts_probe_scan(); /* in func */ end loop; /* in func */ end; /* in func */ $$;
+DO
+
+-- verify the first segment is recovered to the original state.
+select role, preferred_role from gp_segment_configuration where content = 0;
+ role | preferred_role 
+------+----------------
+ p    | p              
+ m    | m              
+(2 rows)
+
+-- cleanup
+drop table t_restart;
+DROP
+!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
+(exited with code 0)
+!\retcode gpconfig -r wal_keep_segments --skipvalidation;
+(exited with code 0)
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation;
+(exited with code 0)
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -189,6 +189,7 @@ test: segwalrep/fts_unblock_primary
 test: segwalrep/mirror_promotion
 test: segwalrep/cancel_commit_pending_replication
 test: segwalrep/twophase_tolerance_with_mirror_promotion
+test: segwalrep/restartpoint_remove_xlog
 test: segwalrep/failover_with_many_records
 test: segwalrep/dtm_recovery_on_standby
 test: segwalrep/commit_blocking_on_standby

--- a/src/test/isolation2/sql/segwalrep/restartpoint_remove_xlog.sql
+++ b/src/test/isolation2/sql/segwalrep/restartpoint_remove_xlog.sql
@@ -1,0 +1,128 @@
+-- Test a bug that restartpoint removes xlog segment files which still
+-- has prepared but not-yet-committed/aborted transactions.
+
+include: helpers/server_helpers.sql;
+
+!\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
+!\retcode gpconfig -c wal_keep_segments -v 0 --skipvalidation;
+-- Allow extra time for mirror promotion to complete recovery to avoid
+-- gprecoverseg BEGIN failures due to gang creation failure as some primaries
+-- are not up. Setting these increase the number of retries in gang creation in
+-- case segment is in recovery. Approximately we want to wait 30 seconds.
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
+!\retcode gpstop -u;
+
+create extension if not exists gp_inject_fault;
+
+create or replace function wait_for_replication_replay (retries int) returns bool as
+$$
+declare
+	i int; /* in func */
+	result bool; /* in func */
+begin /* in func */
+	i := 0; /* in func */
+	-- Wait until the mirror (content 0) has replayed up to flush location
+	loop /* in func */
+		SELECT flush_location = replay_location INTO result from gp_stat_replication where gp_segment_id = 0; /* in func */
+		if result then /* in func */
+			return true; /* in func */
+		end if; /* in func */
+
+		if i >= retries then /* in func */
+		   return false; /* in func */
+		end if; /* in func */
+		perform pg_sleep(0.1); /* in func */
+		i := i + 1; /* in func */
+	end loop; /* in func */
+end; /* in func */
+$$ language plpgsql;
+
+
+create table t_restart (a int);
+
+-- generate an orphaned prepare transaction.
+select gp_inject_fault('dtm_broadcast_prepare', 'suspend', dbid)
+  from gp_segment_configuration where role = 'p' and content = -1;
+-- assume (2), (1) are on different segments and one tuple is on the first segment.
+-- the test finally double-check that.
+1&: insert into t_restart values(2),(1);
+select gp_wait_until_triggered_fault('dtm_broadcast_prepare', 1, dbid)
+  from gp_segment_configuration where role = 'p' and content = -1;
+
+-- trigger xlog file switch on the first segment.
+-- start_ignore
+0U: select pg_switch_xlog();
+-- end_ignore
+checkpoint;
+-- start_ignore
+0U: select pg_switch_xlog();
+-- end_ignore
+checkpoint;
+
+-- wait until the restartpoints on seg0 finish so that if the bug is not fixed,
+-- the xlog segment file with the orphaned prepare transaction will be removed,
+-- and then if the mirror is promoted it will panic like this:
+-- FATAL","58P01","requested WAL segment pg_xlog/000000010000000000000003 has already been removed
+-- The call stack is: StartupXLOG()->PrescanPreparedTransactions()...
+select * from wait_for_replication_replay(5000);
+
+-- shutdown primary and make sure the segment is down
+-1U: select pg_ctl((SELECT datadir from gp_segment_configuration c
+  where c.role='p' and c.content=0), 'stop', 'immediate');
+select gp_request_fts_probe_scan();
+select role, preferred_role from gp_segment_configuration where content = 0;
+
+-- double confirm that promote succeeds.
+-- also double confirm that
+--  1. tuples (2) and (1) are located on two segments (thus we are testing 2pc with prepared transaction).
+--  2. there are tuples on the first segment (we have been testing on the first segment).
+insert into t_restart values(2),(1);
+select gp_segment_id, * from t_restart;
+
+select gp_inject_fault('dtm_broadcast_prepare', 'reset', dbid)
+  from gp_segment_configuration where role = 'p' and content = -1;
+1<:
+
+-- confirm the "orphaned" prepared trnasaction commits finally.
+select * from t_restart;
+
+-- recovery the nodes
+!\retcode gprecoverseg -a;
+
+-- loop while segments come in sync
+do $$
+begin /* in func */
+  for i in 1..120 loop /* in func */
+    if (select count(*) = 2 from gp_segment_configuration where content = 0 and mode = 's') then /* in func */
+      return; /* in func */
+    end if; /* in func */
+    perform gp_request_fts_probe_scan(); /* in func */
+  end loop; /* in func */
+end; /* in func */
+$$;
+
+!\retcode gprecoverseg -ar;
+
+-- loop while segments come in sync
+do $$
+begin /* in func */
+  for i in 1..120 loop /* in func */
+    if (select count(*) = 2 from gp_segment_configuration where content = 0 and mode = 's') then /* in func */
+      return; /* in func */
+    end if; /* in func */
+    perform gp_request_fts_probe_scan(); /* in func */
+  end loop; /* in func */
+end; /* in func */
+$$;
+
+-- verify the first segment is recovered to the original state.
+select role, preferred_role from gp_segment_configuration where content = 0;
+
+-- cleanup
+drop table t_restart;
+!\retcode gpconfig -r create_restartpoint_on_ckpt_record_replay --skipvalidation;
+!\retcode gpconfig -r wal_keep_segments --skipvalidation;
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation;
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation;
+!\retcode gpstop -u;


### PR DESCRIPTION
…still have prepared but not yet committed/aborted transaction xlog.

This happens because restartpoint does not consider the oldest prepared
transaction when calculating the xlog seg number. Note checkpoint is doing the
right thing.

Typically when such case is encountered mirror could FATAL during promotion
with stack like below.

"FATAL","58P01","requested WAL segment pg_xlog/000000010000000000000003 has already been removed",

1    0xae1453 postgres errstart (elog.c:557)
2    0x566225 postgres <symbol not found> (xlogutils.c:572)
3    0x5669b3 postgres read_local_xlog_page (xlogutils.c:870)
4    0x564777 postgres <symbol not found> (xlogreader.c:503)
5    0x56400e postgres XLogReadRecord (xlogreader.c:226)
6    0x54c0e0 postgres PrescanPreparedTransactions (twophase.c:1696)
7    0x559dcc postgres StartupXLOG (xlog.c:7595)
8    0x8e6b3b postgres StartupProcessMain (startup.c:248)
9    0x5b028a postgres AuxiliaryProcessMain (bootstrap.c:437)
10   0x8e58f6 postgres <symbol not found> (postmaster.c:5827)
11   0x8dfbe1 postgres PostmasterMain (postmaster.c:1500)
12   0x7d973f postgres <symbol not found> (main.c:264)
13   0x3397e1ed5d libc.so.6 __libc_start_main + 0xfd
14   0x490059 postgres <symbol not found> + 0x490059
