### PR TITLE
Remove trailing semicolon typo

### DIFF
--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -600,7 +600,7 @@ workfile_report_inconsistency(void)
 	if (!dlist_is_empty(&workfile_shared->activeList))
 	{
 		node = &workfile_shared->activeList.head;
-		if (node->next == NULL || node->next->prev != node);
+		if (node->next == NULL || node->next->prev != node)
 			ereport(LOG, (errmsg("workfile activeList is corrupted: "
 							"node = %p, next = %p, next->prev = %p",
 							node, node->next, node->next ? node->next->prev : NULL)));


### PR DESCRIPTION
This fixes an accidental trailing semicolon that "liberated" some
logging from the condition. This was introduced in 4c7854ee5545a and it
generates a compiler warning for me:

> workfile_mgr.c:603:54: warning: if statement has empty body [-Wempty-body]
>                 if (node->next == NULL || node->next->prev != node);
>                                                                    ^
> workfile_mgr.c:603:54: note: put the semicolon on a separate line to silence this warning
> 1 warning generated.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
