### PR TITLE
Remove unnecessary projections from duplicate sensitive Distribute in ORCA

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -2085,6 +2085,8 @@ CTranslatorDXLToPlStmt::TranslateDXLRedistributeMotionToResultHashFilters
 		output_context
 		);
 
+	bool targetlist_modified = false;
+
 	// translate hash expr list
 	if (EdxlopPhysicalMotionRedistribute == motion_dxlop->GetDXLOperator())
 	{
@@ -2132,6 +2134,7 @@ CTranslatorDXLToPlStmt::TranslateDXLRedistributeMotionToResultHashFilters
 								     CTranslatorUtils::CreateMultiByteCharStringFromWCString(str_unnamed_col.GetBuffer()),
 								     false /* resjunk */);
 				plan->targetlist = gpdb::LAppend(plan->targetlist, (void *) target_entry);
+				targetlist_modified = true;
 			}
 
 			result->hashFilterColIdx[ul] = target_entry->resno;
@@ -2155,6 +2158,65 @@ CTranslatorDXLToPlStmt::TranslateDXLRedistributeMotionToResultHashFilters
 	plan->lefttree = child_plan;
 
 	SetParamIds(plan);
+
+	Plan *child_result = (Plan *) result;
+
+	if (targetlist_modified)
+	{
+		// If the targetlist is modified by adding any expressions, such as for
+		// hashFilterColIdx & hashFilterFuncs, add an additional Result node on top
+		// to project only the elements from the original targetlist.
+		// This is needed in case the Result node is created under the Hash
+		// operator (or any non-projecting node), which expects the targetlist of its
+		// child node to contain only elements that are to be hashed.
+		// We should not generate a plan where the target list of a non-projecting
+		// node such as Hash does not match its child. Additional expressions
+		// here can cause issues with memtuple bindings that can lead to errors.
+		Result *result = MakeNode(Result);
+
+		Plan *plan = &(result->plan);
+		plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+
+		// keep the same costs & rows estimates
+		plan->startup_cost = child_result->startup_cost;
+		plan->total_cost = child_result->total_cost;
+		plan->plan_rows = child_result->plan_rows;
+		plan->plan_width = child_result->plan_width;
+
+		// populate the targetlist based on child_result's original targetlist
+		plan->targetlist = NIL;
+		ListCell *lc = NULL;
+		ULONG ul = 0;
+		ForEach (lc, child_result->targetlist)
+		{
+			if (ul++ >= project_list_dxlnode->Arity())
+			{
+				// done with the original targetlist, stop
+				// all expressions added after project_list_dxlnode->Arity() are
+				// not output cols, but rather hash expressions and should not be projected
+				break;
+			}
+
+			TargetEntry *te = (TargetEntry *) lfirst(lc);
+			Var *var = gpdb::MakeVar(OUTER_VAR,
+									 te->resno,
+									 gpdb::ExprType((Node *) te->expr),
+									 gpdb::ExprTypeMod((Node *) te->expr),
+									 0	/* varlevelsup */);
+			TargetEntry *new_te = gpdb::MakeTargetEntry((Expr *) var,
+														ul, /* resno */
+														te->resname,
+														te->resjunk);
+			plan->targetlist = gpdb::LAppend(plan->targetlist, new_te);
+		}
+
+		plan->qual = NIL;
+		plan->lefttree = child_result;
+
+		SetParamIds(plan);
+
+		return (Plan *) result;
+	}
 
 	return (Plan *) result;
 }

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -12048,3 +12048,54 @@ select enable_xform('CXformInnerJoin2HashJoin');
  CXformInnerJoin2HashJoin is enabled
 (1 row)
 
+drop table if exists t55;
+NOTICE:  table "t55" does not exist, skipping
+drop table if exists tp;
+NOTICE:  table "tp" does not exist, skipping
+create table t55 (c int, lid int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t55 select i, i from generate_series(1, 1000) i;
+set optimizer_join_order = query;
+explain verbose
+CREATE TABLE TP AS
+WITH META AS (SELECT '2020-01-01' AS VALID_DT, '99' AS LOAD_ID)
+SELECT DISTINCT L1.c, L1.lid
+FROM t55 L1 CROSS JOIN META
+WHERE L1.lid = int4in(unknownout(meta.load_id));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ HashAggregate  (cost=15.68..15.78 rows=4 width=8)
+   Output: l1.c, l1.lid
+   Group Key: l1.c, l1.lid
+   ->  Hash Join  (cost=0.02..15.63 rows=4 width=8)
+         Output: l1.c, l1.lid
+         Hash Cond: (l1.lid = int4in(unknownout(meta.load_id)))
+         ->  Seq Scan on orca.t55 l1  (cost=0.00..13.00 rows=334 width=8)
+               Output: l1.c, l1.lid
+         ->  Hash  (cost=0.01..0.01 rows=1 width=32)
+               Output: meta.load_id
+               ->  Subquery Scan on meta  (cost=0.00..0.01 rows=1 width=32)
+                     Output: meta.load_id
+                     ->  Result  (cost=0.00..0.01 rows=1 width=64)
+                           Output: '2020-01-01', '99'
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off, optimizer_cte_inlining_bound=1000, optimizer_join_order=query, optimizer_metadata_caching=on
+(16 rows)
+
+CREATE TABLE TP AS
+WITH META AS (SELECT '2020-01-01' AS VALID_DT, '99' AS LOAD_ID)
+SELECT DISTINCT L1.c, L1.lid
+FROM t55 L1 CROSS JOIN META
+WHERE L1.lid = int4in(unknownout(meta.load_id));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+reset optimizer_join_order;
+SELECT * from tp;
+ c  | lid 
+----+-----
+ 99 |  99
+(1 row)
+

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -12246,3 +12246,61 @@ select enable_xform('CXformInnerJoin2HashJoin');
  CXformInnerJoin2HashJoin is enabled
 (1 row)
 
+drop table if exists t55;
+NOTICE:  table "t55" does not exist, skipping
+drop table if exists tp;
+NOTICE:  table "tp" does not exist, skipping
+create table t55 (c int, lid int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t55 select i, i from generate_series(1, 1000) i;
+set optimizer_join_order = query;
+explain verbose
+CREATE TABLE TP AS
+WITH META AS (SELECT '2020-01-01' AS VALID_DT, '99' AS LOAD_ID)
+SELECT DISTINCT L1.c, L1.lid
+FROM t55 L1 CROSS JOIN META
+WHERE L1.lid = int4in(unknownout(meta.load_id));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..437.37 rows=134 width=8)
+   Output: c, lid
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.12 rows=134 width=8)
+         Output: c, lid
+         ->  HashAggregate  (cost=0.00..431.12 rows=134 width=8)
+               Output: c, lid
+               Group Key: t55.c, t55.lid
+               ->  Hash Join  (cost=0.00..431.08 rows=134 width=8)
+                     Output: c, lid
+                     Hash Cond: (t55.lid = int4in(unknownout(('99'))))
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.02 rows=334 width=8)
+                           Output: c, lid
+                           Hash Key: lid
+                           ->  Seq Scan on orca.t55  (cost=0.00..431.01 rows=334 width=8)
+                                 Output: c, lid
+                     ->  Hash  (cost=0.00..0.00 rows=1 width=8)
+                           Output: ('99')
+                           ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                                 Output: ('99')
+                                 ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                                       Output: ('99'), int4in(unknownout(('99')))
+                                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                             Output: '99'
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: optimizer=on, optimizer_cte_inlining_bound=1000, optimizer_join_order=query, optimizer_metadata_caching=on
+(25 rows)
+
+CREATE TABLE TP AS
+WITH META AS (SELECT '2020-01-01' AS VALID_DT, '99' AS LOAD_ID)
+SELECT DISTINCT L1.c, L1.lid
+FROM t55 L1 CROSS JOIN META
+WHERE L1.lid = int4in(unknownout(meta.load_id));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+reset optimizer_join_order;
+SELECT * from tp;
+ c  | lid 
+----+-----
+ 99 |  99
+(1 row)
+

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2426,6 +2426,31 @@ SELECT 1 FROM foo1, foo2 WHERE foo1.a = foo2.a AND foo2.c = 3 AND foo2.b IN (SEL
 
 reset optimizer_join_order;
 select enable_xform('CXformInnerJoin2HashJoin');
+
+drop table if exists t55;
+drop table if exists tp;
+
+create table t55 (c int, lid int);
+insert into t55 select i, i from generate_series(1, 1000) i;
+
+set optimizer_join_order = query;
+
+explain verbose
+CREATE TABLE TP AS
+WITH META AS (SELECT '2020-01-01' AS VALID_DT, '99' AS LOAD_ID)
+SELECT DISTINCT L1.c, L1.lid
+FROM t55 L1 CROSS JOIN META
+WHERE L1.lid = int4in(unknownout(meta.load_id));
+
+CREATE TABLE TP AS
+WITH META AS (SELECT '2020-01-01' AS VALID_DT, '99' AS LOAD_ID)
+SELECT DISTINCT L1.c, L1.lid
+FROM t55 L1 CROSS JOIN META
+WHERE L1.lid = int4in(unknownout(meta.load_id));
+
+reset optimizer_join_order;
+SELECT * from tp;
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
Porting #10194 to master. Note that the test query was changed w.r.t 6X
to generate a similar effect in ORCA.

Duplicate sensitive HashDistribute Motions generated by ORCA get
translated to Result nodes with hashFilter cols set. However, if the
Motion needs to distribute based on a complex expression (rather than
just a Var), the expression must be added into the targetlist of the
Result node and then referenced in hashFilterColIdx.

However, this can affect other operators above the Result node. For
example, a Hash operator expects the targetlist of its child node to
contain only elements that are to be hashed. Additional expressions here
can cause issues with memtuple bindings that can lead to errors.

(E.g The attached test case, when run without our fix, will give an
error: "invalid input syntax for integer:")

This PR fixes the issue by adding an additional Result node on top of
the duplicate sensitive Result node to project only the elements from
the original targetlist in such cases.