### PR TITLE
Fix flaky test in recoverseg_from_file

### DIFF
--- a/src/test/isolation2/expected/segwalrep/recoverseg_from_file.out
+++ b/src/test/isolation2/expected/segwalrep/recoverseg_from_file.out
@@ -107,7 +107,7 @@ UPDATE 1
 set allow_system_table_mods to false;
 SET
 
--- we manually change dbid from 2 to 9, which casue the
+-- we manually change dbid from 2 to 9, which causes the
 -- corresponding segment down as well, so recovery full
 -- at here
 !\retcode gprecoverseg -aF;
@@ -120,6 +120,20 @@ SET
 -- start_ignore
 -- end_ignore
 (exited with code 0)
+
+-- recheck gp_segment_configuration after rebalance
+SELECT dbid, role, preferred_role, content, mode, status FROM gp_segment_configuration order by dbid;
+ dbid | role | preferred_role | content | mode | status 
+------+------+----------------+---------+------+--------
+ 1    | p    | p              | -1      | n    | u      
+ 2    | p    | p              | 0       | s    | u      
+ 3    | p    | p              | 1       | s    | u      
+ 4    | p    | p              | 2       | s    | u      
+ 5    | m    | m              | 0       | s    | u      
+ 6    | m    | m              | 1       | s    | u      
+ 7    | m    | m              | 2       | s    | u      
+ 8    | m    | m              | -1      | s    | u      
+(8 rows)
 
 -- remove the config file
 !\retcode rm /tmp/recover_config_file

--- a/src/test/isolation2/expected/segwalrep/recoverseg_from_file.out
+++ b/src/test/isolation2/expected/segwalrep/recoverseg_from_file.out
@@ -53,10 +53,10 @@ select gp_request_fts_probe_scan();
 1Uq: ... <quitting>
 
 -- make the dbid in gp_segment_configuration not continuous
--- dbid=2 corresponds to content id =0
+-- dbid=2 corresponds to content 0 and role p, change it to dbid=9
 set allow_system_table_mods to true;
 SET
-update gp_segment_configuration set dbid=9 where dbid=2;
+update gp_segment_configuration set dbid=9 where content=0 and role='p';
 UPDATE 1
 
 -- trigger failover
@@ -110,7 +110,7 @@ SET
 -- we manually change dbid from 2 to 9, which causes the
 -- corresponding segment down as well, so recovery full
 -- at here
-!\retcode gprecoverseg -aF;
+!\retcode gprecoverseg -a;
 -- start_ignore
 -- end_ignore
 (exited with code 0)

--- a/src/test/isolation2/expected/segwalrep/recoverseg_from_file.out
+++ b/src/test/isolation2/expected/segwalrep/recoverseg_from_file.out
@@ -43,6 +43,29 @@ select gp_request_fts_probe_scan();
  t                         
 (1 row)
 
+-- wait for content 1 (earlier mirror, now primary) to finish the promotion
+1U: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+-- Quit this utility mode session, as need to start fresh one below
+1Uq: ... <quitting>
+
+-- make the dbid in gp_segment_configuration not continuous
+-- dbid=2 corresponds to content id =0
+set allow_system_table_mods to true;
+SET
+update gp_segment_configuration set dbid=9 where dbid=2;
+UPDATE 1
+
+-- trigger failover
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
 -- wait for content 0 (earlier mirror, now primary) to finish the promotion
 0U: select 1;
  ?column? 
@@ -52,12 +75,6 @@ select gp_request_fts_probe_scan();
 -- Quit this utility mode session, as need to start fresh one below
 0Uq: ... <quitting>
 
--- make the dbid in gp_segment_configuration not continuous
-set allow_system_table_mods to true;
-SET
-update gp_segment_configuration set dbid=9 where dbid=2;
-UPDATE 1
-
 -- generate recover config file
 select generate_recover_config_file( (select datadir from gp_segment_configuration c where c.role='m' and c.content=1), (select port from gp_segment_configuration c where c.role='m' and c.content=1)::text);
  generate_recover_config_file 
@@ -65,7 +82,7 @@ select generate_recover_config_file( (select datadir from gp_segment_configurati
                               
 (1 row)
 
--- recover from config file
+-- recover from config file, only seg with content=1 will be recovered
 !\retcode gprecoverseg -a -i /tmp/recover_config_file;
 -- start_ignore
 -- end_ignore

--- a/src/test/isolation2/sql/segwalrep/recoverseg_from_file.sql
+++ b/src/test/isolation2/sql/segwalrep/recoverseg_from_file.sql
@@ -71,13 +71,16 @@ select dbid from gp_segment_configuration where dbid=2;
 update gp_segment_configuration set dbid=2 where dbid=9;
 set allow_system_table_mods to false;
 
--- we manually change dbid from 2 to 9, which casue the
+-- we manually change dbid from 2 to 9, which causes the
 -- corresponding segment down as well, so recovery full
 -- at here
 !\retcode gprecoverseg -aF;
 
 -- rebalance the cluster
 !\retcode gprecoverseg -ar;
+
+-- recheck gp_segment_configuration after rebalance
+SELECT dbid, role, preferred_role, content, mode, status FROM gp_segment_configuration order by dbid;
 
 -- remove the config file
 !\retcode rm /tmp/recover_config_file

--- a/src/test/isolation2/sql/segwalrep/recoverseg_from_file.sql
+++ b/src/test/isolation2/sql/segwalrep/recoverseg_from_file.sql
@@ -40,9 +40,9 @@ select gp_request_fts_probe_scan();
 1Uq:
 
 -- make the dbid in gp_segment_configuration not continuous
--- dbid=2 corresponds to content id =0
+-- dbid=2 corresponds to content 0 and role p, change it to dbid=9
 set allow_system_table_mods to true;
-update gp_segment_configuration set dbid=9 where dbid=2;
+update gp_segment_configuration set dbid=9 where content=0 and role='p';
 
 -- trigger failover
 select gp_request_fts_probe_scan();
@@ -74,7 +74,7 @@ set allow_system_table_mods to false;
 -- we manually change dbid from 2 to 9, which causes the
 -- corresponding segment down as well, so recovery full
 -- at here
-!\retcode gprecoverseg -aF;
+!\retcode gprecoverseg -a;
 
 -- rebalance the cluster
 !\retcode gprecoverseg -ar;


### PR DESCRIPTION
1. after stop primary with content=1, we should check promotion
    status with 1U:
2. after manually update dbid, we should trigger a fts probe and
    wait for the mirror promotion as well.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
