### PR TITLE
[5X backport] Need to lock when accessing global prepared transaction data during c…

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -2298,8 +2298,8 @@ TwoPhaseRecoverMirror(void)
 void
 getTwoPhasePreparedTransactionData(prepared_transaction_agg_state **ptas, char *caller)
 {
-	int			numberOfPrepareXacts     = TwoPhaseState->numPrepXacts;
-	GlobalTransaction *globalTransactionArray   = TwoPhaseState->prepXacts;
+	int			numberOfPrepareXacts;
+	GlobalTransaction *globalTransactionArray;
 	TransactionId xid;
 	XLogRecPtr *recordPtr = NULL;
 	int			maxCount;
@@ -2311,6 +2311,11 @@ getTwoPhasePreparedTransactionData(prepared_transaction_agg_state **ptas, char *
 	Assert(*ptas == NULL);
 
 	TwoPhaseAddPreparedTransactionInit(ptas, &maxCount);
+
+	LWLockAcquire(TwoPhaseStateLock, LW_SHARED);
+
+	numberOfPrepareXacts = TwoPhaseState->numPrepXacts;
+	globalTransactionArray = TwoPhaseState->prepXacts;
 
 	elog(PersistentRecovery_DebugPrintLevel(),
 		 "getTwoPhasePreparedTransactionData: numberOfPrepareXacts = %d",
@@ -2336,6 +2341,8 @@ getTwoPhasePreparedTransactionData(prepared_transaction_agg_state **ptas, char *
 									   recordPtr,
 									   caller);
     }
+
+	LWLockRelease(TwoPhaseStateLock);
 }  /* end getTwoPhasePreparedTransactionData */
 
 


### PR DESCRIPTION
…heckpoint. (#10094)

Those data are stored as extended checkpoint so that prepared transactions are
not forgotten after checkpoint. If we access them without lock, it is possible
that we access some inconsistent data. That will lead to some unknown behaviors.

Reviewed-by: Hao Wu <hawu@pivotal.io>
Reviewed-by: Ashwin Agrawal <aagrawal@pivotal.io>

Cherry-picked from 3c284a3bb6f439e3ae6a607fb63fd624fbaaefc9