### PR TITLE
Fix url_curl on MacOS

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -700,7 +700,7 @@ fill_buffer(URL_CURL_FILE *curl, int want)
 		if (maxfd == -1)
 		{
 			elog(DEBUG2, "curl_multi_fdset set maxfd = %d", maxfd);
-			pg_usleep(100);
+			pg_usleep(100000);
 			// to call curl_multi_perform
 			nfds = 1;
 		}

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -686,14 +686,28 @@ fill_buffer(URL_CURL_FILE *curl, int want)
 						e, curl_easy_strerror(e));
 		}
 
-		if (maxfd <= 0)
+		if (maxfd == 0)
 		{
 			elog(LOG, "curl_multi_fdset set maxfd = %d", maxfd);
 			curl->still_running = 0;
 			break;
 		}
-		nfds = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
-
+		/* When libcurl returns -1 in max_fd, it is because libcurl currently does something
+		 * that isn't possible for your application to monitor with a socket and unfortunately
+		 * you can then not know exactly when the current action is completed using select().
+		 * You then need to wait a while before you proceed and call curl_multi_perform anyway
+		 */
+		if (maxfd == -1)
+		{
+			elog(DEBUG2, "curl_multi_fdset set maxfd = %d", maxfd);
+			pg_usleep(100);
+			// to call curl_multi_perform
+			nfds = 1;
+		}
+		else
+		{
+			nfds = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
+		}
 		if (nfds == -1)
 		{
 			if (errno == EINTR || errno == EAGAIN)


### PR DESCRIPTION
Fix libcurl can not read data from gpfdist
on MacOS

But gpfdist with a pipe can not work on macos as
flock(2) which is used in gfile.c is not supported
on MacOS.

Fix the issue: https://github.com/greenplum-db/gpdb/issues/4105

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
