### PR TITLE
Fix flaky test dtm_recovery_on_standby

### DIFF
--- a/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
@@ -118,6 +118,9 @@ select reinitialize_standby();
 -- end_ignore
 
 -- Sync state between master and standby must be restored at the end.
+do $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select count(*) = 1 from pg_stat_replication) then /* in func */ return; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ end loop; /* in func */ end; /* in func */ $$;
+DO
+
 select application_name, state from pg_stat_replication;
  application_name | state     
 ------------------+-----------

--- a/src/test/isolation2/sql/segwalrep/dtm_recovery_on_standby.sql
+++ b/src/test/isolation2/sql/segwalrep/dtm_recovery_on_standby.sql
@@ -96,4 +96,15 @@ select reinitialize_standby();
 -- end_ignore
 
 -- Sync state between master and standby must be restored at the end.
+do $$
+begin /* in func */
+  for i in 1..120 loop /* in func */
+    if (select count(*) = 1 from pg_stat_replication) then /* in func */
+      return; /* in func */
+    end if; /* in func */
+    perform pg_sleep(0.1); /* in func */
+  end loop; /* in func */
+end; /* in func */
+$$;
+
 select application_name, state from pg_stat_replication;


### PR DESCRIPTION
It takes time to start walsender after gpinitstandby, add a wait loop to reduce
the flaky. It also fix the next test commit_blocking_on_standby.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
