### PR TITLE
Update CCP cluster sysctl to be inline with docs

### DIFF
--- a/concourse/tasks/run_behave_on_ccp_cluster.yml
+++ b/concourse/tasks/run_behave_on_ccp_cluster.yml
@@ -47,7 +47,7 @@ run:
             #sysctl -w net.ipv4.ip_local_port_range=\"10000 65535\"
 
             # additional settings
-            sysctl -w kernel.sem=\"500 2048000 200 40960\"
+            sysctl -w kernel.sem=\"500 2048000 200 4096\"
             sysctl -w kernel.sysrq=1
             sysctl -w kernel.core_uses_pid=1
             sysctl -w kernel.msgmnb=65536
@@ -64,10 +64,8 @@ run:
             sysctl -w vm.zone_reclaim_mode=0
             sysctl -w vm.dirty_expire_centisecs=500
             sysctl -w vm.dirty_writeback_centisecs=100
-            sysctl -w vm.dirty_background_ratio=0
-            sysctl -w vm.dirty_ratio=0
-            sysctl -w vm.dirty_background_bytes=1610612736
-            sysctl -w vm.dirty_bytes=4294967296
+            sysctl -w vm.dirty_background_ratio=3
+            sysctl -w vm.dirty_ratio=10
         '"
     done <cluster_env_files/etc_hostfile
 


### PR DESCRIPTION
Commit 42930ed126d set the sysctl settings in a ccp cluster of VMs to be
identical to that in the docs. This has caused problems in the past, for
example see f765a0ef914 which resolve port overlap conflicts.

Recently, I've seen errors in gpconfig where python fails with "unable
to allocate memory" errors. Usually, on small memory systems like GCP
runs, this is due to the vm.overcommit=2 setting, because python
requests memory very greedily.

As an overarching statement, however, it's worth noting that GCP is
nothing like most customer systems in size or memory/cpu footprint, and
it's also nothing alike because it's on a vm, in the cloud, where some
sysctl settings are set prior to our access to the system on generic
vms.

I've taken the liberty of setting, or mostly unsetting, the OS settings
so that they are some reasonable union of "sensible for greenplum tests"
and "sensible for small vms"

Authored-by: Tyler Ramer <tramer@pivotal.io>
