### PR TITLE
[GP RELEASE]Recompile plperl to set the right RUNPATH

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -338,6 +338,7 @@ sol10_sparc_32_GPDB_BUILDSET=partial
 win64_GPDB_BUILDSET=partial
 win32_GPDB_BUILDSET=partial
 BLD_GPDB_BUILDSET=$($(BLD_ARCH)_GPDB_BUILDSET)
+perl_archlibexp:=$(shell perl -MConfig -e 'print $$Config{archlibexp}')
 
 # set default build steps
 define BUILD_STEPS
@@ -345,6 +346,7 @@ define BUILD_STEPS
 	if [ "$(findstring rhel,$(BLD_ARCH))" = "rhel" ]; then \
 	  cd $(BUILDDIR) && PYGRESQL_LDFLAGS='-Wl,-rpath,\$$$$ORIGIN/../../../lib -Wl,--enable-new-dtags' $(MAKE) $(PARALLEL_MAKE_OPTS) install; \
 	  cd $(BUILDDIR)/src/pl/plpython && $(MAKE) clean && echo 'LDFLAGS += -Wl,-rpath,\$$$$ORIGIN/../../ext/python/lib/ -Wl,--enable-new-dtags' >> Makefile && echo 'LDFLAGS_SL += -Wl,-rpath,\$$$$ORIGIN/../../ext/python/lib/ -Wl,--enable-new-dtags' >> Makefile && $(MAKE) $(PARALLEL_MAKE_OPTS) install && cd $(BUILDDIR) ; \
+	  cd $(BUILDDIR)/src/pl/plperl && $(MAKE) clean && echo "LDFLAGS += -Wl,-rpath,$(perl_archlibexp)/CORE -Wl,--enable-new-dtags" >> GNUmakefile && echo "LDFLAGS_SL += -Wl,-rpath,$(perl_archlibexp)/CORE -Wl,--enable-new-dtags" >> GNUmakefile && $(MAKE) $(PARALLEL_MAKE_OPTS) install && cd $(BUILDDIR) ; \
 	else \
 	  cd $(BUILDDIR) && $(MAKE) $(PARALLEL_MAKE_OPTS) install; \
 	fi \


### PR DESCRIPTION
Currently, GPDB5 is built with --enable-rpath (default configure
option). For plperl, it's Makefile specifies an absolute path to the
location of "$(perl -MConfig -e 'print $Config{archlibexp}')/CORE"
(e.g., /usr/lib64/perl5/CORE on RHEL7). This directory is not on the
default search path for the runtime linker. Without the proper RUNPATH
entry, libperl.so cannot be found when postgres tries to load the plperl
extension.

Without setting correct RUNPATH for plperl.so, will see a error like
followin:
ERROR:  could not load library
"/usr/local/greenplum-db-devel/lib/postgresql/plperl.so": libperl.so:
cannot open shared object file: No such file or directory

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>


dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-173050625-fix-plperl-not-found-sbai
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
