### PR TITLE
Dispatch analyze to segments

### DIFF
--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -8,6 +8,7 @@
 #include "cdb/cdbaocsam.h"
 #include "cdb/cdbvars.h"
 #include "commands/vacuum.h"
+#include "nodes/makefuncs.h"
 #include "storage/bufmgr.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
@@ -25,29 +26,6 @@
 bool			gp_statistics_pullup_from_child_partition = FALSE;
 bool			gp_statistics_use_fkeys = FALSE;
 
-typedef struct
-{
-	/* Table being sampled */
-	Relation	onerel;
-
-	/* Sampled rows and estimated total number of rows in the table. */
-	HeapTuple  *sample_rows;
-	int			num_sample_rows;
-	double		totalrows;
-	double		totaldeadrows;
-
-	/*
-	 * Result tuple descriptor. Each returned row consists of three "fixed"
-	 * columns, plus all the columns of the sampled table (excluding dropped
-	 * columns).
-	 */
-	TupleDesc	outDesc;
-#define NUM_SAMPLE_FIXED_COLS 3
-
-	/* SRF state, to track which rows have already been returned. */
-	int			index;
-	bool		summary_sent;
-} gp_acquire_sample_rows_context;
 
 /*
  * gp_acquire_sample_rows - Acquire a sample set of rows from table.
@@ -107,8 +85,6 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 	MemoryContext oldcontext;
 	Oid			relOid = PG_GETARG_OID(0);
 	int32		targrows = PG_GETARG_INT32(1);
-	bool		inherited = PG_GETARG_BOOL(2);
-	HeapTuple  *sample_rows;
 	TupleDesc	relDesc;
 	TupleDesc	outDesc;
 	int			live_natts;
@@ -118,12 +94,11 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 
 	if (SRF_IS_FIRSTCALL())
 	{
-		double		totalrows;
-		double		totaldeadrows;
 		Relation	onerel;
 		int			attno;
-		int			num_sample_rows;
 		int			outattno;
+		VacuumParams	params;
+		RangeVar	   *this_rangevar;
 
 		funcctx = SRF_FIRSTCALL_INIT();
 
@@ -133,12 +108,27 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		 */
 		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 
+		/* Construct the context to keep across calls. */
+		ctx = (gp_acquire_sample_rows_context *) palloc(sizeof(gp_acquire_sample_rows_context));
+
 		if (!pg_class_ownercheck(relOid, GetUserId()))
 			aclcheck_error(ACLCHECK_NOT_OWNER, ACL_KIND_CLASS,
 						   get_rel_name(relOid));
 
 		onerel = relation_open(relOid, AccessShareLock);
 		relDesc = RelationGetDescr(onerel);
+
+		{
+			params.freeze_min_age = -1;
+			params.freeze_table_age = -1;
+			params.multixact_freeze_min_age = -1;
+			params.multixact_freeze_table_age = -1;
+		}
+		this_rangevar = makeRangeVar(get_namespace_name(onerel->rd_rel->relnamespace),
+									 pstrdup(RelationGetRelationName(onerel)),
+									 -1);
+		analyze_rel(relOid, this_rangevar, VACOPT_ANALYZE, &params, NULL,
+					true, GetAccessStrategy(BAS_VACUUM), ctx);
 
 		/* Count the number of non-dropped cols */
 		live_natts = 0;
@@ -199,48 +189,9 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		BlessTupleDesc(outDesc);
 		funcctx->tuple_desc = outDesc;
 
-		/*
-		 * Collect the actual sample. (We do this only after blessing the output
-		 * tuple, to avoid the very expensive work of scanning the table, if we're
-		 * going to error out because of incorrect column definition, anyway.
-		 * ANALYZE should always get this right, but makes testing manually a bit
-		 * more comfortable.)
-		 */
-		sample_rows = (HeapTuple *) palloc0(targrows * sizeof(HeapTuple));
-
-		if(RelationIsForeign(onerel))
-		{
-			FdwRoutine *fdwroutine;
-			fdwroutine = GetFdwRoutineForRelation(onerel, false);
-			num_sample_rows =
-				fdwroutine->AcquireSampleRowsOnSegment(onerel, DEBUG1,
-													   sample_rows, targrows,
-													   &totalrows, &totaldeadrows);
-
-		}
-		else if (inherited)
-		{
-			num_sample_rows =
-				acquire_inherited_sample_rows(onerel, DEBUG1,
-											  sample_rows, targrows,
-											  &totalrows, &totaldeadrows);
-		}
-		else
-		{
-			num_sample_rows =
-				acquire_sample_rows(onerel, DEBUG1, sample_rows, targrows,
-									&totalrows, &totaldeadrows);
-		}
-
-		/* Construct the context to keep across calls. */
-		ctx = (gp_acquire_sample_rows_context *) palloc(sizeof(gp_acquire_sample_rows_context));
 		ctx->onerel = onerel;
 		funcctx->user_fctx = ctx;
 		ctx->outDesc = outDesc;
-		ctx->sample_rows = sample_rows;
-		ctx->num_sample_rows = num_sample_rows;
-		ctx->totalrows = totalrows;
-		ctx->totaldeadrows = totaldeadrows;
 
 		ctx->index = 0;
 		ctx->summary_sent = false;
@@ -260,7 +211,7 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 	HeapTuple	res;
 
 	/* First return all the sample rows */
-	if (ctx->index < ctx->num_sample_rows)
+	if (ctx->index < ctx->num_sample_rows && ctx->index < targrows)
 	{
 		HeapTuple	relTuple = ctx->sample_rows[ctx->index];
 		int			attno;

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -417,7 +417,7 @@ vacuum(int options, RangeVar *relation, Oid relid, VacuumParams *params,
 				}
 
 				analyze_rel(relid, relation, options, params,
-							va_cols, in_outer_xact, vac_strategy);
+							va_cols, in_outer_xact, vac_strategy, NULL);
 
 				if (use_own_xacts)
 				{

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -179,6 +179,30 @@ typedef struct VacuumParams
 										 * activated, -1 to use default */
 } VacuumParams;
 
+typedef struct
+{
+	/* Table being sampled */
+	Relation	onerel;
+
+	/* Sampled rows and estimated total number of rows in the table. */
+	HeapTuple  *sample_rows;
+	int			num_sample_rows;
+	double		totalrows;
+	double		totaldeadrows;
+
+	/*
+	 * Result tuple descriptor. Each returned row consists of three "fixed"
+	 * columns, plus all the columns of the sampled table (excluding dropped
+	 * columns).
+	 */
+	TupleDesc	outDesc;
+#define NUM_SAMPLE_FIXED_COLS 3
+
+	/* SRF state, to track which rows have already been returned. */
+	int			index;
+	bool		summary_sent;
+} gp_acquire_sample_rows_context;
+
 /* GUC parameters */
 extern PGDLLIMPORT int default_statistics_target;		/* PGDLLIMPORT for
 														 * PostGIS */
@@ -240,7 +264,7 @@ extern void ao_vacuum_rel_post_cleanup(Relation onerel, int options, VacuumParam
 /* in commands/analyze.c */
 extern void analyze_rel(Oid relid, RangeVar *relation, int options,
 			VacuumParams *params, List *va_cols, bool in_outer_xact,
-			BufferAccessStrategy bstrategy);
+			BufferAccessStrategy bstrategy, gp_acquire_sample_rows_context *ctx);
 
 extern bool std_typanalyze(VacAttrStats *stats);
 

--- a/src/test/regress/expected/bfv_statistic.out
+++ b/src/test/regress/expected/bfv_statistic.out
@@ -404,3 +404,20 @@ EXPLAIN SELECT * FROM test_join_card1 t1, test_join_card2 t2, test_join_card3 t3
 DROP TABLE IF EXISTS test_join_card1;
 DROP TABLE IF EXISTS test_join_card2;
 -- end_ignore
+-- Test if the table pg_statistic has data in segments
+DROP TABLE IF EXISTS test_statistic_1;
+CREATE TABLE test_statistic_1(a int, b int);
+INSERT INTO test_statistic_1 SELECT i, i FROM generate_series(1, 1000)i;
+select count(*) from pg_class c, pg_statistic s where c.oid = s.starelid and relname = 'test_statistic_1';
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from pg_class c, gp_dist_random('pg_statistic') s where c.oid = s.starelid and relname = 'test_statistic_1';
+ count 
+-------
+     6
+(1 row)
+
+DROP TABLE test_statistic_1;

--- a/src/test/regress/expected/bfv_statistic_optimizer.out
+++ b/src/test/regress/expected/bfv_statistic_optimizer.out
@@ -425,3 +425,20 @@ EXPLAIN SELECT * FROM test_join_card1 t1, test_join_card2 t2, test_join_card3 t3
 DROP TABLE IF EXISTS test_join_card1;
 DROP TABLE IF EXISTS test_join_card2;
 -- end_ignore
+-- Test if the table pg_statistic has data in segments
+DROP TABLE IF EXISTS test_statistic_1;
+CREATE TABLE test_statistic_1(a int, b int);
+INSERT INTO test_statistic_1 SELECT i, i FROM generate_series(1, 1000)i;
+select count(*) from pg_class c, pg_statistic s where c.oid = s.starelid and relname = 'test_statistic_1';
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from pg_class c, gp_dist_random('pg_statistic') s where c.oid = s.starelid and relname = 'test_statistic_1';
+ count 
+-------
+     6
+(1 row)
+
+DROP TABLE test_statistic_1;

--- a/src/test/regress/expected/gp_aggregates_costs.out
+++ b/src/test/regress/expected/gp_aggregates_costs.out
@@ -33,18 +33,16 @@ explain select avg(b) from cost_agg_t2 group by c;
 insert into cost_agg_t2 select i, random() * 99999,1 from generate_series(1, 200000) i;
 analyze cost_agg_t2;
 explain select avg(b) from cost_agg_t2 group by c;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=30914.97..32210.13 rows=103613 width=36)
-   ->  Finalize HashAggregate  (cost=30914.97..32210.13 rows=34538 width=36)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=43614.00..58686.07 rows=463756 width=36)
+   ->  HashAggregate  (cost=43614.00..49410.95 rows=154586 width=36)
          Group Key: c
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=19930.20..29255.37 rows=103613 width=36)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..37614.00 rows=400000 width=8)
                Hash Key: c
-               ->  Partial HashAggregate  (cost=19930.20..23038.59 rows=103613 width=36)
-                     Group Key: c
-                     ->  Seq Scan on cost_agg_t2  (cost=0.00..13614.00 rows=400000 width=8)
+               ->  Seq Scan on cost_agg_t2  (cost=0.00..13614.00 rows=400000 width=8)
  Optimizer: Postgres query optimizer
-(9 rows)
+(7 rows)
 
 drop table cost_agg_t1;
 drop table cost_agg_t2;

--- a/src/test/regress/sql/bfv_statistic.sql
+++ b/src/test/regress/sql/bfv_statistic.sql
@@ -311,3 +311,14 @@ EXPLAIN SELECT * FROM test_join_card1 t1, test_join_card2 t2, test_join_card3 t3
 DROP TABLE IF EXISTS test_join_card1;
 DROP TABLE IF EXISTS test_join_card2;
 -- end_ignore
+
+-- Test if the table pg_statistic has data in segments
+
+DROP TABLE IF EXISTS test_statistic_1;
+CREATE TABLE test_statistic_1(a int, b int);
+INSERT INTO test_statistic_1 SELECT i, i FROM generate_series(1, 1000)i;
+
+select count(*) from pg_class c, pg_statistic s where c.oid = s.starelid and relname = 'test_statistic_1';
+select count(*) from pg_class c, gp_dist_random('pg_statistic') s where c.oid = s.starelid and relname = 'test_statistic_1';
+
+DROP TABLE test_statistic_1;


### PR DESCRIPTION
Now the system table pg_statisitics only has data in master. But the
hash join skew hash need the some information in pg_statisitics. So
we need to dispatch the analyze command to segment. So that the system
table pg_statistics could have data in segments.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
