### PR TITLE
Revert "Upgrade pgbouncer to 1.13"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "gpAux/extensions/pgbouncer/source"]
 	path = gpAux/extensions/pgbouncer/source
 	url = https://github.com/greenplum-db/pgbouncer.git
+	branch = pgbouncer_1_8_1
 [submodule "gpMgmt/bin/pythonSrc/ext"]
 	path = gpMgmt/bin/pythonSrc/ext
 	url = https://github.com/greenplum-db/pythonsrc-ext.git


### PR DESCRIPTION
This reverts commit 412493b0f1fbba7d27be7dd06c9f3554f6afd5db.

Failed to compile pgbouncer on centos6: can't find libevent.
pgbouncer 1.13 uses pkg-config to look libevent up instead of
using --with-libevent.

Another issue is: pgbouncer does not support libevent version 1.x
in 1.13 version, but we use libevent 1.4 on centos6.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
