### PR TITLE
Fix multiple definition linker error

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -73,7 +73,7 @@ bool		Debug_print_prelim_plan;	/* Shall we log plan before adding
 
 bool		Debug_print_slice_table;	/* Shall we log the slice table? */
 
-bool		Debug_resource_group;	/* Shall we log the resource group? */
+bool		Debug_resource_group = false;	/* Shall we log the resource group? */
 
 bool		Debug_burn_xids;
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -129,7 +129,6 @@ bool        test_AppendOnlyHash_eviction_vs_just_marking_not_inuse = false;
 bool		Debug_appendonly_print_datumstream = false;
 bool		Debug_appendonly_print_visimap = false;
 bool		Debug_appendonly_print_compaction = false;
-bool		Debug_resource_group = false;
 bool		Debug_bitmap_print_insert = false;
 bool		Test_print_direct_dispatch_info = false;
 bool        Test_print_prefetch_joinqual = false;
@@ -194,9 +193,6 @@ int			Debug_dtm_action_protocol = DEBUG_DTM_ACTION_PROTOCOL_DEFAULT;
 
 int			Debug_dtm_action_segment = DEBUG_DTM_ACTION_SEGMENT_DEFAULT;
 int			Debug_dtm_action_nestinglevel = DEBUG_DTM_ACTION_NESTINGLEVEL_DEFAULT;
-
-/* Enable check for compatibility of encoding and locale in createdb */
-bool		gp_encoding_check_locale_compatibility;
 
 int			gp_connection_send_timeout;
 

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -675,6 +675,9 @@ extern bool gp_cte_sharing;
 /* Enable RECURSIVE clauses in common table expressions */
 extern bool gp_recursive_cte;
 
+/* Enable check for compatibility of encoding and locale in createdb */
+extern bool gp_encoding_check_locale_compatibility;
+
 /* Priority for the segworkers relative to the postmaster's priority */
 extern int gp_segworker_relative_priority;
 


### PR DESCRIPTION
Looks like we were missing an "extern" in two places. While I was at it,
also tidy up guc_gp.c by moving the definition of Debug_resource_group
into cdbvars.c, and add declaration of
gp_encoding_check_locale_compatibility to cdbvars.h.

This is uncovered by building with GCC 10 and Clang 11, where
-fno-common is the new default [1][2] (vis a vis -fcommon). I could also
reproduce this by turning on "-fno-common" in older releases of GCC and
Clang.

We were relying on a myth (or legacy compiler behavior, rather) that C
tentative definitions act _just like_ declarations -- in plain English:
missing an "extern" in a global variable declaration-wannabe wouldn't
harm you, as long as you don't put an initial value after it.

This resolves #10072.

[1] "3.17 Options for Code Generation Conventions: -fcommon"
https://gcc.gnu.org/onlinedocs/gcc-10.1.0/gcc/Code-Gen-Options.html#index-tentative-definitions
[2] "Porting to GCC 10" https://gcc.gnu.org/gcc-10/porting_to.html
[3] "[Driver] Default to -fno-common for all targets" https://reviews.llvm.org/D75056

## Here are some reminders before you submit the pull request
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
