### PR TITLE
Fix flaky resgroup test

### DIFF
--- a/src/test/isolation2/input/resgroup/resgroup_move_query.source
+++ b/src/test/isolation2/input/resgroup/resgroup_move_query.source
@@ -118,15 +118,16 @@ SELECT is_session_in_group(pid, 'rg_move_query_mem_small') FROM pg_stat_activity
 
 -- test6: the destination group will wake up 'gp_toolkit.pg_resgroup_move_query' when a new slot become available
 1: SET ROLE role_move_query;
-1&: SELECT pg_sleep(5);
+1&: SELECT pg_sleep(3);
 2: SET ROLE role_move_query_mem_small;
-2&: SELECT pg_sleep(10);
-3&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep(10)%' AND rsgname='rg_move_query_mem_small';
+2: BEGIN;
+2: SELECT hold_memory_by_percent_on_qe(1,0.1);
+3&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND rsgname='rg_move_query_mem_small';
 1<:
 -- connection 1 finished, it will wake up connection 3
 3<:
-3: SELECT rsgname, query FROM pg_stat_activity WHERE state = 'active';
-2<:
+3: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND state = 'idle in transaction';
+2: END;
 
 DROP ROLE role_move_query;
 DROP RESOURCE GROUP rg_move_query;

--- a/src/test/isolation2/output/resgroup/resgroup_move_query.source
+++ b/src/test/isolation2/output/resgroup/resgroup_move_query.source
@@ -163,11 +163,17 @@ END
 -- test6: the destination group will wake up 'gp_toolkit.pg_resgroup_move_query' when a new slot become available
 1: SET ROLE role_move_query;
 SET
-1&: SELECT pg_sleep(5);  <waiting ...>
+1&: SELECT pg_sleep(3);  <waiting ...>
 2: SET ROLE role_move_query_mem_small;
 SET
-2&: SELECT pg_sleep(10);  <waiting ...>
-3&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep(10)%' AND rsgname='rg_move_query_mem_small';  <waiting ...>
+2: BEGIN;
+BEGIN
+2: SELECT hold_memory_by_percent_on_qe(1,0.1);
+ hold_memory_by_percent_on_qe 
+------------------------------
+ 0                            
+(1 row)
+3&: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND rsgname='rg_move_query_mem_small';  <waiting ...>
 1<:  <... completed>
  pg_sleep 
 ----------
@@ -179,17 +185,13 @@ SET
 ------------------------
  t                      
 (1 row)
-3: SELECT rsgname, query FROM pg_stat_activity WHERE state = 'active';
- rsgname       | query                                                               
----------------+---------------------------------------------------------------------
- rg_move_query | SELECT pg_sleep(10);                                                
- admin_group   | SELECT rsgname, query FROM pg_stat_activity WHERE state = 'active'; 
-(2 rows)
-2<:  <... completed>
- pg_sleep 
-----------
-          
+3: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND state = 'idle in transaction';
+ is_session_in_group 
+---------------------
+ t                   
 (1 row)
+2: END;
+END
 
 DROP ROLE role_move_query;
 DROP


### PR DESCRIPTION
pg_resgroup_move_query is an asychronous operation, pg_resgroup_move_query
complete doesn't mean the query has already move to the destination group.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
