### PR TITLE
Support "NDV-preserving" function and op property

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -639,6 +639,28 @@ gpdb::FuncStrict
 	return false;
 }
 
+bool
+gpdb::IsFuncNDVPreserving
+	(
+	Oid funcid
+	)
+{
+	// Given a function oid, return whether it's one of a list of NDV-preserving
+	// functions (estimated NDV of output is similar to that of the input)
+	switch (funcid)
+	{
+		// for now, these are the functions we consider for this optimization
+		case LOWER_OID:
+		case LTRIM_SPACE_OID:
+		case BTRIM_SPACE_OID:
+		case RTRIM_SPACE_OID:
+		case UPPER_OID:
+			return true;
+		default:
+			return false;
+	}
+}
+
 char
 gpdb::FuncStability
 	(
@@ -2126,6 +2148,24 @@ gpdb::IsOpStrict
 	}
 	GP_WRAP_END;
 	return false;
+}
+
+bool
+gpdb::IsOpNDVPreserving
+	(
+	Oid opno
+	)
+{
+	switch (opno)
+	{
+		// for now, we consider only the concatenation op as NDV-preserving
+		// (note that we do additional checks later, e.g. col || 'const' is
+		// NDV-preserving, while col1 || col2 is not)
+		case OIDTextConcatenateOperator:
+			return true;
+		default:
+			return false;
+	}
 }
 
 void

--- a/src/backend/gporca/data/dxl/minidump/EquiJoinOnExpr-Supported.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquiJoinOnExpr-Supported.mdp
@@ -1,0 +1,2071 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Equi-join predicates that have expressions (NDV-preserving as well as general expressions)
+               on one or both sides of the join. Validate that the estimated cardinality is what we expect.
+               Join order is fixed, to avoid unnecessary test failures.
+
+    drop table if exists foo;
+    create table foo(a int, b int, c text);
+    insert into foo select i, i, i::text from generate_series(1,100000) i;
+    analyze foo;
+
+    set optimizer_join_order to query;
+    set optimizer_enumerate_plans = on;
+
+    -- positive test cases, cardinality should stay at 100K (about 140K for LOJ)
+    -- a) two columns
+    -- b) casts of columns
+    -- c) column and NDV-preserving function (with cast)
+    -- d) two NDV-preserving functions
+    -- e) LOJ with non-NDV-preserving expression on outer and NDV-preserving function on inner
+    explain
+    select *
+    from foo base     join foo simple_col  on base.b                  = simple_col.b
+                      join foo cast_col    on base.b::bigint          = cast_col.b::bigint
+                      join foo ndv_pres1   on base.b::bigint          = coalesce(ndv_pres1.b, 0)::bigint
+                      join foo ndv_pres2   on upper(base.c)           = ndv_pres2.c || 'x'
+           left outer join foo expr_outer  on base.a::text || base.c  = trim(expr_outer.c);
+
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="101013,102002,102003,102073,102074,102113,102120,102144,102146,102147,103001,103014,103015,103022,103027,103029,103037,104003,104004,104005,104006,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.654.1.0" Name="||" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="true">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.25.1.0"/>
+        <dxl:OpFunc Mdid="0.1258.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.242787.1.0.2" Name="c" Width="5.000000" NullFreq="0.000000" NdvRemain="100145.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.467.1.0"/>
+        <dxl:Commutator Mdid="0.410.1.0"/>
+        <dxl:InverseOp Mdid="0.411.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.3028.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:ColumnStatistics Mdid="1.242787.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="966"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="966"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2962"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2962"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4970"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4970"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6938"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6938"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7889"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7889"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8959"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8959"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9941"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9941"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10926"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11887"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11887"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12991"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12991"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15137"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15137"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16082"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16082"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17028"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17028"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18068"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20056"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20056"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20969"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20969"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22054"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22054"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23155"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23155"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24266"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24266"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25214"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25214"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27257"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27257"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28298"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28298"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29227"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32119"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32119"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33195"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33195"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34291"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34291"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36188"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36188"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37264"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37264"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38314"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38314"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39298"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39298"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40292"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40292"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41253"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41253"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42177"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44098"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44098"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45089"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45089"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46092"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46092"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47110"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47110"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49161"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49161"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50137"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50137"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51176"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51176"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52182"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52182"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54172"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54172"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55129"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55129"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56094"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56094"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57156"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57156"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58099"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58099"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59098"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59098"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60062"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60062"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62162"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62162"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63093"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63093"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64085"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64085"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66107"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67101"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67101"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68091"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68091"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69075"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69075"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70066"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70066"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71036"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71036"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71929"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71929"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72904"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72904"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73924"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73924"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74939"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74939"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75902"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75902"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77865"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77865"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78829"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78829"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79782"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79782"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80722"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81716"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81716"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82716"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82716"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83675"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83675"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84631"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84631"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85614"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85614"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86543"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86543"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87528"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87528"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88516"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88516"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89418"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89418"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90363"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90363"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91321"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91321"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92281"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92281"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93332"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93332"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94378"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94378"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95383"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95383"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96406"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96406"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97317"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97317"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98455"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98455"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99985"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.242787.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="966"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="966"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2962"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2962"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4970"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4970"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6938"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6938"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7889"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7889"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8959"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8959"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9941"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9941"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10926"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11887"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11887"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12991"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12991"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15137"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15137"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16082"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16082"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17028"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17028"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18068"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20056"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20056"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20969"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20969"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22054"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22054"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23155"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23155"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24266"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24266"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25214"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25214"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27257"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27257"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28298"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28298"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29227"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32119"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32119"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33195"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33195"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34291"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34291"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36188"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36188"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37264"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37264"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38314"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38314"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39298"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39298"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40292"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40292"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41253"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41253"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42177"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44098"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44098"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45089"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45089"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46092"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46092"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47110"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47110"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49161"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49161"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50137"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50137"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51176"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51176"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52182"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52182"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54172"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54172"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55129"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55129"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56094"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56094"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57156"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57156"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58099"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58099"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59098"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59098"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60062"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60062"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62162"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62162"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63093"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63093"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64085"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64085"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66107"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67101"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67101"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68091"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68091"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69075"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69075"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70066"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70066"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71036"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71036"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71929"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71929"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72904"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72904"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73924"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73924"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74939"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74939"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75902"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75902"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77865"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77865"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78829"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78829"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79782"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79782"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80722"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81716"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81716"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82716"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82716"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83675"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83675"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84631"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84631"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85614"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85614"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86543"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86543"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87528"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87528"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88516"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88516"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89418"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89418"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90363"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90363"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91321"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91321"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92281"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92281"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93332"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93332"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94378"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94378"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95383"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95383"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96406"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96406"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97317"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97317"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98455"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1001.450000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98455"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99985"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:MDCast Mdid="3.20.1.0;20.1.0" Name="int8" BinaryCoercible="true" SourceTypeId="0.20.1.0" DestinationTypeId="0.20.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBFunc Mdid="0.481.1.0" Name="int8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.3027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.98.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.67.1.0"/>
+        <dxl:Commutator Mdid="0.98.1.0"/>
+        <dxl:InverseOp Mdid="0.531.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.1995.1.0"/>
+          <dxl:Opfamily Mdid="0.3035.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.242787.1.0" Name="foo" Rows="100145.000000" EmptyRelation="false"/>
+      <dxl:GPDBFunc Mdid="0.871.1.0" Name="upper" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="true">
+        <dxl:ResultType Mdid="0.25.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Relation Mdid="0.242787.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.25.1.0" Nullable="true" ColWidth="5">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:GPDBFunc Mdid="0.885.1.0" Name="btrim" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="true">
+        <dxl:ResultType Mdid="0.25.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:MDCast Mdid="3.23.1.0;20.1.0" Name="int8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.20.1.0" CastFuncId="0.481.1.0" CoercePathType="1"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.25.1.0"/>
+        <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="13" ColName="c" TypeMdid="0.25.1.0"/>
+        <dxl:Ident ColId="21" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="22" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="23" ColName="c" TypeMdid="0.25.1.0"/>
+        <dxl:Ident ColId="31" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="33" ColName="c" TypeMdid="0.25.1.0"/>
+        <dxl:Ident ColId="41" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="42" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="43" ColName="c" TypeMdid="0.25.1.0"/>
+        <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="53" ColName="c" TypeMdid="0.25.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Left">
+        <dxl:LogicalJoin JoinType="Inner">
+          <dxl:LogicalJoin JoinType="Inner">
+            <dxl:LogicalJoin JoinType="Inner">
+              <dxl:LogicalJoin JoinType="Inner">
+                <dxl:LogicalGet>
+                  <dxl:TableDescriptor Mdid="0.242787.1.0" TableName="foo">
+                    <dxl:Columns>
+                      <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                      <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:LogicalGet>
+                <dxl:LogicalGet>
+                  <dxl:TableDescriptor Mdid="0.242787.1.0" TableName="foo">
+                    <dxl:Columns>
+                      <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="13" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                      <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:LogicalGet>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:LogicalJoin>
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="0.242787.1.0" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="21" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="22" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="23" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                    <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                <dxl:FuncExpr FuncId="0.481.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                  <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:FuncExpr>
+                <dxl:FuncExpr FuncId="0.481.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                  <dxl:Ident ColId="22" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:FuncExpr>
+              </dxl:Comparison>
+            </dxl:LogicalJoin>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.242787.1.0" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="31" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="32" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="33" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                  <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+              <dxl:FuncExpr FuncId="0.481.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:FuncExpr>
+              <dxl:FuncExpr FuncId="0.481.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                <dxl:Coalesce TypeMdid="0.23.1.0">
+                  <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:Coalesce>
+              </dxl:FuncExpr>
+            </dxl:Comparison>
+          </dxl:LogicalJoin>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.242787.1.0" TableName="foo">
+              <dxl:Columns>
+                <dxl:Column ColId="41" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="42" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="43" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                <dxl:Column ColId="44" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="45" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="46" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="47" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="48" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="49" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="50" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+            <dxl:FuncExpr FuncId="0.871.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+              <dxl:Ident ColId="3" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:FuncExpr>
+            <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+              <dxl:Ident ColId="43" ColName="c" TypeMdid="0.25.1.0"/>
+              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABXg=" LintValue="4244762772"/>
+            </dxl:OpExpr>
+          </dxl:Comparison>
+        </dxl:LogicalJoin>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.242787.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="51" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="52" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="53" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+              <dxl:Column ColId="54" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="55" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="56" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="57" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="58" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="59" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="60" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+          <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+            <dxl:CoerceViaIO TypeMdid="0.25.1.0" CoercionForm="1" Location="0">
+              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:CoerceViaIO>
+            <dxl:Ident ColId="3" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:OpExpr>
+          <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+            <dxl:Ident ColId="53" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:FuncExpr>
+        </dxl:Comparison>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="7257">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="2796.936115" Rows="140203.000000" Width="78"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="10" Alias="a">
+            <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="11" Alias="b">
+            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="12" Alias="c">
+            <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="20" Alias="a">
+            <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="21" Alias="b">
+            <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="22" Alias="c">
+            <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="30" Alias="a">
+            <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="31" Alias="b">
+            <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="32" Alias="c">
+            <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="40" Alias="a">
+            <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="41" Alias="b">
+            <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="42" Alias="c">
+            <dxl:Ident ColId="42" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="50" Alias="a">
+            <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="51" Alias="b">
+            <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="52" Alias="c">
+            <dxl:Ident ColId="52" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Left">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="2756.181906" Rows="140203.000000" Width="78"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="a">
+              <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="11" Alias="b">
+              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="12" Alias="c">
+              <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="a">
+              <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="21" Alias="b">
+              <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="22" Alias="c">
+              <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="30" Alias="a">
+              <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="31" Alias="b">
+              <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="32" Alias="c">
+              <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="40" Alias="a">
+              <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="41" Alias="b">
+              <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="42" Alias="c">
+              <dxl:Ident ColId="42" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="50" Alias="a">
+              <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="51" Alias="b">
+              <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="52" Alias="c">
+              <dxl:Ident ColId="52" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+              <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+                <dxl:CoerceViaIO TypeMdid="0.25.1.0" CoercionForm="1" Location="0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:CoerceViaIO>
+                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:OpExpr>
+              <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                <dxl:Ident ColId="52" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:FuncExpr>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="2284.586295" Rows="100145.000000" Width="65"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="c">
+                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="b">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="c">
+                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="a">
+                <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="b">
+                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="c">
+                <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="30" Alias="a">
+                <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="31" Alias="b">
+                <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="32" Alias="c">
+                <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="40" Alias="a">
+                <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="41" Alias="b">
+                <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="42" Alias="c">
+                <dxl:Ident ColId="42" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr TypeMdid="0.25.1.0">
+                <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+                  <dxl:CoerceViaIO TypeMdid="0.25.1.0" CoercionForm="1" Location="0">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:CoerceViaIO>
+                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:OpExpr>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:HashJoin JoinType="Inner">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="2277.794795" Rows="100145.000000" Width="65"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="c">
+                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="10" Alias="a">
+                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="11" Alias="b">
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="12" Alias="c">
+                  <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="a">
+                  <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="b">
+                  <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="22" Alias="c">
+                  <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="30" Alias="a">
+                  <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="31" Alias="b">
+                  <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="32" Alias="c">
+                  <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="40" Alias="a">
+                  <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="41" Alias="b">
+                  <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="42" Alias="c">
+                  <dxl:Ident ColId="42" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                  <dxl:FuncExpr FuncId="0.871.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+                  </dxl:FuncExpr>
+                  <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+                    <dxl:Ident ColId="42" ColName="c" TypeMdid="0.25.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABXg=" LintValue="4244762772"/>
+                  </dxl:OpExpr>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1816.197560" Rows="100145.000000" Width="52"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="b">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="c">
+                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="10" Alias="a">
+                    <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="11" Alias="b">
+                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="12" Alias="c">
+                    <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="20" Alias="a">
+                    <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="21" Alias="b">
+                    <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="22" Alias="c">
+                    <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="30" Alias="a">
+                    <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="31" Alias="b">
+                    <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="32" Alias="c">
+                    <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr TypeMdid="0.25.1.0">
+                    <dxl:FuncExpr FuncId="0.871.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                      <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+                    </dxl:FuncExpr>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:HashJoin JoinType="Inner">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1810.764359" Rows="100145.000000" Width="52"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="b">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="c">
+                      <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="10" Alias="a">
+                      <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="11" Alias="b">
+                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="12" Alias="c">
+                      <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="20" Alias="a">
+                      <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="21" Alias="b">
+                      <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="22" Alias="c">
+                      <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="30" Alias="a">
+                      <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="31" Alias="b">
+                      <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="32" Alias="c">
+                      <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                      <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:Cast>
+                      <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                        <dxl:Coalesce TypeMdid="0.23.1.0">
+                          <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                        </dxl:Coalesce>
+                      </dxl:Cast>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:HashJoin JoinType="Inner">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1350.950273" Rows="100145.000000" Width="39"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="b">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="2" Alias="c">
+                        <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="a">
+                        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="b">
+                        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="12" Alias="c">
+                        <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="20" Alias="a">
+                        <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="21" Alias="b">
+                        <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="22" Alias="c">
+                        <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:JoinFilter/>
+                    <dxl:HashCondList>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                        <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:Cast>
+                        <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                          <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:Cast>
+                      </dxl:Comparison>
+                    </dxl:HashCondList>
+                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="892.919335" Rows="100145.000000" Width="26"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="a">
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="b">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="2" Alias="c">
+                          <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="10" Alias="a">
+                          <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="11" Alias="b">
+                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="12" Alias="c">
+                          <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr TypeMdid="0.20.1.0">
+                          <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:Cast>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:HashJoin JoinType="Inner">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="890.202735" Rows="100145.000000" Width="26"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="a">
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="b">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="c">
+                            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="10" Alias="a">
+                            <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="11" Alias="b">
+                            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="12" Alias="c">
+                            <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:JoinFilter/>
+                        <dxl:HashCondList>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:HashCondList>
+                        <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="433.954945" Rows="100145.000000" Width="13"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="0" Alias="a">
+                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="1" Alias="b">
+                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="2" Alias="c">
+                              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:HashExprList>
+                            <dxl:HashExpr TypeMdid="0.23.1.0">
+                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:HashExpr>
+                          </dxl:HashExprList>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.789476" Rows="100145.000000" Width="13"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="0" Alias="a">
+                                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="1" Alias="b">
+                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="2" Alias="c">
+                                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.242787.1.0" TableName="foo">
+                              <dxl:Columns>
+                                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:RedistributeMotion>
+                        <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="433.954945" Rows="100145.000000" Width="13"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="10" Alias="a">
+                              <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="11" Alias="b">
+                              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="12" Alias="c">
+                              <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:HashExprList>
+                            <dxl:HashExpr TypeMdid="0.23.1.0">
+                              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:HashExpr>
+                          </dxl:HashExprList>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.789476" Rows="100145.000000" Width="13"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="10" Alias="a">
+                                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="11" Alias="b">
+                                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="12" Alias="c">
+                                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.242787.1.0" TableName="foo">
+                              <dxl:Columns>
+                                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:RedistributeMotion>
+                      </dxl:HashJoin>
+                    </dxl:RedistributeMotion>
+                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="433.954945" Rows="100145.000000" Width="13"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="20" Alias="a">
+                          <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="21" Alias="b">
+                          <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="22" Alias="c">
+                          <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr TypeMdid="0.20.1.0">
+                          <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                            <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:Cast>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.789476" Rows="100145.000000" Width="13"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="20" Alias="a">
+                            <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="21" Alias="b">
+                            <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="22" Alias="c">
+                            <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.242787.1.0" TableName="foo">
+                          <dxl:Columns>
+                            <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="21" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="22" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                            <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                            <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:RedistributeMotion>
+                  </dxl:HashJoin>
+                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="433.954945" Rows="100145.000000" Width="13"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="30" Alias="a">
+                        <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="31" Alias="b">
+                        <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="32" Alias="c">
+                        <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr TypeMdid="0.20.1.0">
+                        <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                          <dxl:Coalesce TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                          </dxl:Coalesce>
+                        </dxl:Cast>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.789476" Rows="100145.000000" Width="13"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="30" Alias="a">
+                          <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="31" Alias="b">
+                          <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="32" Alias="c">
+                          <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.242787.1.0" TableName="foo">
+                        <dxl:Columns>
+                          <dxl:Column ColId="30" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="31" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="32" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                          <dxl:Column ColId="33" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="34" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="35" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="36" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="37" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="38" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="39" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:RedistributeMotion>
+                </dxl:HashJoin>
+              </dxl:RedistributeMotion>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="433.954945" Rows="100145.000000" Width="13"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="40" Alias="a">
+                    <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="41" Alias="b">
+                    <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="42" Alias="c">
+                    <dxl:Ident ColId="42" ColName="c" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr TypeMdid="0.25.1.0">
+                    <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+                      <dxl:Ident ColId="42" ColName="c" TypeMdid="0.25.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABXg=" LintValue="4244762772"/>
+                    </dxl:OpExpr>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.789476" Rows="100145.000000" Width="13"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="40" Alias="a">
+                      <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="41" Alias="b">
+                      <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="42" Alias="c">
+                      <dxl:Ident ColId="42" ColName="c" TypeMdid="0.25.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.242787.1.0" TableName="foo">
+                    <dxl:Columns>
+                      <dxl:Column ColId="40" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="41" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="42" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                      <dxl:Column ColId="43" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="44" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="45" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="46" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="47" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="48" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="49" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:RedistributeMotion>
+            </dxl:HashJoin>
+          </dxl:RedistributeMotion>
+          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="433.954945" Rows="100145.000000" Width="13"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="50" Alias="a">
+                <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="51" Alias="b">
+                <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="52" Alias="c">
+                <dxl:Ident ColId="52" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr TypeMdid="0.25.1.0">
+                <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                  <dxl:Ident ColId="52" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:FuncExpr>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.789476" Rows="100145.000000" Width="13"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="50" Alias="a">
+                  <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="51" Alias="b">
+                  <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="52" Alias="c">
+                  <dxl:Ident ColId="52" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.242787.1.0" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="50" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="51" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="52" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                  <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="54" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="55" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="56" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="57" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="58" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="59" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:RedistributeMotion>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/EquiJoinOnExpr-Unsupported.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquiJoinOnExpr-Unsupported.mdp
@@ -1,0 +1,1634 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Equi-join predicates that have expressions (NDV-preserving as well as general expressions)
+               on one or both sides of the join. Validate that the estimated cardinality is what we expect.
+               Join order is fixed, to avoid unnecessary test failures.
+    drop table if exists foo;
+    create table foo(a int, b int, c text);
+    insert into foo select i, i, i::text from generate_series(1,100000) i;
+    analyze foo;
+    set optimizer_join_order to query;
+    set optimizer_enumerate_plans = on;
+    -- negative test cases, cardinality will increase by a lot in each step
+    -- a) two non-NDV-preserving expressions
+    -- b) one side of the operator accessing both tables
+    -- c) inner of LOJ using an expression
+    -- d) coalesce with columns in second or later argument
+    explain
+    select *
+    from foo base     join foo two_expr    on base.b+1               = two_expr.b+1
+                      join foo mixed_tbls  on base.b + mixed_tbls.b  = mixed_tbls.a
+           left outer join foo expr_inner  on base.a::text           = substring(expr_inner.c,3);
+                      join foo coal        on 5*base.b               = coalesce(coal.a, coal.b);
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="101013,102002,102003,102073,102074,102113,102120,102144,102146,102147,103001,103014,103015,103022,103027,103029,103037,104003,104004,104005,104006,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.57350.1.0" Name="foo" Rows="100203.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.57350.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.25.1.0" Nullable="true" ColWidth="5">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.514.1.0" Name="*" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.23.1.0"/>
+        <dxl:OpFunc Mdid="0.141.1.0"/>
+        <dxl:Commutator Mdid="0.514.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.57350.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="925"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="925"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1945"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1945"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2931"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2931"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3921"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3921"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4898"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4898"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7013"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7013"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9010"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10065"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10065"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11144"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11144"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12055"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13014"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13916"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14843"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14843"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15893"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15893"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16876"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17871"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17871"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18794"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18794"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19812"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20839"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20839"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21817"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21817"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22848"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23836"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23836"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24905"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24905"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25888"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25888"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26796"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27784"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27784"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28759"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28759"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29775"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29775"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30745"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30745"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31753"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31753"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32696"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32696"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33646"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33646"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34592"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34592"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35558"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35558"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37559"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37559"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39611"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39611"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41573"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41573"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43543"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43543"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44437"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44437"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45425"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45425"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46435"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46435"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47405"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47405"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48368"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48368"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50367"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50367"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51404"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51404"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52424"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52424"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53397"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53397"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54389"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55395"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55395"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56385"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56385"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57467"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57467"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58399"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58399"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59393"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59393"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60419"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60419"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61412"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61412"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62401"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62401"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63451"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63451"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64418"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64418"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65404"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65404"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66314"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66314"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67315"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67315"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68387"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68387"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69397"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69397"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70389"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71403"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71403"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72390"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74593"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74593"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75498"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75498"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76484"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76484"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77492"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77492"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78453"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78453"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79424"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79424"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80426"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80426"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81496"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81496"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82461"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82461"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83471"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83471"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84447"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84447"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85530"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85530"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86473"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86473"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87456"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87456"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88449"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88449"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89475"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89475"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90594"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91640"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92489"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92489"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93404"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93404"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94347"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94347"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96379"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96379"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97390"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98461"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98461"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.57350.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="925"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="925"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1945"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1945"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2931"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2931"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3921"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3921"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4898"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4898"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7013"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7013"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9010"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10065"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10065"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11144"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11144"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12055"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13014"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13916"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14843"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14843"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15893"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15893"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16876"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17871"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17871"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18794"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18794"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19812"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20839"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20839"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21817"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21817"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22848"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23836"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23836"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24905"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24905"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25888"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25888"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26796"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27784"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27784"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28759"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28759"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29775"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29775"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30745"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30745"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31753"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31753"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32696"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32696"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33646"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33646"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34592"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34592"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35558"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35558"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37559"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37559"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39611"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39611"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41573"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41573"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43543"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43543"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44437"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44437"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45425"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45425"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46435"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46435"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47405"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47405"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48368"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48368"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50367"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50367"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51404"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51404"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52424"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52424"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53397"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53397"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54389"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55395"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55395"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56385"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56385"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57467"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57467"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58399"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58399"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59393"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59393"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60419"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60419"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61412"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61412"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62401"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62401"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63451"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63451"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64418"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64418"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65404"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65404"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66314"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66314"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67315"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67315"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68387"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68387"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69397"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69397"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70389"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71403"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71403"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72390"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74593"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74593"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75498"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75498"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76484"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76484"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77492"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77492"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78453"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78453"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79424"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79424"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80426"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80426"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81496"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81496"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82461"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82461"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83471"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83471"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84447"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84447"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85530"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85530"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86473"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86473"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87456"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87456"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88449"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88449"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89475"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89475"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90594"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91640"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92489"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92489"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93404"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93404"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94347"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94347"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96379"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96379"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97390"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98461"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1002.030000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98461"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.551.1.0" Name="+" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.23.1.0"/>
+        <dxl:OpFunc Mdid="0.177.1.0"/>
+        <dxl:Commutator Mdid="0.551.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBFunc Mdid="0.937.1.0" Name="substring" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false">
+        <dxl:ResultType Mdid="0.25.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:ColumnStatistics Mdid="1.57350.1.0.2" Name="c" Width="5.000000" NullFreq="0.000000" NdvRemain="100203.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.3027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.98.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.67.1.0"/>
+        <dxl:Commutator Mdid="0.98.1.0"/>
+        <dxl:InverseOp Mdid="0.531.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.1995.1.0"/>
+          <dxl:Opfamily Mdid="0.3035.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.25.1.0"/>
+        <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="13" ColName="c" TypeMdid="0.25.1.0"/>
+        <dxl:Ident ColId="21" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="22" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="23" ColName="c" TypeMdid="0.25.1.0"/>
+        <dxl:Ident ColId="31" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="33" ColName="c" TypeMdid="0.25.1.0"/>
+        <dxl:Ident ColId="41" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="42" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="43" ColName="c" TypeMdid="0.25.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Inner">
+        <dxl:LogicalJoin JoinType="Left">
+          <dxl:LogicalJoin JoinType="Inner">
+            <dxl:LogicalJoin JoinType="Inner">
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="0.57350.1.0" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                    <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="0.57350.1.0" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                    <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:OpExpr>
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:OpExpr>
+              </dxl:Comparison>
+            </dxl:LogicalJoin>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.57350.1.0" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="21" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="22" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="23" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                  <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="22" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:OpExpr>
+              <dxl:Ident ColId="21" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:LogicalJoin>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.57350.1.0" TableName="foo">
+              <dxl:Columns>
+                <dxl:Column ColId="31" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="32" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="33" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+            <dxl:CoerceViaIO TypeMdid="0.25.1.0" CoercionForm="1" Location="0">
+              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:CoerceViaIO>
+            <dxl:FuncExpr FuncId="0.937.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+              <dxl:Ident ColId="33" ColName="c" TypeMdid="0.25.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+            </dxl:FuncExpr>
+          </dxl:Comparison>
+        </dxl:LogicalJoin>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.57350.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="41" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="42" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="43" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+              <dxl:Column ColId="44" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="45" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="46" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="47" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="48" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="49" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="50" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:OpExpr OperatorName="*" OperatorMdid="0.514.1.0" OperatorType="0.23.1.0">
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:OpExpr>
+          <dxl:Coalesce TypeMdid="0.23.1.0">
+            <dxl:Ident ColId="41" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="42" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:Coalesce>
+        </dxl:Comparison>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="13">
+      <dxl:HashJoin JoinType="Inner">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="58837188745941401600.000000" Rows="258611551791821375930368.000000" Width="65"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="10" Alias="a">
+            <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="11" Alias="b">
+            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="12" Alias="c">
+            <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="20" Alias="a">
+            <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="21" Alias="b">
+            <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="22" Alias="c">
+            <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="30" Alias="a">
+            <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="31" Alias="b">
+            <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="32" Alias="c">
+            <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="40" Alias="a">
+            <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="41" Alias="b">
+            <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="42" Alias="c">
+            <dxl:Ident ColId="42" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:JoinFilter/>
+        <dxl:HashCondList>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:OpExpr OperatorName="*" OperatorMdid="0.514.1.0" OperatorType="0.23.1.0">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:OpExpr>
+            <dxl:Coalesce TypeMdid="0.23.1.0">
+              <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:Coalesce>
+          </dxl:Comparison>
+        </dxl:HashCondList>
+        <dxl:HashJoin JoinType="Inner">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1174299168377619.750000" Rows="6452190847375362048.000000" Width="52"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="a">
+              <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="11" Alias="b">
+              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="12" Alias="c">
+              <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="a">
+              <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="21" Alias="b">
+              <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="22" Alias="c">
+              <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="30" Alias="a">
+              <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="31" Alias="b">
+              <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="32" Alias="c">
+              <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:OpExpr>
+              <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:JoinFilter>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              </dxl:OpExpr>
+              <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              </dxl:OpExpr>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="421574917.028659" Rows="10040641209.000000" Width="26"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="b">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="c">
+                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="a">
+                <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="b">
+                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="c">
+                <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="420602045.833115" Rows="10040641209.000000" Width="26"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="10" Alias="a">
+                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="11" Alias="b">
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="12" Alias="c">
+                  <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="a">
+                  <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="b">
+                  <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="22" Alias="c">
+                  <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="455.914808" Rows="300609.000000" Width="13"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="a">
+                    <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="11" Alias="b">
+                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="12" Alias="c">
+                    <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.789934" Rows="100203.000000" Width="13"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="10" Alias="a">
+                      <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="11" Alias="b">
+                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="12" Alias="c">
+                      <dxl:Ident ColId="12" ColName="c" TypeMdid="0.25.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.57350.1.0" TableName="foo">
+                    <dxl:Columns>
+                      <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                      <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:BroadcastMotion>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.789934" Rows="100203.000000" Width="13"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="20" Alias="a">
+                    <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="21" Alias="b">
+                    <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="22" Alias="c">
+                    <dxl:Ident ColId="22" ColName="c" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.57350.1.0" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="21" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="22" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                    <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:NestedLoopJoin>
+          </dxl:GatherMotion>
+          <dxl:HashJoin JoinType="Left">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="366415.690333" Rows="4016296564.800000" Width="26"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="c">
+                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="30" Alias="a">
+                <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="31" Alias="b">
+                <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="32" Alias="c">
+                <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                <dxl:CoerceViaIO TypeMdid="0.25.1.0" CoercionForm="1" Location="0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:CoerceViaIO>
+                <dxl:FuncExpr FuncId="0.937.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                  <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                </dxl:FuncExpr>
+              </dxl:Comparison>
+            </dxl:HashCondList>
+            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="437.452071" Rows="100203.000000" Width="13"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="c">
+                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.789934" Rows="100203.000000" Width="13"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="b">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="c">
+                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.57350.1.0" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:GatherMotion>
+            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="437.452071" Rows="100203.000000" Width="13"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="30" Alias="a">
+                  <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="31" Alias="b">
+                  <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="32" Alias="c">
+                  <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.789934" Rows="100203.000000" Width="13"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="30" Alias="a">
+                    <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="31" Alias="b">
+                    <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="32" Alias="c">
+                    <dxl:Ident ColId="32" ColName="c" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.57350.1.0" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="30" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="31" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="32" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                    <dxl:Column ColId="33" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="34" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="35" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="36" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="37" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="38" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="39" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:GatherMotion>
+          </dxl:HashJoin>
+        </dxl:HashJoin>
+        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="437.452071" Rows="100203.000000" Width="13"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="40" Alias="a">
+              <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="41" Alias="b">
+              <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="42" Alias="c">
+              <dxl:Ident ColId="42" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.789934" Rows="100203.000000" Width="13"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="40" Alias="a">
+                <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="41" Alias="b">
+                <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="42" Alias="c">
+                <dxl:Ident ColId="42" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.57350.1.0" TableName="foo">
+              <dxl:Columns>
+                <dxl:Column ColId="40" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="41" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="42" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="5"/>
+                <dxl:Column ColId="43" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="44" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="45" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="46" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="47" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="48" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="49" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+      </dxl:HashJoin>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/InnerJoin-With-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InnerJoin-With-OuterRefs.mdp
@@ -530,7 +530,7 @@
     <dxl:Plan Id="0" SpaceSize="21">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="641930.734375" Rows="1000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="3219.015625" Rows="1000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="27" Alias="?column?">
@@ -541,7 +541,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="641927.781250" Rows="1000.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="3216.062500" Rows="1000.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="27" Alias="?column?">
@@ -552,7 +552,7 @@
                 </dxl:ParamList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1919.921875" Rows="80.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1608.203125" Rows="0.200000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="i">
@@ -681,7 +681,7 @@
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="641922.875000" Rows="1000.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="3211.156250" Rows="1000.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/OuterJoin-With-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OuterJoin-With-OuterRefs.mdp
@@ -1,5 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Left outer join with outer refs in join predicate
+
+    drop table if exists x,y,z;
+    create table x(i int, j int);
+    create table y(i int, j int);
+    create table z(i int, j int);
+
+    insert into x select i, i%2 from generate_series(1, 10) i;
+    insert into y select i, i%2 from generate_series(1, 10) i;
+    insert into z select i, i%2 from generate_series(1, 1000) i;
+
+    analyze x;
+    analyze y;
+    analyze z;
+
+    set optimizer_enumerate_plans = on;
+    set optimizer_segments = 2;
+    explain select (select x.i from x left outer join y on x.i+y.i = z.i) from z;
+  ]]>
+  </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>

--- a/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
@@ -173,7 +173,7 @@
       <dxl:SumAgg Mdid="0.0.0.0"/>
       <dxl:CountAgg Mdid="0.2147.1.0"/>
     </dxl:Type>
-    <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+    <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
       <dxl:LeftType Mdid="0.23.1.0"/>
       <dxl:RightType Mdid="0.23.1.0"/>
       <dxl:ResultType Mdid="0.16.1.0"/>
@@ -185,14 +185,14 @@
         <dxl:Opfamily Mdid="0.3027.1.0"/>
       </dxl:Opfamilies>
     </dxl:GPDBScalarOp>
-    <dxl:GPDBFunc Mdid="0.274.1.0" Name="timeofday" ReturnsSet="false" Stability="Volatile" DataAccess="NoSQL" IsStrict="true">
+    <dxl:GPDBFunc Mdid="0.274.1.0" Name="timeofday" ReturnsSet="false" Stability="Volatile" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false">
       <dxl:ResultType Mdid="0.25.1.0"/>
     </dxl:GPDBFunc>
     <dxl:GPDBAgg Mdid="0.2101.1.0" Name="avg" IsSplittable="true" HashAggCapable="true">
       <dxl:ResultType Mdid="0.1700.1.0"/>
       <dxl:IntermediateResultType Mdid="0.17.1.0"/>
     </dxl:GPDBAgg>
-    <dxl:GPDBFunc Mdid="0.17135.1.0" Name="fooro" ReturnsSet="true" Stability="Volatile" DataAccess="ReadsSQLData" IsStrict="false">
+    <dxl:GPDBFunc Mdid="0.17135.1.0" Name="fooro" ReturnsSet="true" Stability="Volatile" DataAccess="ReadsSQLData" IsStrict="false" IsNDVPreserving="false">
       <dxl:ResultType Mdid="0.2249.1.0"/>
       <dxl:OutputColumns TypeMdids="0.23.1.0,0.23.1.0"/>
     </dxl:GPDBFunc>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
@@ -1076,11 +1076,9 @@ namespace gpopt
 			static
 			BOOL FCrossJoin(CExpression *pexpr);
 
-			// extract scalar ident column reference from scalar expression containing
-			// only one scalar ident in the tree
-			const static
-			CColRef *PcrExtractFromScExpression(CExpression *pexpr);
-
+			// is this scalar expression an NDV-preserving function (used for join stats derivation)
+			static
+			BOOL IsExprNDVPreserving(CExpression *pexpr, const CColRef **underlying_colref);
 
 			// search the given array of predicates for predicates with equality or IS NOT
 			// DISTINCT FROM operators that has one side equal to the given expression

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -5115,18 +5115,112 @@ CUtils::FCrossJoin
 	return fCrossJoin;
 }
 
-// extract scalar ident column reference from scalar expression containing
-// only one scalar ident in the tree
-const CColRef *
-CUtils::PcrExtractFromScExpression
+// Determine whether a scalar expression consists only of a scalar id and NDV-preserving
+// functions plus casts. If so, return the corresponding CColRef.
+BOOL
+CUtils::IsExprNDVPreserving
 	(
- 	CExpression *pexpr
+	 CExpression *pexpr,
+	 const CColRef **underlying_colref
 	)
 {
-	if (pexpr->DeriveUsedColumns()->Size() == 1)
-		return pexpr->DeriveUsedColumns()->PcrFirst();
+	CExpression *curr_expr = pexpr;
 
-	return NULL;
+	*underlying_colref = NULL;
+
+	// go down the expression tree, visiting the child containing a scalar ident until
+	// we found the ident or until we found a non-NDV-preserving function (at which point there
+	// is no more need to check)
+	while (1)
+	{
+		COperator *pop = curr_expr->Pop();
+		ULONG child_with_scalar_ident = 0;
+
+		switch (pop->Eopid())
+		{
+			case COperator::EopScalarIdent:
+			{
+				// we reached the bottom of the expression, return the ColRef
+				CScalarIdent *cr = CScalarIdent::PopConvert(pop);
+
+				*underlying_colref = cr->Pcr();
+				GPOS_ASSERT(1 == pexpr->DeriveUsedColumns()->Size());
+				return true;
+			}
+
+			case COperator::EopScalarCast:
+				// skip over casts
+				// Note: We might in the future investigate whether there are some casts
+				// that reduce NDVs by too much. Most, if not all, casts that have that potential are
+				// converted to functions, though. Examples: timestamp -> date, double precision -> int.
+				break;
+
+			case COperator::EopScalarCoalesce:
+			{
+				// coalesce(col, const1, ... constn) is treated as an NDV-preserving function
+				for (ULONG c=1; c<curr_expr->Arity(); c++)
+				{
+					if (0 < (*curr_expr)[c]->DeriveUsedColumns()->Size())
+					{
+						// this coalesce has a ColRef in the second or later arguments, assume for
+						// now that this doesn't preserve NDVs (we could add logic to support this case later)
+						return false;
+					}
+				}
+				break;
+			}
+			case COperator::EopScalarFunc:
+			{
+				// check whether the function is NDV-preserving
+				CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
+				CScalarFunc *sf = CScalarFunc::PopConvert(pop);
+				const IMDFunction *pmdfunc = md_accessor->RetrieveFunc(sf->FuncMdId());
+
+				if (!pmdfunc->IsNDVPreserving() || 1 != curr_expr->Arity())
+				{
+					return false;
+				}
+				break;
+			}
+
+			case COperator::EopScalarOp:
+			{
+				CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
+				CScalarOp *so = CScalarOp::PopConvert(pop);
+				const IMDScalarOp *pmdscop = md_accessor->RetrieveScOp(so->MdIdOp());
+
+				if (!pmdscop->IsNDVPreserving() || 2 != curr_expr->Arity())
+				{
+					return false;
+				}
+
+				// col <op> const is NDV-preserving, and so is const <op> col
+				if (0 ==(*curr_expr)[1]->DeriveUsedColumns()->Size())
+				{
+					// col <op> const
+					child_with_scalar_ident = 0;
+				}
+				else if (0 ==(*curr_expr)[0]->DeriveUsedColumns()->Size())
+				{
+					// const <op> col
+					child_with_scalar_ident = 1;
+				}
+				else
+				{
+					// give up for now, both children reference a column,
+					// e.g. col1 <op> col2
+					return false;
+				}
+				break;
+			}
+
+			default:
+				// anything else we see is considered non-NDV-preserving
+				return false;
+		}
+
+		curr_expr = (*curr_expr)[child_with_scalar_ident];
+	}
 }
 
 

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDifference.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDifference.cpp
@@ -182,7 +182,8 @@ CLogicalDifference::PstatsDerive
 														exprhdl, 
 														pexprScCond, 
 														output_colrefsets, 
-														outer_refs
+														outer_refs,
+														true // is an LASJ
 														);
 	IStatistics *LASJ_stats = outer_stats->CalcLASJoinStats
 											(

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDifferenceAll.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDifferenceAll.cpp
@@ -179,7 +179,8 @@ CLogicalDifferenceAll::PstatsDerive
 														exprhdl, 
 														pexprScCond, 
 														output_colrefsets, 
-														outer_refs
+														outer_refs,
+														true // is an LASJ
 														);
 	IStatistics *LASJ_stats = outer_stats->CalcLASJoinStats
 											(

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalIntersectAll.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalIntersectAll.cpp
@@ -200,7 +200,8 @@ CLogicalIntersectAll::PstatsDerive
 														exprhdl, 
 														pexprScCond, 
 														output_colrefsets, 
-														outer_refs
+														outer_refs,
+														true // is a semi-join
 														);
 	IStatistics *pstatsSemiJoin = CLogicalLeftSemiJoin::PstatsDerive(mp, join_preds_stats, outer_stats, inner_side_stats);
 

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalLeftAntiSemiJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalLeftAntiSemiJoin.cpp
@@ -149,7 +149,7 @@ CLogicalLeftAntiSemiJoin::PstatsDerive
 	GPOS_ASSERT(Esp(exprhdl) > EspNone);
 	IStatistics *outer_stats = exprhdl.Pstats(0);
 	IStatistics *inner_side_stats = exprhdl.Pstats(1);
-	CStatsPredJoinArray *join_preds_stats = CStatsPredUtils::ExtractJoinStatsFromExprHandle(mp, exprhdl);
+	CStatsPredJoinArray *join_preds_stats = CStatsPredUtils::ExtractJoinStatsFromExprHandle(mp, exprhdl, true /*LASJ*/);
 	IStatistics *pstatsLASJoin = outer_stats->CalcLASJoinStats
 												(
 												mp,

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalLeftSemiJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalLeftSemiJoin.cpp
@@ -171,7 +171,7 @@ CLogicalLeftSemiJoin::PstatsDerive
 	GPOS_ASSERT(Esp(exprhdl) > EspNone);
 	IStatistics *outer_stats = exprhdl.Pstats(0);
 	IStatistics *inner_side_stats = exprhdl.Pstats(1);
-	CStatsPredJoinArray *join_preds_stats = CStatsPredUtils::ExtractJoinStatsFromExprHandle(mp, exprhdl);
+	CStatsPredJoinArray *join_preds_stats = CStatsPredUtils::ExtractJoinStatsFromExprHandle(mp, exprhdl, true/*semi-join*/);
 	IStatistics *pstatsSemiJoin = PstatsDerive(mp, join_preds_stats, outer_stats, inner_side_stats);
 
 	join_preds_stats->Release();

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDGPDBFunc.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDGPDBFunc.h
@@ -60,6 +60,8 @@ namespace gpdxl
 
 			// function strictness (i.e. whether func returns NULL on NULL input)
 			BOOL m_is_strict;
+
+			BOOL m_is_ndv_preserving;
 			
 			// private copy ctor
 			CParseHandlerMDGPDBFunc(const CParseHandlerMDGPDBFunc &);

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDGPDBScalarOp.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDGPDBScalarOp.h
@@ -65,6 +65,9 @@ namespace gpdxl
 			IMDId *m_mdid_hash_opfamily;
 			IMDId *m_mdid_legacy_hash_opfamily;
 
+			// preserves NDVs of inputs
+			BOOL m_is_ndv_preserving;
+
 			// private copy ctor
 			CParseHandlerMDGPDBScalarOp(const CParseHandlerMDGPDBScalarOp &);
 			

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -573,6 +573,7 @@ namespace gpdxl
 		EdxltokenCmpOther,
 		
 		EdxltokenReturnsNullOnNullInput,
+		EdxltokenIsNDVPreserving,
 
 		EdxltokenTriggers,
 		EdxltokenTrigger,
@@ -598,6 +599,7 @@ namespace gpdxl
 		EdxltokenGPDBFuncResultTypeId,
 		EdxltokenGPDBFuncReturnsSet,
 		EdxltokenGPDBFuncStrict,
+		EdxltokenGPDBFuncNDVPreserving,
 		
 		EdxltokenGPDBCast,
 		EdxltokenGPDBCastBinaryCoercible,

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDFunctionGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDFunctionGPDB.h
@@ -50,7 +50,7 @@ namespace gpmd
 			IMDId *m_mdid_type_result;
 			
 			// output argument types
-		IMdIdArray *m_mdid_types_array;
+			IMdIdArray *m_mdid_types_array;
 
 			// whether function returns a set of values
 			BOOL m_returns_set;
@@ -63,6 +63,10 @@ namespace gpmd
 
 			// function strictness (i.e. whether func returns NULL on NULL input)
 			BOOL m_is_strict;
+
+			// function result has very similar number of distinct values as the
+			// single function argument (used for cardinality estimation)
+			BOOL m_is_ndv_preserving;
 
 			// dxl token array for stability
 			Edxltoken m_dxl_func_stability_array[EfsSentinel];
@@ -97,7 +101,8 @@ namespace gpmd
 				BOOL ReturnsSet,
 				EFuncStbl func_stability,
 				EFuncDataAcc func_data_access,
-				BOOL is_strict
+				BOOL is_strict,
+				BOOL is_ndv_preserving
 				);
 			
 			virtual
@@ -133,6 +138,12 @@ namespace gpmd
 				return m_is_strict;
 			}
 			
+			virtual
+			BOOL IsNDVPreserving() const
+			{
+				return m_is_ndv_preserving;
+			}
+
 			// function stability
 			virtual
 			EFuncStbl GetFuncStability() const

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDScalarOpGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDScalarOpGPDB.h
@@ -71,7 +71,7 @@ namespace gpmd
 			
 			// does operator return NULL when all inputs are NULL?
 			BOOL m_returns_null_on_null_input;
-			
+
 			// operator classes this operator belongs to
 			IMdIdArray *m_mdid_opfamilies_array;
 
@@ -80,6 +80,10 @@ namespace gpmd
 
 			// compatible legacy hash op family using legacy (cdbhash) opclass
 			IMDId *m_mdid_legacy_hash_opfamily;
+
+			// does operator preserve the NDV of its input(s)
+			// (used for cardinality estimation)
+			BOOL m_is_ndv_preserving;
 
 			CMDScalarOpGPDB(const CMDScalarOpGPDB &);
 			
@@ -101,7 +105,8 @@ namespace gpmd
 				BOOL returns_null_on_null_input,
 				IMdIdArray *mdid_opfamilies_array,
 				IMDId *m_mdid_hash_opfamily,
-				IMDId *mdid_legacy_hash_opfamily
+				IMDId *mdid_legacy_hash_opfamily,
+				BOOL is_ndv_preserving
 				);
 			
 			~CMDScalarOpGPDB();
@@ -154,6 +159,10 @@ namespace gpmd
 			// the implementation in GPDB returns what STRICT property states
 			virtual
 			BOOL ReturnsNullOnNullInput() const;
+
+			// preserves NDVs of its inputs?
+			virtual
+			BOOL IsNDVPreserving() const;
 
 			// comparison type
 			virtual

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDFunction.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDFunction.h
@@ -65,6 +65,10 @@ namespace gpmd
 			virtual 
 			BOOL IsStrict() const = 0;
 			
+			// does function preserve NDVs of input (for cardinality estimation)
+			virtual
+			BOOL IsNDVPreserving() const = 0;
+
 			// does function return a set of values
 			virtual 
 			BOOL ReturnsSet() const = 0;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDScalarOp.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDScalarOp.h
@@ -75,6 +75,10 @@ namespace gpmd
 			virtual
 			BOOL ReturnsNullOnNullInput() const = 0;
 
+			// preserves NDVs of its inputs?
+			virtual
+			BOOL IsNDVPreserving() const = 0;
+
 			virtual
 			IMDType::ECmpType ParseCmpType() const = 0;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPred.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPred.h
@@ -55,9 +55,8 @@ namespace gpnaucrates
 				EstatscmptINDF,	// is not distinct from
 				EstatscmptLike,	// LIKE predicate comparison
 				EstatscmptNotLike,	// NOT LIKE predicate comparison
-				// NDV comparision for equality predicate on columns with functions, ex f(a) = b or a = f(b)
-				EstatscmptEqNDVOuter, // use Outer NDV on inner side also
-				EstatscmptEqNDVInner, // use Inner NDV on outer side also
+				// NDV comparison for equality predicate on columns with functions, ex f(a) = b or a = f(b)
+				EstatscmptEqNDV,
 				EstatscmptOther
 			};
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPredJoin.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatsPredJoin.h
@@ -64,6 +64,11 @@ namespace gpnaucrates
 			{}
 
 			// accessors
+			BOOL HasValidColIdOuter() const
+			{
+				return gpos::ulong_max != m_colidOuter;
+			}
+
 			ULONG ColIdOuter() const
 			{
 				return m_colidOuter;
@@ -73,6 +78,11 @@ namespace gpnaucrates
 			CStatsPred::EStatsCmpType GetCmpType() const
 			{
 				return m_stats_cmp_type;
+			}
+
+			BOOL HasValidColIdInner() const
+			{
+				return gpos::ulong_max != m_colidInner;
 			}
 
 			ULONG ColIdInner() const

--- a/src/backend/gporca/libnaucrates/src/md/CMDFunctionGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDFunctionGPDB.cpp
@@ -38,7 +38,8 @@ CMDFunctionGPDB::CMDFunctionGPDB
 	BOOL ReturnsSet,
 	EFuncStbl func_stability,
 	EFuncDataAcc func_data_access,
-	BOOL is_strict
+	BOOL is_strict,
+	BOOL is_ndv_preserving
 	)
 	:
 	m_mp(mp),
@@ -49,7 +50,8 @@ CMDFunctionGPDB::CMDFunctionGPDB
 	m_returns_set(ReturnsSet),
 	m_func_stability(func_stability),
 	m_func_data_access(func_data_access),
-	m_is_strict(is_strict)
+	m_is_strict(is_strict),
+	m_is_ndv_preserving(is_ndv_preserving)
 {
 	GPOS_ASSERT(m_mdid->IsValid());
 	GPOS_ASSERT(EfsSentinel > func_stability);
@@ -228,6 +230,7 @@ CMDFunctionGPDB::Serialize
 	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenGPDBFuncStability), GetFuncStabilityStr());
 	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenGPDBFuncDataAccess), GetFuncDataAccessStr());
 	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenGPDBFuncStrict), m_is_strict);
+	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenGPDBFuncNDVPreserving), m_is_ndv_preserving);
 
 	SerializeMDIdAsElem(xml_serializer, CDXLTokens::GetDXLTokenStr(EdxltokenGPDBFuncResultTypeId), m_mdid_type_result);
 

--- a/src/backend/gporca/libnaucrates/src/md/CMDScalarOpGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDScalarOpGPDB.cpp
@@ -43,7 +43,8 @@ CMDScalarOpGPDB::CMDScalarOpGPDB
 	BOOL returns_null_on_null_input,
 	IMdIdArray *mdid_opfamilies_array,
 	IMDId *mdid_hash_opfamily,
-	IMDId *mdid_legacy_hash_opfamily
+	IMDId *mdid_legacy_hash_opfamily,
+	BOOL is_ndv_preserving
 	)
 	:
 	m_mp(mp),
@@ -59,7 +60,8 @@ CMDScalarOpGPDB::CMDScalarOpGPDB
 	m_returns_null_on_null_input(returns_null_on_null_input),
 	m_mdid_opfamilies_array(mdid_opfamilies_array),
 	m_mdid_hash_opfamily(mdid_hash_opfamily),
-	m_mdid_legacy_hash_opfamily(mdid_legacy_hash_opfamily)
+	m_mdid_legacy_hash_opfamily(mdid_legacy_hash_opfamily),
+	m_is_ndv_preserving(is_ndv_preserving)
 {
 	GPOS_ASSERT(NULL != mdid_opfamilies_array);
 	m_dxl_str = CDXLUtils::SerializeMDObj(m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
@@ -236,6 +238,12 @@ CMDScalarOpGPDB::ReturnsNullOnNullInput() const
 }
 
 
+BOOL
+CMDScalarOpGPDB::IsNDVPreserving() const
+{
+	return m_is_ndv_preserving;
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CMDScalarOpGPDB::ParseCmpType
@@ -272,6 +280,7 @@ CMDScalarOpGPDB::Serialize
 	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenName), m_mdname->GetMDName());
 	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenGPDBScalarOpCmpType), IMDType::GetCmpTypeStr(m_comparision_type));
 	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenReturnsNullOnNullInput), m_returns_null_on_null_input);
+	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenIsNDVPreserving), m_is_ndv_preserving);
 
 	Edxltoken dxl_token_array[8] = {
 							EdxltokenGPDBScalarOpLeftTypeId, EdxltokenGPDBScalarOpRightTypeId, 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDGPDBFunc.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDGPDBFunc.cpp
@@ -105,6 +105,17 @@ CParseHandlerMDGPDBFunc::StartElement
 											EdxltokenGPDBFunc
 											);
 		
+		// parse whether func is NDV-preserving
+		m_is_ndv_preserving = CDXLOperatorFactory::ExtractConvertAttrValueToBool
+											(
+											m_parse_handler_mgr->GetDXLMemoryManager(),
+											attrs,
+											EdxltokenGPDBFuncNDVPreserving,
+											EdxltokenGPDBFunc,
+											true, // optional
+											false // default is false
+											);
+
 		// parse func stability property
 		const XMLCh *xmlszStbl = CDXLOperatorFactory::ExtractAttrValue
 														(
@@ -190,7 +201,8 @@ CParseHandlerMDGPDBFunc::EndElement
 												m_returns_set,
 												m_func_stability,
 												m_func_data_access,
-												m_is_strict);
+												m_is_strict,
+												m_is_ndv_preserving);
 		
 		// deactivate handler
 		m_parse_handler_mgr->DeactivateHandler();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDGPDBScalarOp.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDGPDBScalarOp.cpp
@@ -53,7 +53,8 @@ CParseHandlerMDGPDBScalarOp::CParseHandlerMDGPDBScalarOp
 	m_comparision_type(IMDType::EcmptOther),
 	m_returns_null_on_null_input(false),
 	m_mdid_hash_opfamily(NULL),
-	m_mdid_legacy_hash_opfamily(NULL)
+	m_mdid_legacy_hash_opfamily(NULL),
+	m_is_ndv_preserving(false)
 {
 }
 
@@ -121,6 +122,17 @@ CParseHandlerMDGPDBScalarOp::StartElement
 								EdxltokenGPDBScalarOp
 								);
 		}
+
+		// ndv-preserving property is optional
+		m_is_ndv_preserving = CDXLOperatorFactory::ExtractConvertAttrValueToBool
+							(
+							m_parse_handler_mgr->GetDXLMemoryManager(),
+							attrs,
+							EdxltokenIsNDVPreserving,
+							EdxltokenGPDBScalarOp,
+							true, // is optional
+							false // default value
+							);
 
 	}
 	else if (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenGPDBScalarOpLeftTypeId), element_local_name))
@@ -292,7 +304,8 @@ CParseHandlerMDGPDBScalarOp::EndElement
 				m_returns_null_on_null_input,
 				mdid_opfamilies_array,
 				m_mdid_hash_opfamily,
-				m_mdid_legacy_hash_opfamily
+				m_mdid_legacy_hash_opfamily,
+				m_is_ndv_preserving
 				)
 				;
 		

--- a/src/backend/gporca/libnaucrates/src/statistics/CLeftSemiJoinStatsProcessor.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CLeftSemiJoinStatsProcessor.cpp
@@ -34,8 +34,11 @@ CLeftSemiJoinStatsProcessor::CalcLSJoinStatsStatic
 	ULongPtrArray *inner_colids = GPOS_NEW(mp) ULongPtrArray(mp);
 	for (ULONG ul = 0; ul < length; ul++)
 	{
-		ULONG colid = ((*join_preds_stats)[ul])->ColIdInner();
-		inner_colids->Append(GPOS_NEW(mp) ULONG(colid));
+		if ((*join_preds_stats)[ul]->HasValidColIdInner())
+		{
+			ULONG colid = ((*join_preds_stats)[ul])->ColIdInner();
+			inner_colids->Append(GPOS_NEW(mp) ULONG(colid));
+		}
 	}
 
 	// dummy agg columns required for group by derivation

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -1180,6 +1180,7 @@ CStatisticsUtils::DeriveStatsForDynamicScan
 														scalar_expr,
 														output_colrefs,
 														outer_refs,
+														true, // semi-join
 														&unsupported_pred_stats
 														);
 
@@ -1863,9 +1864,7 @@ CStatisticsUtils::IsStatsCmpTypeNdvEq
 	 CStatsPred::EStatsCmpType stats_cmp_type
 	)
 {
-	return (CStatsPred::EstatscmptEqNDVOuter == stats_cmp_type ||
-			CStatsPred::EstatscmptEqNDVInner == stats_cmp_type
-			);
+	return (CStatsPred::EstatscmptEqNDV == stats_cmp_type);
 }
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatsPredUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatsPredUtils.cpp
@@ -59,34 +59,29 @@ CStatsPredUtils::StatsCmpType
 
 	CStatsPred::EStatsCmpType stats_cmp_type = CStatsPred::EstatscmptOther;
 
+	CWStringConst str_eq(GPOS_WSZ_LIT("="));
 	CWStringConst str_lt(GPOS_WSZ_LIT("<"));
 	CWStringConst str_leq(GPOS_WSZ_LIT("<="));
-	CWStringConst str_eq(GPOS_WSZ_LIT("="));
 	CWStringConst str_geq(GPOS_WSZ_LIT(">="));
 	CWStringConst str_gt(GPOS_WSZ_LIT(">"));
 	CWStringConst str_neq(GPOS_WSZ_LIT("<>"));
 
-	if (str_opname->Equals(&str_lt))
-	{
-		stats_cmp_type = CStatsPred::EstatscmptL;
-	}
-	if (str_opname->Equals(&str_leq))
-	{
-		stats_cmp_type = CStatsPred::EstatscmptLEq;
-	}
 	if (str_opname->Equals(&str_eq))
 	{
 		stats_cmp_type = CStatsPred::EstatscmptEq;
-	}
-	if (str_opname->Equals(&str_geq))
+	} else if (str_opname->Equals(&str_lt))
+	{
+		stats_cmp_type = CStatsPred::EstatscmptL;
+	} else if (str_opname->Equals(&str_leq))
+	{
+		stats_cmp_type = CStatsPred::EstatscmptLEq;
+	} else if (str_opname->Equals(&str_geq))
 	{
 		stats_cmp_type = CStatsPred::EstatscmptGEq;
-	}
-	if (str_opname->Equals(&str_gt))
+	} else if (str_opname->Equals(&str_gt))
 	{
 		stats_cmp_type = CStatsPred::EstatscmptG;
-	}
-	if (str_opname->Equals(&str_neq))
+	} else if (str_opname->Equals(&str_neq))
 	{
 		stats_cmp_type = CStatsPred::EstatscmptNEq;
 	}
@@ -323,39 +318,68 @@ CStatsPredUtils::GetPredStats
 
 
 //---------------------------------------------------------------------------
-//	@function:
-//		CStatsPredUtils::IsPredCmpColsOrIgnoreCast
+//		CStatsPredUtils::IsJoinPredSupportedForStatsEstimation
 //
-//	@doc:
-// 		Is the expression a comparison of scalar ident or cast of a scalar ident?
-//		Extract relevant info.
+//		Given a join predicate <expr>, return whether this is a supported
+//		join predicate for cardinality estimation, and what method to use
+//		to build the join statistics.
 //
+//		Also return ColRefs for those sides of the comparison predicate that
+//		can be used (either the entire histogram or just the NDV).
+//
+//		Supported predicates:
+//
+//		All of these must reference the outer table only on one side
+//		and the inner table only on the other side.
+//
+//		col1 <op> col2          (op could be INDF, IDF, =, <, <=, >, >=, <>)
+//		col1 = p(col2)          (p is an NDV-preserving function)
+//		p(col1) = p(col2)
+//		col1 = expr(col2...coln)
+//		p(col1) = expr(col2...coln)
+//
+//		plus variations of the above, flipping sides and adding casts.
+//		Non-NDV-preserving expressions are not allowed on the inner side
+//		of semi and anti-semijoins because we need the NDV of the join column
+//		for those (LOJ stats are calculated using a semi-join, so the
+//		restriction affects those as well).
+//
+//		For all but the first line above, we use an NDV-based stats method.
 //---------------------------------------------------------------------------
 BOOL
-CStatsPredUtils::IsPredCmpColsOrIgnoreCast
+CStatsPredUtils::IsJoinPredSupportedForStatsEstimation
 	(
 	CExpression *expr,
-	const CColRef **col_ref_left,
+	CColRefSetArray *output_col_refsets,  // array of output columns of join's relational inputs
+	BOOL is_semi_or_anti_join,
 	CStatsPred::EStatsCmpType *stats_pred_cmp_type,
-	const CColRef **col_ref_right,
-	BOOL &left_is_null,
-	BOOL &right_is_null
+	const CColRef **col_ref_outer,
+	const CColRef **col_ref_inner
 	)
 {
-	GPOS_ASSERT(NULL != col_ref_left);
-	GPOS_ASSERT(NULL != col_ref_right);
+	GPOS_ASSERT(NULL != col_ref_outer);
+	GPOS_ASSERT(NULL != col_ref_inner);
+	GPOS_ASSERT(NULL == *col_ref_outer);
+	GPOS_ASSERT(NULL == *col_ref_inner);
 	COperator *expr_op = expr->Pop();
 
 	BOOL is_INDF = CPredicateUtils::FINDF(expr);
 	BOOL is_IDF = CPredicateUtils::FIDF(expr);
 	BOOL is_scalar_cmp = (COperator::EopScalarCmp == expr_op->Eopid());
-	if (!is_scalar_cmp && !is_INDF && !is_IDF)
-	{
-		return false;
-	}
-
+	// left and right children of our join pred operator
 	CExpression *expr_left = NULL;
 	CExpression *expr_right = NULL;
+
+	// initialize output parameters
+	*col_ref_inner = NULL;
+	*col_ref_outer = NULL;
+
+	if (!is_scalar_cmp && !is_INDF && !is_IDF)
+	{
+		// an unsupported expression
+		*stats_pred_cmp_type = CStatsPred::EstatscmptOther;
+		return false;
+	}
 
 	if (is_INDF)
 	{
@@ -384,52 +408,134 @@ CStatsPredUtils::IsPredCmpColsOrIgnoreCast
 		expr_right = (*expr)[1];
 	}
 
-	(*col_ref_left) = CCastUtils::PcrExtractFromScIdOrCastScId(expr_left);
-	(*col_ref_right) = CCastUtils::PcrExtractFromScIdOrCastScId(expr_right);
+	// expr_left and expr_right associated with the outer and inner tables
+	CExpression *assigned_expr_outer = NULL;
+	CExpression *assigned_expr_inner = NULL;
 
-	// if the equi join is of type f(a) = f(b) then it is unsupported stats comparison
-	// So, we fall back to default stats.(from Selinger et al.)
-	if (NULL == *col_ref_left && NULL == *col_ref_right)
-		return false;
-
-	if (NULL == *col_ref_left || NULL == *col_ref_right)
+	if (!AssignExprsToOuterAndInner(output_col_refsets, expr_left, expr_right, &assigned_expr_outer, &assigned_expr_inner))
 	{
-		if (NULL == *col_ref_left)
-		{
-			left_is_null = true;
-		}
-
-		if (NULL == *col_ref_right)
-		{
-			right_is_null = true;
-		}
-
-		// if the scalar cmp is of equality type, we may not have been able to extract
-		// the column referenes of scalar ident if they had any other expression than cast
-		// on top of them.
-		// in such cases, check if there is still a possibility to extract scalar ident,
-		// if there is more than one column reference on either side, this is unsupported
-		// If supported, mark the comparison as NDV-based
-
-		if (*stats_pred_cmp_type == CStatsPred::EstatscmptEq)
-		{
-			(*col_ref_left) = CUtils::PcrExtractFromScExpression(expr_left);
-			(*col_ref_right) = CUtils::PcrExtractFromScExpression(expr_right);
-			
-			if (NULL == *col_ref_left || NULL == *col_ref_right)
-			{
-				return false;
-			}
-
-			return true;
-		}
-		// failed to extract a scalar ident
+		// we are not dealing with a join predicate where one side of the operator
+		// refers to the outer table and the other side refers to the inner
 		return false;
+	}
+
+	// check whether left or right expressions are simple columns or casts
+	// of simple columns
+	(*col_ref_outer) = CCastUtils::PcrExtractFromScIdOrCastScId(assigned_expr_outer);
+	(*col_ref_inner) = CCastUtils::PcrExtractFromScIdOrCastScId(assigned_expr_inner);
+
+	if (NULL != *col_ref_outer && NULL != *col_ref_inner)
+	{
+		// a simple predicate of the form col1 <op> col2 (casts are allowed)
+		return true;
+	}
+
+	// if the scalar cmp is of equality type, we may not have been able to extract
+	// the column references of scalar ident if they had any other expression than cast
+	// on top of them.
+	// in such cases, check if there is still a possibility to extract scalar ident,
+	// if there is more than one column reference on either side, this is unsupported
+	// If supported, mark the comparison as NDV-based
+
+	if (*stats_pred_cmp_type == CStatsPred::EstatscmptEq)
+	{
+		BOOL outer_is_ndv_preserving =
+			(NULL != *col_ref_outer || CUtils::IsExprNDVPreserving(assigned_expr_outer, col_ref_outer));
+		BOOL inner_is_ndv_preserving =
+			(NULL != *col_ref_inner || CUtils::IsExprNDVPreserving(assigned_expr_inner, col_ref_inner));
+
+		if (!outer_is_ndv_preserving && !inner_is_ndv_preserving)
+		{
+			// join pred of the form f(a) = f(b) with neither side NDV-preserving, this is not supported
+			return false;
+		}
+
+		if (is_semi_or_anti_join && !inner_is_ndv_preserving)
+		{
+			// non-NDV-preserving functions on the inner of a semi-join or anti-semijoin
+			// are not supported, we need the NDV of the inner join columns to calculate
+			// the stats
+			return false;
+		}
+
+		// a join predicate that involves an NDV-preserving function on at least one side, one of
+		// *col_ref_inner and *col_ref_outer may be NULL. If expr(...) is a non-NDV-preserving
+		// expression and p is an NDV-preserving function, then we can have one of the following
+		// (including variations with flipped sides and casts added):
+		// col1 = p(col2)                (use max of both NDVs)
+		// p(col1) = p(col2)             (use max of both NDVs)
+		// col1 = expr(col2...coln)      (use NDV of col1)
+		// p(col1) = expr(col2...coln)   (use NDV of col1)
+		*stats_pred_cmp_type = CStatsPred::EstatscmptEqNDV;
+		return true;
+	}
+
+	// failed to extract a scalar ident
+	return false;
+}
+
+
+BOOL
+CStatsPredUtils::AssignExprsToOuterAndInner
+	(
+	CColRefSetArray *output_col_refsets,  // array of output columns of join's relational inputs
+	CExpression *expr_1,
+	CExpression *expr_2,
+	CExpression **outer_expr,
+	CExpression **inner_expr
+	)
+{
+	// see also CPhysicalJoin::FPredKeysSeparated(), which returns similar info
+	CColRefSet *used_cols_1 = expr_1->DeriveUsedColumns();
+	CColRefSet *used_cols_2 = expr_2->DeriveUsedColumns();
+	ULONG child_index_1 = 0;
+	ULONG child_index_2 = 0;
+
+	if (0 == used_cols_1->Size() || 0 == used_cols_2->Size())
+	{
+		// one of the sides is a constant
+		return false;
+	}
+
+	// try just one ColRef from each side and find the associated input table
+	child_index_1 = CUtils::UlPcrIndexContainingSet(output_col_refsets, used_cols_1->PcrAny());
+	child_index_2 = CUtils::UlPcrIndexContainingSet(output_col_refsets, used_cols_2->PcrAny());
+
+	if (gpos::ulong_max == child_index_1 || gpos::ulong_max == child_index_2)
+	{
+		// the predicate refers to columns that are not available
+		// (predicate from NAry join that refers to tables not yet being processed)
+		return false;
+	}
+	if (child_index_1 == child_index_2)
+	{
+		// both sides refer to the same input table
+		return false;
+	}
+
+	// we tried one ColRef above, now try all of them, if there are multiple
+	if ((1 < used_cols_1->Size() && !(*output_col_refsets)[child_index_1]->ContainsAll(used_cols_1)) ||
+		(1 < used_cols_2->Size() && !(*output_col_refsets)[child_index_2]->ContainsAll(used_cols_2)))
+	{
+		// at least one of the sides refers to more than one input table
+		return false;
+	}
+
+	if (child_index_1 < child_index_2)
+	{
+		GPOS_ASSERT(0 == child_index_1 && 1 == child_index_2);
+		*outer_expr = expr_1;
+		*inner_expr = expr_2;
+	}
+	else
+	{
+		GPOS_ASSERT(0 == child_index_2 && 1 == child_index_1);
+		*outer_expr = expr_2;
+		*inner_expr = expr_1;
 	}
 
 	return true;
 }
-
 
 //---------------------------------------------------------------------------
 //	@function:
@@ -1133,28 +1239,6 @@ CStatsPredUtils::GetStatsPredFromBoolExpr
 	return GPOS_NEW(mp) CStatsPredPoint(colid, CStatsPred::EstatscmptEq, GPOS_NEW(mp) CPoint(datum));
 }
 
-CStatsPred::EStatsCmpType
-CStatsPredUtils::DeriveStatCmpEqNDVType
-		(
-		 ULONG left_index,
-		 ULONG right_index,
-		 BOOL left_is_null,
-		 BOOL right_is_null
-		 )
-{
-	GPOS_ASSERT(left_is_null || right_is_null);
-
-	// given an equi join condition f(a) = b, if the func is on
-	// outer side, consider the NDV stats on inner
-	if ((left_is_null && (left_index < right_index)) ||
-		(right_is_null && (right_index < left_index)))
-	{
-		return CStatsPred::EstatscmptEqNDVInner;
-	}
-
-	// otherwise consider NDV stats on outer
-	return CStatsPred::EstatscmptEqNDVOuter;
-}
 //---------------------------------------------------------------------------
 //	@function:
 //		CStatsPredUtils::ExtractJoinStatsFromJoinPred
@@ -1170,6 +1254,7 @@ CStatsPredUtils::ExtractJoinStatsFromJoinPred
 	CExpression *join_pred_expr,
 	CColRefSetArray *output_col_refsets,  // array of output columns of join's relational inputs
 	CColRefSet *outer_refs,
+	BOOL is_semi_or_anti_join,
 	CExpressionArray *unsupported_expr_array
 	)
 {
@@ -1184,16 +1269,23 @@ CStatsPredUtils::ExtractJoinStatsFromJoinPred
 		return NULL;
 	}
 
-	const CColRef *col_ref_left = NULL;
-	const CColRef *col_ref_right = NULL;
-	BOOL left_is_from_expr = false;
-	BOOL right_is_from_expr = false;
+	const CColRef *col_ref_outer = NULL;
+	const CColRef *col_ref_inner = NULL;
 	CStatsPred::EStatsCmpType stats_cmp_type = CStatsPred::EstatscmptOther;
 
-	BOOL fSupportedScIdentComparison = IsPredCmpColsOrIgnoreCast(join_pred_expr, &col_ref_left, &stats_cmp_type, &col_ref_right, left_is_from_expr, right_is_from_expr);
+	BOOL fSupportedScIdentComparison = IsJoinPredSupportedForStatsEstimation
+										(
+										 join_pred_expr,
+										 output_col_refsets,
+										 is_semi_or_anti_join,
+										 &stats_cmp_type,
+										 &col_ref_outer,
+										 &col_ref_inner
+										);
 	if (fSupportedScIdentComparison && CStatsPred::EstatscmptOther != stats_cmp_type)
 	{
-		if (!IMDType::StatsAreComparable(col_ref_left->RetrieveType(), col_ref_right->RetrieveType()))
+		if (NULL != col_ref_outer && NULL != col_ref_inner &&
+			!IMDType::StatsAreComparable(col_ref_outer->RetrieveType(), col_ref_inner->RetrieveType()))
 		{
 			// unsupported statistics comparison between the histogram boundaries of the columns
 			join_pred_expr->AddRef();
@@ -1201,24 +1293,10 @@ CStatsPredUtils::ExtractJoinStatsFromJoinPred
 			return NULL;
 		}
 
-		ULONG index_left = CUtils::UlPcrIndexContainingSet(output_col_refsets, col_ref_left);
-		ULONG index_right = CUtils::UlPcrIndexContainingSet(output_col_refsets, col_ref_right);
+		ULONG outer_id = (NULL != col_ref_outer ? col_ref_outer->Id() : gpos::ulong_max);
+		ULONG inner_id = (NULL != col_ref_inner ? col_ref_inner->Id() : gpos::ulong_max);
 
-		if (left_is_from_expr || right_is_from_expr)
-		{
-			stats_cmp_type = DeriveStatCmpEqNDVType(index_left, index_right, left_is_from_expr, right_is_from_expr);
-		}
-
-		if (gpos::ulong_max != index_left && gpos::ulong_max != index_right &&
-			index_left != index_right)
-		{
-			if (index_left < index_right)
-			{
-				return GPOS_NEW(mp) CStatsPredJoin(col_ref_left->Id(), stats_cmp_type, col_ref_right->Id());
-			}
-
-			return GPOS_NEW(mp) CStatsPredJoin(col_ref_right->Id(), stats_cmp_type, col_ref_left->Id());
-		}
+		return GPOS_NEW(mp) CStatsPredJoin(outer_id, stats_cmp_type, inner_id);
 	}
 
 	if (CColRefSet::FCovered(output_col_refsets, col_refset_used))
@@ -1248,6 +1326,7 @@ CStatsPredUtils::ExtractJoinStatsFromJoinPredArray
 	CExpression *scalar_expr,
 	CColRefSetArray *output_col_refsets,  // array of output columns of join's relational inputs
 	CColRefSet *outer_refs,
+	BOOL is_semi_or_antijoin,
 	CStatsPred **unsupported_stats_pred_array
 	)
 {
@@ -1270,6 +1349,7 @@ CStatsPredUtils::ExtractJoinStatsFromJoinPredArray
 										predicate_expr,
 										output_col_refsets,
 										outer_refs,
+										is_semi_or_antijoin,
 										unsupported_expr_array
 										);
 		if (NULL != join_stats)
@@ -1314,7 +1394,8 @@ CStatsPredUtils::ExtractJoinStatsFromExpr
 	CExpressionHandle &expr_handle,
 	CExpression *pexprScalarInput,
 	CColRefSetArray *output_col_refsets, // array of output columns of join's relational inputs
-	CColRefSet *outer_refs
+	CColRefSet *outer_refs,
+	BOOL is_semi_or_anti_join
 	)
 {
 	GPOS_ASSERT(NULL != output_col_refsets);
@@ -1330,6 +1411,7 @@ CStatsPredUtils::ExtractJoinStatsFromExpr
 										scalar_expr,
 										output_col_refsets,
 										outer_refs,
+										is_semi_or_anti_join,
 										&unsupported_pred_stats
 										);
 
@@ -1353,8 +1435,9 @@ CStatsPredUtils::ExtractJoinStatsFromExpr
 CStatsPredJoinArray *
 CStatsPredUtils::ExtractJoinStatsFromExprHandle
 	(
-	CMemoryPool *mp,
-	CExpressionHandle &expr_handle
+	 CMemoryPool *mp,
+	 CExpressionHandle &expr_handle,
+	 BOOL is_semi_or_anti_join
 	)
 {
 	// in case of subquery in join predicate, we return empty stats
@@ -1376,7 +1459,15 @@ CStatsPredUtils::ExtractJoinStatsFromExprHandle
 	CExpression *scalar_expr = expr_handle.PexprScalarChild(expr_handle.Arity() - 1);
 	CColRefSet *outer_refs = expr_handle.DeriveOuterReferences();
 
-	CStatsPredJoinArray *join_pred_stats = ExtractJoinStatsFromExpr(mp, expr_handle, scalar_expr, output_col_refsets, outer_refs);
+	CStatsPredJoinArray *join_pred_stats = ExtractJoinStatsFromExpr
+											(
+											 mp,
+											 expr_handle,
+											 scalar_expr,
+											 output_col_refsets,
+											 outer_refs,
+											 is_semi_or_anti_join
+											);
 
 	// clean up
 	output_col_refsets->Release();

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -613,6 +613,7 @@ CDXLTokens::Init
 			{EdxltokenCmpOther, GPOS_WSZ_LIT("Other")},
 			
 			{EdxltokenReturnsNullOnNullInput, GPOS_WSZ_LIT("ReturnsNullOnNullInput")},
+			{EdxltokenIsNDVPreserving, GPOS_WSZ_LIT("IsNDVPreserving")},
 
 			{EdxltokenTriggers, GPOS_WSZ_LIT("Triggers")},
 			{EdxltokenTrigger, GPOS_WSZ_LIT("Trigger")},
@@ -638,7 +639,8 @@ CDXLTokens::Init
 			{EdxltokenGPDBFuncResultTypeId, GPOS_WSZ_LIT("ResultType")},
 			{EdxltokenGPDBFuncReturnsSet, GPOS_WSZ_LIT("ReturnsSet")},
 			{EdxltokenGPDBFuncStrict, GPOS_WSZ_LIT("IsStrict")},
-			
+			{EdxltokenGPDBFuncNDVPreserving, GPOS_WSZ_LIT("IsNDVPreserving")},
+
 			{EdxltokenGPDBAgg, GPOS_WSZ_LIT("GPDBAgg")},
 			{EdxltokenGPDBIsAggOrdered, GPOS_WSZ_LIT("IsOrdered")},
 			{EdxltokenGPDBAggResultTypeId, GPOS_WSZ_LIT("ResultType")},

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -141,7 +141,7 @@ SingleColumnHomogenousIndexOnRoot-AO SingleColumnHomogenousIndexOnRoot-HEAP;
 
 CStatsTest:
 Stat-Derivation-Leaf-Pattern MissingBoolColStats JoinColWithOnlyNDV UnsupportedStatsPredicate
-StatsFilter-AnyWithNewColStats;
+StatsFilter-AnyWithNewColStats EquiJoinOnExpr-Supported EquiJoinOnExpr-Unsupported;
 
 CICGMiscTest:
 BroadcastSkewedHashjoin OrderByNullsFirst ConvertHashToRandomSelect ConvertHashToRandomInsert HJN-DeeperOuter CTAS CTAS-Random CheckAsUser

--- a/src/include/catalog/pg_operator.h
+++ b/src/include/catalog/pg_operator.h
@@ -536,6 +536,7 @@ DATA(insert OID = 643 (  "<>"	   PGNSP PGUID b f f	19	19	16 643 93 namene neqsel
 DESCR("not equal");
 DATA(insert OID = 654 (  "||"	   PGNSP PGUID b f f	25	25	25	 0 0 textcat - - ));
 DESCR("concatenate");
+#define OIDTextConcatenateOperator 654
 
 DATA(insert OID = 660 (  "<"	   PGNSP PGUID b f f	19	19	16 662 663 namelt scalarltsel scalarltjoinsel ));
 DESCR("less than");

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -1912,8 +1912,10 @@ DATA(insert OID =  868 (  strpos	   PGNSP PGUID 12 1 0 0 0 f f f f t f i s 2 0 2
 DESCR("position of substring");
 DATA(insert OID =  870 (  lower		   PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 25 "25" _null_ _null_ _null_ _null_ _null_ lower _null_ _null_ _null_ ));
 DESCR("lowercase");
+#define LOWER_OID 870
 DATA(insert OID =  871 (  upper		   PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 25 "25" _null_ _null_ _null_ _null_ _null_ upper _null_ _null_ _null_ ));
 DESCR("uppercase");
+#define UPPER_OID 871
 DATA(insert OID =  872 (  initcap	   PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 25 "25" _null_ _null_ _null_ _null_ _null_ initcap _null_ _null_ _null_ ));
 DESCR("capitalize each word");
 DATA(insert OID =  873 (  lpad		   PGNSP PGUID 12 1 0 0 0 f f f f t f i s 3 0 25 "25 23 25" _null_ _null_ _null_ _null_ _null_	lpad _null_ _null_ _null_ ));
@@ -1936,14 +1938,17 @@ DATA(insert OID =  880 (  rpad		   PGNSP PGUID 14 1 0 0 0 f f f f t f i s 2 0 25
 DESCR("right-pad string to length");
 DATA(insert OID =  881 (  ltrim		   PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 25 "25" _null_ _null_ _null_ _null_ _null_ ltrim1 _null_ _null_ _null_ ));
 DESCR("trim spaces from left end of string");
+#define LTRIM_SPACE_OID 881
 DATA(insert OID =  882 (  rtrim		   PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 25 "25" _null_ _null_ _null_ _null_ _null_ rtrim1 _null_ _null_ _null_ ));
 DESCR("trim spaces from right end of string");
+#define RTRIM_SPACE_OID 882
 DATA(insert OID =  883 (  substr	   PGNSP PGUID 12 1 0 0 0 f f f f t f i s 2 0 25 "25 23" _null_ _null_ _null_ _null_ _null_ text_substr_no_len _null_ _null_ _null_ ));
 DESCR("extract portion of string");
 DATA(insert OID =  884 (  btrim		   PGNSP PGUID 12 1 0 0 0 f f f f t f i s 2 0 25 "25 25" _null_ _null_ _null_ _null_ _null_ btrim _null_ _null_ _null_ ));
 DESCR("trim selected characters from both ends of string");
 DATA(insert OID =  885 (  btrim		   PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 25 "25" _null_ _null_ _null_ _null_ _null_ btrim1 _null_ _null_ _null_ ));
 DESCR("trim spaces from both ends of string");
+#define BTRIM_SPACE_OID 885
 
 DATA(insert OID =  936 (  substring    PGNSP PGUID 12 1 0 0 0 f f f f t f i s 3 0 25 "25 23 23" _null_ _null_ _null_ _null_ _null_	text_substr _null_ _null_ _null_ ));
 DESCR("extract portion of string");

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -204,6 +204,9 @@ namespace gpdb {
 	// is the given function strict
 	bool FuncStrict(Oid funcid);
 
+	// does this preserve the NDVs of its inputs?
+	bool IsFuncNDVPreserving(Oid funcid);
+
 	// stability property of given function
 	char FuncStability(Oid funcid);
 
@@ -479,6 +482,9 @@ namespace gpdb {
 
 	// is the given operator strict
 	bool IsOpStrict(Oid opno);
+
+	// does it preserve the NDVs of its inputs
+	bool IsOpNDVPreserving(Oid opno);
 
 	// get input types for a given operator
 	void GetOpInputTypes(Oid opno, Oid *lefttype, Oid *righttype);

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -165,6 +165,7 @@ namespace gpdxl
 				IMDFunction::EFuncStbl *stability, // output: function stability
 				IMDFunction::EFuncDataAcc *access, // output: function data access
 				BOOL *is_strict, // output: is function strict?
+				BOOL *is_ndv_preserving, // output: preserves NDVs of inputs
 				BOOL *ReturnsSet // output: does function return set?
 				);
 

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -4246,23 +4246,26 @@ select * from
     (tenk1 as a1 full join (select 1 as id) as yy on (a1.unique1 = yy.id))
   on (xx.id = coalesce(yy.id));
                       QUERY PLAN                      
-------------------------------------------------------
- Hash Left Join
-   Hash Cond: ((1) = COALESCE((1)))
-   ->  Result
-   ->  Hash
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               ->  Merge Full Join
-                     Merge Cond: (unique1 = (1))
-                     ->  Sort
-                           Sort Key: unique1
-                           ->  Seq Scan on tenk1
-                     ->  Sort
-                           Sort Key: (1)
-                           ->  Result
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Left Join
+         Hash Cond: ((1) = COALESCE((1)))
+         ->  Result
+               ->  Result
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: COALESCE((1))
+                     ->  Merge Full Join
+                           Merge Cond: (unique1 = (1))
+                           ->  Sort
+                                 Sort Key: unique1
+                                 ->  Seq Scan on tenk1
+                           ->  Sort
+                                 Sort Key: (1)
                                  ->  Result
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(15 rows)
+                                       ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
 
 select * from
   (select 1 as id) as xx


### PR DESCRIPTION
Orca uses this property for cardinality estimation of joins.
For example, a join predicate foo join bar on foo.a = upper(bar.b)
will have a cardinality estimate similar to foo join bar on foo.a = bar.b.

Other functions, like foo join bar on foo.a = substring(bar.b, 1, 1)
won't be treated that way, since they are more likely to have a greater
effect on join cardinalities.

Since this is specific to ORCA, we use logic in the translator to determine
whether a function or operator is NDV-preserving. Right now, we consider
a very limited set of operators, we may add more at a later time.

Let's assume that we join tables R and S and that f is a function or
expression that refers to a single column and does not preserve
NDVs. Let's also assume that p is a function or expression that also
refers to a single column and that does preserve NDVs:

```
join predicate       card. estimate                         comment
-------------------  -------------------------------------  -----------------------------
col1 = col2          |R| * |S| / max(NDV(col1), NDV(col2))  build an equi-join histogram
f(col1) = p(col2)    |R| * |S| / NDV(col2)                  use NDV-based estimation
f(col1) = col2       |R| * |S| / NDV(col2)                  use NDV-based estimation
p(col1) = col2       |R| * |S| / max(NDV(col1), NDV(col2))  use NDV-based estimation
p(col1) = p(col2)    |R| * |S| / max(NDV(col1), NDV(col2))  use NDV-based estimation
otherwise            |R| * |S| * 0.4                        this is an unsupported pred
```
Note that adding casts to these expressions is ok, as well as switching left and right side.

Here is a list of expressions that we currently treat as NDV-preserving:

coalesce(col, const)
col || const
lower(col)
trim(col)
upper(col)

One more note: We need the NDVs of the inner side of Semi and
Anti-joins for cardinality estimation, so only normal columns and
NDV-preserving functions are allowed in that case.

This is a port of these GPDB 5X and GPOrca PRs:
https://github.com/greenplum-db/gporca/pull/585
https://github.com/greenplum-db/gpdb/pull/10090

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
