### PR TITLE
Fixed the \dm empty output error (#10163)

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -3741,7 +3741,7 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
     if (isGPDB())   /* GPDB? */
     {
 	appendPQExpBuffer(&buf, "AND c.relstorage IN (");
-	if (showTables || showIndexes || showSeq || (showSystem && showTables))
+	if (showTables || showIndexes || showSeq || (showSystem && showTables) || showMatViews)
 		appendPQExpBuffer(&buf, "'h', 'a', 'c',");
 	if (showExternal)
 		appendPQExpBuffer(&buf, "'x',");

--- a/src/test/regress/expected/matview_ao.out
+++ b/src/test/regress/expected/matview_ao.out
@@ -1,3 +1,6 @@
+drop role if exists matview_ao_role;
+create role matview_ao_role;
+set role matview_ao_role;
 CREATE TABLE t_matview_ao (id int NOT NULL PRIMARY KEY, type text NOT NULL, amt numeric NOT NULL);
 INSERT INTO t_matview_ao VALUES
   (1, 'x', 2),
@@ -95,3 +98,25 @@ SELECT * FROM m_aocs;
  x    |      5
 (3 rows)
 
+\dm m_heap
+                   List of relations
+ Schema |  Name  |       Type        |      Owner      
+--------+--------+-------------------+-----------------
+ public | m_heap | materialized view | matview_ao_role
+(1 row)
+
+\dm m_ao
+                  List of relations
+ Schema | Name |       Type        |      Owner      
+--------+------+-------------------+-----------------
+ public | m_ao | materialized view | matview_ao_role
+(1 row)
+
+\dm m_aocs
+                   List of relations
+ Schema |  Name  |       Type        |      Owner      
+--------+--------+-------------------+-----------------
+ public | m_aocs | materialized view | matview_ao_role
+(1 row)
+
+RESET role;

--- a/src/test/regress/sql/matview_ao.sql
+++ b/src/test/regress/sql/matview_ao.sql
@@ -1,3 +1,7 @@
+drop role if exists matview_ao_role;
+create role matview_ao_role;
+set role matview_ao_role;
+
 CREATE TABLE t_matview_ao (id int NOT NULL PRIMARY KEY, type text NOT NULL, amt numeric NOT NULL);
 INSERT INTO t_matview_ao VALUES
   (1, 'x', 2),
@@ -38,3 +42,8 @@ SELECT * FROM m_aocs;
 REFRESH MATERIALIZED VIEW m_aocs;
 SELECT * FROM m_aocs;
 
+\dm m_heap
+\dm m_ao
+\dm m_aocs
+
+RESET role;


### PR DESCRIPTION
The psql client ignored rel storage when he create the \dm command.
So the output of \dm was empty. Add the correct rel storage check in command.

This pr backport from master 999f187e8ec8e9b883989035e9738d92ebf0b8ea
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
