### PR TITLE
Move query to a resource group with memory_limit 0

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -4785,8 +4785,11 @@ ResGroupGetGroupAvailableMem(Oid groupId)
 	LWLockAcquire(ResGroupLock, LW_SHARED);
 	group = groupHashFind(groupId, true);
 	Assert(group != NULL);
-	availMem = slotGetMemQuotaExpected(&group->caps) +
-						group->memSharedGranted - group->memSharedUsage;
+	if (group->caps.memLimit == RESGROUP_UNLIMITED_MEMORY_LIMIT)
+		availMem = (uint32) pg_atomic_read_u32(&pResGroupControl->freeChunks);
+	else
+		availMem = slotGetMemQuotaExpected(&group->caps) +
+				   group->memSharedGranted - group->memSharedUsage;
 	LWLockRelease(ResGroupLock);
 	return availMem;
 }

--- a/src/test/isolation2/input/resgroup/resgroup_move_query.source
+++ b/src/test/isolation2/input/resgroup/resgroup_move_query.source
@@ -115,6 +115,8 @@ SELECT is_session_in_group(pid, 'rg_move_query_mem_small') FROM pg_stat_activity
 3: SELECT is_session_in_group(pid, 'rg_move_query_mem_small') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND state = 'idle in transaction';
 1: END;
 1q:
+2q:
+3q:
 
 -- test6: the destination group will wake up 'pg_resgroup_move_query' when a new slot become available
 1: SET ROLE role_move_query;
@@ -127,6 +129,19 @@ SELECT is_session_in_group(pid, 'rg_move_query_mem_small') FROM pg_stat_activity
 3<:
 3: SELECT rsgname, query FROM pg_stat_activity WHERE state = 'active';
 2<:
+1q:
+2q:
+3q:
+
+-- test7: the destination group memory_limit is 0, meaning use the global shared memory
+1: ALTER RESOURCE GROUP rg_move_query SET memory_limit 0;
+1: SET ROLE role_move_query_mem_small;
+1: BEGIN;
+1: SELECT hold_memory_by_percent_on_qe(1,0.1);
+2: SELECT pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND rsgname='rg_move_query_mem_small';
+2: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND state = 'idle in transaction';
+1q:
+2q:
 
 DROP ROLE role_move_query;
 DROP RESOURCE GROUP rg_move_query;

--- a/src/test/isolation2/output/resgroup/resgroup_move_query.source
+++ b/src/test/isolation2/output/resgroup/resgroup_move_query.source
@@ -159,6 +159,8 @@ END
 1: END;
 END
 1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
 
 -- test6: the destination group will wake up 'pg_resgroup_move_query' when a new slot become available
 1: SET ROLE role_move_query;
@@ -190,6 +192,34 @@ SET
 ----------
           
 (1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+
+-- test7: the destination group memory_limit is 0, meaning use the global shared memory
+1: ALTER RESOURCE GROUP rg_move_query SET memory_limit 0;
+ALTER
+1: SET ROLE role_move_query_mem_small;
+SET
+1: BEGIN;
+BEGIN
+1: SELECT hold_memory_by_percent_on_qe(1,0.1);
+ hold_memory_by_percent_on_qe 
+------------------------------
+ 0                            
+(1 row)
+2: SELECT pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND rsgname='rg_move_query_mem_small';
+ pg_resgroup_move_query 
+------------------------
+ t                      
+(1 row)
+2: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND state = 'idle in transaction';
+ is_session_in_group 
+---------------------
+ t                   
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
 
 DROP ROLE role_move_query;
 DROP


### PR DESCRIPTION
When move a query to a resource group whose memory_limit is 0, the available
memory is the current available global shared memory.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
