### PR TITLE
Fix a recursive AbortTransaction issue

### DIFF
--- a/src/backend/cdb/cdblocaldistribxact.c
+++ b/src/backend/cdb/cdblocaldistribxact.c
@@ -95,7 +95,8 @@ LocalDistribXact_ChangeState(int pgprocno,
 			break;
 
 		case LOCALDISTRIBXACT_STATE_ABORTED:
-			if (oldState != LOCALDISTRIBXACT_STATE_ACTIVE)
+			if (oldState != LOCALDISTRIBXACT_STATE_ACTIVE &&
+				oldState != LOCALDISTRIBXACT_STATE_ABORTED)
 				elog(PANIC,
 					 "Expected distributed transaction xid = %u to local element to be in state \"Active\" or \"Abort Delivery\" and "
 					 "found state \"%s\"",

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -520,8 +520,6 @@ ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid)
 	Assert(pgxact->nxids == 0);
 	Assert(pgxact->overflowed == false);
 
-	proc->localDistribXactData.state = LOCALDISTRIBXACT_STATE_NONE;
-
 	resetGxact();
 }
 

--- a/src/test/isolation2/expected/distributed_transactions.out
+++ b/src/test/isolation2/expected/distributed_transactions.out
@@ -1,0 +1,55 @@
+-- Test error after ProcArrayEndTransaction
+
+-- abort fail on QD
+SELECT gp_inject_fault( 'abort_after_procarray_end', 'error', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+BEGIN;
+BEGIN
+CREATE TABLE test_xact_abort_failure(a int);
+CREATE
+ABORT;
+ERROR:  fault triggered, fault name:'abort_after_procarray_end' fault type:'error'
+SELECT gp_inject_fault( 'abort_after_procarray_end', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- abort fail on QE
+SELECT gp_inject_fault( 'abort_after_procarray_end', 'error', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+BEGIN;
+BEGIN
+CREATE TABLE test_xact_abort_failure(a int);
+CREATE
+ABORT;
+ABORT
+SELECT gp_inject_fault( 'abort_after_procarray_end', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- abort fail in local transaction
+SELECT gp_inject_fault( 'abort_after_procarray_end', 'error', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+0U: BEGIN;
+BEGIN
+0U: CREATE TABLE test_xact_abort_failure(a int);
+CREATE
+0U: ABORT;
+ERROR:  fault triggered, fault name:'abort_after_procarray_end' fault type:'error'
+SELECT gp_inject_fault( 'abort_after_procarray_end', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -234,3 +234,5 @@ ignore: restore_memory_accounting_default
 test: setup_startup_memory_accounting
 test: oom_startup_memory
 test: restore_memory_accounting_default
+
+test: distributed_transactions

--- a/src/test/isolation2/sql/distributed_transactions.sql
+++ b/src/test/isolation2/sql/distributed_transactions.sql
@@ -1,0 +1,22 @@
+-- Test error after ProcArrayEndTransaction
+
+-- abort fail on QD
+SELECT gp_inject_fault( 'abort_after_procarray_end', 'error', 1);
+BEGIN;
+CREATE TABLE test_xact_abort_failure(a int);
+ABORT;
+SELECT gp_inject_fault( 'abort_after_procarray_end', 'reset', 1);
+
+-- abort fail on QE
+SELECT gp_inject_fault( 'abort_after_procarray_end', 'error', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+BEGIN;
+CREATE TABLE test_xact_abort_failure(a int);
+ABORT;
+SELECT gp_inject_fault( 'abort_after_procarray_end', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+
+-- abort fail in local transaction
+SELECT gp_inject_fault( 'abort_after_procarray_end', 'error', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+0U: BEGIN;
+0U: CREATE TABLE test_xact_abort_failure(a int);
+0U: ABORT;
+SELECT gp_inject_fault( 'abort_after_procarray_end', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;


### PR DESCRIPTION
When the error happens after ProcArrayEndTransaction, it will recurse back to
AbortTransaction, we need to make sure it will not generate extra WAL record
and not fail the assertions.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
