### PR TITLE
PXF: fix glob matching in PXF paths for Hadoop-compatible filesystems

### DIFF
--- a/gpcontrib/pxf/src/pxffragment.c
+++ b/gpcontrib/pxf/src/pxffragment.c
@@ -126,7 +126,7 @@ get_data_fragment_list(GPHDUri *hadoop_uri,
 	List	   *data_fragments = NIL;
 
 	Assert(hadoop_uri->data != NULL);
-	char	   *restMsg = concat(2, "http://%s:%s/%s/%s/Fragmenter/getFragments?path=", hadoop_uri->data);
+	char	   *restMsg = "http://%s:%s/%s/%s/Fragmenter/getFragments";
 
 	rest_request(hadoop_uri, client_context, restMsg);
 
@@ -154,7 +154,7 @@ rest_request(GPHDUri *hadoop_uri, ClientContext *client_context, char *rest_msg)
  * parse the response of the PXF Fragments call. An example:
  *
  * Request:
- * 		curl --header "X-GP-FRAGMENTER: HdfsDataFragmenter" "http://goldsa1mac.local:50070/pxf/v2/Fragmenter/getFragments?path=demo" (demo is a directory)
+ * 		curl --header "X-GP-FRAGMENTER: HdfsDataFragmenter" "http://goldsa1mac.local:50070/pxf/v2/Fragmenter/getFragments" (demo is a directory)
  *
  * Response (left as a single line purposefully):
  * {"PXFFragments":[{"index":0,"userData":null,"sourceName":"demo/text2.csv","metadata":"rO0ABXcQAAAAAAAAAAAAAAAAAAAABXVyABNbTGphdmEubGFuZy5TdHJpbmc7rdJW5+kde0cCAAB4cAAAAAN0ABxhZXZjZWZlcm5hczdtYnAuY29ycC5lbWMuY29tdAAcYWV2Y2VmZXJuYXM3bWJwLmNvcnAuZW1jLmNvbXQAHGFldmNlZmVybmFzN21icC5jb3JwLmVtYy5jb20=","replicas":["10.207.4.23","10.207.4.23","10.207.4.23"]},{"index":0,"userData":null,"sourceName":"demo/text_csv.csv","metadata":"rO0ABXcQAAAAAAAAAAAAAAAAAAAABnVyABNbTGphdmEubGFuZy5TdHJpbmc7rdJW5+kde0cCAAB4cAAAAAN0ABxhZXZjZWZlcm5hczdtYnAuY29ycC5lbWMuY29tdAAcYWV2Y2VmZXJuYXM3bWJwLmNvcnAuZW1jLmNvbXQAHGFldmNlZmVybmFzN21icC5jb3JwLmVtYy5jb20=","replicas":["10.207.4.23","10.207.4.23","10.207.4.23"]}]}


### PR DESCRIPTION
When querying a PXF external table with some glob matching paths in the
LOCATION URI, Tomcat is rejecting the paths. In this commit, we remove
the `path` query string parameter as it has been deprecated and is no
longer used in the server, and it's causing issues with Tomcat because
the query string parameter is not URL-encoded.
