### PR TITLE
Allow AOCO tables to be inherited

### DIFF
--- a/gpcontrib/zstd/expected/compression_zstd.out
+++ b/gpcontrib/zstd/expected/compression_zstd.out
@@ -103,11 +103,17 @@ SELECT * FROM zstdtest_19 ORDER BY (id, t) DESC LIMIT 5;
 
 -- Test the bounds of compresslevel. None of these are allowed.
 CREATE TABLE zstdtest_invalid (id int4) WITH (appendonly=true, compresstype=zstd, compresslevel=-1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  value -1 out of bounds for option "compresslevel"
 DETAIL:  Valid values are between "0" and "19".
 CREATE TABLE zstdtest_invalid (id int4) WITH (appendonly=true, compresstype=zstd, compresslevel=0);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  compresstype "zstd" can't be used with compresslevel 0
 CREATE TABLE zstdtest_invalid (id int4) WITH (appendonly=true, compresstype=zstd, compresslevel=20);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  value 20 out of bounds for option "compresslevel"
 DETAIL:  Valid values are between "0" and "19".
 -- CREATE TABLE for heap table with compresstype=zstd should fail

--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -215,37 +215,6 @@ RelationGetAttributeOptions(Relation rel)
 }
 
 /*
- * Given a WITH(...) clause and no other column encoding directives -- such as
- * in the case of CREATE TABLE WITH () AS SELECT -- fill in the column encoding
- * catalog entries for that relation.
- */
-void
-AddDefaultRelationAttributeOptions(Relation rel, List *options)
-{
-	Datum opts;
-	AttrNumber attno;
-	List *ce;
-
-	/* only supported on AOCO at this stage */
-	if (!RelationIsAoCols(rel))
-		return;
-
-	ce = form_default_storage_directive(options);
-	if (!ce)
-		ce = default_column_encoding_clause();
-
-	ce = transformStorageEncodingClause(ce);
-
-	opts = transformRelOptions(PointerGetDatum(NULL), ce, NULL, NULL, true, false);
-
-	for (attno = 1; attno <= RelationGetNumberOfAttributes(rel); attno++)
-		add_attribute_encoding_entry(RelationGetRelid(rel),
-									 attno,
-									 opts);
-	CommandCounterIncrement();
-}
-
-/*
  * Work horse underneath DefineRelation().
  *
  * Simply adds user specified ENCODING () clause information to

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -173,7 +173,7 @@ create_ctas_internal(List *attrList, IntoClause *into, QueryDesc *queryDesc, boo
 	create->is_add_part = false;
 	create->is_split_part = false;
 	create->buildAoBlkdir = false;
-	create->attr_encodings = NULL; /* Handle by AddDefaultRelationAttributeOptions() */
+	create->attr_encodings = NULL; /* filled in by DefineRelation */
 
 	/* Save them in CreateStmt for dispatching. */
 	create->relKind = relkind;
@@ -312,13 +312,6 @@ create_ctas_nodata(List *tlist, IntoClause *into, QueryDesc *queryDesc)
 	/* Create the relation definition using the ColumnDef list */
 	intoRelationAddr = create_ctas_internal(attrList, into, queryDesc, true);
 
-	/* Add column encoding entries based on the WITH clause */
-	if (into->options)
-	{
-		Relation rel = heap_open(intoRelationAddr.objectId, AccessExclusiveLock);
-		AddDefaultRelationAttributeOptions(rel, into->options);
-		heap_close(rel, NoLock);
-	}
 	return intoRelationAddr;
 }
 
@@ -683,19 +676,6 @@ intorel_initplan(struct QueryDesc *queryDesc, int eflags)
 	 * Finally we can open the target table
 	 */
 	intoRelationDesc = heap_open(intoRelationAddr.objectId, AccessExclusiveLock);
-
-	/*
-	 * Add column encoding entries based on the WITH clause.
-	 *
-	 * NOTE:  we could also do this expansion during parse analysis, by
-	 * expanding the IntoClause options field into some attr_encodings field
-	 * (cf. CreateStmt and transformCreateStmt()). As it stands, there's no real
-	 * benefit for doing that from a code complexity POV. In fact, it would mean
-	 * more code. If, however, we supported column encoding syntax during CTAS,
-	 * it would be a good time to relocate this code.
-	 */
-	AddDefaultRelationAttributeOptions(intoRelationDesc,
-									   into->options);
 
 	/*
 	 * Check INSERT permission on the constructed table.

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -2137,13 +2137,6 @@ MergeAttributes(List *schema, List *supers, char relpersistence,
 					 errmsg("cannot inherit from temporary relation \"%s\"",
 							parent->relname)));
 
-		/* Reject if parent is CO for non-partitioned table */
-		if (RelationIsAoCols(relation) && !is_partition)
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("cannot inherit relation \"%s\" as it is column oriented",
-							parent->relname)));
-
 		/* If existing rel is temp, it must belong to this session */
 		if (relation->rd_rel->relpersistence == RELPERSISTENCE_TEMP &&
 			!relation->rd_islocaltemp)

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -390,32 +390,6 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			/* set our global sliceid variable for elog. */
 			currentSliceId = LocallyExecutingSliceIndex(estate);
 
-			/* Determine OIDs for into relation, if any */
-			if (queryDesc->plannedstmt->intoClause != NULL)
-			{
-				IntoClause *intoClause = queryDesc->plannedstmt->intoClause;
-				Oid         reltablespace;
-
-				cdb_sync_oid_to_segments();
-
-				/* MPP-10329 - must always dispatch the tablespace */
-				if (intoClause->tableSpaceName)
-				{
-					reltablespace = get_tablespace_oid(intoClause->tableSpaceName, false);
-					queryDesc->ddesc->intoTableSpaceName = intoClause->tableSpaceName;
-				}
-				else
-				{
-					reltablespace = GetDefaultTablespace(intoClause->rel->relpersistence);
-
-					/* Need the real tablespace id for dispatch */
-					if (!OidIsValid(reltablespace))
-						reltablespace = MyDatabaseTableSpace;
-
-					queryDesc->ddesc->intoTableSpaceName = get_tablespace_name(reltablespace);
-				}
-			}
-
 			/* InitPlan() will acquire locks by walking the entire plan
 			 * tree -- we'd like to avoid acquiring the locks until
 			 * *after* we've set up the interconnect */

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -372,7 +372,7 @@ _outQueryDispatchDesc(StringInfo str, const QueryDispatchDesc *node)
 {
 	WRITE_NODE_TYPE("QUERYDISPATCHDESC");
 
-	WRITE_STRING_FIELD(intoTableSpaceName);
+	WRITE_NODE_FIELD(intoCreateStmt);
 	WRITE_NODE_FIELD(paramInfo);
 	WRITE_NODE_FIELD(oidAssignments);
 	WRITE_NODE_FIELD(sliceTable);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1395,7 +1395,7 @@ _readQueryDispatchDesc(void)
 {
 	READ_LOCALS(QueryDispatchDesc);
 
-	READ_STRING_FIELD(intoTableSpaceName);
+	READ_NODE_FIELD(intoCreateStmt);
 	READ_NODE_FIELD(paramInfo);
 	READ_NODE_FIELD(oidAssignments);
 	READ_NODE_FIELD(sliceTable);

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -277,12 +277,6 @@ transformCreateStmt(CreateStmt *stmt, const char *queryString, bool createPartit
 				(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 				 errmsg("cannot mix inheritance with partitioning")));
 
-	/* Disallow inheritance for CO table */
-	if (stmt->inhRelations && is_aocs(stmt->options))
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("INHERITS clause cannot be used with column oriented tables")));
-
 	/*
 	 * GPDB_91_MERGE_FIXME: Previous gpdb does not allow create
 	 * partition on temp table. Let's follow this at this moment

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -4550,6 +4550,8 @@ transformAttributeEncoding(List *stenc, CreateStmt *stmt, List *columns)
 	if (stenc && !can_enc)
 		UNSUPPORTED_ORIENTATION_ERROR();
 
+	validateColumnStorageEncodingClauses(stenc, columns);
+
 	/* get the default clause, if there is one. */
 	foreach(lc, stenc)
 	{
@@ -4657,8 +4659,6 @@ transformAttributeEncoding(List *stenc, CreateStmt *stmt, List *columns)
 		else
 			newenc = NULL;
 	}
-
-	validateColumnStorageEncodingClauses(newenc, columns);
 
 	return newenc;
 }

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1205,14 +1205,6 @@ ProcessUtilitySlow(Node *parsetree,
 							 */
 							CommandCounterIncrement();
 
-							/* Add column encoding entries based on the WITH clauses */
-							if (cstmt->isCtas && cstmt->options)
-							{
-								Relation rel = heap_open(address.objectId, AccessExclusiveLock);
-								AddDefaultRelationAttributeOptions(rel, cstmt->options);
-								heap_close(rel, NoLock);
-							}
-
 							if (relKind != RELKIND_COMPOSITE_TYPE)
 							{
 								/*

--- a/src/include/catalog/pg_attribute_encoding.h
+++ b/src/include/catalog/pg_attribute_encoding.h
@@ -65,6 +65,5 @@ extern void AddRelationAttributeEncodings(Relation rel, List *attr_encodings);
 extern void RemoveAttributeEncodingsByRelid(Oid relid);
 extern void cloneAttributeEncoding(Oid oldrelid, Oid newrelid, AttrNumber max_attno);
 extern Datum *get_rel_attoptions(Oid relid, AttrNumber max_attno);
-extern void AddDefaultRelationAttributeOptions(Relation rel, List *options);
 
 #endif   /* PG_ATTRIBUTE_ENCODING_H */

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -223,7 +223,7 @@ typedef struct QueryDispatchDesc
 	 * For a SELECT INTO statement, this stores the tablespace to use for the
 	 * new table and related auxiliary tables.
 	 */
-	char		*intoTableSpaceName;
+	CreateStmt *intoCreateStmt;
 
 	/*
 	 * Oids to use, for new objects created in a CREATE command.

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -60,6 +60,7 @@ typedef struct
 	List	   *fkconstraints;	/* FOREIGN KEY constraints */
 	List	   *ixconstraints;	/* index-creating constraints */
 	List	   *inh_indexes;	/* cloned indexes from INCLUDING INDEXES */
+	List	   *attr_encodings; /* List of ColumnReferenceStorageDirectives */
 	List	   *blist;			/* "before list" of things to do before
 								 * creating the table */
 	List	   *alist;			/* "after list" of things to do after creating

--- a/src/include/parser/parse_utilcmd.h
+++ b/src/include/parser/parse_utilcmd.h
@@ -31,4 +31,6 @@ extern List *transformCreateSchemaStmt(CreateSchemaStmt *stmt);
 
 extern GpPolicy *getPolicyForDistributedBy(DistributedBy *distributedBy, TupleDesc tupdesc);
 
+extern List *transformAttributeEncoding(List *stenc, CreateStmt *stmt, List *columns);
+
 #endif   /* PARSE_UTILCMD_H */

--- a/src/include/parser/parse_utilcmd.h
+++ b/src/include/parser/parse_utilcmd.h
@@ -31,6 +31,6 @@ extern List *transformCreateSchemaStmt(CreateSchemaStmt *stmt);
 
 extern GpPolicy *getPolicyForDistributedBy(DistributedBy *distributedBy, TupleDesc tupdesc);
 
-extern List *transformAttributeEncoding(List *stenc, CreateStmt *stmt, List *columns);
+extern List *transformAttributeEncoding(List *columns, List *stenc, List *taboptions, bool *found_enc);
 
 #endif   /* PARSE_UTILCMD_H */

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -479,6 +479,17 @@ ERROR:  compresslevel=19 is out of range for zlib (should be in the range 1 to 9
 create table t1 (i int encoding (compresstype=zlib, ahhhh=boooooo))
 with (appendonly=true, orientation=column);
 ERROR:  unrecognized parameter "ahhhh"
+-- Invalid column references in COLUMN ENCODING clause
+create table t1 (i text,
+                 column non_existent encoding (compresstype=zlib))
+with (appendonly=true, orientation=column);
+ERROR:  column "non_existent" does not exist
+-- Conflicting column references for the same column
+create table t1 (dupe text,
+                 column dupe encoding (compresstype=zlib),
+		 column dupe encoding (compresstype=zlib))
+with (appendonly=true, orientation=column);
+ERROR:  column "dupe" referenced in more than one COLUMN ENCODING clause
 -- Inheritance: check that we don't support inheritance on tables using
 -- column compression
 create table ccddlparent (i int encoding (compresstype=zlib))

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -490,16 +490,68 @@ create table t1 (dupe text,
 		 column dupe encoding (compresstype=zlib))
 with (appendonly=true, orientation=column);
 ERROR:  column "dupe" referenced in more than one COLUMN ENCODING clause
--- Inheritance: check that we don't support inheritance on tables using
--- column compression
-create table ccddlparent (i int encoding (compresstype=zlib))
+-- Inheritance. The ENCODING options are not inherited from the parent.
+create table ccddlparent (parentcol int encoding (compresstype=zlib))
 with (appendonly = true, orientation = column);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'parentcol' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table ccddlchild (j int encoding (compresstype=zlib))
+create table ccddlchild (childcol int encoding (compresstype=zlib))
 inherits(ccddlparent) with (appendonly = true, orientation = column);
-ERROR:  INHERITS clause cannot be used with column oriented tables
+NOTICE:  table has parent, setting distribution columns to match parent table
+-- but you can specify it explicitly
+create table ccddlchild2 (childcol int,
+			  parentcol int encoding (compresstype=zlib))
+inherits(ccddlparent) with (appendonly = true, orientation = column);
+NOTICE:  table has parent, setting distribution columns to match parent table
+NOTICE:  moving and merging column "parentcol" with inherited definition
+DETAIL:  User-specified column moved to the position of the inherited column.
+execute ccddlcheck;
+   relname   | attnum |                     attoptions                      
+-------------+--------+-----------------------------------------------------
+ ccddlparent |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddlchild  |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlchild  |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddlchild2 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlchild2 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+(5 rows)
+
 drop table ccddlparent cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to append only columnar table ccddlchild
+drop cascades to append only columnar table ccddlchild2
+-- Multiple inheritance. Not particularly interesting because the
+-- encoding options are not copied from any parent, but let's test
+-- it anyway.
+create table ccddlparent1 (parentcol1 int encoding (compresstype=zlib),
+                           parentcol2 int)
+with (appendonly = true, orientation = column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'parentcol1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table ccddlparent2 (parentcol1 int,
+                           parentcol2 int encoding (compresstype=zlib))
+with (appendonly = true, orientation = column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'parentcol1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table ccddlchild (childcol int)
+inherits(ccddlparent1, ccddlparent2) with (appendonly = true, orientation = column);
+NOTICE:  table has parent, setting distribution columns to match parent table
+NOTICE:  merging multiple inherited definitions of column "parentcol1"
+NOTICE:  merging multiple inherited definitions of column "parentcol2"
+execute ccddlcheck;
+   relname    | attnum |                     attoptions                      
+--------------+--------+-----------------------------------------------------
+ ccddlparent1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddlparent1 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlparent2 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlparent2 |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddlchild   |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlchild   |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlchild   |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+(7 rows)
+
+drop table ccddlparent1 cascade;
+NOTICE:  drop cascades to append only columnar table ccddlchild
+drop table ccddlparent2 cascade;
 -- Conflict between default and with, in the LIKE case
 create table ccddl (i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -1691,7 +1691,9 @@ NOTICE:  CREATE TABLE will create partition "a_1_prt_p1" for table "a"
 ERROR:  partition specific ENCODING clause not supported in SUBPARTITION TEMPLATE
 LINE 3:       subpartition template(start(1) end(10) default column ...
                                     ^
--- partition level mention of column encoding but the table isn't heap oriented
+-- Partition level mention of column encoding but the table is not column
+-- oriented. This used to throw an error, but we're more lenient now. The
+-- ENCODING clause is simply ignored.
 CREATE TABLE ccddl
 (a1 int,a2 char(5),a3 text,a4 timestamp ,a5 date) 
 partition by range(a1) 
@@ -1703,7 +1705,12 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 NOTICE:  CREATE TABLE will create partition "ccddl_1_prt_1" for table "ccddl"
 NOTICE:  CREATE TABLE will create partition "ccddl_1_prt_2" for table "ccddl"
-ERROR:  ENCODING clause only supported with column oriented partitioned tables
+execute ccddlcheck;
+ relname | attnum | attoptions 
+---------+--------+------------
+(0 rows)
+
+drop table ccddl;
 -----------------------------------------------------------------------
 -- Type support
 -- Expect: success

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -225,8 +225,50 @@ SELECT count(*) FROM tenk_aocs3;
 SELECT count(*) FROM tenk_aocs4;
 
 -- INHERITS
--- This is not supported in aocs and should error out
-CREATE TABLE tenk_inherits_tenk_aocs1() INHERITS (tenk_aocs1);
+-- This used to be forbidden, but we allow it now.
+CREATE TABLE aocs_inh_parent (parent_t text,
+                              parent_t_8k text encoding (blocksize=8192))
+WITH (appendonly=true, orientation=column);
+
+-- The storage options are not inherited, but you can specify them explicitly.
+CREATE TABLE aocs_inh_child1 ()
+INHERITS (aocs_parent)
+WITH (appendonly=true, orientation=column);
+CREATE TABLE aocs_inh_child2 (parent_t text ENCODING (compresstype=zlib))
+INHERITS (aocs_inh_parent)
+WITH (appendonly=true, orientation=column);
+
+-- This syntax works even without explicitly listing the column.
+CREATE TABLE aocs_inh_child3 (COLUMN parent_t ENCODING (compresstype=zlib))
+INHERITS (aocs_inh_parent)
+WITH (appendonly=true, orientation=column);
+
+SELECT c.relname, ae.attnum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh%' AND c.oid=ae.attrelid ORDER BY 1,2;
+
+-- Multiple inheritance
+-- The ENCODING of parent_t_8k column doesn't match that of the other parent table.
+-- That's OK, because we don't try to copy the compression options from the parents.
+CREATE TABLE aocs_inh_parent2 (parent_t text,
+                               parent_t_8k text encoding (blocksize=16384),
+                               otherparent_t_8k text encoding (blocksize=8192))
+WITH (appendonly=true, orientation=column);
+CREATE TABLE aocs_inh_multichild ()
+INHERITS (aocs_inh_parent, aocs_inh_parent2)
+WITH (appendonly=true, orientation=column);
+
+SELECT c.relname, ae.attnum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh_multi%' AND c.oid=ae.attrelid ORDER BY 1,2;
+
+-- AOCO table inherits a heap table.
+CREATE TABLE aocs_inh2_parent_heap (parent_t text, parent_t2 text);
+CREATE TABLE aocs_inh2_child1 () INHERITS (aocs_inh2_parent_heap)
+WITH (appendonly=true, orientation=column);
+CREATE TABLE aocs_inh2_child2 (COLUMN parent_t ENCODING (compresstype=zlib)) INHERITS (aocs_inh2_parent_heap)
+WITH (appendonly=true, orientation=column);
+
+SELECT c.relname, ae.attnum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh2_%' AND c.oid=ae.attrelid ORDER BY 1,2;
+
+-- don't drop the tables, to also test pg_dump & restore of them.
+
 
 -- NYI
 -- test get_ao_compression_ratio. use uncompressed table, so result is always 1.
@@ -471,7 +513,7 @@ DROP TABLE syscoltest;
 -- supported sql
 --------------------
 DROP TABLE tenk_heap_for_aocs;
-DROP TABLE tenk_aocs1;
+DROP TABLE tenk_aocs1 CASCADE;
 DROP TABLE tenk_aocs2;
 DROP TABLE tenk_aocs3;
 DROP TABLE tenk_aocs4;

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -423,9 +423,67 @@ SELECT count(*) FROM tenk_aocs4;
 (1 row)
 
 -- INHERITS
--- This is not supported in aocs and should error out
-CREATE TABLE tenk_inherits_tenk_aocs1() INHERITS (tenk_aocs1);
-ERROR:  cannot inherit relation "tenk_aocs1" as it is column oriented
+-- This used to be forbidden, but we allow it now.
+CREATE TABLE aocs_inh_parent (parent_t text,
+                              parent_t_8k text encoding (blocksize=8192))
+WITH (appendonly=true, orientation=column);
+-- The storage options are not inherited, but you can specify them explicitly.
+CREATE TABLE aocs_inh_child1 ()
+INHERITS (aocs_parent)
+WITH (appendonly=true, orientation=column);
+ERROR:  relation "aocs_parent" does not exist
+CREATE TABLE aocs_inh_child2 (parent_t text ENCODING (compresstype=zlib))
+INHERITS (aocs_inh_parent)
+WITH (appendonly=true, orientation=column);
+-- This syntax works even without explicitly listing the column.
+CREATE TABLE aocs_inh_child3 (COLUMN parent_t ENCODING (compresstype=zlib))
+INHERITS (aocs_inh_parent)
+WITH (appendonly=true, orientation=column);
+SELECT c.relname, ae.attnum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh%' AND c.oid=ae.attrelid ORDER BY 1,2;
+     relname     | attnum |                     attoptions                      
+-----------------+--------+-----------------------------------------------------
+ aocs_inh_child2 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh_child2 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh_child3 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ aocs_inh_child3 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh_parent |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh_parent |      2 | {blocksize=8192,compresstype=none,compresslevel=0}
+(6 rows)
+
+-- Multiple inheritance
+-- The ENCODING of parent_t_8k column doesn't match that of the other parent table.
+-- That's OK, because we don't try to copy the compression options from the parents.
+CREATE TABLE aocs_inh_parent2 (parent_t text,
+                               parent_t_8k text encoding (blocksize=16384),
+                               otherparent_t_8k text encoding (blocksize=8192))
+WITH (appendonly=true, orientation=column);
+CREATE TABLE aocs_inh_multichild ()
+INHERITS (aocs_inh_parent, aocs_inh_parent2)
+WITH (appendonly=true, orientation=column);
+SELECT c.relname, ae.attnum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh_multi%' AND c.oid=ae.attrelid ORDER BY 1,2;
+       relname       | attnum |                     attoptions                      
+---------------------+--------+-----------------------------------------------------
+ aocs_inh_multichild |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh_multichild |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh_multichild |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+(3 rows)
+
+-- AOCO table inherits a heap table.
+CREATE TABLE aocs_inh2_parent_heap (parent_t text, parent_t2 text);
+CREATE TABLE aocs_inh2_child1 () INHERITS (aocs_inh2_parent_heap)
+WITH (appendonly=true, orientation=column);
+CREATE TABLE aocs_inh2_child2 (COLUMN parent_t ENCODING (compresstype=zlib)) INHERITS (aocs_inh2_parent_heap)
+WITH (appendonly=true, orientation=column);
+SELECT c.relname, ae.attnum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh2_%' AND c.oid=ae.attrelid ORDER BY 1,2;
+     relname      | attnum |                     attoptions                      
+------------------+--------+-----------------------------------------------------
+ aocs_inh2_child1 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh2_child1 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh2_child2 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ aocs_inh2_child2 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+(4 rows)
+
+-- don't drop the tables, to also test pg_dump & restore of them.
 -- NYI
 -- test get_ao_compression_ratio. use uncompressed table, so result is always 1.
 -- SELECT get_ao_compression_ratio('tenk_aocs2');
@@ -974,7 +1032,7 @@ DROP TABLE syscoltest;
 -- supported sql
 --------------------
 DROP TABLE tenk_heap_for_aocs;
-DROP TABLE tenk_aocs1;
+DROP TABLE tenk_aocs1 CASCADE;
 DROP TABLE tenk_aocs2;
 DROP TABLE tenk_aocs3;
 DROP TABLE tenk_aocs4;

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -67,7 +67,7 @@ CREATE TABLE tenk_ao13 (like tenk_heap) with (appendoptimized=true);
 CREATE TABLE tenk_ao14 (like tenk_heap) with (appendonly=true, appendoptimized=false);
 ERROR:  parameter "appendonly" specified more than once
 CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=maybe);
-ERROR:  invalid value for option "appendonly"
+ERROR:  invalid value for boolean option "appendonly": maybe
 CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=true, appendoptimized=true);
 ERROR:  parameter "appendonly" specified more than once
 CREATE TABLE tenk_ao15 (like tenk_heap) with (appendoptimized=true) 

--- a/src/test/regress/sql/column_compression.sql
+++ b/src/test/regress/sql/column_compression.sql
@@ -520,7 +520,9 @@ create table a (i int, j int) with (appendonly=true, orientation=column)
                             start(10) end(20))
 (partition p1 start(1) end(10));
 
--- partition level mention of column encoding but the table isn't heap oriented
+-- Partition level mention of column encoding but the table is not column
+-- oriented. This used to throw an error, but we're more lenient now. The
+-- ENCODING clause is simply ignored.
 CREATE TABLE ccddl
 (a1 int,a2 char(5),a3 text,a4 timestamp ,a5 date) 
 partition by range(a1) 
@@ -528,6 +530,8 @@ partition by range(a1)
 		start(1) end(1000) every(500),
 		COLUMN a1 ENCODING (compresstype=zlib,compresslevel=4,blocksize=32768)
 	);
+execute ccddlcheck;
+drop table ccddl;
 
 -----------------------------------------------------------------------
 -- Type support

--- a/src/test/regress/sql/column_compression.sql
+++ b/src/test/regress/sql/column_compression.sql
@@ -191,13 +191,39 @@ create table t1 (dupe text,
 		 column dupe encoding (compresstype=zlib))
 with (appendonly=true, orientation=column);
 
--- Inheritance: check that we don't support inheritance on tables using
--- column compression
-create table ccddlparent (i int encoding (compresstype=zlib))
+-- Inheritance. The ENCODING options are not inherited from the parent.
+create table ccddlparent (parentcol int encoding (compresstype=zlib))
 with (appendonly = true, orientation = column);
-create table ccddlchild (j int encoding (compresstype=zlib))
+create table ccddlchild (childcol int encoding (compresstype=zlib))
 inherits(ccddlparent) with (appendonly = true, orientation = column);
+
+-- but you can specify it explicitly
+create table ccddlchild2 (childcol int,
+			  parentcol int encoding (compresstype=zlib))
+inherits(ccddlparent) with (appendonly = true, orientation = column);
+
+execute ccddlcheck;
+
 drop table ccddlparent cascade;
+
+-- Multiple inheritance. Not particularly interesting because the
+-- encoding options are not copied from any parent, but let's test
+-- it anyway.
+create table ccddlparent1 (parentcol1 int encoding (compresstype=zlib),
+                           parentcol2 int)
+with (appendonly = true, orientation = column);
+
+create table ccddlparent2 (parentcol1 int,
+                           parentcol2 int encoding (compresstype=zlib))
+with (appendonly = true, orientation = column);
+
+create table ccddlchild (childcol int)
+inherits(ccddlparent1, ccddlparent2) with (appendonly = true, orientation = column);
+
+execute ccddlcheck;
+
+drop table ccddlparent1 cascade;
+drop table ccddlparent2 cascade;
 
 -- Conflict between default and with, in the LIKE case
 create table ccddl (i int);

--- a/src/test/regress/sql/column_compression.sql
+++ b/src/test/regress/sql/column_compression.sql
@@ -180,6 +180,17 @@ with (appendonly=true, orientation=column);
 create table t1 (i int encoding (compresstype=zlib, ahhhh=boooooo))
 with (appendonly=true, orientation=column);
 
+-- Invalid column references in COLUMN ENCODING clause
+create table t1 (i text,
+                 column non_existent encoding (compresstype=zlib))
+with (appendonly=true, orientation=column);
+
+-- Conflicting column references for the same column
+create table t1 (dupe text,
+                 column dupe encoding (compresstype=zlib),
+		 column dupe encoding (compresstype=zlib))
+with (appendonly=true, orientation=column);
+
 -- Inheritance: check that we don't support inheritance on tables using
 -- column compression
 create table ccddlparent (i int encoding (compresstype=zlib))


### PR DESCRIPTION
Because why not? This was forbidden back in 2012, with an old JIRA ticket that said:
    
    MPP-15735 - Inheritance is not supported with column oriented table
    
    This shouldn't be possible:

    Create table parent_tb2 (a1 int, a2 char(5), a3 text, a4 timestamp,
           a5 date, column a1 ENCODING (compresstype=zlib,compresslevel=9,blocksize=32768))
      with (appendonly=true,orientation=column)
      distributed by (a1);

    Create table child_tb4 (c1 int, c2 char) inherits(parent_tb2)
      with (appendonly = true, orientation = column);

    The reason is, dealing with column compression and inheritance is tricky
    and inheritance shouldn't even be supported.

That explanation didn't go into any details, but I can see the trickiness.
There are many places you can specify column compression options even
without inheritance: in gp_default_storage_options GUC, in an ENCODING
directive in CREATE TABLE command, in a "COLUMN foo ENCODING ..."
directive in the CREATE TABLE command, or in the datatype's default
storage options. Inheritance adds another dimension to it: should the
current gp_default_storage_options override the options inherited from the
parent? What if there are multiple parents with conflicting options?

The easiest solution is to never inherit the column encoding options from
the parent. That's a bit lame, but there's some precedence for that with
partitions: if you ALTER TABLE ADD PARTITION, the encoding options are
also not copied from the parent. So that's what this patch does.

One interesting corner case is to specify the options for an inherited
column with "CREATE TABLE (COLUMN parentcol ENCODING ...) INHERITS (...)".
Thanks to the previous refactoring, that works, even though 'parentcol'
is not explicitly listed in the CREATE TABLE command but inherited from
the parent. To make dump & restore of that work correctly, modify pg_dump
so that it always uses the "COLUMN foo ENCODING ..." syntax to specify
the options, instead of just tacking "ENCODING ..." after the column
definition.

One excuse for doing this right now is that even though we had forbidden
"CREATE TABLE <tab> INHERITS (<parent>)" on AOCO tables, we missed "ALTER
TABLE <tab> INHERIT <parent>". That was still allowed, and if you did
that you got an inherited AOCO table that worked just fine, except that
when it was dumped with pg_dump, the dump was unrestorable. It would have
been trivial to add a check to forbid "ALTER TABLE INHERIT" on an AOCO
table, instead, but it's even better to allow it.
