### PR TITLE
gpexpand: behave: cleanup leaked segs after rollback

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -402,6 +402,13 @@ Feature: expand the cluster by adding more segments
         And run rollback
         And verify the gp_segment_configuration has been restored
         And unset fault inject
+		# The rollback will remove the new segment's datadir, but this is not
+		# enough to let it quit, it might stop immediately, it might stop after
+		# tens of minutes.  If it does not quit in time, in later tests the new
+		# segments might fail to be launched due to port conflicts.  So we must
+		# force it to quit now.
+        And the database is not running
+        And the user runs remote command "pkill postgres" on host "sdw1"
 
     @gpexpand_no_mirrors
     @gpexpand_with_special_character

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -401,6 +401,18 @@ def impl(context, command):
     if has_exception(context):
         raise context.exception
 
+@given('the user runs remote command "{command}" on host "{hostname}"')
+@when('the user runs remote command "{command}" on host "{hostname}"')
+@then('the user runs remote command "{command}" on host "{hostname}"')
+def impl(context, command, hostname):
+    run_command_remote(context,
+                       command,
+                       hostname,
+                       os.getenv("GPHOME") + '/greenplum_path.sh',
+                       'export MASTER_DATA_DIRECTORY=%s' % master_data_dir)
+    if has_exception(context):
+        raise context.exception
+
 @given('the user runs command "{command}" eok')
 @when('the user runs command "{command}" eok')
 @then('the user runs command "{command}" eok')


### PR DESCRIPTION
In the scenario "inject a fail and test if rollback is ok" the expansion
is canceled after the new segment is launched, it must be shutdown in
time to prevent port conflicts in followings scenarios.

This is to fix a flaky gpexpand behave test, no new test is added.  It is also needed on 6X branch.  It has been verified on a devel 6X pipeline.

## Here are some reminders before you submit the pull request
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
