### PR TITLE
Error client connection if DTM recovery in-progress

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1079,23 +1079,12 @@ cdb_setup(void)
 		Gp_role == GP_ROLE_DISPATCH &&
 		!*shmDtmStarted)
 	{
-		while (true)
-		{
-			int rc;
-			if (*shmDtmStarted)
-				break;
-			CHECK_FOR_INTERRUPTS();
-			/* wait for 100ms or postmaster dies */
-			rc = WaitLatch(&MyProc->procLatch,
-				   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH, 100);
-
-			ResetLatch(&MyProc->procLatch);
-			if (rc & WL_POSTMASTER_DEATH)
-				proc_exit(1);
-		}
+		ereport(FATAL,
+				(errcode(ERRCODE_CANNOT_CONNECT_NOW),
+				 errmsg(POSTMASTER_IN_RECOVERY_MSG),
+				 errdetail("waiting for distributed transaction recovery to complete")));
 	}
 }
-
 
 /*
  * performs all necessary cleanup required when leaving Greenplum


### PR DESCRIPTION
Client connections used to wait for dtx recovery process to complete
distributed transaction recovery. Depending on situation this waiting
could be infinite. To avoid hung connections though in certain
situation where dtx recovery can't complete the distributed
transactions, better to error out and let client retry in this
situation similar to local crash recovery situation.

Discussion:
https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/dgU9il8l24A/NTAz2cl5BQAJ

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
