### PR TITLE
Mask out work_mem in auto_explain tests

### DIFF
--- a/contrib/auto_explain/init_file
+++ b/contrib/auto_explain/init_file
@@ -14,4 +14,7 @@ s/Rows Removed by Filter: .*/Rows Removed by Filter: /
 m/Memory used:\s+[0-9]+kB.*/
 s/Memory used:\s+[0-9]+kB.*/Memory used:/
 
+m/work_mem: \d+kB  Segments: \d+  Max: \d+kB \(segment \d+\)/
+s/work_mem: \d+kB  Segments: \d+  Max: \d+kB \(segment \d+\)/work_mem: 99kB  Segments: 9  Max: 99kB/
+
 -- end_matchsubs


### PR DESCRIPTION
Commit 73ca7e7731917 (greenplum-db/gpdb#7195) introduced a simple suite
that exercises auto_explain. However, it went beyond a simple "EXPLAIN",
and instead it ran a muted version of EXPLAIN ANALYZE.

Comparing the output of "EXPLAIN ANALYZE" in a regress test is always
error-prone and flaky. To wit, commit 1348afc0054e3 (#7608) had to be
done shortly after 73ca7e7731917, because the feature was time
sensitive. More recently commit 2e4d99fa3f50e (#10032) was forced to
memorize the work_mem, likely compiled with --enable-cassert, and missed
the case when we were configured without asserts, failing the test with
a smaller-than-expected work_mem.

This commit puts a band aid on it by masking the numeric values of
work_mem in auto_explain output.

## Here are some reminders before you submit the pull request
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
