### PR TITLE
Log fewer errors

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.101.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.102.", GPORCA_VERSION_STRING, 6);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.101.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.102.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12523,7 +12523,7 @@ int
 main ()
 {
 
-return strncmp("3.101.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.102.", GPORCA_VERSION_STRING, 6);
 
   ;
   return 0;
@@ -12533,7 +12533,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.101.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.102.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.101.0@gpdb/stable
+orca/v3.102.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.101.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.102.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -1055,7 +1055,7 @@ COptTasks::OptimizeTask
 		}
 		else
 		{
-			opt_ctxt->m_is_unexpected_failure = IsUnexpectedFailure(ex);
+			opt_ctxt->m_is_unexpected_failure = IsLoggableFailure(ex);
 		}
 		GPOS_RETHROW(ex);
 	}

--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -59,7 +59,14 @@ log_optimizer(PlannedStmt *plan, bool fUnexpectedFailure)
 		(fUnexpectedFailure && OPTIMIZER_UNEXPECTED_FAIL == optimizer_log_failure) || 		/* unexpected fall back */
 		(!fUnexpectedFailure && OPTIMIZER_EXPECTED_FAIL == optimizer_log_failure))			/* expected fall back */
 	{
-		elog(LOG, "Pivotal Optimizer (GPORCA) failed to produce plan");
+		if (fUnexpectedFailure)
+		{
+			elog(LOG, "Pivotal Optimizer (GPORCA) failed to produce plan (unexpected)");
+		}
+		else
+		{
+			elog(LOG, "Pivotal Optimizer (GPORCA) failed to produce plan");
+		}
 		return;
 	}
 }


### PR DESCRIPTION
This is a continuation of commit 456b2b3 in GPORCA. Adding more errors to the list that
doesn't get logged in log file. We are also removing the code that writes to std::cerr,
generating a not very nice looking log message. Instead, add the info whether the error was
unexpected to another log message that we also generate.

This is a cherry-pick of GPDB master PR greenplum-db/gpdb#10100.
The corresponding Orca PR is https://github.com/greenplum-db/gporca/pull/586.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
