### PR TITLE
README: Fix documentation to install Greenplum with ORCA in Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Follow [appropriate linux steps](README.linux.md) for getting your system ready 
 
 ## xerces
 
-ORCA uses a customized version of xerces. For the most up-to-date way of
-building, see the README at the following repository:
+ORCA requires xerces 3.1 or gp-xerces. For the most up-to-date way of
+building gp-xerces, see the README at the following repository:
 
 * https://github.com/greenplum-db/gp-xerces
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Follow [these macOS steps](README.macOS.md) for getting your system ready for GP
 ### Installing dependencies (for Linux developers)
 Follow [appropriate linux steps](README.linux.md) for getting your system ready for GPDB
 
+## xerces
+
+ORCA uses a customized version of xerces. For the most up-to-date way of
+building, see the README at the following repository:
+
+* https://github.com/greenplum-db/gp-xerces
+
 ### Build the database
 
 ```

--- a/README.ubuntu.bash
+++ b/README.ubuntu.bash
@@ -22,7 +22,6 @@ apt-get install -y \
   libperl-dev \
   libreadline-dev \
   libssl-dev \
-  libxerces-c-dev \
   libxml2-dev \
   libyaml-dev \
   libzstd-dev \


### PR DESCRIPTION
While installing ORCA in Ubuntu 18.04 I ran into some issues while
trying to install gp-xerces. During the build, Greenplum was trying to
link against the installed xerces `libxerces-c-dev`, which is installed
by running the `./README.ubuntu.bash` script. By default, Ubuntu 18.04
will install xerces 3.2, which is incompatible with the version used by
Greenplum 6.
