### PR TITLE
VPATH fixes

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -1,6 +1,6 @@
 top_builddir = ..
 include $(top_builddir)/src/Makefile.global
-include $(top_builddir)/gpMgmt/Makefile.behave
+include $(top_srcdir)/gpMgmt/Makefile.behave
 
 SUBDIRS= sbin bin doc
 

--- a/src/backend/access/aocs/test/Makefile
+++ b/src/backend/access/aocs/test/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=aocsam
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 aocsam.t: \
 	$(MOCK_DIR)/backend/catalog/pg_attribute_encoding_mock.o \

--- a/src/backend/access/appendonly/test/Makefile
+++ b/src/backend/access/appendonly/test/Makefile
@@ -5,7 +5,7 @@ include $(top_builddir)/src/Makefile.global
 TARGETS=aomd appendonly_visimap appendonly_visimap_entry \
 	aomd_filehandler aosegfiles
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 appendonly_visimap.t: \
 	$(MOCK_DIR)/backend/access/appendonly/appendonly_visimap_entry_mock.o \

--- a/src/backend/access/external/test/Makefile
+++ b/src/backend/access/external/test/Makefile
@@ -4,6 +4,6 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=url_curl
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 url_curl.t: $(MOCK_DIR)/backend/cdb/cdbutil_mock.o

--- a/src/backend/access/rmgrdesc/test/Makefile
+++ b/src/backend/access/rmgrdesc/test/Makefile
@@ -4,4 +4,4 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=xactdesc
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk

--- a/src/backend/access/transam/test/Makefile
+++ b/src/backend/access/transam/test/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=xact distributedlog xlog varsup
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 distributedlog.t: \
 	$(MOCK_DIR)/backend/access/transam/slru_mock.o \

--- a/src/backend/cdb/dispatcher/test/Makefile
+++ b/src/backend/cdb/dispatcher/test/Makefile
@@ -5,7 +5,7 @@ include $(top_builddir)/src/Makefile.global
 TARGETS=cdbdispatchresult \
 		cdbgang
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 cdbdispatchresult.t: \
 	$(MOCK_DIR)/backend/libpq/pqexpbuffer_mock.o \
@@ -23,4 +23,4 @@ cdbgang.t: \
 	$(MOCK_DIR)/backend/utils/mmgr/redzone_handler_mock.o \
 	$(MOCK_DIR)/backend/utils/misc/faultinjector_mock.o
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk

--- a/src/backend/cdb/test/Makefile
+++ b/src/backend/cdb/test/Makefile
@@ -7,7 +7,7 @@ TARGETS=cdbbufferedread \
 
 TARGETS += cdbappendonlyxlog
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 cdbdistributedsnapshot.t: $(MOCK_DIR)/backend/access/transam/distributedlog_mock.o
 

--- a/src/backend/commands/test/Makefile
+++ b/src/backend/commands/test/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=tablecmds
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 tablecmds.t: \
 	$(MOCK_DIR)/backend/access/aocs/aocs_compaction_mock.o

--- a/src/backend/fts/test/Makefile
+++ b/src/backend/fts/test/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=ftsmessagehandler ftsprobe
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 ftsmessagehandler.t: \
     $(MOCK_DIR)/backend/utils/error/assert_mock.o \

--- a/src/backend/gpopt/Makefile
+++ b/src/backend/gpopt/Makefile
@@ -8,11 +8,7 @@
 subdir = src/backend/gpopt
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpos/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpopt/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
-
+include $(srcdir)/gpopt.mk
 
 SUBDIRS = config translate relcache utils
 

--- a/src/backend/gpopt/config/Makefile
+++ b/src/backend/gpopt/config/Makefile
@@ -9,7 +9,7 @@ subdir = src/backend/gpopt/config
 top_builddir = ../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gpopt/gpopt.mk
+include $(top_srcdir)/src/backend/gpopt/gpopt.mk
 
 OBJS = CConfigParamMapping.o
 

--- a/src/backend/gpopt/gpopt.mk
+++ b/src/backend/gpopt/gpopt.mk
@@ -1,4 +1,4 @@
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpos/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpopt/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
+override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libgpos/include $(CPPFLAGS)
+override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libgpopt/include $(CPPFLAGS)
+override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
+override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)

--- a/src/backend/gpopt/relcache/Makefile
+++ b/src/backend/gpopt/relcache/Makefile
@@ -9,7 +9,7 @@ subdir = src/backend/gpopt/relcache
 top_builddir = ../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gpopt/gpopt.mk
+include $(top_srcdir)/src/backend/gpopt/gpopt.mk
 
 OBJS = CMDProviderRelcache.o
 

--- a/src/backend/gpopt/translate/Makefile
+++ b/src/backend/gpopt/translate/Makefile
@@ -9,7 +9,7 @@ subdir = src/backend/gpopt/translate
 top_builddir = ../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gpopt/gpopt.mk
+include $(top_srcdir)/src/backend/gpopt/gpopt.mk
 
 OBJS =  CMappingColIdVar.o \
 		CMappingVarColId.o \

--- a/src/backend/gpopt/utils/Makefile
+++ b/src/backend/gpopt/utils/Makefile
@@ -9,7 +9,7 @@ subdir = src/backend/gpopt/utils
 top_builddir = ../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gpopt/gpopt.mk
+include $(top_srcdir)/src/backend/gpopt/gpopt.mk
 
 OBJS = COptTasks.o CConstExprEvaluatorProxy.o CMemoryPoolPalloc.o CMemoryPoolPallocManager.o funcs.o
 

--- a/src/backend/gporca/gporca.mk
+++ b/src/backend/gporca/gporca.mk
@@ -1,7 +1,7 @@
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpos/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpopt/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
+override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libgpos/include $(CPPFLAGS)
+override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libgpopt/include $(CPPFLAGS)
+override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
+override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
 # Do not omit frame pointer. Even with RELEASE builds, it is used for
 # backtracing.
 override CXXFLAGS := -Werror -Wextra -Wpedantic -Wno-variadic-macros -fno-omit-frame-pointer $(CXXFLAGS)

--- a/src/backend/gporca/libgpdbcost/src/Makefile
+++ b/src/backend/gporca/libgpdbcost/src/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpdbcost/src
 top_builddir = ../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CCostModelGPDB.o \
               CCostModelGPDBLegacy.o \

--- a/src/backend/gporca/libgpopt/src/Makefile
+++ b/src/backend/gporca/libgpopt/src/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpopt/src
 top_builddir = ../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 SUBDIRS     = base engine eval mdcache metadata minidump operators optimizer search translate xforms
 OBJS        = exception.o init.o

--- a/src/backend/gporca/libgpopt/src/base/Makefile
+++ b/src/backend/gporca/libgpopt/src/base/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpopt/src/base
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CAutoOptCtxt.o \
               CCTEInfo.o \

--- a/src/backend/gporca/libgpopt/src/engine/Makefile
+++ b/src/backend/gporca/libgpopt/src/engine/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpopt/src/engine
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CEngine.o \
               CEnumeratorConfig.o \

--- a/src/backend/gporca/libgpopt/src/eval/Makefile
+++ b/src/backend/gporca/libgpopt/src/eval/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpopt/src/eval
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CConstExprEvaluatorDXL.o \
               CConstExprEvaluatorDefault.o

--- a/src/backend/gporca/libgpopt/src/mdcache/Makefile
+++ b/src/backend/gporca/libgpopt/src/mdcache/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpopt/src/mdcache
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CMDAccessor.o \
               CMDAccessorUtils.o \

--- a/src/backend/gporca/libgpopt/src/metadata/Makefile
+++ b/src/backend/gporca/libgpopt/src/metadata/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpopt/src/metadata
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CColumnDescriptor.o \
               CIndexDescriptor.o \

--- a/src/backend/gporca/libgpopt/src/minidump/Makefile
+++ b/src/backend/gporca/libgpopt/src/minidump/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpopt/src/minidump
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CDXLMinidump.o \
               CMetadataAccessorFactory.o \

--- a/src/backend/gporca/libgpopt/src/operators/Makefile
+++ b/src/backend/gporca/libgpopt/src/operators/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpopt/src/operators
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CExpression.o \
               CExpressionFactorizer.o \

--- a/src/backend/gporca/libgpopt/src/optimizer/Makefile
+++ b/src/backend/gporca/libgpopt/src/optimizer/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpopt/src/optimizer
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = COptimizer.o COptimizerConfig.o
 

--- a/src/backend/gporca/libgpopt/src/search/Makefile
+++ b/src/backend/gporca/libgpopt/src/search/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpopt/src/search
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CBinding.o \
               CGroup.o \

--- a/src/backend/gporca/libgpopt/src/translate/Makefile
+++ b/src/backend/gporca/libgpopt/src/translate/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpopt/src/translate
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CTranslatorDXLToExpr.o \
               CTranslatorDXLToExprUtils.o \

--- a/src/backend/gporca/libgpopt/src/xforms/Makefile
+++ b/src/backend/gporca/libgpopt/src/xforms/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpopt/src/xforms
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CDecorrelator.o \
               CJoinOrder.o \

--- a/src/backend/gporca/libgpos/src/Makefile
+++ b/src/backend/gporca/libgpos/src/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpos/src
 top_builddir = ../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 SUBDIRS     = common error io memory string task
 OBJS        = _api.o utils.o

--- a/src/backend/gporca/libgpos/src/common/Makefile
+++ b/src/backend/gporca/libgpos/src/common/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpos/src/common
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CAutoTimer.o \
               CBitSet.o \

--- a/src/backend/gporca/libgpos/src/error/Makefile
+++ b/src/backend/gporca/libgpos/src/error/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpos/src/error
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CAutoExceptionStack.o \
               CAutoTrace.o \

--- a/src/backend/gporca/libgpos/src/io/Makefile
+++ b/src/backend/gporca/libgpos/src/io/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpos/src/io
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CFileDescriptor.o \
               CFileReader.o \

--- a/src/backend/gporca/libgpos/src/memory/Makefile
+++ b/src/backend/gporca/libgpos/src/memory/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpos/src/memory
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CAutoMemoryPool.o \
               CCacheFactory.o \

--- a/src/backend/gporca/libgpos/src/string/Makefile
+++ b/src/backend/gporca/libgpos/src/string/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpos/src/string
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CStringStatic.o \
               CWString.o \

--- a/src/backend/gporca/libgpos/src/task/Makefile
+++ b/src/backend/gporca/libgpos/src/task/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpos/src/task
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CAutoSuspendAbort.o \
               CAutoTaskProxy.o \

--- a/src/backend/gporca/libgpos/src/test/Makefile
+++ b/src/backend/gporca/libgpos/src/test/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libgpos/src/memory
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 include $(top_srcdir)/src/backend/common.mk
 

--- a/src/backend/gporca/libnaucrates/src/Makefile
+++ b/src/backend/gporca/libnaucrates/src/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libnaucrates/src
 top_builddir = ../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 SUBDIRS     = base md operators parser statistics xml
 OBJS        = CCostModelConfigSerializer.o \

--- a/src/backend/gporca/libnaucrates/src/base/Makefile
+++ b/src/backend/gporca/libnaucrates/src/base/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libnaucrates/src/base
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CDatumBoolGPDB.o \
               CDatumGenericGPDB.o \

--- a/src/backend/gporca/libnaucrates/src/md/Makefile
+++ b/src/backend/gporca/libnaucrates/src/md/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libnaucrates/src/md
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CDXLBucket.o \
               CDXLColStats.o \

--- a/src/backend/gporca/libnaucrates/src/operators/Makefile
+++ b/src/backend/gporca/libnaucrates/src/operators/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libnaucrates/src/operators
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CDXLColDescr.o \
               CDXLColRef.o \

--- a/src/backend/gporca/libnaucrates/src/parser/Makefile
+++ b/src/backend/gporca/libnaucrates/src/parser/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libnaucrates/src/parser
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CParseHandlerAgg.o \
               CParseHandlerAppend.o \

--- a/src/backend/gporca/libnaucrates/src/statistics/Makefile
+++ b/src/backend/gporca/libnaucrates/src/statistics/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libnaucrates/src/statistics
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CBucket.o \
               CFilterStatsProcessor.o \

--- a/src/backend/gporca/libnaucrates/src/xml/Makefile
+++ b/src/backend/gporca/libnaucrates/src/xml/Makefile
@@ -8,7 +8,7 @@ subdir = src/backend/gporca/libnaucrates/src/xml
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-include $(top_builddir)/src/backend/gporca/gporca.mk
+include $(top_srcdir)/src/backend/gporca/gporca.mk
 
 OBJS        = CDXLMemoryManager.o \
               CDXLSections.o \

--- a/src/backend/libpq/Makefile
+++ b/src/backend/libpq/Makefile
@@ -11,7 +11,7 @@
 subdir = src/backend/libpq
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
-override CPPFLAGS += -I$(libpq_srcdir) -I$(top_srcdir)/src/port
+override CPPFLAGS += -I$(libpq_srcdir) -I$(top_builddir)/src/port
 
 # be-fsstubs is here for historical reasons, probably belongs elsewhere
 

--- a/src/backend/libpq/test/Makefile
+++ b/src/backend/libpq/test/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=pqcomm auth
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 auth.t: $(MOCK_DIR)/backend/utils/fmgr/fmgr_mock.o
 

--- a/src/backend/postmaster/test/Makefile
+++ b/src/backend/postmaster/test/Makefile
@@ -4,5 +4,5 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=checkpointer
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 checkpointer.t: $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o

--- a/src/backend/replication/test/Makefile
+++ b/src/backend/replication/test/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=gp_replication
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 gp_replication.t: \
     $(MOCK_DIR)/backend/utils/error/assert_mock.o \

--- a/src/backend/storage/ipc/test/Makefile
+++ b/src/backend/storage/ipc/test/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=procarray
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 procarray.t: $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o \
 			 $(MOCK_DIR)/backend/cdb/cdbtm_mock.o
 

--- a/src/backend/storage/lmgr/test/Makefile
+++ b/src/backend/storage/lmgr/test/Makefile
@@ -4,4 +4,4 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=lock
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk

--- a/src/backend/tcop/test/Makefile
+++ b/src/backend/tcop/test/Makefile
@@ -9,7 +9,7 @@ TARGETS=postgres
 # conflict resolution. If those hooks are needed then bring it back and then
 # enable the tests or delete the tests.
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 postgres.t: \
 	$(MOCK_DIR)/backend/commands/async_mock.o \

--- a/src/backend/utils/cache/test/Makefile
+++ b/src/backend/utils/cache/test/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=lsyscache
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 lsyscache.t: \
 	$(MOCK_DIR)/backend/utils/cache/syscache_mock.o \

--- a/src/backend/utils/datumstream/test/Makefile
+++ b/src/backend/utils/datumstream/test/Makefile
@@ -4,4 +4,4 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=datumstreamblock
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk

--- a/src/backend/utils/fmgr/test/Makefile
+++ b/src/backend/utils/fmgr/test/Makefile
@@ -4,6 +4,6 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=dfmgr
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 dfmgr.t: $(MOCK_DIR)/backend/utils/error/elog_mock.o

--- a/src/backend/utils/hash/test/Makefile
+++ b/src/backend/utils/hash/test/Makefile
@@ -4,6 +4,6 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=dynahash
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 dynahash.t: $(MOCK_DIR)/backend/access/transam/xact_mock.o

--- a/src/backend/utils/init/test/Makefile
+++ b/src/backend/utils/init/test/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=postinit
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 postinit.t: \
 	$(MOCK_DIR)/backend/utils/error/elog_mock.o \

--- a/src/backend/utils/misc/test/Makefile
+++ b/src/backend/utils/misc/test/Makefile
@@ -7,4 +7,4 @@ TARGETS = ps_status bitstream bitmap_compression faultinjector_warnings pg_mkdir
 faultinjector_warnings.t: ../faultinjector_warnings.o faultinjector_warnings_test.o
 
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk

--- a/src/backend/utils/mmgr/test/Makefile
+++ b/src/backend/utils/mmgr/test/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=vmem_tracker redzone_handler runaway_cleaner idle_tracker event_version memprot
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 vmem_tracker.t: \
 	$(MOCK_DIR)/backend/storage/ipc/shmem_mock.o \

--- a/src/backend/utils/resgroup/test/Makefile
+++ b/src/backend/utils/resgroup/test/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=resgroup
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 resgroup.t: \
 	$(MOCK_DIR)/backend/commands/resgroupcmds_mock.o \

--- a/src/backend/utils/resource_manager/test/Makefile
+++ b/src/backend/utils/resource_manager/test/Makefile
@@ -4,4 +4,4 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=memquota
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk

--- a/src/backend/utils/sort/test/Makefile
+++ b/src/backend/utils/sort/test/Makefile
@@ -4,4 +4,4 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=string_wrapper
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk

--- a/src/backend/utils/test/Makefile
+++ b/src/backend/utils/test/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=session_state
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 session_state.t: \
 	$(MOCK_DIR)/backend/storage/ipc/shmem_mock.o \

--- a/src/backend/utils/time/test/Makefile
+++ b/src/backend/utils/time/test/Makefile
@@ -4,7 +4,7 @@ include $(top_builddir)/src/Makefile.global
 
 TARGETS=sharedsnapshot
 
-include $(top_builddir)/src/backend/mock.mk
+include $(top_srcdir)/src/backend/mock.mk
 
 sharedsnapshot.t: \
 	$(MOCK_DIR)/backend/storage/ipc/shmem_mock.o \

--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -2,7 +2,7 @@ subdir = src/bin/gpfdist
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
-override CPPFLAGS := -I. $(CPPFLAGS) $(apr_includes) $(apr_cppflags)
+override CPPFLAGS := -I$(srcdir) $(CPPFLAGS) $(apr_includes) $(apr_cppflags)
 override CFLAGS := $(CFLAGS) $(apr_cflags)
 
 OBJS = gpfdist.o gpfdist_helper.o fstream.o gfile.o

--- a/src/bin/pg_dump/test/Makefile
+++ b/src/bin/pg_dump/test/Makefile
@@ -6,7 +6,7 @@ TARGETS=dumputils
 
 override CPPFLAGS+= -I$(top_srcdir)/src/interfaces/libpq 
 
-include $(top_builddir)/src/Makefile.mock
+include $(top_srcdir)/src/Makefile.mock
 
 dumputils.t: dumputils_test.o $(CMOCKERY_OBJS)
 	$(CC) $^ $(libpq_pgport) $(LDFLAGS) $(LIBS) $(libpq) -o $@

--- a/src/interfaces/gppc/Makefile
+++ b/src/interfaces/gppc/Makefile
@@ -8,7 +8,7 @@
 # GPPC needs (i.e. headers and makefiles) are installed along with pg_config.
 #-------------------------------------------------------------------------
 
-subdir = src/backend/gppc
+subdir = src/interfaces/gppc
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -48,7 +48,7 @@ pg_regress$(X): pg_regress.o pg_regress_main.o $(WIN32RES) | submake-libpgport s
 # dependencies ensure that path changes propagate
 pg_regress.o: pg_regress.c $(top_builddir)/src/port/pg_config_paths.h
 pg_regress.o: override CPPFLAGS += -I$(top_builddir)/src/port $(EXTRADEFS)
-regress_gp.o: override CFLAGS += -I$(top_builddir)/src/interfaces/libpq
+regress_gp.o: override CPPFLAGS += -I$(libpq_srcdir)
 regress_gp.o: override LDFLAGS += -L$(top_builddir)/src/interfaces/libpq
 
 .PHONY: scan_flaky_fault_injectors


### PR DESCRIPTION
### TL;DR: `srcdir`, `builddir`, potato potahto.
See either commit message for details.

### Long form: This will be a straightforward and boring review.

This fixes up quite a few confusion around the use of top_srcdir vs
top_builddir. Amusingly most of this is uncovered by running merely a
"make clean" on a VPATH build.

While we're here I've taken the liberty to fix a surrounding mistake
like CPPFLAGS vs CFLAGS, and slightly eliminate some duplication,
using Makefile inclusion.

This should let a VPATH build successfully compile (but not
link -- yet -- due to #10072).

This should resolve #10071 