### PR TITLE
Enable reognization on partition leaf node (#9975)

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4600,6 +4600,8 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 			{
 				Oid relid = RelationGetRelid(rel);
 				PartStatus ps = rel_part_status(relid);
+				DistributedBy *ldistro;
+				GpPolicy	  *policy;
 
 				ATExternalPartitionCheck(cmd->subtype, rel, recursing);
 
@@ -4611,6 +4613,25 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 						case PART_STATUS_ROOT:
 							break;
 						case PART_STATUS_LEAF:
+							Assert(PointerIsValid(cmd->def));
+							Assert(IsA(cmd->def, List));
+							/* The distributeby clause is the second element of cmd->def */
+							ldistro = (DistributedBy *)lsecond((List *)cmd->def);
+							if (ldistro == NULL)
+								break;
+							ldistro->numsegments = rel->rd_cdbpolicy->numsegments;
+
+							policy =  getPolicyForDistributedBy(ldistro, rel->rd_att);
+
+							if(!GpPolicyEqual(policy, rel->rd_cdbpolicy))
+								/*Reject interior branches of partitioned tables.*/
+								ereport(ERROR,
+										(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+												errmsg("can't set the distribution policy of \"%s\"",
+													   RelationGetRelationName(rel)),
+												errhint("Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.")));
+							break;
+
 						case PART_STATUS_INTERIOR:
 							/*Reject interior branches of partitioned tables.*/
 							ereport(ERROR,

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1409,4 +1409,57 @@ HINT:  Drop the primary key first
 CREATE TABLE alter_table_with_unique_index (a int unique);
 ALTER TABLE alter_table_with_unique_index SET DISTRIBUTED RANDOMLY;
 ERROR:  cannot set to DISTRIBUTED RANDOMLY because relation has unique index
-HINT:  Drop the unique index first
+HINT:  Drop the unique index first.
+-- Enable reorg partition leaf table
+create table reorg_leaf (a int, b int, c int) distributed by (c)
+partition by range(a)
+subpartition by range (b)
+subpartition template
+(start(0) end (10) every (5))
+(partition p0 start (0) end (5),
+	partition p1 start (5) end (10));
+insert into reorg_leaf select i, i, i from generate_series(0, 9) i;
+select *, gp_segment_id from reorg_leaf_1_prt_p0;
+ a | b | c | gp_segment_id 
+---+---+---+---------------
+ 2 | 2 | 2 |             0
+ 3 | 3 | 3 |             0
+ 4 | 4 | 4 |             0
+ 0 | 0 | 0 |             1
+ 1 | 1 | 1 |             1
+(5 rows)
+
+alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(b);
+ERROR:  can't set the distribution policy of "reorg_leaf_1_prt_p0"
+HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(c);
+ERROR:  can't set the distribution policy of "reorg_leaf_1_prt_p0"
+HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+alter table reorg_leaf_1_prt_p0 set with (reorganize=true);
+ERROR:  can't set the distribution policy of "reorg_leaf_1_prt_p0"
+HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true) distributed by(b);
+ERROR:  can't set the distribution policy of "reorg_leaf_1_prt_p0_2_prt_1"
+HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true) distributed by(c);
+select *, gp_segment_id from reorg_leaf_1_prt_p0;
+ a | b | c | gp_segment_id 
+---+---+---+---------------
+ 2 | 2 | 2 |             0
+ 3 | 3 | 3 |             0
+ 4 | 4 | 4 |             0
+ 0 | 0 | 0 |             1
+ 1 | 1 | 1 |             1
+(5 rows)
+
+alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true);
+select *, gp_segment_id from reorg_leaf_1_prt_p0;
+ a | b | c | gp_segment_id 
+---+---+---+---------------
+ 2 | 2 | 2 |             0
+ 3 | 3 | 3 |             0
+ 4 | 4 | 4 |             0
+ 0 | 0 | 0 |             1
+ 1 | 1 | 1 |             1
+(5 rows)
+

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -285,6 +285,7 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
 (1 row)
 
 -- github issues 5795. explain fails previously.
+--start_ignore
 explain SELECT * from information_schema.key_column_usage;
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
@@ -315,6 +316,7 @@ explain SELECT * from information_schema.key_column_usage;
  Optimizer: Postgres query optimizer
 (25 rows)
 
+--end_ignore
 -- github issue 5794.
 set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -316,6 +316,7 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
 (1 row)
 
 -- github issues 5795. explain fails previously.
+--start_ignore
 explain SELECT * from information_schema.key_column_usage;
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
@@ -346,6 +347,7 @@ explain SELECT * from information_schema.key_column_usage;
  Optimizer: Postgres query optimizer
 (25 rows)
 
+--end_ignore
 -- github issue 5794.
 set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -428,3 +428,22 @@ CREATE TABLE alter_table_with_primary_key (a int primary key);
 ALTER TABLE alter_table_with_primary_key SET DISTRIBUTED RANDOMLY;
 CREATE TABLE alter_table_with_unique_index (a int unique);
 ALTER TABLE alter_table_with_unique_index SET DISTRIBUTED RANDOMLY;
+
+-- Enable reorg partition leaf table
+create table reorg_leaf (a int, b int, c int) distributed by (c)
+partition by range(a)
+subpartition by range (b)
+subpartition template
+(start(0) end (10) every (5))
+(partition p0 start (0) end (5),
+	partition p1 start (5) end (10));
+insert into reorg_leaf select i, i, i from generate_series(0, 9) i;
+select *, gp_segment_id from reorg_leaf_1_prt_p0;
+alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(b);
+alter table reorg_leaf_1_prt_p0 set with (reorganize=true) distributed by(c);
+alter table reorg_leaf_1_prt_p0 set with (reorganize=true);
+alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true) distributed by(b);
+alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true) distributed by(c);
+select *, gp_segment_id from reorg_leaf_1_prt_p0;
+alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true);
+select *, gp_segment_id from reorg_leaf_1_prt_p0;

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -147,7 +147,9 @@ explain (format yaml, costs off) SELECT * FROM dummy_aotab;
 explain (format xml, costs off) insert into dummy_aotab values (1);
 
 -- github issues 5795. explain fails previously.
+--start_ignore
 explain SELECT * from information_schema.key_column_usage;
+--end_ignore
 
 -- github issue 5794.
 set gp_enable_explain_allstat=on;


### PR DESCRIPTION
We are not allowed to modify the distribution of partition leaf table
after gpdb6. Because the distibution of root table and leaf table must
be same. But if only reorg on the partition leaf table, it will not
cause this problem. So we enable reorg when the distibution was not be
changed.

backport from master cbcfafe6257a40e04a0c521704476654fbf050f6
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
