### PR TITLE
Enhance gpcheckcat persistent check

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2695,7 +2695,9 @@ def checkPersistentTables():
       FROM   gp_persistent_relation_node_check() p
         LEFT OUTER JOIN pg_class c
           ON (p.relfilenode_oid = c.relfilenode)
-      WHERE (p.segment_file_num = 0 or c.relstorage != 'h')
+      WHERE (c.relstorage is not null and c.relstorage != 'h') or
+            (c.relstorage is not null and segment_file_num = 0) or
+            (c.relstorage is null)
     ) b ON (a.tablespace_oid   = b.tablespace_oid    and
             a.database_oid     = b.database_oid      and
             a.relfilenode_oid  = b.relfilenode_oid   and

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -409,6 +409,14 @@ Feature: gpcheckcat tests
         Then gpcheckcat should print "Table pg_type has a dependency issue on oid .* at content 0" to stdout
         And the user runs "dropdb gpcheckcat_dependency"
 
+    @persistent_filesystem
+    Scenario: gpcheckcat should report filesystem persistence errors.
+        Given database "persistent_filesystem_db" is dropped and recreated
+		And the user runs "psql -t -c "select fselocation || '/base/' || pg_database.oid || '123456789.2' from pg_catalog.pg_filespace_entry, pg_database where fsedbid = 2 and datname = 'persistent_filesystem_db'" | xargs touch"
+        When the user runs "gpcheckcat -R persistent persistent_filesystem_db"
+        Then gpcheckcat should print "Failed test\(s\) that are not reported here: persistent" to stdout
+        And the user runs "dropdb persistent_filesystem_db"
+
     @persistent
     Scenario: gpcheckcat should report persistence errors # we need to run this test at the end because it makes the database go into a PANIC state.
         Given database "persistent_db" is dropped and recreated


### PR DESCRIPTION
gpcheckcat persistent check is consist of a series of extra/missing
check, one is to detect the extra relation files in the file system
after a table is dropped, the main idea is:
1. using gp_persistent_relation_node_check() to list all relation
   files in the filesystem
2. say whether catalog pg_class contains the entries referring to
   those relfilenodes.
3. say whether catalog pg_persistent_relation_node contains the
   entries referring to those relfilenodes.

Another background is:
heap tables only ever store segment_file_num 0 in the persistent
tables, while ao/co tables will store every segment_file_num that
they use, so we need to handle the difference in the SQL file,
otherwise, segment_file_num > 0 will be treated as extra files.

With the old filter in the SQL file, extra segment files > 0 cannot
be detected, so enhance the filter.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
