### PR TITLE
Fixed the \dm empty output error

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -4026,7 +4026,7 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
     if (isGPDB())   /* GPDB? */
     {
 	appendPQExpBuffer(&buf, "AND c.relstorage IN (");
-	if (showTables || showIndexes || showSeq || (showSystem && showTables))
+	if (showTables || showIndexes || showSeq || (showSystem && showTables) || showMatViews)
 		appendPQExpBuffer(&buf, "'h', 'a', 'c',");
 	if (showExternal)
 		appendPQExpBuffer(&buf, "'x',");

--- a/src/test/regress/expected/matview_ao.out
+++ b/src/test/regress/expected/matview_ao.out
@@ -104,3 +104,24 @@ SELECT * FROM m_aocs;
  x    |      5
 (3 rows)
 
+\dm m_heap
+               List of relations
+ Schema |  Name  |       Type        |  Owner  
+--------+--------+-------------------+---------
+ public | m_heap | materialized view | gpadmin
+(1 row)
+
+\dm m_ao
+              List of relations
+ Schema | Name |       Type        |  Owner  
+--------+------+-------------------+---------
+ public | m_ao | materialized view | gpadmin
+(1 row)
+
+\dm m_aocs
+               List of relations
+ Schema |  Name  |       Type        |  Owner  
+--------+--------+-------------------+---------
+ public | m_aocs | materialized view | gpadmin
+(1 row)
+

--- a/src/test/regress/sql/matview_ao.sql
+++ b/src/test/regress/sql/matview_ao.sql
@@ -40,3 +40,6 @@ SELECT * FROM m_aocs;
 REFRESH MATERIALIZED VIEW m_aocs;
 SELECT * FROM m_aocs;
 
+\dm m_heap
+\dm m_ao
+\dm m_aocs


### PR DESCRIPTION
The psql client ignored rel storage when he create the \dm command.
So the output of \dm was empty. Add the correct rel storage check in command.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
