### PR TITLE
docs - add views pg_stat_all_tables and indexes - 6X

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -587,6 +587,12 @@
               <xref href="#track_activity_query_size"/>
             </li>
             <li>
+              <xref href="#track_activities"/>
+            </li>
+            <li>
+              <xref href="#track_counts"/>
+            </li>
+            <li>
               <xref href="#transaction_isolation"/>
             </li>
             <li>
@@ -8869,6 +8875,38 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
       </table>
     </body>
   </topic>
+  <topic id="track_activities">
+    <title>track_activities</title>
+    <body>
+      <p>Enables the collection of information on the currently executing command of each session,
+        along with the time when that command began execution. The default value is
+          <codeph>true</codeph>. Only superusers can change this setting. See the <codeph><xref
+            href="../system_catalogs/pg_stat_activity.xml">pg_stat_activity</xref></codeph> view</p>
+      <note>Even when enabled, this information is not visible to all users, only to superusers and
+        the user owning the session being reported on, so it should not represent a security risk. </note>
+      <table id="table_f1l_fwm_vlb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">true</entry>
+              <entry colname="col3">master<p>system</p><p>reload</p><p>superuser</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
   <topic id="track_activity_query_size">
     <title>track_activity_query_size</title>
     <body>
@@ -8891,6 +8929,34 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
               <entry colname="col1">integer</entry>
               <entry colname="col2">1024</entry>
               <entry colname="col3">local<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="track_counts">
+    <title>track_counts</title>
+    <body>
+      <p>Enables the collection of information on the currently executing command of each session,
+        along with the time at which that command began execution.</p>
+      <table id="table_e5c_fwm_vlb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">true</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p><p>superuser</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -8881,7 +8881,8 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
       <p>Enables the collection of information on the currently executing command of each session,
         along with the time when that command began execution. The default value is
           <codeph>true</codeph>. Only superusers can change this setting. See the <codeph><xref
-            href="../system_catalogs/pg_stat_activity.xml">pg_stat_activity</xref></codeph> view</p>
+            href="../system_catalogs/pg_stat_activity.xml">pg_stat_activity</xref></codeph>
+        view.</p>
       <note>Even when enabled, this information is not visible to all users, only to superusers and
         the user owning the session being reported on, so it should not represent a security risk. </note>
       <table id="table_f1l_fwm_vlb">

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -894,8 +894,14 @@
             <p>
               <xref href="guc-list.xml#stats_queue_level" type="section">stats_queue_level</xref>
             </p>
+            <p>
+              <xref href="guc-list.xml#track_activities" type="section"/>
+            </p>
           </stentry>
           <stentry>
+            <p>
+              <xref href="guc-list.xml#track_counts" type="section">track_counts</xref>
+            </p>
             <p>
               <xref href="guc-list.xml#update_process_title" type="section"
                 >update_process_title</xref>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -277,7 +277,9 @@
             <topicref href="guc-list.xml#topic_k52_fqm_f3b"/>
             <topicref href="guc-list.xml#TimeZone"/>
             <topicref href="guc-list.xml#timezone_abbreviations"/>
+            <topicref href="guc-list.xml#track_activities"/>
             <topicref href="guc-list.xml#track_activity_query_size"/>
+            <topicref href="guc-list.xml#track_counts"/>
             <topicref href="guc-list.xml#transaction_isolation"/>
             <topicref href="guc-list.xml#transaction_read_only"/>
             <topicref href="guc-list.xml#transform_null_equals"/>

--- a/gpdb-doc/dita/ref_guide/ref_guide.ditamap
+++ b/gpdb-doc/dita/ref_guide/ref_guide.ditamap
@@ -265,6 +265,8 @@
 				<topicref href="system_catalogs/pg_shdepend.xml"/>
 				<topicref href="system_catalogs/pg_shdescription.xml"/>
 				<topicref href="system_catalogs/pg_stat_activity.xml"/>
+				<topicref href="system_catalogs/pg_stat_indexes.xml"/>
+				<topicref href="system_catalogs/pg_stat_tables.xml"/>
 				<topicref href="system_catalogs/pg_stat_last_operation.xml"/>
 				<topicref href="system_catalogs/pg_stat_last_shoperation.xml"/>
 				<topicref href="system_catalogs/pg_stat_operations.xml"/>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-views.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-views.xml
@@ -59,13 +59,19 @@
         <xref href="./pg_stat_activity.xml#topic1" type="topic" format="dita"/>
       </li>
       <li>
+        <xref href="./pg_stat_indexes.xml" type="topic" format="dita"/>
+      </li>
+      <li>
+        <xref href="./pg_stat_tables.xml" type="topic" format="dita"/>
+      </li>
+      <li>
         <xref href="./pg_stat_replication.xml#topic1" type="topic" format="dita"/>
       </li>
       <li>
         <xref href="./pg_stats_resqueue.xml#topic1" type="topic" format="dita"/>
       </li>
-      <li>session_level_memory_consumption (See "Viewing Session Memory Usage Information" in the
-          <cite>Greenplum Database Administrator Guide</cite>.)</li>
+      <li>session_level_memory_consumption (See <xref
+          href="../../admin_guide/managing/monitor.xml#topic_slt_ddv_1q"/>)</li>
     </ul>
     <p>For more information about the standard system views supported in PostgreSQL and Greenplum
       Database, see the following sections of the PostgreSQL documentation:</p>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_indexes.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_indexes.xml
@@ -73,10 +73,10 @@
       </tgroup>
     </table>
     <section id="index_stats_all_6x">
-      <title>Index Access Statistics From the Master and Segment Instances</title>
+      <title>Index Access Statistics from the Master and Segment Instances</title>
       <p>To display index access statistics that combine statistics from the master and the segment
         instances you can create these views. A user requires <codeph>SELECT</codeph> privilege on
-        the views to use the views.</p>
+        the views to use them.</p>
       <codeblock>-- Create these index access statistics views
 --   pg_stat_all_indexes_gpdb6
 --   pg_stat_sys_indexes_gpdb6

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_indexes.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_indexes.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="gi143896">pg_stat_all_indexes</title>
+  <body>
+    <p>The <codeph>pg_stat_all_indexes</codeph> view shows one row for each index in the current
+      database that displays statistics about accesses to that specific index. </p>
+    <p>The <codeph>pg_stat_user_indexes</codeph> and <codeph>pg_stat_sys_indexes</codeph> views
+      contain the same information, but filtered to only show user and system indexes
+      respectively.</p>
+    <p>In Greenplum Database 6, the <codeph>pg_stat_*_indexes</codeph> views display access
+      statistics for indexes only from the master instance. Access statistics from segment instances
+      are ignored. You can create views that display usage statistics that combine statistics from
+      the master and the segment instances, see <xref href="#topic1/index_stats_all_6x"
+        format="dita"/>.</p>
+    <table id="table_vdd_xjf_vlb">
+      <title>pg_catalog.pg_stat_all_indexes View</title>
+      <tgroup cols="3">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="110pt"/>
+        <colspec colnum="3" colname="col3" colwidth="210pt"/>
+        <thead>
+          <row>
+            <entry>Column</entry>
+            <entry>Type</entry>
+            <entry>Description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry><codeph>relid</codeph></entry>
+            <entry>oid</entry>
+            <entry>OID of the table for this index</entry>
+          </row>
+          <row>
+            <entry><codeph>indexrelid</codeph></entry>
+            <entry>oid</entry>
+            <entry>OID of this index</entry>
+          </row>
+          <row>
+            <entry><codeph>schemaname</codeph></entry>
+            <entry>name</entry>
+            <entry>Name of the schema this index is in</entry>
+          </row>
+          <row>
+            <entry><codeph>relname</codeph></entry>
+            <entry>name</entry>
+            <entry>Name of the table for this index</entry>
+          </row>
+          <row>
+            <entry><codeph>indexrelname</codeph></entry>
+            <entry>name</entry>
+            <entry>Name of this index</entry>
+          </row>
+          <row>
+            <entry><codeph>idx_scan</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of index scans initiated on this index</entry>
+          </row>
+          <row>
+            <entry><codeph>idx_tup_read</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of index entries returned by scans on this index</entry>
+          </row>
+          <row>
+            <entry><codeph>idx_tup_fetch</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of live table rows fetched by simple index scans using this index</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+    <section id="index_stats_all_6x">
+      <title>Index Access Statistics From the Master and Segment Instances</title>
+      <p>To display index access statistics that combine statistics from the master and the segment
+        instances you can create these views. A user requires <codeph>SELECT</codeph> privilege on
+        the views to use the views.</p>
+      <codeblock>-- Create these index access statistics views
+--   pg_stat_all_indexes_gpdb6
+--   pg_stat_sys_indexes_gpdb6
+--   pg_stat_user_indexes_gpdb6
+
+CREATE VIEW pg_stat_all_indexes_gpdb6 AS
+SELECT
+    s.relid,
+    s.indexrelid,
+    s.schemaname,
+    s.relname,
+    s.indexrelname,
+    m.idx_scan,
+    m.idx_tup_read,
+    m.idx_tup_fetch
+FROM
+    (SELECT
+         relid,
+         indexrelid,
+         schemaname,
+         relname,
+         indexrelname,
+         sum(idx_scan) as idx_scan,
+         sum(idx_tup_read) as idx_tup_read,
+         sum(idx_tup_fetch) as idx_tup_fetch
+     FROM gp_dist_random('pg_stat_all_indexes')
+     WHERE relid >= 16384
+     GROUP BY relid, indexrelid, schemaname, relname, indexrelname
+     UNION ALL
+     SELECT *
+     FROM pg_stat_all_indexes
+     WHERE relid &lt; 16384) m, pg_stat_all_indexes s
+WHERE m.relid = s.relid;
+
+
+CREATE VIEW pg_stat_sys_indexes_gpdb6 AS 
+    SELECT * FROM pg_stat_all_indexes_gpdb6
+    WHERE schemaname IN ('pg_catalog', 'information_schema') OR
+          schemaname ~ '^pg_toast';
+
+
+CREATE VIEW pg_stat_user_indexes_gpdb6 AS 
+    SELECT * FROM pg_stat_all_indexes_gpdb6
+    WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND
+          schemaname !~ '^pg_toast';
+</codeblock>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_indexes.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_indexes.xml
@@ -56,7 +56,8 @@
           <row>
             <entry><codeph>idx_scan</codeph></entry>
             <entry>bigint</entry>
-            <entry>Number of index scans initiated on this index</entry>
+            <entry>Total number of index scans initiated on this index from all segment
+              instances</entry>
           </row>
           <row>
             <entry><codeph>idx_tup_read</codeph></entry>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_tables.xml
@@ -46,7 +46,8 @@
           <row>
             <entry><codeph>seq_scan</codeph></entry>
             <entry>bigint</entry>
-            <entry>Number of sequential scans initiated on this table</entry>
+            <entry>Total number of sequential scans initiated on this table from all segment
+              instances</entry>
           </row>
           <row>
             <entry><codeph>seq_tup_read</codeph></entry>
@@ -56,7 +57,8 @@
           <row>
             <entry><codeph>idx_scan</codeph></entry>
             <entry>bigint</entry>
-            <entry>Number of index scans initiated on this table</entry>
+            <entry>Total number of index scans initiated on this index from all segment
+              instances</entry>
           </row>
           <row>
             <entry><codeph>idx_tup_fetch</codeph></entry>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_tables.xml
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="gi143896">pg_stat_all_tables</title>
+  <body id="table_stats_all">
+    <p>The <codeph>pg_stat_all_tables</codeph> view shows one row for each table in the current
+      database (including TOAST tables) that displays statistics about accesses to that specific
+      table. </p>
+    <p>The <codeph>pg_stat_user_tables</codeph> and <codeph>pg_stat_sys_table</codeph>s views
+      contain the same information, but filtered to only show user and system tables
+      respectively.</p>
+    <p>In Greenplum Database 6, the <codeph>pg_stat_*_tables</codeph> views display access
+      statistics for tables only from the master instance. Access statistics from segment instances
+      are ignored. You can create views that display usage statistics, see <xref
+        href="#topic1/tbl_stats_all_6x" format="dita"/>.</p>
+    <table id="table_rxm_tjf_vlb">
+      <title>pg_catalog.pg_stat_all_table View</title>
+      <tgroup cols="3">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="110pt"/>
+        <colspec colnum="3" colname="col3" colwidth="210pt"/>
+        <thead>
+          <row>
+            <entry>Column</entry>
+            <entry>Type</entry>
+            <entry>Description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry><codeph>relid</codeph></entry>
+            <entry>oid</entry>
+            <entry>OID of a table</entry>
+          </row>
+          <row>
+            <entry><codeph>schemaname</codeph></entry>
+            <entry>name</entry>
+            <entry>Name of the schema that this table is in</entry>
+          </row>
+          <row>
+            <entry><codeph>relname</codeph></entry>
+            <entry>name</entry>
+            <entry>Name of this table</entry>
+          </row>
+          <row>
+            <entry><codeph>seq_scan</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of sequential scans initiated on this table</entry>
+          </row>
+          <row>
+            <entry><codeph>seq_tup_read</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of live rows fetched by sequential scans</entry>
+          </row>
+          <row>
+            <entry><codeph>idx_scan</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of index scans initiated on this table</entry>
+          </row>
+          <row>
+            <entry><codeph>idx_tup_fetch</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of live rows fetched by index scans</entry>
+          </row>
+          <row>
+            <entry><codeph>n_tup_ins</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of rows inserted</entry>
+          </row>
+          <row>
+            <entry><codeph>n_tup_upd</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of rows updated (includes HOT updated rows)</entry>
+          </row>
+          <row>
+            <entry><codeph>n_tup_del</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of rows deleted</entry>
+          </row>
+          <row>
+            <entry><codeph>n_tup_hot_upd</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of rows HOT updated (i.e., with no separate index update required)</entry>
+          </row>
+          <row>
+            <entry><codeph>n_live_tup</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Estimated number of live rows</entry>
+          </row>
+          <row>
+            <entry><codeph>n_dead_tup</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Estimated number of dead rows</entry>
+          </row>
+          <row>
+            <entry><codeph>n_mod_since_analyze</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Estimated number of rows modified since this table was last analyzed</entry>
+          </row>
+          <row>
+            <entry><codeph>last_vacuum</codeph></entry>
+            <entry>timestamp with time zone</entry>
+            <entry>Last time at which this table was manually vacuumed (not counting <codeph>VACUUM
+                FULL</codeph>)</entry>
+          </row>
+          <row>
+            <entry><codeph>last_autovacuum</codeph></entry>
+            <entry>timestamp with time zone</entry>
+            <entry>Last time at which this table was vacuumed by the autovacuum
+              daemon<sup>1</sup></entry>
+          </row>
+          <row>
+            <entry><codeph>last_analyze</codeph></entry>
+            <entry>timestamp with time zone</entry>
+            <entry>Last time at which this table was manually analyzed</entry>
+          </row>
+          <row>
+            <entry><codeph>last_autoanalyze</codeph></entry>
+            <entry>timestamp with time zone</entry>
+            <entry>Last time at which this table was analyzed by the autovacuum
+              daemon<sup>1</sup></entry>
+          </row>
+          <row>
+            <entry><codeph>vacuum_count</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of times this table has been manually vacuumed (not counting
+                <codeph>VACUUM FULL</codeph>)</entry>
+          </row>
+          <row>
+            <entry><codeph>autovacuum_count</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of times this table has been vacuumed by the autovacuum
+              daemon<sup>1</sup></entry>
+          </row>
+          <row>
+            <entry><codeph>analyze_count</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of times this table has been manually analyzed</entry>
+          </row>
+          <row>
+            <entry><codeph>autoanalyze_count</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of times this table has been analyzed by the autovacuum daemon
+                <sup>1</sup></entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+    <p>
+      <note><sup>1</sup> In Greenplum Database, the autovacuum daemon is disabled and not supported
+        for user defined databases.</note>
+    </p>
+    <section id="tbl_stats_all_6x">
+      <title>Table Access Statistics From the Master and Segment Instances</title>
+      <p>To display table access statistics that combine statistics from the master and the segment
+        instances you can create these views. A user requires <codeph>SELECT</codeph> privilege on
+        the views to use the views.</p>
+      <codeblock>-- Create these table access statistics views
+--   pg_stat_all_tables_gpdb6
+--   pg_stat_sys_tables_gpdb6
+--   pg_stat_user_tables_gpdb6
+
+CREATE VIEW pg_stat_all_tables_gpdb6 AS
+SELECT
+    s.relid,
+    s.schemaname,
+    s.relname,
+    m.seq_scan,
+    m.seq_tup_read,
+    m.idx_scan,
+    m.idx_tup_fetch,
+    m.n_tup_ins,
+    m.n_tup_upd,
+    m.n_tup_del,
+    m.n_tup_hot_upd,
+    m.n_live_tup,
+    m.n_dead_tup,
+    s.n_mod_since_analyze,
+    s.last_vacuum,
+    s.last_autovacuum,
+    s.last_analyze,
+    s.last_autoanalyze,
+    s.vacuum_count,
+    s.autovacuum_count,
+    s.analyze_count,
+    s.autoanalyze_count
+FROM
+    (SELECT
+         relid,
+         schemaname,
+         relname,
+         sum(seq_scan) as seq_scan,
+         sum(seq_tup_read) as seq_tup_read,
+         sum(idx_scan) as idx_scan,
+         sum(idx_tup_fetch) as idx_tup_fetch,
+         sum(n_tup_ins) as n_tup_ins,
+         sum(n_tup_upd) as n_tup_upd,
+         sum(n_tup_del) as n_tup_del,
+         sum(n_tup_hot_upd) as n_tup_hot_upd,
+         sum(n_live_tup) as n_live_tup,
+         sum(n_dead_tup) as n_dead_tup,
+         max(n_mod_since_analyze) as n_mod_since_analyze,
+         max(last_vacuum) as last_vacuum,
+         max(last_autovacuum) as last_autovacuum,
+         max(last_analyze) as last_analyze,
+         max(last_autoanalyze) as last_autoanalyze,
+         max(vacuum_count) as vacuum_count,
+         max(autovacuum_count) as autovacuum_count,
+         max(analyze_count) as analyze_count,
+         max(autoanalyze_count) as autoanalyze_count
+     FROM gp_dist_random('pg_stat_all_tables')
+     WHERE relid >= 16384
+     GROUP BY relid, schemaname, relname
+     UNION ALL
+     SELECT *
+     FROM pg_stat_all_tables
+     WHERE relid &lt; 16384) m, pg_stat_all_tables s
+ WHERE m.relid = s.relid;
+
+
+CREATE VIEW pg_stat_sys_tables_gpdb6 AS 
+    SELECT * FROM pg_stat_all_tables_gpdb6
+    WHERE schemaname IN ('pg_catalog', 'information_schema') OR
+          schemaname ~ '^pg_toast';
+
+
+CREATE VIEW pg_stat_user_tables_gpdb6 AS 
+    SELECT * FROM pg_stat_all_tables_gpdb6
+    WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND
+          schemaname !~ '^pg_toast';
+</codeblock>
+    </section>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_tables.xml
@@ -5,8 +5,7 @@
   <title id="gi143896">pg_stat_all_tables</title>
   <body id="table_stats_all">
     <p>The <codeph>pg_stat_all_tables</codeph> view shows one row for each table in the current
-      database (including TOAST tables) that displays statistics about accesses to that specific
-      table. </p>
+      database (including TOAST tables) to display statistics about accesses to that specific table. </p>
     <p>The <codeph>pg_stat_user_tables</codeph> and <codeph>pg_stat_sys_table</codeph>s views
       contain the same information, but filtered to only show user and system tables
       respectively.</p>
@@ -103,25 +102,23 @@
           <row>
             <entry><codeph>last_vacuum</codeph></entry>
             <entry>timestamp with time zone</entry>
-            <entry>Last time at which this table was manually vacuumed (not counting <codeph>VACUUM
+            <entry>Last time this table was manually vacuumed (not counting <codeph>VACUUM
                 FULL</codeph>)</entry>
           </row>
           <row>
             <entry><codeph>last_autovacuum</codeph></entry>
             <entry>timestamp with time zone</entry>
-            <entry>Last time at which this table was vacuumed by the autovacuum
-              daemon<sup>1</sup></entry>
+            <entry>Last time this table was vacuumed by the autovacuum daemon<sup>1</sup></entry>
           </row>
           <row>
             <entry><codeph>last_analyze</codeph></entry>
             <entry>timestamp with time zone</entry>
-            <entry>Last time at which this table was manually analyzed</entry>
+            <entry>Last time this table was manually analyzed</entry>
           </row>
           <row>
             <entry><codeph>last_autoanalyze</codeph></entry>
             <entry>timestamp with time zone</entry>
-            <entry>Last time at which this table was analyzed by the autovacuum
-              daemon<sup>1</sup></entry>
+            <entry>Last time this table was analyzed by the autovacuum daemon<sup>1</sup></entry>
           </row>
           <row>
             <entry><codeph>vacuum_count</codeph></entry>
@@ -154,10 +151,10 @@
         for user defined databases.</note>
     </p>
     <section id="tbl_stats_all_6x">
-      <title>Table Access Statistics From the Master and Segment Instances</title>
+      <title>Table Access Statistics from the Master and Segment Instances</title>
       <p>To display table access statistics that combine statistics from the master and the segment
         instances you can create these views. A user requires <codeph>SELECT</codeph> privilege on
-        the views to use the views.</p>
+        the views to use them.</p>
       <codeblock>-- Create these table access statistics views
 --   pg_stat_all_tables_gpdb6
 --   pg_stat_sys_tables_gpdb6


### PR DESCRIPTION
The views currently display access statistics only from master.
Add 6.x specific DDL for views that display access statistics from master and segments.

Also add some statistics GUCs.
--track_activities
--track_counts
Please check the GUCs set classifications are correct.

Link to HTML output on a temporary GDPB draft doc web site.

https://docs-msk-gpdb6-dev.cfapps.io/6-7/ref_guide/system_catalogs/pg_stat_indexes.html
https://docs-msk-gpdb6-dev.cfapps.io/6-7/ref_guide/system_catalogs/pg_stat_tables.html

https://docs-msk-gpdb6-dev.cfapps.io/6-7/ref_guide/config_params/guc-list.html#track_activities
https://docs-msk-gpdb6-dev.cfapps.io6-7/ref_guide/config_params/guc-list.html#track_counts

