### PR TITLE
gpexpand: behave: allow pkill to fail

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -408,7 +408,7 @@ Feature: expand the cluster by adding more segments
 		# segments might fail to be launched due to port conflicts.  So we must
 		# force it to quit now.
         And the database is not running
-        And the user runs remote command "pkill postgres" on host "sdw1"
+        And the user runs remote command "pkill postgres || true" on host "sdw1"
 
     @gpexpand_no_mirrors
     @gpexpand_with_special_character


### PR DESCRIPTION
We use "pkill postgres" to cleanup leaked segments in the behave tests,
if the postgress processes already exited the pkill command would fail
with code 1, "No processes matched or none of them could be signalled".

Fixed by ignoring the return code of pkill.

This is a follow-up of https://github.com/greenplum-db/gpdb/pull/10101

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
