### PR TITLE
Add GUC write_to_gpfdist_timeout

### DIFF
--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -29,6 +29,7 @@
 
 /* GUC */
 int readable_external_table_timeout = 0;
+int writable_external_table_timeout = 600;
 
 static void base16_encode(char *raw, int len, char *encoded);
 static char *get_eol_delimiter(List *params);

--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -29,7 +29,7 @@
 
 /* GUC */
 int readable_external_table_timeout = 0;
-int write_to_gpfdist_timeout = 600;
+int write_to_gpfdist_timeout = 300;
 
 static void base16_encode(char *raw, int len, char *encoded);
 static char *get_eol_delimiter(List *params);

--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -29,7 +29,7 @@
 
 /* GUC */
 int readable_external_table_timeout = 0;
-int writable_external_table_timeout = 600;
+int write_to_gpfdist_timeout = 600;
 
 static void base16_encode(char *raw, int len, char *encoded);
 static char *get_eol_delimiter(List *params);

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -557,6 +557,7 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 	unsigned int retry_count = 0;
 	/* retry at most 600s by default when any error happens */
 	time_t start_time = time(NULL);
+	time_t now;
 	time_t end_time = start_time + writable_external_table_timeout;
 
 	while (true)
@@ -602,8 +603,11 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 		/*
 		 * Retry until MAX_TRY_WAIT_TIME or end_time is reached
 		 */
-		if ((wait_time > MAX_TRY_WAIT_TIME || time(NULL) >= end_time) && writable_external_table_timeout > 0)
+		now = time(NULL);
+		if ((wait_time > MAX_TRY_WAIT_TIME || now >= end_time) && writable_external_table_timeout > 0)
 		{
+			elog(LOG, "abort writing data to gpfdist, wait_time = %d, duration = %d, writable_external_table_timeout = %d",
+				wait_time, now-start_time, writable_external_table_timeout);
 			ereport(ERROR,
 					(errcode(ERRCODE_CONNECTION_FAILURE),
 					 errmsg("error when writing data to gpfdist %s, quit after %d tries",

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -567,8 +567,7 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 		 * when work load is high:
 		 *	- 'could not connect to server'
 		 *	- gpfdist return timeout (HTTP 408)
-		 * By default it will wait at least min(127, write_to_gpfdist_timeout) seconds before abort.
-		 * 1 + 2 + 4 + 8 + 16 + 32 + 64 = 127
+		 * By default it will wait at least write_to_gpfdist_timeout seconds before abort.
 		 */
 		CURLcode e = curl_easy_perform(file->curl->handle);
 		if (CURLE_OK != e)
@@ -604,7 +603,7 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 		 * Retry until end_time is reached
 		 */
 		now = time(NULL);
-		if (now >= end_time && write_to_gpfdist_timeout > 0)
+		if (now >= end_time)
 		{
 			elog(LOG, "abort writing data to gpfdist, wait_time = %d, duration = %ld, write_to_gpfdist_timeout = %d",
 				wait_time, now - start_time, write_to_gpfdist_timeout);
@@ -617,6 +616,8 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 		{
 			unsigned int for_wait = 0;
 			wait_time = wait_time > MAX_TRY_WAIT_TIME ? MAX_TRY_WAIT_TIME : wait_time;
+			/* For last retry before end_time */
+			wait_time = wait_time > end_time - now ? end_time - now : wait_time;
 			elog(LOG, "failed to send request to gpfdist (%s), will retry after %d seconds", file->curl_url, wait_time);
 			while (for_wait++ < wait_time)
 			{
@@ -1130,13 +1131,8 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	{
 		// TIMEOUT for POST only, GET is single HTTP request,
 		// probablity take long time.
-		long timeout = 300L;
 		elog(LOG, "write_to_gpfdist_timeout = %d", write_to_gpfdist_timeout);
-		if (write_to_gpfdist_timeout > 0 && write_to_gpfdist_timeout < timeout)
-		{
-			timeout = write_to_gpfdist_timeout;
-		}
-		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_TIMEOUT, timeout);
+		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_TIMEOUT, (long)write_to_gpfdist_timeout);
 
 		/*init sequence number*/
 		file->seq_number = 1;

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -606,7 +606,7 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 		now = time(NULL);
 		if ((wait_time > MAX_TRY_WAIT_TIME || now >= end_time) && writable_external_table_timeout > 0)
 		{
-			elog(LOG, "abort writing data to gpfdist, wait_time = %d, duration = %d, writable_external_table_timeout = %d",
+			elog(LOG, "abort writing data to gpfdist, wait_time = %d, duration = %ld, writable_external_table_timeout = %d",
 				wait_time, now-start_time, writable_external_table_timeout);
 			ereport(ERROR,
 					(errcode(ERRCODE_CONNECTION_FAILURE),
@@ -615,8 +615,9 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 		}
 		else
 		{
-			elog(LOG, "failed to send request to gpfdist (%s), will retry after %d seconds", file->curl_url, wait_time);
 			unsigned int for_wait = 0;
+			wait_time = wait_time > MAX_TRY_WAIT_TIME ? MAX_TRY_WAIT_TIME : wait_time;
+			elog(LOG, "failed to send request to gpfdist (%s), will retry after %d seconds", file->curl_url, wait_time);
 			while (for_wait++ < wait_time)
 			{
 				pg_usleep(1000000);

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -602,7 +602,7 @@ gp_curl_easy_perform_backoff_and_check_response(URL_CURL_FILE *file)
 		/*
 		 * Retry until MAX_TRY_WAIT_TIME or end_time is reached
 		 */
-		if (wait_time > MAX_TRY_WAIT_TIME || (time(NULL) >= end_time && writable_external_table_timeout > 0))
+		if ((wait_time > MAX_TRY_WAIT_TIME || time(NULL) >= end_time) && writable_external_table_timeout > 0)
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_CONNECTION_FAILURE),

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2898,6 +2898,17 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
+		{"writable_external_table_timeout", PGC_USERSET, EXTERNAL_TABLES,
+			gettext_noop("Timeout (in seconds) for writing data to gpfdist server."),
+			gettext_noop("Default value is 600. A value of 0 turns off the timeout."),
+			GUC_UNIT_S | GUC_NOT_IN_SAMPLE
+		},
+		&writable_external_table_timeout,
+		600, 0, INT_MAX,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"writable_external_table_bufsize", PGC_USERSET, EXTERNAL_TABLES,
 			gettext_noop("Buffer size in kilobytes for writable external table before writing data to gpfdist."),
 			gettext_noop("Valid value is between 32K and 128M: [32, 131072]."),

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2898,12 +2898,12 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
-		{"writable_external_table_timeout", PGC_USERSET, EXTERNAL_TABLES,
+		{"write_to_gpfdist_timeout", PGC_USERSET, EXTERNAL_TABLES,
 			gettext_noop("Timeout (in seconds) for writing data to gpfdist server."),
-			gettext_noop("Default value is 600. A value of 0 turns off the timeout."),
+			gettext_noop("Default value is 600. A value of 0 indicates 'retry forever'."),
 			GUC_UNIT_S | GUC_NOT_IN_SAMPLE
 		},
-		&writable_external_table_timeout,
+		&write_to_gpfdist_timeout,
 		600, 0, INT_MAX,
 		NULL, NULL, NULL
 	},

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2900,11 +2900,11 @@ struct config_int ConfigureNamesInt_gp[] =
 	{
 		{"write_to_gpfdist_timeout", PGC_USERSET, EXTERNAL_TABLES,
 			gettext_noop("Timeout (in seconds) for writing data to gpfdist server."),
-			gettext_noop("Default value is 600. A value of 0 indicates 'retry forever'."),
+			gettext_noop("Default value is 300."),
 			GUC_UNIT_S | GUC_NOT_IN_SAMPLE
 		},
 		&write_to_gpfdist_timeout,
-		600, 0, INT_MAX,
+		300, 1, 7200,
 		NULL, NULL, NULL
 	},
 

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -518,7 +518,7 @@ DROP EXTERNAL TABLE IF EXISTS ext_table_multi_locations;
 select * from exttab1_gpfdist_stop;
 -- end_ignore
 
--- Test GUC writable_external_table_timeout. gpfdist is stopped, insert will retry until timeout
+-- Test GUC write_to_gpfdist_timeout. gpfdist is stopped, insert will retry until timeout
 
 CREATE TABLE test_guc (a int, b text) DISTRIBUTED BY (a);
 INSERT INTO  test_guc VALUES (generate_series(1,256), 'test_guc');
@@ -526,7 +526,7 @@ INSERT INTO  test_guc VALUES (generate_series(1,256), 'test_guc');
 CREATE WRITABLE EXTERNAL TABLE wext_test_guc (a int, b text) LOCATION ('gpfdist://127.0.0.1:7070/test_guc.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null');
 
 -- retry interval 1, 2, 4, 8, 16, then timeout. total 6 tries
-set writable_external_table_timeout = 20;
+set write_to_gpfdist_timeout = 20;
 INSERT INTO wext_test_guc SELECT * FROM test_guc;
 
 DROP TABLE IF EXISTS test_guc;

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -518,6 +518,20 @@ DROP EXTERNAL TABLE IF EXISTS ext_table_multi_locations;
 select * from exttab1_gpfdist_stop;
 -- end_ignore
 
+-- Test GUC writable_external_table_timeout. gpfdist is stopped, insert will retry until timeout
+
+CREATE TABLE test_guc (a int, b text) DISTRIBUTED BY (a);
+INSERT INTO  test_guc VALUES (generate_series(1,256), 'test_guc');
+
+CREATE WRITABLE EXTERNAL TABLE wext_test_guc (a int, b text) LOCATION ('gpfdist://127.0.0.1:7070/test_guc.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null');
+
+-- retry interval 1, 2, 4, 8, 16, then timeout. total 6 tries
+set writable_external_table_timeout = 20;
+INSERT INTO wext_test_guc SELECT * FROM test_guc;
+
+DROP TABLE IF EXISTS test_guc;
+DROP EXTERNAL TABLE IF EXISTS wext_test_guc;
+
 --
 -- get an error for missing gpfdist
 --

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -711,6 +711,16 @@ DROP TABLE IF EXISTS table_multi_locations;
 DROP EXTERNAL TABLE IF EXISTS ext_table_multi_locations;
 -- start_ignore
 -- end_ignore
+-- Test GUC writable_external_table_timeout. gpfdist is stopped, insert will retry until timeout
+CREATE TABLE test_guc (a int, b text) DISTRIBUTED BY (a);
+INSERT INTO  test_guc VALUES (generate_series(1,256), 'test_guc');
+CREATE WRITABLE EXTERNAL TABLE wext_test_guc (a int, b text) LOCATION ('gpfdist://127.0.0.1:7070/test_guc.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null');
+-- retry interval 1, 2, 4, 8, 16, then timeout. total 6 tries
+set writable_external_table_timeout = 20;
+INSERT INTO wext_test_guc SELECT * FROM test_guc;
+ERROR:  error when writing data to gpfdist http://127.0.0.1:7070/test_guc.tbl, quit after 6 tries  (seg0 10.152.8.113:6005 pid=17374)
+DROP TABLE IF EXISTS test_guc;
+DROP EXTERNAL TABLE IF EXISTS wext_test_guc;
 --
 -- get an error for missing gpfdist
 --

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -711,12 +711,12 @@ DROP TABLE IF EXISTS table_multi_locations;
 DROP EXTERNAL TABLE IF EXISTS ext_table_multi_locations;
 -- start_ignore
 -- end_ignore
--- Test GUC writable_external_table_timeout. gpfdist is stopped, insert will retry until timeout
+-- Test GUC write_to_gpfdist_timeout. gpfdist is stopped, insert will retry until timeout
 CREATE TABLE test_guc (a int, b text) DISTRIBUTED BY (a);
 INSERT INTO  test_guc VALUES (generate_series(1,256), 'test_guc');
 CREATE WRITABLE EXTERNAL TABLE wext_test_guc (a int, b text) LOCATION ('gpfdist://127.0.0.1:7070/test_guc.tbl') FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null');
 -- retry interval 1, 2, 4, 8, 16, then timeout. total 6 tries
-set writable_external_table_timeout = 20;
+set write_to_gpfdist_timeout = 20;
 INSERT INTO wext_test_guc SELECT * FROM test_guc;
 ERROR:  error when writing data to gpfdist http://127.0.0.1:7070/test_guc.tbl, quit after 6 tries  (seg0 10.152.8.113:6005 pid=17374)
 DROP TABLE IF EXISTS test_guc;

--- a/src/include/access/url.h
+++ b/src/include/access/url.h
@@ -124,5 +124,6 @@ extern size_t url_custom_fwrite(void *ptr, size_t size, URL_FILE *file, CopyStat
 
 /* GUC */
 extern int readable_external_table_timeout;
+extern int writable_external_table_timeout;
 
 #endif

--- a/src/include/access/url.h
+++ b/src/include/access/url.h
@@ -124,6 +124,6 @@ extern size_t url_custom_fwrite(void *ptr, size_t size, URL_FILE *file, CopyStat
 
 /* GUC */
 extern int readable_external_table_timeout;
-extern int writable_external_table_timeout;
+extern int write_to_gpfdist_timeout;
 
 #endif

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -435,7 +435,7 @@
 		"quote_all_identifiers",
 		"random_page_cost",
 		"readable_external_table_timeout",
-		"writable_external_table_timeout",
+		"write_to_gpfdist_timeout",
 		"repl_catchup_within_range",
 		"resource_cleanup_gangs_on_wait",
 		"resource_scheduler",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -435,6 +435,7 @@
 		"quote_all_identifiers",
 		"random_page_cost",
 		"readable_external_table_timeout",
+		"writable_external_table_timeout",
 		"repl_catchup_within_range",
 		"resource_cleanup_gangs_on_wait",
 		"resource_scheduler",


### PR DESCRIPTION
write_to_gpfdist_timeout controls timeout value (in seconds) for writing data to gpfdist server.
Default value is 300, valid scope is [1, 7200]

### Prior behavior: 
- CURLOPT_TIMEOUT is hard code 300s
- For CURLE_OPERATION_TIMEDOUT error, retry twice. total time 300s *2
- For other errors retry 7 times with double interval time, total time is about 127s

### Current behavior
- set CURLOPT_TIMEOUT as write_to_gpfdist_timeout, default value is 300
- For any error, retry with double interval time, returns SQL ERROR if write_to_gpfdist_timeout is reached

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
