### PR TITLE
Fix incorrect loop bound in _outMotion

### DIFF
--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1299,7 +1299,7 @@ _outMotion(StringInfo str, const Motion *node)
 
 	WRITE_NODE_FIELD(hashExprs);
 	appendStringInfoLiteral(str, " :hashFuncs");
-	for (i = 0; i < list_length(node->hashExprs); i++)
+	for (i = 0; i < list_length(node->hashFuncs); i++)
 		appendStringInfo(str, " %u", node->hashFuncs[i]);
 
 	WRITE_INT_FIELD(numSortCols);


### PR DESCRIPTION
When appending the hashFunc, we should iterate through the length of
hashFuncs, not hashExprs (although they have the same length in this
case).

Co-authored-by: Shreedhar Hardikar <shardikar@pivotal.io>
Co-authored-by: Chris Hajas <chajas@pivotal.io>