### PR TITLE
Fix flaky test in recoverseg_from_file

### DIFF
--- a/src/test/isolation2/expected/segwalrep/recoverseg_from_file.out
+++ b/src/test/isolation2/expected/segwalrep/recoverseg_from_file.out
@@ -43,6 +43,29 @@ select gp_request_fts_probe_scan();
  t                         
 (1 row)
 
+-- wait for content 1 (earlier mirror, now primary) to finish the promotion
+1U: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+-- Quit this utility mode session, as need to start fresh one below
+1Uq: ... <quitting>
+
+-- make the dbid in gp_segment_configuration not continuous
+-- dbid=2 corresponds to content id =0
+set allow_system_table_mods to true;
+SET
+update gp_segment_configuration set dbid=9 where dbid=2;
+UPDATE 1
+
+-- trigger failover
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
 -- wait for content 0 (earlier mirror, now primary) to finish the promotion
 0U: select 1;
  ?column? 
@@ -52,12 +75,6 @@ select gp_request_fts_probe_scan();
 -- Quit this utility mode session, as need to start fresh one below
 0Uq: ... <quitting>
 
--- make the dbid in gp_segment_configuration not continuous
-set allow_system_table_mods to true;
-SET
-update gp_segment_configuration set dbid=9 where dbid=2;
-UPDATE 1
-
 -- generate recover config file
 select generate_recover_config_file( (select datadir from gp_segment_configuration c where c.role='m' and c.content=1), (select port from gp_segment_configuration c where c.role='m' and c.content=1)::text);
  generate_recover_config_file 
@@ -65,7 +82,7 @@ select generate_recover_config_file( (select datadir from gp_segment_configurati
                               
 (1 row)
 
--- recover from config file
+-- recover from config file, only seg with content=1 will be recovered
 !\retcode gprecoverseg -a -i /tmp/recover_config_file;
 -- start_ignore
 -- end_ignore


### PR DESCRIPTION
1. after stop primary with content=1, we should check promotion
status with 1U:
2. after manually update dbid, we should trigger a fts probe and
wait for the mirror promotion as well.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
