### PR TITLE
docs - add views pg_stat_all_tables and indexes

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -569,7 +569,13 @@
               <xref href="#timezone_abbreviations"/>
             </li>
             <li>
+              <xref href="#track_activities"/>
+            </li>
+            <li>
               <xref href="#track_activity_query_size"/>
+            </li>
+            <li>
+              <xref href="#track_counts"/>
             </li>
             <li>
               <xref href="#transaction_isolation"/>
@@ -8705,6 +8711,38 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
       </table>
     </body>
   </topic>
+  <topic id="track_activities">
+    <title>track_activities</title>
+    <body>
+      <p>Enables the collection of information on the currently executing command of each session,
+        along with the time when that command began execution. This parameter is
+          <codeph>true</codeph> by default. Only superusers can change this setting. See the
+          <codeph>pg_stat_activity</codeph> view</p>
+      <note>Even when enabled, this information is not visible to all users, only to superusers and
+        the user owning the session being reported on, so it should not represent a security risk. </note>
+      <table id="table_f1l_fwm_vlb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">true</entry>
+              <entry colname="col3">master<p>system</p><p>reload</p><p>superuser</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
   <topic id="track_activity_query_size">
     <title>track_activity_query_size</title>
     <body>
@@ -8727,6 +8765,35 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
               <entry colname="col1">integer</entry>
               <entry colname="col2">1024</entry>
               <entry colname="col3">local<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="track_counts">
+    <title>track_counts</title>
+    <body>
+      <p>Collects information about executing commands. Enables the collection of information on the
+        currently executing command of each session, along with the time at which that command began
+        execution.</p>
+      <table id="table_e5c_fwm_vlb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">true</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p><p>superuser</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -8717,7 +8717,7 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
       <p>Enables the collection of information on the currently executing command of each session,
         along with the time when that command began execution. This parameter is
           <codeph>true</codeph> by default. Only superusers can change this setting. See the
-          <codeph>pg_stat_activity</codeph> view</p>
+          <codeph>pg_stat_activity</codeph> view.</p>
       <note>Even when enabled, this information is not visible to all users, only to superusers and
         the user owning the session being reported on, so it should not represent a security risk. </note>
       <table id="table_f1l_fwm_vlb">

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -852,8 +852,14 @@
             <p>
               <xref href="guc-list.xml#stats_queue_level" type="section">stats_queue_level</xref>
             </p>
+            <p>
+              <xref href="guc-list.xml#track_activities" type="section">track_activities</xref>
+            </p>
           </stentry>
           <stentry>
+            <p>
+              <xref href="guc-list.xml#track_counts" type="section">track_counts</xref>
+            </p>
             <p>
               <xref href="guc-list.xml#update_process_title" type="section"
                 >update_process_title</xref>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -271,7 +271,9 @@
             <topicref href="guc-list.xml#topic_k52_fqm_f3b"/>
             <topicref href="guc-list.xml#TimeZone"/>
             <topicref href="guc-list.xml#timezone_abbreviations"/>
+            <topicref href="guc-list.xml#track_activities"/>
             <topicref href="guc-list.xml#track_activity_query_size"/>
+            <topicref href="guc-list.xml#track_counts"/>
             <topicref href="guc-list.xml#transaction_isolation"/>
             <topicref href="guc-list.xml#transaction_read_only"/>
             <topicref href="guc-list.xml#transform_null_equals"/>

--- a/gpdb-doc/dita/ref_guide/ref_guide.ditamap
+++ b/gpdb-doc/dita/ref_guide/ref_guide.ditamap
@@ -265,6 +265,8 @@
 				<topicref href="system_catalogs/pg_shdepend.xml"/>
 				<topicref href="system_catalogs/pg_shdescription.xml"/>
 				<topicref href="system_catalogs/pg_stat_activity.xml"/>
+				<topicref href="system_catalogs/pg_stat_indexes.xml"/>
+				<topicref href="system_catalogs/pg_stat_tables.xml"/>
 				<topicref href="system_catalogs/pg_stat_last_operation.xml"/>
 				<topicref href="system_catalogs/pg_stat_last_shoperation.xml"/>
 				<topicref href="system_catalogs/pg_stat_operations.xml"/>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-views.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/catalog_ref-views.xml
@@ -59,13 +59,19 @@
         <xref href="./pg_stat_activity.xml#topic1" type="topic" format="dita"/>
       </li>
       <li>
+        <xref href="./pg_stat_indexes.xml" type="topic" format="dita"/>
+      </li>
+      <li>
+        <xref href="./pg_stat_tables.xml" type="topic" format="dita"/>
+      </li>
+      <li>
         <xref href="./pg_stat_replication.xml#topic1" type="topic" format="dita"/>
       </li>
       <li>
         <xref href="./pg_stats_resqueue.xml#topic1" type="topic" format="dita"/>
       </li>
-      <li>session_level_memory_consumption (See "Viewing Session Memory Usage Information" in the
-          <cite>Greenplum Database Administrator Guide</cite>.)</li>
+      <li>session_level_memory_consumption (See <xref
+          href="../../admin_guide/managing/monitor.xml#topic_slt_ddv_1q"/>.)</li>
     </ul>
     <p>For more information about the standard system views supported in PostgreSQL and Greenplum
       Database, see the following sections of the PostgreSQL documentation:</p>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_indexes.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_indexes.xml
@@ -51,7 +51,8 @@
           <row>
             <entry><codeph>idx_scan</codeph></entry>
             <entry>bigint</entry>
-            <entry>Number of index scans initiated on this index</entry>
+            <entry>Total number of index scans initiated on this index from all segment
+              instances</entry>
           </row>
           <row>
             <entry><codeph>idx_tup_read</codeph></entry>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_indexes.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_indexes.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="gi143896">pg_stat_all_indexes</title>
+  <body>
+    <p>The <codeph>pg_stat_all_indexes</codeph> view shows one row for each index in the current
+      database that displays statistics about accesses to that specific index. </p>
+    <p>The <codeph>pg_stat_user_indexes</codeph> and <codeph>pg_stat_sys_indexes</codeph> views
+      contain the same information, but filtered to only show user and system indexes
+      respectively.</p>
+    <table id="table_z1h_m5k_xlb">
+      <title>pg_catalog.pg_stat_all_indexes View 5.x, 6.x</title>
+      <tgroup cols="3">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="110pt"/>
+        <colspec colnum="3" colname="col3" colwidth="210pt"/>
+        <thead>
+          <row>
+            <entry>Column</entry>
+            <entry>Type</entry>
+            <entry>Description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry><codeph>relid</codeph></entry>
+            <entry>oid</entry>
+            <entry>OID of the table for this index</entry>
+          </row>
+          <row>
+            <entry><codeph>indexrelid</codeph></entry>
+            <entry>oid</entry>
+            <entry>OID of this index</entry>
+          </row>
+          <row>
+            <entry><codeph>schemaname</codeph></entry>
+            <entry>name</entry>
+            <entry>Name of the schema this index is in</entry>
+          </row>
+          <row>
+            <entry><codeph>relname</codeph></entry>
+            <entry>name</entry>
+            <entry>Name of the table for this index</entry>
+          </row>
+          <row>
+            <entry><codeph>indexrelname</codeph></entry>
+            <entry>name</entry>
+            <entry>Name of this index</entry>
+          </row>
+          <row>
+            <entry><codeph>idx_scan</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of index scans initiated on this index</entry>
+          </row>
+          <row>
+            <entry><codeph>idx_tup_read</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of index entries returned by scans on this index</entry>
+          </row>
+          <row>
+            <entry><codeph>idx_tup_fetch</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of live table rows fetched by simple index scans using this index</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_tables.xml
@@ -42,7 +42,8 @@
           <row>
             <entry><codeph>seq_scan</codeph></entry>
             <entry>bigint</entry>
-            <entry>Number of sequential scans initiated on this table</entry>
+            <entry>Total number of sequential scans initiated on this table from all segment
+              instances</entry>
           </row>
           <row>
             <entry><codeph>seq_tup_read</codeph></entry>
@@ -52,7 +53,8 @@
           <row>
             <entry><codeph>idx_scan</codeph></entry>
             <entry>bigint</entry>
-            <entry>Number of index scans initiated on this table</entry>
+            <entry>Total number of index scans initiated on this table from all segment
+              instances</entry>
           </row>
           <row>
             <entry><codeph>idx_tup_fetch</codeph></entry>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_tables.xml
@@ -5,8 +5,7 @@
   <title id="gi143896">pg_stat_all_tables</title>
   <body id="table_stats_all">
     <p>The <codeph>pg_stat_all_tables</codeph> view shows one row for each table in the current
-      database (including TOAST tables) that displays statistics about accesses to that specific
-      table. </p>
+      database (including TOAST tables) to display statistics about accesses to that specific table. </p>
     <p>The <codeph>pg_stat_user_tables</codeph> and <codeph>pg_stat_sys_table</codeph>s views
       contain the same information, but filtered to only show user and system tables
       respectively.</p>
@@ -99,25 +98,23 @@
           <row>
             <entry><codeph>last_vacuum</codeph></entry>
             <entry>timestamp with time zone</entry>
-            <entry>Last time at which this table was manually vacuumed (not counting <codeph>VACUUM
+            <entry>Last time this table was manually vacuumed (not counting <codeph>VACUUM
                 FULL</codeph>)</entry>
           </row>
           <row>
             <entry><codeph>last_autovacuum</codeph></entry>
             <entry>timestamp with time zone</entry>
-            <entry>Last time at which this table was vacuumed by the autovacuum
-              daemon<sup>1</sup></entry>
+            <entry>Last time this table was vacuumed by the autovacuum daemon<sup>1</sup></entry>
           </row>
           <row>
             <entry><codeph>last_analyze</codeph></entry>
             <entry>timestamp with time zone</entry>
-            <entry>Last time at which this table was manually analyzed</entry>
+            <entry>Last time this table was manually analyzed</entry>
           </row>
           <row>
             <entry><codeph>last_autoanalyze</codeph></entry>
             <entry>timestamp with time zone</entry>
-            <entry>Last time at which this table was analyzed by the autovacuum
-              daemon<sup>1</sup></entry>
+            <entry>Last time this table was analyzed by the autovacuum daemon<sup>1</sup></entry>
           </row>
           <row>
             <entry><codeph>vacuum_count</codeph></entry>

--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_tables.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_tables.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1" xml:lang="en">
+  <title id="gi143896">pg_stat_all_tables</title>
+  <body id="table_stats_all">
+    <p>The <codeph>pg_stat_all_tables</codeph> view shows one row for each table in the current
+      database (including TOAST tables) that displays statistics about accesses to that specific
+      table. </p>
+    <p>The <codeph>pg_stat_user_tables</codeph> and <codeph>pg_stat_sys_table</codeph>s views
+      contain the same information, but filtered to only show user and system tables
+      respectively.</p>
+    <table id="table_rxm_tjf_vlb">
+      <title>pg_catalog.pg_stat_all_table View</title>
+      <tgroup cols="3">
+        <colspec colnum="1" colname="col1" colwidth="131pt"/>
+        <colspec colnum="2" colname="col2" colwidth="110pt"/>
+        <colspec colnum="3" colname="col3" colwidth="210pt"/>
+        <thead>
+          <row>
+            <entry>Column</entry>
+            <entry>Type</entry>
+            <entry>Description</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry><codeph>relid</codeph></entry>
+            <entry>oid</entry>
+            <entry>OID of a table</entry>
+          </row>
+          <row>
+            <entry><codeph>schemaname</codeph></entry>
+            <entry>name</entry>
+            <entry>Name of the schema that this table is in</entry>
+          </row>
+          <row>
+            <entry><codeph>relname</codeph></entry>
+            <entry>name</entry>
+            <entry>Name of this table</entry>
+          </row>
+          <row>
+            <entry><codeph>seq_scan</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of sequential scans initiated on this table</entry>
+          </row>
+          <row>
+            <entry><codeph>seq_tup_read</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of live rows fetched by sequential scans</entry>
+          </row>
+          <row>
+            <entry><codeph>idx_scan</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of index scans initiated on this table</entry>
+          </row>
+          <row>
+            <entry><codeph>idx_tup_fetch</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of live rows fetched by index scans</entry>
+          </row>
+          <row>
+            <entry><codeph>n_tup_ins</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of rows inserted</entry>
+          </row>
+          <row>
+            <entry><codeph>n_tup_upd</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of rows updated (includes HOT updated rows)</entry>
+          </row>
+          <row>
+            <entry><codeph>n_tup_del</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of rows deleted</entry>
+          </row>
+          <row>
+            <entry><codeph>n_tup_hot_upd</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of rows HOT updated (i.e., with no separate index update required)</entry>
+          </row>
+          <row>
+            <entry><codeph>n_live_tup</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Estimated number of live rows</entry>
+          </row>
+          <row>
+            <entry><codeph>n_dead_tup</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Estimated number of dead rows</entry>
+          </row>
+          <row>
+            <entry><codeph>n_mod_since_analyze</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Estimated number of rows modified since this table was last analyzed</entry>
+          </row>
+          <row>
+            <entry><codeph>last_vacuum</codeph></entry>
+            <entry>timestamp with time zone</entry>
+            <entry>Last time at which this table was manually vacuumed (not counting <codeph>VACUUM
+                FULL</codeph>)</entry>
+          </row>
+          <row>
+            <entry><codeph>last_autovacuum</codeph></entry>
+            <entry>timestamp with time zone</entry>
+            <entry>Last time at which this table was vacuumed by the autovacuum
+              daemon<sup>1</sup></entry>
+          </row>
+          <row>
+            <entry><codeph>last_analyze</codeph></entry>
+            <entry>timestamp with time zone</entry>
+            <entry>Last time at which this table was manually analyzed</entry>
+          </row>
+          <row>
+            <entry><codeph>last_autoanalyze</codeph></entry>
+            <entry>timestamp with time zone</entry>
+            <entry>Last time at which this table was analyzed by the autovacuum
+              daemon<sup>1</sup></entry>
+          </row>
+          <row>
+            <entry><codeph>vacuum_count</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of times this table has been manually vacuumed (not counting
+                <codeph>VACUUM FULL</codeph>)</entry>
+          </row>
+          <row>
+            <entry><codeph>autovacuum_count</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of times this table has been vacuumed by the autovacuum
+              daemon<sup>1</sup></entry>
+          </row>
+          <row>
+            <entry><codeph>analyze_count</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of times this table has been manually analyzed</entry>
+          </row>
+          <row>
+            <entry><codeph>autoanalyze_count</codeph></entry>
+            <entry>bigint</entry>
+            <entry>Number of times this table has been analyzed by the autovacuum daemon
+                <sup>1</sup></entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+    <p>
+      <note><sup>1</sup> In Greenplum Database, the autovacuum daemon is disabled and not supported
+        for user defined databases.</note>
+    </p>
+  </body>
+</topic>


### PR DESCRIPTION
add catalog views
pg_stat_all_indexes
pg_stat_all_tables

Also add some statistics GUCs.
--track_activities
--track_counts
This is a port of a 6X_STABLE doc PR #10227

Link to HTML docs on temporary GPDB draft doc site
https://docs-msk-gpdb7-dev.cfapps.io/7-0/ref_guide/system_catalogs/pg_stat_indexes.html
https://docs-msk-gpdb7-dev.cfapps.io/7-0/ref_guide/system_catalogs/pg_stat_tables.html

https://docs-msk-gpdb7-dev.cfapps.io/7-0/ref_guide/config_params/guc-list.html#track_activities
https://docs-msk-gpdb7-dev.cfapps.io/7-0/ref_guide/config_params/guc-list.html#track_counts