### PR TITLE
[6x Bugfix] Fix a startup process hang issue when primary node has not yet commit…

### DIFF
--- a/src/test/isolation2/expected/segwalrep/checkpoint_with_prepare.out
+++ b/src/test/isolation2/expected/segwalrep/checkpoint_with_prepare.out
@@ -1,0 +1,115 @@
+-- Test a bug that restarting a primary could lead to startup process hang if
+-- before shutdown checkpoint there are prepared but not yet committed/aborted
+-- transactions.
+
+include: helpers/server_helpers.sql;
+CREATE
+
+-- Allow extra time for mirror promotion to complete recovery to avoid
+-- gprecoverseg BEGIN failures due to gang creation failure as some primaries
+-- are not up. Setting these increase the number of retries in gang creation in
+-- case segment is in recovery.
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
+-- start_ignore
+20200522:10:14:15:048787 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
+-- start_ignore
+20200522:10:14:16:048845 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+20200522:10:14:16:048903 gpstop:host67:pguo-[INFO]:-Starting gpstop with args: -u
+20200522:10:14:16:048903 gpstop:host67:pguo-[INFO]:-Gathering information and validating the environment...
+20200522:10:14:16:048903 gpstop:host67:pguo-[INFO]:-Obtaining Greenplum Master catalog information
+20200522:10:14:16:048903 gpstop:host67:pguo-[INFO]:-Obtaining Segment details from master...
+20200522:10:14:16:048903 gpstop:host67:pguo-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.7.1+dev.62.g140d8966aa build dev'
+20200522:10:14:16:048903 gpstop:host67:pguo-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)
+
+create extension if not exists gp_inject_fault;
+CREATE
+
+create table t_ckpt (a int);
+CREATE
+
+-- generate an 'orphaned' prepare transaction.
+select gp_inject_fault('dtm_broadcast_prepare', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- assume (2), (1) are on different segments and one tuple is on the first
+-- segment.  the test finally double-check that.
+1&: insert into t_ckpt values(2),(1);  <waiting ...>
+select gp_wait_until_triggered_fault('dtm_broadcast_prepare', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- restart seg0 with 'fast' mode.
+-1U: select pg_ctl((SELECT datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'restart', 'fast');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- run the query and fail as expected since the gangs are gone and will be
+-- recreated in later query.
+select * from t_ckpt;
+ERROR:  terminating connection due to administrator command  (seg0 slice1 192.168.235.128:6002 pid=48781)
+
+-- the below queries also verify that the startup process on seg0 is not hanging.
+
+-- finish the suspended 2pc query.
+select gp_inject_fault('dtm_broadcast_prepare', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+INSERT 2
+
+-- double confirm the assumption for the test:
+--  1. tuples (2) and (1) are located on two segments (thus we are testing 2pc with prepared transaction).
+--  2. there are tuples on the first segment (we have been testing on the first segment).
+select gp_segment_id, * from t_ckpt;
+ gp_segment_id | a 
+---------------+---
+ 1             | 1 
+ 0             | 2 
+(2 rows)
+
+-- cleanup
+drop table t_ckpt;
+DROP
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation;
+-- start_ignore
+20200522:10:14:23:048981 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-r gp_gang_creation_retry_count --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation;
+-- start_ignore
+20200522:10:14:23:049123 gpconfig:host67:pguo-[INFO]:-completed successfully with parameters '-r gp_gang_creation_retry_timer --skipvalidation'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+20200522:10:14:24:049265 gpstop:host67:pguo-[INFO]:-Starting gpstop with args: -u
+20200522:10:14:24:049265 gpstop:host67:pguo-[INFO]:-Gathering information and validating the environment...
+20200522:10:14:24:049265 gpstop:host67:pguo-[INFO]:-Obtaining Greenplum Master catalog information
+20200522:10:14:24:049265 gpstop:host67:pguo-[INFO]:-Obtaining Segment details from master...
+20200522:10:14:24:049265 gpstop:host67:pguo-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.7.1+dev.62.g140d8966aa build dev'
+20200522:10:14:24:049265 gpstop:host67:pguo-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -190,6 +190,9 @@ test: segwalrep/mirror_promotion
 test: segwalrep/cancel_commit_pending_replication
 test: segwalrep/twophase_tolerance_with_mirror_promotion
 test: segwalrep/restartpoint_remove_xlog
+# Both restartpoint_remove_xlog and checkpoint_with_prepare run checkpoint so
+# put them together to make the subsequent checkpoint faster.
+test: segwalrep/checkpoint_with_prepare
 test: segwalrep/failover_with_many_records
 test: segwalrep/dtm_recovery_on_standby
 test: segwalrep/commit_blocking_on_standby

--- a/src/test/isolation2/sql/segwalrep/checkpoint_with_prepare.sql
+++ b/src/test/isolation2/sql/segwalrep/checkpoint_with_prepare.sql
@@ -1,0 +1,52 @@
+-- Test a bug that restarting a primary could lead to startup process hang if
+-- before shutdown checkpoint there are prepared but not yet committed/aborted
+-- transactions.
+
+include: helpers/server_helpers.sql;
+
+-- Allow extra time for mirror promotion to complete recovery to avoid
+-- gprecoverseg BEGIN failures due to gang creation failure as some primaries
+-- are not up. Setting these increase the number of retries in gang creation in
+-- case segment is in recovery.
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
+!\retcode gpstop -u;
+
+create extension if not exists gp_inject_fault;
+
+create table t_ckpt (a int);
+
+-- generate an 'orphaned' prepare transaction.
+select gp_inject_fault('dtm_broadcast_prepare', 'suspend', dbid)
+  from gp_segment_configuration where role = 'p' and content = -1;
+-- assume (2), (1) are on different segments and one tuple is on the first
+-- segment.  the test finally double-check that.
+1&: insert into t_ckpt values(2),(1);
+select gp_wait_until_triggered_fault('dtm_broadcast_prepare', 1, dbid)
+  from gp_segment_configuration where role = 'p' and content = -1;
+
+-- restart seg0 with 'fast' mode.
+-1U: select pg_ctl((SELECT datadir from gp_segment_configuration c
+  where c.role='p' and c.content=0), 'restart', 'fast');
+
+-- run the query and fail as expected since the gangs are gone and will be
+-- recreated in later query.
+select * from t_ckpt;
+
+-- the below queries also verify that the startup process on seg0 is not hanging.
+
+-- finish the suspended 2pc query.
+select gp_inject_fault('dtm_broadcast_prepare', 'reset', dbid)
+  from gp_segment_configuration where role = 'p' and content = -1;
+1<:
+
+-- double confirm the assumption for the test:
+--  1. tuples (2) and (1) are located on two segments (thus we are testing 2pc with prepared transaction).
+--  2. there are tuples on the first segment (we have been testing on the first segment).
+select gp_segment_id, * from t_ckpt;
+
+-- cleanup
+drop table t_ckpt;
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation;
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation;
+!\retcode gpstop -u;


### PR DESCRIPTION
…ted/aborted prepare xlog before shutdown checkpoint.

On primary if there is prepared transaction that is not committed or aborted,
restarting it with the fast mode could lead to startup process hang. That's
because it was cleanly shutdown so there is no recovery, however some variables
which are used by PrescanPreparedTransactions() are only initialized during
recovery.

The stack of the hanging startup process is as below:

0x0000000000bfb756 in pg_usleep (microsec=1000) at pgsleep.c:56
0x00000000005668ad in read_local_xlog_page (state=0x2a9c580, targetPagePtr=201326592, reqLen=32768, targetRecPtr=201571064, cur_page=0x2ab32e0 "\a",
    pageTLI=0x2a9c5c0) at xlogutils.c:829
0x00000000005646ef in ReadPageInternal (state=0x2a9c580, pageptr=201555968, reqLen=15128) at xlogreader.c:503
0x0000000000563f86 in XLogReadRecord (state=0x2a9c580, RecPtr=201571064, errormsg=0x7ffe895409d8) at xlogreader.c:226
0x000000000054c0e0 in PrescanPreparedTransactions (xids_p=0x0, nxids_p=0x0) at twophase.c:1696
0x0000000000559dcc in StartupXLOG () at xlog.c:7595
0x00000000008e6c2f in StartupProcessMain () at startup.c:242
