### PR TITLE
docs - enhance the pxf supported platforms section

### DIFF
--- a/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
@@ -8,6 +8,19 @@ You can query the external table via Greenplum Database, leaving the referenced 
 
 ## <a id="suppplat"></a> Supported Platforms
 
+### <a id="os"></a> Operating Systems
+
+PXF supports the Red Hat Enterprise Linux 64-bit 7.x, CentOS 64-bit 7.x, and Ubuntu 18.04 LTS operating system platforms.
+
+<div class="note">Starting in 6.x, Greenplum does not vendor <code>cURL</code> and instead loads the system-provided library. PXF requires <code>cURL</code> version 7.29.0 or newer. The officially-supported <code>cURL</code> for the CentOS 6.x and Red Hat Enterprise Linux 6.x operating systems is version 7.19.*. Greenplum Database 6 does not support running PXF on CentOS 6.x or RHEL 6.x due to this limitation.</div>
+
+### <a id="java"></a> Java
+
+PXF supports Java 8 and Java 11.
+
+
+### <a id="hadoop"></a> Hadoop
+
 PXF bundles all of the Hadoop JAR files on which it depends, and supports the following Hadoop component versions:
 
 | PXF Version | Hadoop Version | Hive Server Version | HBase Server Version |

--- a/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
@@ -12,7 +12,7 @@ You can query the external table via Greenplum Database, leaving the referenced 
 
 PXF supports the Red Hat Enterprise Linux 64-bit 7.x, CentOS 64-bit 7.x, and Ubuntu 18.04 LTS operating system platforms.
 
-<div class="note">Starting in 6.x, Greenplum does not vendor <code>cURL</code> and instead loads the system-provided library. PXF requires <code>cURL</code> version 7.29.0 or newer. The officially-supported <code>cURL</code> for the CentOS 6.x and Red Hat Enterprise Linux 6.x operating systems is version 7.19.*. Greenplum Database 6 does not support running PXF on CentOS 6.x or RHEL 6.x due to this limitation.</div>
+<div class="note">Starting in 6.x, Greenplum does not bundle <code>cURL</code> and instead loads the system-provided library. PXF requires <code>cURL</code> version 7.29.0 or newer. The officially-supported <code>cURL</code> for the CentOS 6.x and Red Hat Enterprise Linux 6.x operating systems is version 7.19.*. Greenplum Database 6 does not support running PXF on CentOS 6.x or RHEL 6.x due to this limitation.</div>
 
 ### <a id="java"></a> Java
 


### PR DESCRIPTION
in this PR:
- add subsections for os/java/hadoop
- add os info and note about centos6 curl issue
- add java info
