### PR TITLE
docs - add pxf v5.12 to supported platforms

### DIFF
--- a/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
+++ b/gpdb-doc/markdown/pxf/intro_pxf.html.md.erb
@@ -25,7 +25,7 @@ PXF bundles all of the Hadoop JAR files on which it depends, and supports the fo
 
 | PXF Version | Hadoop Version | Hive Server Version | HBase Server Version |
 |-------------|----------------|---------------------|-------------|
-| 5.10, 5.11 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
+| 5.10, 5.11, 5.12 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
 | 5.9 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
 | 5.8 | 2.x | 1.x | 1.3.2 |
 


### PR DESCRIPTION
update supported platforms for pxf version 5.12.0.  

the docs for v5.12.0 pxf features (hive* column projection, IGNORE_MISSING_PATH) were already merged to master in https://github.com/greenplum-db/gpdb/pull/10086 and https://github.com/greenplum-db/gpdb/pull/10010 and will be backported to 6X_STABLE.
