### PR TITLE
[BACKPORT] Support multiple INITPLAN functions in one query.

### DIFF
--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -103,7 +103,7 @@ FunctionNext_guts(FunctionScanState *node)
 		{
 
 			char rwfile_prefix[100];
-			function_scan_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix));
+			function_scan_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix), node->initplanId);
 
 			node->ts_state->matstore = ntuplestore_create_readerwriter(rwfile_prefix, 0, false);
 			
@@ -398,6 +398,7 @@ ExecInitFunctionScan(FunctionScan *node, EState *estate, int eflags)
 	scanstate->eflags = eflags;
 	scanstate->resultInTupleStore = node->resultInTupleStore;
 	scanstate->ts_state = palloc0(sizeof(GenericTupStore));
+	scanstate->initplanId = node->initplanId;
 	scanstate->ts_pos = NULL;
 	/*
 	 * are we adding an ordinality column?
@@ -714,6 +715,18 @@ ExecReScanFunctionScan(FunctionScanState *node)
 			ExecClearTuple(fs->func_slot);
 	}
 
+	/*
+	 * For function execute on INITPLAN, tuplestore accessor needs to
+	 * seek to the begin of file for rescan.
+	 *
+	 * Note that we've already stored the function result in tuplestore by
+	 * INITPLAN node, so there is no need to re-use the tuplestore in
+	 * function scan, which is used to avoid re-executing the
+	 * function again when rescan a FunctionScan
+	 */
+	if(node->resultInTupleStore && node->ts_pos)
+		ntuplestore_acc_seek_bof(node->ts_pos);
+
 	ExecScanReScan(&node->ss);
 
 	ItemPointerSet(&node->cdb_fake_ctid, 0, 0);
@@ -789,8 +802,8 @@ ExecSquelchFunctionScan(FunctionScanState *node)
 }
 
 void
-function_scan_create_bufname_prefix(char* p, int size)
+function_scan_create_bufname_prefix(char* p, int size, int initplan_id)
 {
-	snprintf(p, size, "FUNCTION_SCAN_%d",
-			 gp_session_id);
+	snprintf(p, size, "FUNCTION_SCAN_%d_%d",
+			 gp_session_id, initplan_id);
 }

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1051,7 +1051,7 @@ PG_TRY();
 	{
 		char rwfile_prefix[100];
 
-		function_scan_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix));
+		function_scan_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix), subplan->plan_id);
 		
 		node->ts_state->matstore = ntuplestore_create_readerwriter(rwfile_prefix, PlanStateOperatorMemKB((PlanState *)(node->planstate)) * 1024, true);
 		

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -757,6 +757,7 @@ _copyFunctionScan(const FunctionScan *from)
 	COPY_SCALAR_FIELD(funcordinality);
 	COPY_NODE_FIELD(param);
 	COPY_SCALAR_FIELD(resultInTupleStore);
+	COPY_SCALAR_FIELD(initplanId);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -770,6 +770,7 @@ _outFunctionScan(StringInfo str, const FunctionScan *node)
 	WRITE_BOOL_FIELD(funcordinality);
 	WRITE_NODE_FIELD(param);
 	WRITE_BOOL_FIELD(resultInTupleStore);
+	WRITE_INT_FIELD(initplanId);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1825,6 +1825,7 @@ _readFunctionScan(void)
 	READ_BOOL_FIELD(funcordinality);
 	READ_NODE_FIELD(param);
 	READ_BOOL_FIELD(resultInTupleStore);
+	READ_INT_FIELD(initplanId);
 
 	READ_DONE();
 }

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2071,9 +2071,10 @@ typedef struct FunctionScanState
 	bool		resultInTupleStore; /* function result stored in tuplestore */
 	void       *ts_pos;				/* accessor to the tuplestore */
 	GenericTupStore *ts_state;		/* tuple store state */
+	int			initplanId;			/* initplan is for function execute on initplan */
 } FunctionScanState;
 
-extern void function_scan_create_bufname_prefix(char *p, int size);
+extern void function_scan_create_bufname_prefix(char *p, int size, int initplan_id);
 
 /* ----------------
  * TableFunctionState information

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -747,6 +747,7 @@ typedef struct FunctionScan
 	bool		funcordinality; /* WITH ORDINALITY */
 	Param      *param;			/* used when funtionscan run as initplan */
 	bool		resultInTupleStore; /* function result stored in tuplestore */
+	int			initplanId;			/* initplan id for function execute on initplan */
 } FunctionScan;
 
 /* ----------------

--- a/src/test/regress/expected/function_extensions.out
+++ b/src/test/regress/expected/function_extensions.out
@@ -480,7 +480,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'co
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
- Redistribute Motion 1:3  (slice1)  (cost=0.25..30.25 rows=1000 width=36)
+ Redistribute Motion 1:3  (slice1)  (cost=0.25..10.25 rows=1000 width=36)
    Hash Key: get_country.country_id
    ->  Function Scan on get_country  (cost=0.25..10.25 rows=1000 width=36)
          InitPlan 1 (returns $0)  (slice2)
@@ -491,7 +491,6 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 CREATE TABLE t1_function_scan AS SELECT * FROM get_country();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'country_id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-NOTICE:  table "country" does not exist, skipping
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CONTEXT:  SQL statement "create table public.country( country_id integer,
@@ -628,5 +627,55 @@ SELECT get_temp_file_num();
  get_temp_file_num 
 -------------------
  0
+(1 row)
+
+-- test join case with two INITPLAN functions
+DROP TABLE IF EXISTS t5_function_scan;
+NOTICE:  table "t5_function_scan" does not exist, skipping
+CREATE TABLE t5_function_scan AS SELECT * FROM get_id(), get_country();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CONTEXT:  SQL statement "create table public.country( country_id integer,
+    country character varying(50))"
+PL/pgSQL function get_country() line 4 at SQL statement
+SELECT count(*) FROM t5_function_scan;
+ count  
+--------
+ 300000
+(1 row)
+
+-- test union all 
+DROP TABLE IF EXISTS t6_function_scan;
+NOTICE:  table "t6_function_scan" does not exist, skipping
+CREATE TABLE t6_function_scan AS SELECT 100/(1+ 1* random())::int id, 'cc'::text cc UNION ALL SELECT * FROM  get_country();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CONTEXT:  SQL statement "create table public.country( country_id integer,
+    country character varying(50))"
+PL/pgSQL function get_country() line 4 at SQL statement
+SELECT count(*) FROM t6_function_scan;
+ count 
+-------
+     4
+(1 row)
+
+DROP TABLE IF EXISTS t7_function_scan;
+NOTICE:  table "t7_function_scan" does not exist, skipping
+CREATE TABLE t7_function_scan AS SELECT * FROM  get_country() UNION ALL SELECT 100/(1+ 1* random())::int, 'cc'::text;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CONTEXT:  SQL statement "create table public.country( country_id integer,
+    country character varying(50))"
+PL/pgSQL function get_country() line 4 at SQL statement
+SELECT count(*) FROM t7_function_scan;
+ count 
+-------
+     4
 (1 row)
 

--- a/src/test/regress/expected/function_extensions_optimizer.out
+++ b/src/test/regress/expected/function_extensions_optimizer.out
@@ -484,7 +484,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'co
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
- Redistribute Motion 1:3  (slice1)  (cost=0.25..30.25 rows=1000 width=36)
+ Redistribute Motion 1:3  (slice1)  (cost=0.25..10.25 rows=1000 width=36)
    Hash Key: get_country.country_id
    ->  Function Scan on get_country  (cost=0.25..10.25 rows=1000 width=36)
          InitPlan 1 (returns $0)  (slice2)
@@ -495,7 +495,6 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 CREATE TABLE t1_function_scan AS SELECT * FROM get_country();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'country_id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-NOTICE:  table "country" does not exist, skipping
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CONTEXT:  SQL statement "create table public.country( country_id integer,
@@ -632,5 +631,55 @@ SELECT get_temp_file_num();
  get_temp_file_num 
 -------------------
  0
+(1 row)
+
+-- test join case with two INITPLAN functions
+DROP TABLE IF EXISTS t5_function_scan;
+NOTICE:  table "t5_function_scan" does not exist, skipping
+CREATE TABLE t5_function_scan AS SELECT * FROM get_id(), get_country();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CONTEXT:  SQL statement "create table public.country( country_id integer,
+    country character varying(50))"
+PL/pgSQL function get_country() line 4 at SQL statement
+SELECT count(*) FROM t5_function_scan;
+ count  
+--------
+ 300000
+(1 row)
+
+-- test union all 
+DROP TABLE IF EXISTS t6_function_scan;
+NOTICE:  table "t6_function_scan" does not exist, skipping
+CREATE TABLE t6_function_scan AS SELECT 100/(1+ 1* random())::int id, 'cc'::text cc UNION ALL SELECT * FROM  get_country();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CONTEXT:  SQL statement "create table public.country( country_id integer,
+    country character varying(50))"
+PL/pgSQL function get_country() line 4 at SQL statement
+SELECT count(*) FROM t6_function_scan;
+ count 
+-------
+     4
+(1 row)
+
+DROP TABLE IF EXISTS t7_function_scan;
+NOTICE:  table "t7_function_scan" does not exist, skipping
+CREATE TABLE t7_function_scan AS SELECT * FROM  get_country() UNION ALL SELECT 100/(1+ 1* random())::int, 'cc'::text;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'country_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CONTEXT:  SQL statement "create table public.country( country_id integer,
+    country character varying(50))"
+PL/pgSQL function get_country() line 4 at SQL statement
+SELECT count(*) FROM t7_function_scan;
+ count 
+-------
+     4
 (1 row)
 

--- a/src/test/regress/sql/function_extensions.sql
+++ b/src/test/regress/sql/function_extensions.sql
@@ -2,7 +2,6 @@
 -- Test extensions to functions (MPP-16060)
 -- 	1. data access indicators
 -- -----------------------------------------------------------------
-
 -- test prodataaccess
 create function func1(int, int) returns int as
 $$
@@ -330,3 +329,17 @@ CREATE TABLE t4_function_scan AS SELECT 444, (1 / (0* random()))::text UNION ALL
 
 -- Temp file number after running INITPLAN function, number should not changed.
 SELECT get_temp_file_num();
+
+-- test join case with two INITPLAN functions
+DROP TABLE IF EXISTS t5_function_scan;
+CREATE TABLE t5_function_scan AS SELECT * FROM get_id(), get_country();
+SELECT count(*) FROM t5_function_scan;
+
+-- test union all 
+DROP TABLE IF EXISTS t6_function_scan;
+CREATE TABLE t6_function_scan AS SELECT 100/(1+ 1* random())::int id, 'cc'::text cc UNION ALL SELECT * FROM  get_country();
+SELECT count(*) FROM t6_function_scan;
+
+DROP TABLE IF EXISTS t7_function_scan;
+CREATE TABLE t7_function_scan AS SELECT * FROM  get_country() UNION ALL SELECT 100/(1+ 1* random())::int, 'cc'::text;
+SELECT count(*) FROM t7_function_scan;


### PR DESCRIPTION
We now use initplan id to differentiate the tuplestore used by
different INITPLAN functions. INITPLAN will also write the function
result into different tuplestores.

Also fix the bug which appends initplan in the wrong place. It may
generate wrong result in UNION ALL case.

cherry-pick from: 2589a3

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
