### PR TITLE
value scan use ctid crash

### DIFF
--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -171,6 +171,16 @@ FunctionNext_guts(FunctionScanState *node)
 									   ScanDirectionIsForward(direction),
 									   false,
 									   scanslot);
+
+		/*
+		 * CDB: Label each row with a synthetic ctid if needed for subquery dedup.
+		 */
+		if (node->cdb_want_ctid &&
+			!TupIsNull(scanslot))
+		{
+			slot_set_ctid_from_fake(scanslot, &node->cdb_fake_ctid);
+		}
+
 		return scanslot;
 	}
 

--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -499,3 +499,16 @@ EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
 (6 rows)
 
 DROP TABLE A;
+--
+-- Test the ctid in function scan
+--
+create table t1(a int) ;
+insert into t1 select i from generate_series(1, 100000) i;
+analyze t1;
+select count(*) from pg_backend_pid() b(a) where b.a % 100000 in (select a from t1);
+ count 
+-------
+     1
+(1 row)
+
+drop table t1;

--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -500,15 +500,67 @@ EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
 
 DROP TABLE A;
 --
--- Test the ctid in function scan
+-- Test the ctid in Function and Values Scans
 --
 create table t1(a int) ;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into t1 select i from generate_series(1, 100000) i;
 analyze t1;
+-- Function Scan
+explain
+select count(*) from pg_backend_pid() b(a) where b.a % 100000 in (select a from t1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=1611.83..1611.84 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=1611.76..1611.81 rows=1 width=8)
+         ->  Aggregate  (cost=1611.76..1611.77 rows=1 width=8)
+               ->  HashAggregate  (cost=1611.56..1611.72 rows=6 width=6)
+                     Group Key: b.ctid
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.02..1611.52 rows=6 width=6)
+                           Hash Key: b.ctid
+                           ->  Hash Join  (cost=0.02..1611.19 rows=6 width=6)
+                                 Hash Cond: (t1.a = (b.a % 100000))
+                                 ->  Seq Scan on t1  (cost=0.00..1111.00 rows=33334 width=4)
+                                 ->  Hash  (cost=0.01..0.01 rows=1 width=10)
+                                       ->  Function Scan on b  (cost=0.00..0.01 rows=1 width=10)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
 select count(*) from pg_backend_pid() b(a) where b.a % 100000 in (select a from t1);
  count 
 -------
      1
+(1 row)
+
+-- Values Scan
+-- We use a large number of entries, to make sure the fake ctids are generated
+-- correctly even when the offset number in the TID wraps around.
+select string_agg('(' || g || ')', ', ') as lots_of_values from generate_series(1, 66000) g
+\gset
+explain
+select count(*) from ( values :lots_of_values ) as b(a) where b.a % 100000 in (select a from t1);
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=5001.06..5001.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=5001.00..5001.05 rows=1 width=8)
+         ->  Aggregate  (cost=5001.00..5001.01 rows=1 width=8)
+               ->  HashAggregate  (cost=4588.50..4918.50 rows=11000 width=6)
+                     Group Key: "*VALUES*".ctid
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=2361.00..4506.00 rows=11000 width=6)
+                           Hash Key: "*VALUES*".ctid
+                           ->  Hash Join  (cost=2361.00..3846.00 rows=11000 width=6)
+                                 Hash Cond: (("*VALUES*".column1 % 100000) = t1.a)
+                                 ->  Values Scan on "*VALUES*"  (cost=0.00..825.00 rows=22000 width=10)
+                                 ->  Hash  (cost=1111.00..1111.00 rows=33334 width=4)
+                                       ->  Seq Scan on t1  (cost=0.00..1111.00 rows=33334 width=4)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+select count(*) from ( values :lots_of_values ) as b(a) where b.a % 100000 in (select a from t1);
+ count 
+-------
+ 66000
 (1 row)
 
 drop table t1;

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -497,15 +497,63 @@ EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
 
 DROP TABLE A;
 --
--- Test the ctid in function scan
+-- Test the ctid in Function and Values Scans
 --
 create table t1(a int) ;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into t1 select i from generate_series(1, 100000) i;
 analyze t1;
+-- Function Scan
+explain
+select count(*) from pg_backend_pid() b(a) where b.a % 100000 in (select a from t1);
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..450.95 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..450.95 rows=1 width=1)
+         ->  Hash Semi Join  (cost=0.00..450.95 rows=1 width=1)
+               Hash Cond: ((b % 100000) = a)
+               ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                     ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                           ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+               ->  Hash  (cost=431.62..431.62 rows=33334 width=4)
+                     ->  Seq Scan on t1  (cost=0.00..431.62 rows=33334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
 select count(*) from pg_backend_pid() b(a) where b.a % 100000 in (select a from t1);
  count 
 -------
      1
+(1 row)
+
+-- Values Scan
+-- We use a large number of entries, to make sure the fake ctids are generated
+-- correctly even when the offset number in the TID wraps around.
+select string_agg('(' || g || ')', ', ') as lots_of_values from generate_series(1, 66000) g
+\gset
+explain
+select count(*) from ( values :lots_of_values ) as b(a) where b.a % 100000 in (select a from t1);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..443.14 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..443.14 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..443.14 rows=1 width=8)
+               ->  Hash Semi Join  (cost=0.00..443.14 rows=22000 width=1)
+                     Hash Cond: (("Values".column1 % 100000) = t1.a)
+                     ->  Result  (cost=0.00..0.95 rows=22000 width=4)
+                           ->  Result  (cost=0.00..0.95 rows=22000 width=4)
+                                 ->  Values Scan on "Values"  (cost=0.00..0.26 rows=22000 width=4)
+                     ->  Hash  (cost=431.62..431.62 rows=33334 width=4)
+                           ->  Seq Scan on t1  (cost=0.00..431.62 rows=33334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select count(*) from ( values :lots_of_values ) as b(a) where b.a % 100000 in (select a from t1);
+ count 
+-------
+ 66000
 (1 row)
 
 drop table t1;

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -496,3 +496,16 @@ EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
 (9 rows)
 
 DROP TABLE A;
+--
+-- Test the ctid in function scan
+--
+create table t1(a int) ;
+insert into t1 select i from generate_series(1, 100000) i;
+analyze t1;
+select count(*) from pg_backend_pid() b(a) where b.a % 100000 in (select a from t1);
+ count 
+-------
+     1
+(1 row)
+
+drop table t1;

--- a/src/test/regress/sql/bfv_subquery.sql
+++ b/src/test/regress/sql/bfv_subquery.sql
@@ -291,3 +291,13 @@ SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
 EXPLAIN SELECT (EXISTS (SELECT UNNEST(X))) AS B FROM A;
 
 DROP TABLE A;
+
+--
+-- Test the ctid in function scan
+--
+
+create table t1(a int) ;
+insert into t1 select i from generate_series(1, 100000) i;
+analyze t1;
+select count(*) from pg_backend_pid() b(a) where b.a % 100000 in (select a from t1);
+drop table t1;


### PR DESCRIPTION
When converting semi-join to inner-join, one distinct agg on ctid is added
above the hash-join node. But tuples from VALUE scan may have invalid ctids;
so the assert check failed. 

This patch is based on commit d8886cf9.

Query:

```
SELECT * FROM tmp A WHERE (a=any(values (0),(1), (5), (99))) and (b >= '2019-09-20 00:00:00' AND b < '2019-09-21 00:00:00')
 AND (c = ANY(VALUES ('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),
 ('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),
 ('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),
 ('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),
 ('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),
 ('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),
 ('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),
 ('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),
 ('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),
 ('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),
 ('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),
 ('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),
 ('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307'),('3307')))
 
```


Query Plan:

```
 Gather Motion 2:1  (slice1; segments: 2)  (cost=126.36..126.44 rows=9 width=2224)
   ->  HashAggregate  (cost=126.36..126.44 rows=5 width=2224)
         Group Key: a.ctid, "*VALUES*".ctid
         ->  Hash Join  (cost=121.31..126.32 rows=5 width=2224)
               Hash Cond: ("*VALUES*_1".column1 = (a.c)::text)
               ->  Values Scan on "*VALUES*_1"  (cost=0.00..3.79 rows=152 width=32)
               ->  Hash  (cost=121.22..121.22 rows=4 width=2224)
                     ->  Hash Semi Join  (cost=0.10..121.22 rows=4 width=2224)
                           Hash Cond: (a.a = ("*VALUES*".column1)::numeric)
                           ->  Seq Scan on tmp a  (cost=0.00..121.00 rows=7 width=2218)
                                 Filter: ((b >= '2019-09-20 00:00:00'::timestamp without time zone) AND (b < '2019-09-21 00:00:00'::timestamp without time zone))
                           ->  Hash  (cost=0.05..0.05 rows=2 width=10)
                                 ->  Values Scan on "*VALUES*"  (cost=0.00..0.05 rows=2 width=10)
 Optimizer: Postgres query optimizer
```
 
 
Error Log:
```
ERROR:  Unexpected internal error (execTuples.c:1559)  (seg0 slice1 xx:40000 pid=145348) (execTuples.c:1559)
DETAIL:  FailedAssertion("!(((bool) (((const void*)(&(htup->t_self)) != ((void *)0)) && ((&(htup->t_self))->ip_posid != 0))))", File: "execTuples.c", Line: 1559)
HINT:  Process 145348 will wait for gp_debug_linger=120 seconds before termination.
Note that its locks and other resources will not be released until then.
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
