### PR TITLE
Handle DTX_STATE_PREPARING rollback more correctly.

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1263,9 +1263,6 @@ exec_mpp_query(const char *query_string,
 		/* Make sure we are in a transaction command */
 		start_xact_command();
 
-		/* If we got a cancel signal in parsing or prior command, quit */
-		CHECK_FOR_INTERRUPTS();
-
 		/*
 		 * OK to analyze, rewrite, and plan this query.
 		 *
@@ -1274,7 +1271,6 @@ exec_mpp_query(const char *query_string,
 		 */
 		oldcontext = MemoryContextSwitchTo(MessageContext);
 
-		/* If we got a cancel signal in analysis or planning, quit */
 		CHECK_FOR_INTERRUPTS();
 
 		/*

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -65,7 +65,7 @@ typedef enum
 	/**
 	 * Transaction rollback has been requested and QD is notifying all QD processes.
 	 *
-	 * _SOME_PREPARED means that at least one QE has done the first phase of two-phase commit.
+	 * _SOME_PREPARED means that some QEs may have done the first phase of two-phase commit.
 	 */
 	DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED,
 


### PR DESCRIPTION
For the scenario that the master are in preparing state but need to rollback,
The segments might finish prepare or fail at prepare. Our code should basically
be able to handle them, but consider the extreme corner case that QE prepare
fails after flushing prepare xlog and set the related gxact as valid - in such
case it will error out and abort the transaction and then set the context as
DTX_CONTEXT_LOCAL_ONLY, finally the current code path will not be able to abort
the prepared transaction on the segment. So instead of handling the code logic
in a tricky way, we simply do both transaction abort and prepare abort to avoid
this and tolerate other potential product bugs (mostly want to avoid orphaned
prepared transaction due to this kind of issue.  orphaned parepared transaction
is not that harmful on gpdb master but is serious on gpdb 6 since on gpdb 6 we
have no way to recycle xlog files after the orphaned prepared transaction xlog
lsn.).  Also on QD we do not need a separate code path for writer gang reset
(now use DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED also, instead of
current DTX_STATE_RETRY_ABORT_PREPARED).

Besides, current QE DTX_PROTOCOL_COMMAND_ABORT_SOME_PREPARED handling code
seems to be not correct (though maybe harmless). It should only enter the
DTX_CONTEXT_LOCAL_ONLY (prepare fail, writer gang reset etc) or
DTX_CONTEXT_QE_PREPARED (prepared) scenario. So modifying the code to reflect
this.