### PR TITLE
Fix bug when union all replicated tables with different numsegments

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -410,6 +410,11 @@ cdbpath_create_motion_path(PlannerInfo *root,
 				pathkeys = subpath->pathkeys;
 			}
 		}
+		else if (CdbPathLocus_IsSegmentGeneral(locus))
+		{
+			subpath->locus.numsegments = Min(subpath->locus.numsegments, locus.numsegments);
+			return subpath;
+		}
 		else
 			goto invalid_motion_request;
 	}

--- a/src/test/regress/expected/union_gp.out
+++ b/src/test/regress/expected/union_gp.out
@@ -272,6 +272,41 @@ select a from base where a = 'foo';
 (3 rows)
 
 --
+-- Test union all two replicated tables with different numsegments
+--
+create table rep2(c1 int, c2 int) distributed replicated;
+create table rep3(c1 int, c2 int) distributed replicated;
+set allow_system_table_mods = on;
+update gp_distribution_policy set numsegments = 2
+  where localoid = 'rep2'::regclass;
+select localoid::regclass, policytype, numsegments
+  from gp_distribution_policy
+  where localoid::regclass in ('rep2', 'rep3');
+ localoid | policytype | numsegments 
+----------+------------+-------------
+ rep3     | r          |           3
+ rep2     | r          |           2
+(2 rows)
+
+explain select * from rep2 union all select * from rep3;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=1922.00..1922.00 rows=172200 width=8)
+   ->  Append  (cost=0.00..1922.00 rows=172200 width=8)
+         ->  Seq Scan on rep2  (cost=0.00..961.00 rows=86100 width=8)
+         ->  Seq Scan on rep3  (cost=0.00..961.00 rows=86100 width=8)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select * from rep2 union all select * from rep3;
+ c1 | c2 
+----+----
+(0 rows)
+
+reset allow_system_table_mods;
+drop table rep2;
+drop table rep3;
+--
 -- Setup
 --
 --start_ignore

--- a/src/test/regress/sql/union_gp.sql
+++ b/src/test/regress/sql/union_gp.sql
@@ -98,6 +98,23 @@ select a from base
 union all
 select a from base where a = 'foo';
 
+--
+-- Test union all two replicated tables with different numsegments
+--
+create table rep2(c1 int, c2 int) distributed replicated;
+create table rep3(c1 int, c2 int) distributed replicated;
+set allow_system_table_mods = on;
+update gp_distribution_policy set numsegments = 2
+  where localoid = 'rep2'::regclass;
+select localoid::regclass, policytype, numsegments
+  from gp_distribution_policy
+  where localoid::regclass in ('rep2', 'rep3');
+explain select * from rep2 union all select * from rep3;
+select * from rep2 union all select * from rep3;
+reset allow_system_table_mods;
+drop table rep2;
+drop table rep3;
+
 
 --
 -- Setup


### PR DESCRIPTION
`select c.c1, c.c2 from d1 c union all select a.c1, a.c2 from d2 a;`
Both d1 and d2 are replicated tables, but the `numsegments` of them
in gp_distribution_policy are different. This could happen during
gpexpanding. The bug exists in function cdbpath_create_motion_path.
Both subpath->locus and locus are SegmentGeneral, but the locuses
are not equal

Co-authored-by: Pengzhou Tang <ptang@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
