### PR TITLE
Skip external tables during analyze

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2061,8 +2061,9 @@ acquire_inherited_sample_rows(Relation onerel, int elevel,
 		/* We already got the needed lock */
 		childrel = heap_open(childOID, NoLock);
 
-		/* Ignore if temp table of another backend */
-		if (RELATION_IS_OTHER_TEMP(childrel))
+		/* Ignore if temp table of another backend or external table */
+		if (RELATION_IS_OTHER_TEMP(childrel) ||
+			RelationIsExternal(childrel))
 		{
 			/* ... but release the lock on it */
 			Assert(childrel != onerel);

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -950,6 +950,8 @@ HINT:  Use WITHOUT VALIDATION.
 alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
 truncate foo_p;
 ERROR:  "foo_p_1_prt_3" is an external relation and can't be truncated
+analyze foo_p;
+WARNING:  skipping "foo_p_1_prt_3" --- cannot analyze non-tables or special system tables
 drop table foo_p;
 drop table bar_p;
 -- Check for overflow of circular data types like time

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -954,6 +954,8 @@ HINT:  Use WITHOUT VALIDATION.
 alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
 truncate foo_p;
 ERROR:  "foo_p_1_prt_3" is an external relation and can't be truncated
+analyze foo_p;
+WARNING:  skipping "foo_p_1_prt_3" --- cannot analyze non-tables or special system tables
 drop table foo_p;
 drop table bar_p;
 -- Check for overflow of circular data types like time

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -442,6 +442,7 @@ create readable external table bar_p(i int, j int) location ('gpfdist://host.inv
 alter table foo_p exchange partition for(rank(3)) with table bar_p;
 alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
 truncate foo_p;
+analyze foo_p;
 drop table foo_p;
 drop table bar_p;
 


### PR DESCRIPTION
Analyze error'd with "ERROR: unsupported table type" if external table
is part of partition hierarchy. Also, that blocks analyzing database
wide as can't analyze such partitions. This commit adds check to skip
external tables during acquire_inherited_sample_rows().

Fixes #9506 github issue.
Co-authored-by: Alexandra Wang <lewang@pivotal.io>

This works on master (well there are relcache reference leak warnings which needs investigation) but fails on 6X_STABLE hence opening PR against GPDB6 only.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
