### PR TITLE
Clarify code that parses DISTRIBUTED BY, with new DistributionKeyElem node.

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -7568,19 +7568,19 @@ can_implement_dist_on_part(Relation rel, DistributedBy *dist)
 	i = 0;
 	foreach(lc, dist->keyCols)
 	{
-		IndexElem  *ielem = (IndexElem *) lfirst(lc);
+		DistributionKeyElem *dkelem = (DistributionKeyElem *) lfirst(lc);
 		AttrNumber	attnum;
 		HeapTuple	tuple;
 		bool		ok = false;
 
-		Assert(IsA(ielem, IndexElem));
+		Assert(IsA(dkelem, DistributionKeyElem));
 
-		tuple = SearchSysCacheAttName(RelationGetRelid(rel), ielem->name);
+		tuple = SearchSysCacheAttName(RelationGetRelid(rel), dkelem->name);
 		if (!HeapTupleIsValid(tuple))
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_COLUMN),
 					 errmsg("column \"%s\" of relation \"%s\" does not exist",
-							ielem->name,
+							dkelem->name,
 							RelationGetRelationName(rel))));
 
 		attnum = ((Form_pg_attribute) GETSTRUCT(tuple))->attnum;

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3180,6 +3180,18 @@ _copyColumnDef(const ColumnDef *from)
 	return newnode;
 }
 
+static DistributionKeyElem *
+_copyDistributionKeyElem(const DistributionKeyElem *from)
+{
+	DistributionKeyElem  *newnode = makeNode(DistributionKeyElem);
+
+	COPY_STRING_FIELD(name);
+	COPY_NODE_FIELD(opclass);
+	COPY_LOCATION_FIELD(location);
+
+	return newnode;
+}
+
 static ColumnReferenceStorageDirective *
 _copyColumnReferenceStorageDirective(const ColumnReferenceStorageDirective *from)
 {
@@ -6334,6 +6346,9 @@ copyObject(const void *from)
 			break;
 		case T_ColumnDef:
 			retval = _copyColumnDef(from);
+			break;
+		case T_DistributionKeyElem:
+			retval = _copyDistributionKeyElem(from);
 			break;
 		case T_ColumnReferenceStorageDirective:
 			retval = _copyColumnReferenceStorageDirective(from);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1312,6 +1312,16 @@ _equalCreateStmt(const CreateStmt *a, const CreateStmt *b)
 }
 
 static bool
+_equalDistributionKeyElem(const DistributionKeyElem *a, const DistributionKeyElem *b)
+{
+	COMPARE_STRING_FIELD(name);
+	COMPARE_NODE_FIELD(opclass);
+	COMPARE_LOCATION_FIELD(location);
+
+	return true;
+}
+
+static bool
 _equalColumnReferenceStorageDirective(const ColumnReferenceStorageDirective *a,
 									   const ColumnReferenceStorageDirective *b)
 {
@@ -3764,6 +3774,9 @@ equal(const void *a, const void *b)
 			break;
 		case T_RowIdExpr:
 			retval = _equalRowIdExpr(a, b);
+			break;
+		case T_DistributionKeyElem:
+			retval = _equalDistributionKeyElem(a, b);
 			break;
 
 		default:

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1635,6 +1635,9 @@ _outNode(StringInfo str, void *obj)
 			case T_CreateForeignTableStmt:
 				_outCreateForeignTableStmt(str, obj);
 				break;
+			case T_DistributionKeyElem:
+				_outDistributionKeyElem(str, obj);
+				break;
 			case T_ColumnReferenceStorageDirective:
 				_outColumnReferenceStorageDirective(str, obj);
 				break;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3072,6 +3072,16 @@ _outCreateForeignTableStmt(StringInfo str, const CreateForeignTableStmt *node)
 #endif /* COMPILING_BINARY_FUNCS */
 
 static void
+_outDistributionKeyElem(StringInfo str, const DistributionKeyElem *node)
+{
+	WRITE_NODE_TYPE("DISTRIBUTIONKEYELEM");
+
+	WRITE_STRING_FIELD(name);
+	WRITE_NODE_FIELD(opclass);
+	WRITE_LOCATION_FIELD(location);
+}
+
+static void
 _outColumnReferenceStorageDirective(StringInfo str, const ColumnReferenceStorageDirective *node)
 {
 	WRITE_NODE_TYPE("COLUMNREFERENCESTORAGEDIRECTIVE");
@@ -5765,6 +5775,9 @@ outNode(StringInfo str, const void *obj)
 				break;
 			case T_CreateForeignTableStmt:
 				_outCreateForeignTableStmt(str, obj);
+				break;
+			case T_DistributionKeyElem:
+				_outDistributionKeyElem(str, obj);
 				break;
 			case T_ColumnReferenceStorageDirective:
 				_outColumnReferenceStorageDirective(str, obj);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2582,6 +2582,9 @@ readNodeBinary(void)
 			case T_CreateForeignTableStmt:
 				return_value = _readCreateForeignTableStmt();
 				break;
+			case T_DistributionKeyElem:
+				return_value = _readDistributionKeyElem();
+				break;
 			case T_ColumnReferenceStorageDirective:
 				return_value = _readColumnReferenceStorageDirective();
 				break;

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2120,6 +2120,18 @@ _readColumnDef(void)
 	READ_DONE();
 }
 
+static DistributionKeyElem *
+_readDistributionKeyElem(void)
+{
+	READ_LOCALS(DistributionKeyElem);
+
+	READ_STRING_FIELD(name);
+	READ_NODE_FIELD(opclass);
+	READ_LOCATION_FIELD(location);
+
+	READ_DONE();
+}
+
 static ColumnRef *
 _readColumnRef(void)
 {
@@ -4390,6 +4402,8 @@ parseNodeString(void)
 		return_value = _readDropRoleStmt();
 	else if (MATCHX("DROPSTMT"))
 		return_value = _readDropStmt();
+	else if (MATCHX("DISTRIBUTIONKEYELEM"))
+		return_value = _readDistributionKeyElem();
 	else if (MATCHX("EXTTABLETYPEDESC"))
 		return_value = _readExtTableTypeDesc();
 	else if (MATCHX("FUNCCALL"))

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -575,6 +575,7 @@ typedef enum NodeTag
 	T_OnConflictClause,
 	T_CommonTableExpr,
 	T_ColumnReferenceStorageDirective,
+	T_DistributionKeyElem,
 	T_RoleSpec,
 
 	/*

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -758,6 +758,17 @@ typedef struct XmlSerialize
 	int			location;		/* token location, or -1 if unknown */
 } XmlSerialize;
 
+/*
+ * DISTRIBUTED BY (<col> [opcass] [, ...])
+ */
+typedef struct DistributionKeyElem
+{
+	NodeTag		type;
+	char	   *name;			/* name of attribute to index, or NULL */
+	List	   *opclass;		/* name of desired opclass; NIL = default */
+	int			location;		/* token location, or -1 if unknown */
+} DistributionKeyElem;
+
 
 /****************************************************************************
  *	Nodes for a Query tree

--- a/src/test/regress/expected/gp_create_table.out
+++ b/src/test/regress/expected/gp_create_table.out
@@ -182,7 +182,7 @@ select distkey, distclass from gp_distribution_policy where localoid='bar'::regc
 
 drop table if exists foo;
 drop table if exists bar;
--- check for duplicate columns in DISTRIBUTED BY clause
+-- check for duplicate and non-existent columns in DISTRIBUTED BY clause
 create table foo (a int, b text) distributed by (b,B);
 ERROR:  duplicate column in DISTRIBUTED BY clause
 LINE 1: create table foo (a int, b text) distributed by (b,B);
@@ -192,9 +192,13 @@ ERROR:  duplicate column in DISTRIBUTED BY clause
 LINE 1: create table foo (a int, b int) distributed by (a,aA,A);
                                                              ^
 create table foo (a int, b int) distributed by (a,aA);
-ERROR:  column "aa" named in 'DISTRIBUTED BY' clause does not exist
+ERROR:  column "aa" named in DISTRIBUTED BY clause does not exist
+LINE 1: create table foo (a int, b int) distributed by (a,aA);
+                                                          ^
 create table foo (a int, b int) distributed by (b,a,aabb);
-ERROR:  column "aabb" named in 'DISTRIBUTED BY' clause does not exist
+ERROR:  column "aabb" named in DISTRIBUTED BY clause does not exist
+LINE 1: create table foo (a int, b int) distributed by (b,a,aabb);
+                                                            ^
 create table foo (a int, b int) distributed by (c,C);
 ERROR:  duplicate column in DISTRIBUTED BY clause
 LINE 1: create table foo (a int, b int) distributed by (c,C);
@@ -218,6 +222,10 @@ create table fooctas as select * from foo distributed by (i,i);
 ERROR:  duplicate column in DISTRIBUTED BY clause
 LINE 1: ...ate table fooctas as select * from foo distributed by (i,i);
                                                                     ^
+create table fooctas as select * from foo distributed by (i,nope);
+ERROR:  column "nope" named in DISTRIBUTED BY clause does not exist
+LINE 1: ... table fooctas as select * from foo distributed by (i,nope);
+                                                                 ^
 drop table foo;
 -- check if number of DISTRIBUTED BY clause exceed the limitation (1600)
 create table foo (

--- a/src/test/regress/sql/gp_create_table.sql
+++ b/src/test/regress/sql/gp_create_table.sql
@@ -118,7 +118,7 @@ select distkey, distclass from gp_distribution_policy where localoid='bar'::regc
 drop table if exists foo;
 drop table if exists bar;
 
--- check for duplicate columns in DISTRIBUTED BY clause
+-- check for duplicate and non-existent columns in DISTRIBUTED BY clause
 create table foo (a int, b text) distributed by (b,B);
 create table foo (a int, b int) distributed by (a,aA,A);
 create table foo (a int, b int) distributed by (a,aA);
@@ -129,6 +129,7 @@ create table foo (a int, b int, c int) distributed by (c, c, b);
 create table foo ("I" int, i int) distributed by ("I",I);
 select distkey, distclass from gp_distribution_policy where localoid='foo'::regclass;
 create table fooctas as select * from foo distributed by (i,i);
+create table fooctas as select * from foo distributed by (i,nope);
 drop table foo;
 
 -- check if number of DISTRIBUTED BY clause exceed the limitation (1600)


### PR DESCRIPTION
Introduce a new DistributionKeyElem to hold each element in the list of
columns (and optionally their opclasses) in DISTRIBUTED BY (<col> [opclass],
...) syntax. Previously, we have used IndexElem, which conveniently also
holds a column name and its opclass, but it was not a very good fit because
IndexElem also contains many other fields that are not needed. Using a
new node type specifically for DISTRIBUTED BY makes the code dealing with
distribution key lists more clear. To compare, PostgreSQL v10 uses a struct
called PartitionElem for similar purposes in PARTITION BY clause. (But that
is not to be confused with the PartitionElem struct in GPDB 6 and below,
which is also related to partitioning sytnax but is quite different!)

Unlike IndexElem, the new node type includes a 'location' field, to
provide error position information in error messages. This can be seen in
the error message changes in 'gp_create_table' test.

While we're at it, remove the quotes around DISTRIBUTED BY in the
"column <col> named in DISTRIBTED BY clause does not exist", for
consistency with the same error message thrown with CREATE TABLE AS from
setQryDistributionPolicy() function, and with the "duplicate column in
DISTRIBUTED BY clause" error. The error thrown in CTAS case was not
covered by existing tests, so also add a test for that.
