### PR TITLE
Fix a hung issue caused by gp_interconnect_id disorder

### DIFF
--- a/src/backend/cdb/cdbsubplan.c
+++ b/src/backend/cdb/cdbsubplan.c
@@ -134,12 +134,6 @@ preprocess_initplans(QueryDesc *queryDesc)
 				 * later Init plans can depend on previous ones.
 				 */
 				ExecSetParamPlan(sps, sps->planstate->ps_ExprContext, queryDesc);
-
-				/*
-				 * We dispatched, and have returned. We may have used the
-				 * interconnect; so let's bump the interconnect-id.
-				 */
-				queryDesc->estate->es_sliceTable->ic_instance_id = ++gp_interconnect_id;
 			}
 		}
 

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1071,6 +1071,8 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 	nTotalSlices = sliceTbl->numSlices;
 	sliceVector = palloc0(nTotalSlices * sizeof(SliceVec));
 	nSlices = fillSliceVector(sliceTbl, rootIdx, sliceVector, nTotalSlices);
+	/* Each slice table has a unique-id. */
+	sliceTbl->ic_instance_id = ++gp_interconnect_id;
 
 	pQueryParms = cdbdisp_buildPlanQueryParms(queryDesc, planRequiresTxn);
 	queryText = buildGpQueryString(pQueryParms, &queryTextLength);

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -72,7 +72,7 @@ static void destroy_interconnect_handle(interconnect_handle_t *h);
 static interconnect_handle_t *find_interconnect_handle(ChunkTransportState *icContext);
 
 static void
-logChunkParseDetails(MotionConn *conn)
+logChunkParseDetails(MotionConn *conn, uint32 ic_instance_id)
 {
 	struct icpkthdr *pkt;
 
@@ -82,7 +82,7 @@ logChunkParseDetails(MotionConn *conn)
 	pkt = (struct icpkthdr *) conn->pBuff;
 
 	elog(LOG, "Interconnect parse details: pkt->len %d pkt->seq %d pkt->flags 0x%x conn->active %d conn->stopRequest %d pkt->icId %d my_icId %d",
-		 pkt->len, pkt->seq, pkt->flags, conn->stillActive, conn->stopRequested, pkt->icId, gp_interconnect_id);
+		 pkt->len, pkt->seq, pkt->flags, conn->stillActive, conn->stopRequested, pkt->icId, ic_instance_id);
 
 	elog(LOG, "Interconnect parse details continued: peer: srcpid %d dstpid %d recvslice %d sendslice %d srccontent %d dstcontent %d",
 		 pkt->srcPid, pkt->dstPid, pkt->recvSliceIndex, pkt->sendSliceIndex, pkt->srcContentId, pkt->dstContentId);
@@ -120,7 +120,7 @@ RecvTupleChunk(MotionConn *conn, ChunkTransportState *transportStates)
 	{
 		if (conn->msgSize - bytesProcessed < TUPLE_CHUNK_HEADER_SIZE)
 		{
-			logChunkParseDetails(conn);
+			logChunkParseDetails(conn, transportStates->sliceTable->ic_instance_id);
 
 			ereport(ERROR,
 					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
@@ -148,7 +148,7 @@ RecvTupleChunk(MotionConn *conn, ChunkTransportState *transportStates)
 			else
 				elog(LOG, "Interconnect error parsing message: no last item");
 
-			logChunkParseDetails(conn);
+			logChunkParseDetails(conn, transportStates->sliceTable->ic_instance_id);
 
 			ereport(ERROR,
 					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
@@ -174,7 +174,7 @@ RecvTupleChunk(MotionConn *conn, ChunkTransportState *transportStates)
 				 */
 				ML_CHECK_FOR_INTERRUPTS(transportStates->teardownActive);
 
-				logChunkParseDetails(conn);
+				logChunkParseDetails(conn, transportStates->sliceTable->ic_instance_id);
 
 				ereport(ERROR,
 						(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1304,9 +1304,6 @@ InitSliceTable(EState *estate, PlannedStmt *plannedstmt)
 	table->instrument_options = INSTRUMENT_NONE;
 	table->hasMotions = false;
 
-	/* Each slice table has a unique-id. */
-	table->ic_instance_id = ++gp_interconnect_id;
-
 	/*
 	 * Initialize the executor slice table.
 	 *

--- a/src/include/cdb/cdbicudpfaultinjection.h
+++ b/src/include/cdb/cdbicudpfaultinjection.h
@@ -212,7 +212,7 @@ testmode_sendto(const char *caller_name, int socket, const void *buffer,
 				break;
 			FAULT_INJECT_BACKUP_PKT();
 			msg->srcPid = -1;	/* There is no such pid. */
-			msg->icId = gp_interconnect_id;
+			msg->icId = 0;
 			msg->seq = 1;
 			write_log("inject fault to sendto: FINC_PKT_MISMATCH");
 			break;


### PR DESCRIPTION
This issue is exposed when doing an experiment to remove the
special "eval_stable_functions" handling in evaluate_function(),
qp_functions_in_* test cases will get stuck sometimes and it turns
out to be a gp_interconnect_id disorder issue.

Under UDPIFC interconnect, gp_interconnect_id is used to
distinguish the executions of MPP-fied plan in the same session
and in the receiver side, packets with smaller gp_interconnect_id
is treated as 'past' packets, receiver will stop the sender to send
the packets.

The RCA of the hung is:
1. QD call InitSliceTable() to advance the gp_interconnect_id and
store it in slice table.
2. In CdbDispatchPlan->exec_make_plan_constant(), QD find some
stable function need to be simplified to const, then it executes
this function first.
3. The function contains the SQL, QD init another slice table and
advance the gp_interconnect_id again, QD dispatch the new plan and
execute it.
4. After the function is simplified to const, QD continues to dispatch
the previous plan, however, the gp_interconnect_id for it becomes the
older one. When a packet comes, if the receiver hasn't set up the
interconnect yet, the packet will be handled by handleMismatch() and
it will be treated as `past` packets and the senders will be stopped
earlier by the receiver. Later the receiver finish the setup of
interconnect, it cannot get any packets from senders and get stuck.

To resolve this, we advance the gp_interconnect_id when a plan is
really dispatched, the plan is dispatched sequentially, so the later
dispatched plan will have a higher gp_interconnect_id.

Also limit the usage of gp_interconnect_id in rx thread of UDPIFC,
we prefer to use sliceTable->ic_instance_id in main thread.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
