### PR TITLE
Fix the gpload error that have no attribute "staging_table" or "fast_path".

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2804,6 +2804,8 @@ class gpload:
         if self.error_table:
             self.log_errors = True
             self.reuse_tables = True
+            self.staging_table = self.getconfig('gpload:preload:staging_table', unicode, default=None)
+            self.fast_match = self.getconfig('gpload:preload:fast_match',bool,False)
         if truncate == True:
             if method=='insert':
                 self.do_truncate(self.schemaTable)

--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -98,7 +98,7 @@ d = mkpath('config')
 if not os.path.exists(d):
     os.mkdir(d)
 
-def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',portNum='8081',database='reuse_gptest',host='localhost',formatOpts='text',file='data/external_file_01.txt',table='texttable',format='text',delimiter="'|'",escape='',quote='',truncate='False',log_errors=None, error_limit='0',error_table=None,externalSchema=None,staging_table=None,fast_match='false', encoding=None):
+def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',portNum='8081',database='reuse_gptest',host='localhost',formatOpts='text',file='data/external_file_01.txt',table='texttable',format='text',delimiter="'|'",escape='',quote='',truncate='False',log_errors=None, error_limit='0',error_table=None,externalSchema=None,staging_table=None,fast_match='false', encoding=None, preload=True):
 
     f = open(mkpath('config/config_file'),'w')
     f.write("VERSION: 1.0.0.1")
@@ -180,11 +180,12 @@ def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',
     if externalSchema:
         f.write("\n   EXTERNAL:")
         f.write("\n    - SCHEMA: "+externalSchema)
-    f.write("\n   PRELOAD:")
-    f.write("\n    - REUSE_TABLES: "+reuse_flag)
-    f.write("\n    - FAST_MATCH: "+fast_match)
-    if staging_table:
-        f.write("\n    - STAGING_TABLE: "+staging_table)
+    if preload:
+        f.write("\n   PRELOAD:")
+        f.write("\n    - REUSE_TABLES: "+reuse_flag)
+        f.write("\n    - FAST_MATCH: "+fast_match)
+        if staging_table:
+            f.write("\n    - STAGING_TABLE: "+staging_table)
     f.write("\n")
     f.close()
 
@@ -442,7 +443,7 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
 
     def test_00_gpload_formatOpts_setup(self):
         "0  gpload setup"
-        for num in range(1,38):
+        for num in range(1,39):
            f = open(mkpath('query%d.sql' % num),'w')
            f.write("\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n"+"\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n")
            f.close()
@@ -743,6 +744,14 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         copy_data('external_file_04.txt','data_file.txt')
         write_config_file(mode='merge',reuse_flag='true',fast_match='false',file='data_file.txt',encoding='xxxx')
         self.doTest(37)
+
+    def test_38_gpload_without_preload(self):
+        "38  gpload insert mode without preload"
+        file = mkpath('setup.sql')
+        runfile(file)
+        copy_data('external_file_04.txt','data_file.txt')
+        write_config_file(mode='insert',reuse_flag='true',fast_match='false',file='data_file.txt',error_table="err_table",error_limit='1000',preload=False)
+        self.doTest(38)
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(GPLoad_FormatOpts_TestCase)

--- a/gpMgmt/bin/gpload_test/gpload2/query38.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query38.ans
@@ -1,0 +1,20 @@
+2020-05-14 18:46:55|INFO|gpload session started 2020-05-14 18:46:55
+2020-05-14 18:46:55|WARN|ERROR_TABLE is not supported. We will set LOG_ERRORS and REUSE_TABLES to True for compatibility.
+2020-05-14 18:47:00|INFO|setting schema 'public' for table 'texttable'
+2020-05-14 18:47:00|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2020-05-14 18:47:00|INFO|did not find an external table to reuse. creating ext_gpload_reusable_3a4a5966_95d0_11ea_b773_784f4393479b
+2020-05-14 18:47:00|INFO|running time: 5.13 seconds
+2020-05-14 18:47:00|INFO|rows Inserted          = 16
+2020-05-14 18:47:00|INFO|rows Updated           = 0
+2020-05-14 18:47:00|INFO|data formatting errors = 0
+2020-05-14 18:47:00|INFO|gpload succeeded
+2020-05-14 18:47:00|INFO|gpload session started 2020-05-14 18:47:00
+2020-05-14 18:47:00|WARN|ERROR_TABLE is not supported. We will set LOG_ERRORS and REUSE_TABLES to True for compatibility.
+2020-05-14 18:47:05|INFO|setting schema 'public' for table 'texttable'
+2020-05-14 18:47:05|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2020-05-14 18:47:05|INFO|reusing external table ext_gpload_reusable_3a4a5966_95d0_11ea_b773_784f4393479b
+2020-05-14 18:47:05|INFO|running time: 5.09 seconds
+2020-05-14 18:47:05|INFO|rows Inserted          = 16
+2020-05-14 18:47:05|INFO|rows Updated           = 0
+2020-05-14 18:47:05|INFO|data formatting errors = 0
+2020-05-14 18:47:05|INFO|gpload succeeded


### PR DESCRIPTION
While gpload is loading data if the configure file contains "error_table" and doesn't contain "preload", an error of no attribute "staging_table" or "fast_path" occurs.

