### PR TITLE
Fix memory accounting.

### DIFF
--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -663,6 +663,7 @@ AllocSetReset(MemoryContext context)
 #endif
 
 	set->accountingParent->currentAllocated -= set->localAllocated;
+	set->localAllocated = 0;
 
 	/* Clear chunk freelists */
 	MemSetAligned(set->freelist, 0, sizeof(set->freelist));
@@ -738,6 +739,7 @@ AllocSetDelete(MemoryContext context, MemoryContext parent)
 	}
 	else
 		set->accountingParent->currentAllocated -= set->localAllocated;
+	set->localAllocated = 0;
 
 	/* Make it look empty, just in case... */
 	MemSetAligned(set->freelist, 0, sizeof(set->freelist));


### PR DESCRIPTION
This showed up as bogus "Executor memory" lines in EXPLAIN ANALYZE
output.

Reviewed-by: Jesse Zhang <jzhang@pivotal.io>
