### PR TITLE
Remove useless materialize plannode in left tree of join.

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -1980,6 +1980,16 @@ cdbpath_motion_for_join(PlannerInfo *root,
 												outer.move_to);
 		if (!outer.path)		/* fail if outer motion not feasible */
 			goto fail;
+
+		if (IsA(outer.path, MaterialPath) && !root->config->may_rescan)
+		{
+			/*
+			 * If we are the outer path and can never be rescanned,
+			 * we could remove the materialize path.
+			 */
+			MaterialPath *mpath = (MaterialPath *) outer.path;
+			outer.path = mpath->subpath;
+		}
 	}
 
 	/*

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1995,6 +1995,14 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 			(subquery->limitCount || subquery->limitOffset))
 			config->force_singleQE = true;
 
+		/*
+		 * Greenplum specific behavior:
+		 * config->may_rescan is used to guide if
+		 * we should add materialize path over motion
+		 * in the left tree of a join.
+		 */
+		config->may_rescan = config->may_rescan || !bms_is_empty(required_outer);
+
 		/* plan_params should not be in use in current query level */
 		Assert(root->plan_params == NIL);
 

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -319,6 +319,8 @@ PlannerConfig *DefaultPlannerConfig(void)
 
 	c1->force_singleQE = false;
 
+	c1->may_rescan = false;
+
 	return c1;
 }
 

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -702,6 +702,14 @@ make_subplan(PlannerInfo *root, Query *orig_subquery,
 	else
 		config->honor_order_by = false;
 
+	/*
+	 * Greenplum specific behavior:
+	 * config->may_rescan is used to guide if
+	 * we should add materialize path over motion
+	 * in the left tree of a join.
+	 */
+	config->may_rescan = true;
+
 	/* Generate Paths for the subquery */
 	subroot = subquery_planner(root->glob, subquery,
 							   root,

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -24,6 +24,7 @@ typedef struct PlannerConfig
 	bool		is_under_subplan; /* True for plan rooted at a subquery which is planned as a subplan */
 
 	bool        force_singleQE; /* True means force gather base rel to singleQE  */
+	bool        may_rescan; /* true means the subquery may be rescanned. */
 } PlannerConfig;
 
 extern PlannerConfig *DefaultPlannerConfig(void);

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -5449,12 +5449,10 @@ select * from int4_tbl a,
 ------------------------------------------------------------------------
  Nested Loop
    Output: a.f1, b.f1, c.q1, c.q2
-   ->  Materialize
+   ->  Gather Motion 3:1  (slice1; segments: 3)
          Output: a.f1
-         ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on public.int4_tbl a
                Output: a.f1
-               ->  Seq Scan on public.int4_tbl a
-                     Output: a.f1
    ->  Materialize
          Output: b.f1, c.q1, c.q2
          ->  Hash Right Join
@@ -5478,8 +5476,7 @@ select * from int4_tbl a,
                                  ->  Seq Scan on public.int4_tbl b
                                        Output: b.f1
  Optimizer: Postgres query optimizer
- Settings: optimizer=off
-(32 rows)
+(29 rows)
 
 select * from int4_tbl a,
   lateral (

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1225,10 +1225,9 @@ inner join lateral
 on true;
                                                            QUERY PLAN                                                            
 ---------------------------------------------------------------------------------------------------------------------------------
- Nested Loop  (cost=10000000001.10..10000000002.21 rows=4 width=20)
-   ->  Materialize  (cost=0.00..1.07 rows=2 width=12)
-         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.06 rows=2 width=12)
-               ->  Seq Scan on t_mylog_issue_8860 ml1  (cost=0.00..1.02 rows=1 width=12)
+ Nested Loop  (cost=10000000001.10..10000000002.20 rows=4 width=20)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.06 rows=2 width=12)
+         ->  Seq Scan on t_mylog_issue_8860 ml1  (cost=0.00..1.02 rows=1 width=12)
    ->  Materialize  (cost=1.10..1.12 rows=1 width=8)
          ->  Subquery Scan on ml2  (cost=1.10..1.11 rows=1 width=8)
                ->  Limit  (cost=1.10..1.10 rows=1 width=12)
@@ -1240,7 +1239,7 @@ on true;
                                        ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.06 rows=2 width=12)
                                              ->  Seq Scan on t_mylog_issue_8860  (cost=0.00..1.02 rows=1 width=12)
  Optimizer: Postgres query optimizer
-(15 rows)
+(14 rows)
 
 select ml1.myid, log_date as first_date, ml2.next_date from t_mylog_issue_8860 ml1
 inner join lateral

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1223,10 +1223,9 @@ inner join lateral
 on true;
                                                            QUERY PLAN                                                            
 ---------------------------------------------------------------------------------------------------------------------------------
- Nested Loop  (cost=10000000001.10..10000000002.21 rows=4 width=20)
-   ->  Materialize  (cost=0.00..1.07 rows=2 width=12)
-         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.06 rows=2 width=12)
-               ->  Seq Scan on t_mylog_issue_8860 ml1  (cost=0.00..1.02 rows=1 width=12)
+ Nested Loop  (cost=10000000001.10..10000000002.20 rows=4 width=20)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.06 rows=2 width=12)
+         ->  Seq Scan on t_mylog_issue_8860 ml1  (cost=0.00..1.02 rows=1 width=12)
    ->  Materialize  (cost=1.10..1.12 rows=1 width=8)
          ->  Subquery Scan on ml2  (cost=1.10..1.11 rows=1 width=8)
                ->  Limit  (cost=1.10..1.10 rows=1 width=12)

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -5528,12 +5528,10 @@ select * from int4_tbl a,
 ------------------------------------------------------------------------
  Nested Loop
    Output: a.f1, b.f1, c.q1, c.q2
-   ->  Materialize
+   ->  Gather Motion 3:1  (slice1; segments: 3)
          Output: a.f1
-         ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on public.int4_tbl a
                Output: a.f1
-               ->  Seq Scan on public.int4_tbl a
-                     Output: a.f1
    ->  Materialize
          Output: b.f1, c.q1, c.q2
          ->  Hash Right Join


### PR DESCRIPTION
When handling join, if the inner path's locus is CdbLocusType_OuterQuery,
it also set the outer path's locus to CdbLocusType_OuterQuery in the
function cdbpath_motion_for_join. And later in cdbpath_create_motion_path,
it will add a materialize path over the motion path if the original path's
locus is CdbLocusType_OuterQuery. If the whole subquery can never be rescanned,
this materialize path is useless and will lead to performance lose. A typical
plan before this patch (from the case regress/expected/join.out) is:

```
  explain (verbose, costs off)
  select * from int4_tbl a,
    lateral (
      select * from int4_tbl b left join int8_tbl c on (b.f1 = q1 and a.f1 = q2)
    ) ss;
                               QUERY PLAN
  ------------------------------------------------------------------------
   Nested Loop
     Output: a.f1, b.f1, c.q1, c.q2
     ->  Materialize  **< this plannode is useless >**
           Output: a.f1
           ->  Gather Motion 3:1  (slice1; segments: 3)
                 Output: a.f1
                 ->  Seq Scan on public.int4_tbl a
                       Output: a.f1
     ->  Materialize
           Output: b.f1, c.q1, c.q2
           ->  Hash Right Join
                 Output: b.f1, c.q1, c.q2
                 Hash Cond: (c.q1 = b.f1)
                 ->  Result
                       Output: c.q1, c.q2
                       Filter: (a.f1 = c.q2)
         ......
```

There are two cases that we can do this safely:

  * not in SubPlan
  * not in lateral join's inner subquery

This commit add a flag in PlannerInfo->config to guide
if we can remove the useless Materialize plannode in join's left tree.
