### PR TITLE
Support multiple INITPLAN functions in one query.

### DIFF
--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -89,7 +89,7 @@ FunctionNext_guts(FunctionScanState *node)
 	 * of executing the real function.
 	 * Tuplestore is filled by the FunctionScan's initplan.
 	 */
-	if(node->resultInTupleStore && Gp_role != GP_ROLE_DISPATCH)
+	if(node->resultInTupleStore)
 	{
 		bool gotOK = false;
 		bool forward = true;
@@ -103,7 +103,7 @@ FunctionNext_guts(FunctionScanState *node)
 		if (!node->ts_state)
 		{
 			char rwfile_prefix[100];
-			function_scan_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix));
+			function_scan_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix), node->initplanId);
 
 			node->ts_state = tuplestore_open_shared(rwfile_prefix,
 													false /* interXact */);
@@ -381,6 +381,7 @@ ExecInitFunctionScan(FunctionScan *node, EState *estate, int eflags)
 	scanstate->ss.ps.state = estate;
 	scanstate->eflags = eflags;
 	scanstate->resultInTupleStore = node->resultInTupleStore;
+	scanstate->initplanId = node->initplanId;
 	scanstate->ts_state = NULL;
 
 	/*
@@ -700,6 +701,18 @@ ExecReScanFunctionScan(FunctionScanState *node)
 			ExecClearTuple(fs->func_slot);
 	}
 
+	/*
+	 * For function execute on INITPLAN, tuplestore accessor needs to
+	 * seek to the begin of file for rescan.
+	 *
+	 * Note that we've already stored the function result in tuplestore by
+	 * INITPLAN node, so there is no need to re-use the tuplestore in
+	 * function scan, which is used to avoid re-executing the
+	 * function again when rescan a FunctionScan
+	 */
+	if(node->resultInTupleStore && node->ts_state)
+		tuplestore_rescan(node->ts_state);
+
 	ExecScanReScan(&node->ss);
 
 	/*
@@ -773,8 +786,8 @@ ExecSquelchFunctionScan(FunctionScanState *node)
 }
 
 void
-function_scan_create_bufname_prefix(char* p, int size)
+function_scan_create_bufname_prefix(char* p, int size, int initplan_id)
 {
-	snprintf(p, size, "FUNCTION_SCAN_%d",
-			 gp_session_id);
+	snprintf(p, size, "FUNCTION_SCAN_%d_%d",
+			 gp_session_id, initplan_id);
 }

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1119,10 +1119,10 @@ PG_TRY();
 	{
 		char rwfile_prefix[100];
 
-		function_scan_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix));
+		function_scan_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix), subplan->plan_id);
 
 		node->ts_state = tuplestore_begin_heap(true, /* randomAccess */
-											  true, /* interXact */
+											  false, /* interXact */
 											  PlanStateOperatorMemKB((PlanState *)(node->planstate)));
 		tuplestore_make_shared(node->ts_state, rwfile_prefix);
 	}

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -824,6 +824,7 @@ _copyFunctionScan(const FunctionScan *from)
 	COPY_SCALAR_FIELD(funcordinality);
 	COPY_NODE_FIELD(param);
 	COPY_SCALAR_FIELD(resultInTupleStore);
+	COPY_SCALAR_FIELD(initplanId);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -862,6 +862,7 @@ _outFunctionScan(StringInfo str, const FunctionScan *node)
 	WRITE_BOOL_FIELD(funcordinality);
 	WRITE_NODE_FIELD(param);
 	WRITE_BOOL_FIELD(resultInTupleStore);
+	WRITE_INT_FIELD(initplanId);
 }
 
 static void

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2826,6 +2826,7 @@ _readFunctionScan(void)
 	READ_BOOL_FIELD(funcordinality);
 	READ_NODE_FIELD(param);
 	READ_BOOL_FIELD(resultInTupleStore);
+	READ_INT_FIELD(initplanId);
 
 	READ_DONE();
 }

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2086,9 +2086,10 @@ typedef struct FunctionScanState
 	/* tuplestore info when function scan run as initplan */
 	bool		resultInTupleStore; /* function result stored in tuplestore */
 	struct Tuplestorestate *ts_state;	/* tuple store state */
+	int			initplanId;			/* initplan is for function execute on initplan */
 } FunctionScanState;
 
-extern void function_scan_create_bufname_prefix(char *p, int size);
+extern void function_scan_create_bufname_prefix(char *p, int size, int initplan_id);
 
 /* ----------------
  * TableFunctionState information

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -775,6 +775,7 @@ typedef struct FunctionScan
 	bool		funcordinality; /* WITH ORDINALITY */
 	Param      *param;			/* used when funtionscan run as initplan */
 	bool		resultInTupleStore; /* function result stored in tuplestore */
+	int			initplanId;			/* initplan id for function execute on initplan */
 } FunctionScan;
 
 /* ----------------

--- a/src/test/regress/expected/function_extensions.out
+++ b/src/test/regress/expected/function_extensions.out
@@ -411,7 +411,7 @@ NOTICE:  unique_violation
 CREATE or replace FUNCTION get_temp_file_num() returns text as
 $$
 import os
-fileNum = len([name for name in os.listdir('base/pgsql_tmp')])
+fileNum = len([name for name in os.listdir(os.environ['MASTER_DATA_DIRECTORY'] + '/base/pgsql_tmp') if name.startswith('FUNCTION_SCAN')])
 return fileNum
 $$ language plpythonu;
 CREATE OR REPLACE FUNCTION get_country()
@@ -470,13 +470,13 @@ NOTICE:  table "t1_function_scan" does not exist, skipping
 EXPLAIN CREATE TABLE t1_function_scan AS SELECT * FROM get_country();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'country_id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Redistribute Motion 1:3  (slice1)  (cost=0.25..30.25 rows=1000 width=36)
    Hash Key: get_country.country_id
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Function Scan on get_country get_country_1  (cost=0.25..10.25 rows=1000 width=36)
    ->  Function Scan on get_country  (cost=0.25..10.25 rows=1000 width=36)
-         InitPlan 1 (returns $0)  (slice2)
-           ->  Function Scan on get_country get_country_1  (cost=0.25..10.25 rows=1000 width=36)
  Optimizer: Postgres query optimizer
 (6 rows)
 
@@ -588,11 +588,54 @@ NOTICE:  table "t4_function_scan" does not exist, skipping
 CREATE TABLE t4_function_scan AS SELECT 444, (1 / (0* random()))::text UNION ALL SELECT * FROM get_country();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '?column?' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  division by zero  (entry db 10.146.0.4:7000 pid=20360)
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ERROR:  division by zero  (entry db 10.146.0.4:7000 pid=24499)
 -- Temp file number after running INITPLAN function, number should not changed.
 SELECT get_temp_file_num();
  get_temp_file_num 
 -------------------
  0
+(1 row)
+
+-- test join case with two INITPLAN functions
+DROP TABLE IF EXISTS t5_function_scan;
+NOTICE:  table "t5_function_scan" does not exist, skipping
+CREATE TABLE t5_function_scan AS SELECT * FROM get_id(), get_country();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(*) FROM t5_function_scan;
+ count  
+--------
+ 300000
+(1 row)
+
+-- test union all 
+DROP TABLE IF EXISTS t6_function_scan;
+NOTICE:  table "t6_function_scan" does not exist, skipping
+CREATE TABLE t6_function_scan AS SELECT 100/(1+ 1* random())::int id, 'cc'::text cc UNION ALL SELECT * FROM  get_country();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(*) FROM t6_function_scan;
+ count 
+-------
+     4
+(1 row)
+
+DROP TABLE IF EXISTS t7_function_scan;
+NOTICE:  table "t7_function_scan" does not exist, skipping
+CREATE TABLE t7_function_scan AS SELECT * FROM  get_country() UNION ALL SELECT 100/(1+ 1* random())::int, 'cc'::text;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(*) FROM t7_function_scan;
+ count 
+-------
+     4
 (1 row)
 

--- a/src/test/regress/expected/function_extensions_optimizer.out
+++ b/src/test/regress/expected/function_extensions_optimizer.out
@@ -415,7 +415,7 @@ NOTICE:  unique_violation
 CREATE or replace FUNCTION get_temp_file_num() returns text as
 $$
 import os
-fileNum = len([name for name in os.listdir('base/pgsql_tmp')])
+fileNum = len([name for name in os.listdir(os.environ['MASTER_DATA_DIRECTORY'] + '/base/pgsql_tmp') if name.startswith('FUNCTION_SCAN')])
 return fileNum
 $$ language plpythonu;
 CREATE OR REPLACE FUNCTION get_country()
@@ -474,13 +474,13 @@ NOTICE:  table "t1_function_scan" does not exist, skipping
 EXPLAIN CREATE TABLE t1_function_scan AS SELECT * FROM get_country();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'country_id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Redistribute Motion 1:3  (slice1)  (cost=0.25..30.25 rows=1000 width=36)
    Hash Key: get_country.country_id
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Function Scan on get_country get_country_1  (cost=0.25..10.25 rows=1000 width=36)
    ->  Function Scan on get_country  (cost=0.25..10.25 rows=1000 width=36)
-         InitPlan 1 (returns $0)  (slice2)
-           ->  Function Scan on get_country get_country_1  (cost=0.25..10.25 rows=1000 width=36)
  Optimizer: Postgres query optimizer
 (6 rows)
 
@@ -592,11 +592,54 @@ NOTICE:  table "t4_function_scan" does not exist, skipping
 CREATE TABLE t4_function_scan AS SELECT 444, (1 / (0* random()))::text UNION ALL SELECT * FROM get_country();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '?column?' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-ERROR:  division by zero  (entry db 10.146.0.4:7000 pid=20360)
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ERROR:  division by zero  (entry db 10.146.0.4:7000 pid=25750)
 -- Temp file number after running INITPLAN function, number should not changed.
 SELECT get_temp_file_num();
  get_temp_file_num 
 -------------------
  0
+(1 row)
+
+-- test join case with two INITPLAN functions
+DROP TABLE IF EXISTS t5_function_scan;
+NOTICE:  table "t5_function_scan" does not exist, skipping
+CREATE TABLE t5_function_scan AS SELECT * FROM get_id(), get_country();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(*) FROM t5_function_scan;
+ count  
+--------
+ 300000
+(1 row)
+
+-- test union all 
+DROP TABLE IF EXISTS t6_function_scan;
+NOTICE:  table "t6_function_scan" does not exist, skipping
+CREATE TABLE t6_function_scan AS SELECT 100/(1+ 1* random())::int id, 'cc'::text cc UNION ALL SELECT * FROM  get_country();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(*) FROM t6_function_scan;
+ count 
+-------
+     4
+(1 row)
+
+DROP TABLE IF EXISTS t7_function_scan;
+NOTICE:  table "t7_function_scan" does not exist, skipping
+CREATE TABLE t7_function_scan AS SELECT * FROM  get_country() UNION ALL SELECT 100/(1+ 1* random())::int, 'cc'::text;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(*) FROM t7_function_scan;
+ count 
+-------
+     4
 (1 row)
 

--- a/src/test/regress/sql/function_extensions.sql
+++ b/src/test/regress/sql/function_extensions.sql
@@ -242,7 +242,7 @@ SELECT trigger_unique();
 CREATE or replace FUNCTION get_temp_file_num() returns text as
 $$
 import os
-fileNum = len([name for name in os.listdir('base/pgsql_tmp')])
+fileNum = len([name for name in os.listdir(os.environ['MASTER_DATA_DIRECTORY'] + '/base/pgsql_tmp') if name.startswith('FUNCTION_SCAN')])
 return fileNum
 $$ language plpythonu;
 
@@ -330,3 +330,17 @@ CREATE TABLE t4_function_scan AS SELECT 444, (1 / (0* random()))::text UNION ALL
 
 -- Temp file number after running INITPLAN function, number should not changed.
 SELECT get_temp_file_num();
+
+-- test join case with two INITPLAN functions
+DROP TABLE IF EXISTS t5_function_scan;
+CREATE TABLE t5_function_scan AS SELECT * FROM get_id(), get_country();
+SELECT count(*) FROM t5_function_scan;
+
+-- test union all 
+DROP TABLE IF EXISTS t6_function_scan;
+CREATE TABLE t6_function_scan AS SELECT 100/(1+ 1* random())::int id, 'cc'::text cc UNION ALL SELECT * FROM  get_country();
+SELECT count(*) FROM t6_function_scan;
+
+DROP TABLE IF EXISTS t7_function_scan;
+CREATE TABLE t7_function_scan AS SELECT * FROM  get_country() UNION ALL SELECT 100/(1+ 1* random())::int, 'cc'::text;
+SELECT count(*) FROM t7_function_scan;


### PR DESCRIPTION
We now use initplan id to differentiate the tuplestore used by
different INITPLAN functions. INITPLAN will also write the function
result into different tuplestores.

Also fix the bug which appends initplan in the wrong place. It may
generate wrong result in UNION ALL case.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
