### PR TITLE
Add knowledge of partition selectors to Orca's DPv2 algorithm

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -3832,7 +3832,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="436174">
+    <dxl:Plan Id="0" SpaceSize="433164">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="654544318.346447" Rows="19136.250000" Width="31"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -3832,7 +3832,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="433164">
+    <dxl:Plan Id="0" SpaceSize="436174">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="654544318.346447" Rows="19136.250000" Width="31"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropRelational.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropRelational.h
@@ -20,6 +20,7 @@
 #include "gpopt/base/CFunctionalDependency.h"
 #include "gpopt/base/CPropConstraint.h"
 #include "gpopt/base/CFunctionProp.h"
+#include "gpopt/metadata/CTableDescriptor.h"
 
 namespace gpopt
 {
@@ -67,6 +68,7 @@ namespace gpopt
 			EdptPfp,
 			EdptJoinDepth,
 			EdptFHasPartialIndexes,
+			EdptTableDescriptor,
 			EdptSentinel
 		};
 
@@ -113,6 +115,8 @@ namespace gpopt
 			// true if all logical operators in the group are of type CLogicalDynamicGet,
 			// and the dynamic get has partial indexes
 			BOOL m_fHasPartialIndexes;
+
+			CTableDescriptor *m_table_descriptor;
 
 			// private copy ctor
 			CDrvdPropRelational(const CDrvdPropRelational &);
@@ -173,7 +177,9 @@ namespace gpopt
 			CFunctionProp *DeriveFunctionProperties(CExpressionHandle &);
 
 			// has partial indexes
-			BOOL DeriveHasPartialIndexes(CExpressionHandle &exprhdl);
+			BOOL DeriveHasPartialIndexes(CExpressionHandle &);
+
+			CTableDescriptor *DeriveTableDescriptor(CExpressionHandle &);
 
 		public:
 
@@ -232,6 +238,8 @@ namespace gpopt
 
 			// has partial indexes
 			BOOL HasPartialIndexes() const;
+
+			CTableDescriptor *GetTableDescriptor() const;
 
 			// shorthand for conversion
 			static

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
@@ -335,6 +335,7 @@ namespace gpopt
 			CFunctionalDependencyArray *DeriveFunctionalDependencies();
 			CPartInfo *DerivePartitionInfo();
 			BOOL DeriveHasPartialIndexes();
+			CTableDescriptor *DeriveTableDescriptor();
 
 			// Scalar property accessors - derived as needed
 			CColRefSet *DeriveDefinedColumns();

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
@@ -317,6 +317,8 @@ namespace gpopt
 			BOOL DeriveHasPartialIndexes();
 			BOOL DeriveHasPartialIndexes(ULONG child_index);
 
+			CTableDescriptor *DeriveTableDescriptor();
+
 			// Scalar property accessors
 			CColRefSet *DeriveDefinedColumns(ULONG child_index);
 			CColRefSet *DeriveUsedColumns(ULONG child_index);

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
@@ -318,6 +318,7 @@ namespace gpopt
 			BOOL DeriveHasPartialIndexes(ULONG child_index);
 
 			CTableDescriptor *DeriveTableDescriptor();
+			CTableDescriptor *DeriveTableDescriptor(ULONG child_index);
 
 			// Scalar property accessors
 			CColRefSet *DeriveDefinedColumns(ULONG child_index);

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
@@ -365,6 +365,10 @@ namespace gpopt
 			// returns the table descriptor for (Dynamic)(BitmapTable)Get operators
 			static
 			CTableDescriptor *PtabdescFromTableGet(COperator *pop);
+
+			// returns the output columns for selected operators
+			static
+			CColRefArray *PoutputColsFromTableGet(COperator *pop);
 			
 			// extract the output columns descriptor from a logical get or dynamic get operator
 			static

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
@@ -281,6 +281,9 @@ namespace gpopt
 			virtual
 			CFunctionProp *DeriveFunctionProperties(CMemoryPool *mp, CExpressionHandle &exprhdl) const;
 
+			virtual
+			CTableDescriptor *DeriveTableDescriptor(CMemoryPool *mp, CExpressionHandle &exprhdl) const;
+
 			//-------------------------------------------------------------------------------------
 			// Derived Stats
 			//-------------------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
@@ -369,7 +369,7 @@ namespace gpopt
 			static
 			CTableDescriptor *PtabdescFromTableGet(COperator *pop);
 
-			// returns the output columns for selected operators
+			// returns the output columns for selected operator
 			static
 			CColRefArray *PoutputColsFromTableGet(COperator *pop);
 			

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalBitmapTableGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalBitmapTableGet.h
@@ -167,6 +167,18 @@ namespace gpopt
 				return 1;
 			}
 
+			// derive table descriptor
+			virtual
+			CTableDescriptor *DeriveTableDescriptor
+				(
+				CMemoryPool *, // mp
+				CExpressionHandle & // exprhdl
+				)
+				const
+			{
+				return m_ptabdesc;
+			}
+
 			// compute required stat columns of the n-th child
 			virtual
 			CColRefSet *PcrsStat

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEConsumer.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEConsumer.h
@@ -148,6 +148,9 @@ namespace gpopt
 			virtual
 			CPartInfo *DerivePartitionInfo(CMemoryPool *mp, CExpressionHandle &exprhdl) const;
 
+			// derive table descriptor
+			virtual CTableDescriptor *DeriveTableDescriptor(CMemoryPool *mp, CExpressionHandle &exprhdl) const;
+
 			// compute required stats columns of the n-th child
 			virtual
 			CColRefSet *PcrsStat

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEProducer.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEProducer.h
@@ -149,6 +149,8 @@ namespace gpopt
 				return PpartinfoPassThruOuter(exprhdl);
 			}
 
+			virtual
+			CTableDescriptor *DeriveTableDescriptor(CMemoryPool *mp,	CExpressionHandle &exprhdl)	const;
 			// compute required stats columns of the n-th child
 			virtual
 			CColRefSet *PcrsStat

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGet.h
@@ -115,6 +115,18 @@ namespace gpopt
 				return 1;
 			}
 
+			// derive table descriptor
+			virtual
+			CTableDescriptor *DeriveTableDescriptor
+				(
+				CMemoryPool *, // mp
+				CExpressionHandle & // exprhdl
+				)
+				const
+			{
+				return m_ptabdesc;
+			}
+
 			//-------------------------------------------------------------------------------------
 			// Required Relational Properties
 			//-------------------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
@@ -220,7 +220,18 @@ namespace gpopt
 			{
 				return 1;
 			}
-			
+
+			// derive table descriptor
+			virtual
+			CTableDescriptor *DeriveTableDescriptor
+				(
+				CMemoryPool *, // mp
+				CExpressionHandle & // exprhdl
+				)
+				const
+			{
+				return m_ptabdesc;
+			}
 
 	}; // class CLogicalDynamicGetBase
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalGet.h
@@ -189,6 +189,18 @@ namespace gpopt
 				return 1;
 			}
 
+			// derive table descriptor
+			virtual
+			CTableDescriptor *DeriveTableDescriptor
+				(
+				CMemoryPool *, // mp
+				CExpressionHandle & // exprhdl
+				)
+				const
+			{
+				return m_ptabdesc;
+			}
+
 			//-------------------------------------------------------------------------------------
 			// Required Relational Properties
 			//-------------------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
@@ -42,9 +42,6 @@ namespace gpopt
 			// table descriptor
 			CTableDescriptor *m_ptabdesc;
 
-			// output columns
-			CColRefArray *m_pdrgpcrOutput;
-
 		public:
 
 			// ctor
@@ -52,7 +49,7 @@ namespace gpopt
 			CLogicalSelect(CMemoryPool *mp);
 
 			// ctor
-			CLogicalSelect(CMemoryPool *mp, CTableDescriptor *ptabdesc, CColRefArray *output_cols);
+			CLogicalSelect(CMemoryPool *mp, CTableDescriptor *ptabdesc);
 
 			// dtor
 			virtual
@@ -76,14 +73,6 @@ namespace gpopt
 			{
 				return m_ptabdesc;
 			}
-
-			// accessors
-			CColRefArray *PdrgpcrOutput() const
-			{
-				return m_pdrgpcrOutput;
-			}
-
-
 
 			//-------------------------------------------------------------------------------------
 			// Derived Relational Properties

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
@@ -102,6 +102,18 @@ namespace gpopt
 				return PpcDeriveConstraintFromPredicates(mp, exprhdl);
 			}
 
+			// derive table descriptor
+			virtual
+			CTableDescriptor *DeriveTableDescriptor
+				(
+				CMemoryPool *, // mp
+				CExpressionHandle &exprhdl
+				)
+				const
+			{
+				return exprhdl.DeriveTableDescriptor(0);
+			}
+
 			// compute partition predicate to pass down to n-th child
 			virtual
 			CExpression *PexprPartPred

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
@@ -39,11 +39,20 @@ namespace gpopt
 
 			ExprPredToExprPredPartMap *m_phmPexprPartPred;
 
+			// table descriptor
+			CTableDescriptor *m_ptabdesc;
+
+			// output columns
+			CColRefArray *m_pdrgpcrOutput;
+
 		public:
 
 			// ctor
 			explicit
 			CLogicalSelect(CMemoryPool *mp);
+
+			// ctor
+			CLogicalSelect(CMemoryPool *mp, CTableDescriptor *ptabdesc, CColRefArray *output_cols);
 
 			// dtor
 			virtual
@@ -61,6 +70,20 @@ namespace gpopt
 			{
 				return "CLogicalSelect";
 			}
+
+			// return table's descriptor
+			CTableDescriptor *Ptabdesc() const
+			{
+				return m_ptabdesc;
+			}
+
+			// accessors
+			CColRefArray *PdrgpcrOutput() const
+			{
+				return m_pdrgpcrOutput;
+			}
+
+
 
 			//-------------------------------------------------------------------------------------
 			// Derived Relational Properties

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysical.h
@@ -239,9 +239,6 @@ namespace gpopt
 				ULONG ulScalarIndex
 				);
 
-			// compute distribution spec from the table descriptor
-			static
-			CDistributionSpec *PdsCompute(CMemoryPool *mp, const CTableDescriptor *ptabdesc, CColRefArray *pdrgpcrOutput);
 
 			// helper for a simple case of computing child's required sort order
 			static
@@ -453,6 +450,10 @@ namespace gpopt
 				ULONG ulOptReq
 				)
 				const = 0;
+
+			// compute distribution spec from the table descriptor
+			static
+			CDistributionSpec *PdsCompute(CMemoryPool *mp, const CTableDescriptor *ptabdesc, CColRefArray *pdrgpcrOutput);
 
 			// compute required sort order of the n-th child
 			virtual

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -242,7 +242,6 @@ namespace gpopt
 				~SExpressionInfo()
 				{
 					m_expr->Release();
-					CRefCount::SafeRelease(m_part_keys_array);
 					CRefCount::SafeRelease(m_contain_PS);
 				}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -475,7 +475,6 @@ namespace gpopt
 			void EnumerateMinCard();
 			void EnumerateGreedyAvoidXProd();
 
-
 		public:
 
 			// ctor

--- a/src/backend/gporca/libgpopt/src/base/CDrvdPropRelational.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDrvdPropRelational.cpp
@@ -137,6 +137,8 @@ CDrvdPropRelational::Derive
 
 	DeriveHasPartialIndexes(exprhdl);
 
+	DeriveTableDescriptor(exprhdl);
+
 	m_is_complete = true;
 }
 
@@ -635,5 +637,25 @@ CDrvdPropRelational::DeriveHasPartialIndexes(CExpressionHandle &exprhdl)
 	}
 
 	return m_fHasPartialIndexes;
+}
+
+// table descriptor
+CTableDescriptor *
+CDrvdPropRelational::GetTableDescriptor() const
+{
+	GPOS_RTL_ASSERT(IsComplete());
+	return m_table_descriptor;
+}
+
+CTableDescriptor *
+CDrvdPropRelational::DeriveTableDescriptor(CExpressionHandle &exprhdl)
+{
+	if (!m_is_prop_derived->ExchangeSet(EdptTableDescriptor))
+	{
+		CLogical *popLogical = CLogical::PopConvert(exprhdl.Pop());
+		m_table_descriptor = popLogical->DeriveTableDescriptor(m_mp, exprhdl);
+	}
+
+	return m_table_descriptor;
 }
 // EOF

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -2267,7 +2267,7 @@ CUtils::PexprLogicalSelect
 	CTableDescriptor *ptabdesc = NULL;
 	if (pexpr->Pop()->Eopid() == CLogical::EopLogicalSelect || pexpr->Pop()->Eopid() == CLogical::EopLogicalGet || pexpr->Pop()->Eopid() == CLogical::EopLogicalDynamicGet)
 	{
-		ptabdesc = CLogical::PtabdescFromTableGet(pexpr->Pop());
+		ptabdesc = pexpr->DeriveTableDescriptor();
 		// there are some cases where we don't populate LogicalSelect currently
 		GPOS_ASSERT_IMP(pexpr->Pop()->Eopid() != CLogical::EopLogicalSelect,NULL != ptabdesc);
 	}

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -2269,16 +2269,8 @@ CUtils::PexprLogicalSelect
 	if (pexpr->Pop()->Eopid() == CLogical::EopLogicalSelect || pexpr->Pop()->Eopid() == CLogical::EopLogicalGet || pexpr->Pop()->Eopid() == CLogical::EopLogicalDynamicGet)
 	{
 		ptabdesc = CLogical::PtabdescFromTableGet(pexpr->Pop());
-		GPOS_ASSERT(NULL != ptabdesc);
-		if (ptabdesc)
-		{
-			ptabdesc->AddRef();
-		}
+		// ptabdesc can be NULL here
 		output_cols = CLogical::PoutputColsFromTableGet(pexpr->Pop());
-		if (output_cols)
-		{
-			output_cols->AddRef();
-		}
 	}
 	return GPOS_NEW(mp) CExpression
 						(

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -2264,10 +2264,26 @@ CUtils::PexprLogicalSelect
 	GPOS_ASSERT(NULL != pexpr);
 	GPOS_ASSERT(NULL != pexprPredicate);
 
+	CTableDescriptor *ptabdesc = NULL;
+	CColRefArray *output_cols = NULL;
+	if (pexpr->Pop()->Eopid() == CLogical::EopLogicalSelect || pexpr->Pop()->Eopid() == CLogical::EopLogicalGet || pexpr->Pop()->Eopid() == CLogical::EopLogicalDynamicGet)
+	{
+		ptabdesc = CLogical::PtabdescFromTableGet(pexpr->Pop());
+		GPOS_ASSERT(NULL != ptabdesc);
+		if (ptabdesc)
+		{
+			ptabdesc->AddRef();
+		}
+		output_cols = CLogical::PoutputColsFromTableGet(pexpr->Pop());
+		if (output_cols)
+		{
+			output_cols->AddRef();
+		}
+	}
 	return GPOS_NEW(mp) CExpression
 						(
 						mp,
-						GPOS_NEW(mp) CLogicalSelect(mp),
+						GPOS_NEW(mp) CLogicalSelect(mp, ptabdesc, output_cols),
 						pexpr,
 						pexprPredicate
 						);

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -2265,17 +2265,16 @@ CUtils::PexprLogicalSelect
 	GPOS_ASSERT(NULL != pexprPredicate);
 
 	CTableDescriptor *ptabdesc = NULL;
-	CColRefArray *output_cols = NULL;
 	if (pexpr->Pop()->Eopid() == CLogical::EopLogicalSelect || pexpr->Pop()->Eopid() == CLogical::EopLogicalGet || pexpr->Pop()->Eopid() == CLogical::EopLogicalDynamicGet)
 	{
 		ptabdesc = CLogical::PtabdescFromTableGet(pexpr->Pop());
-		// ptabdesc can be NULL here
-		output_cols = CLogical::PoutputColsFromTableGet(pexpr->Pop());
+		// there are some cases where we don't populate LogicalSelect currently
+		GPOS_ASSERT_IMP(pexpr->Pop()->Eopid() != CLogical::EopLogicalSelect,NULL != ptabdesc);
 	}
 	return GPOS_NEW(mp) CExpression
 						(
 						mp,
-						GPOS_NEW(mp) CLogicalSelect(mp, ptabdesc, output_cols),
+						GPOS_NEW(mp) CLogicalSelect(mp, ptabdesc),
 						pexpr,
 						pexprPredicate
 						);

--- a/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
@@ -1660,6 +1660,14 @@ CExpression::DeriveHasPartialIndexes()
 	return m_pdprel->DeriveHasPartialIndexes(exprhdl);
 }
 
+CTableDescriptor *
+CExpression::DeriveTableDescriptor()
+{
+	CExpressionHandle exprhdl(m_mp);
+	exprhdl.Attach(this);
+	return m_pdprel->DeriveTableDescriptor(exprhdl);
+}
+
 // Scalar property accessors - derived as needed
 CColRefSet *
 CExpression::DeriveDefinedColumns()

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
@@ -2041,6 +2041,16 @@ CExpressionHandle::DeriveTableDescriptor()
 	return GetRelationalProperties()->GetTableDescriptor();
 }
 
+CTableDescriptor *
+CExpressionHandle::DeriveTableDescriptor(ULONG child_index)
+{
+	if (NULL != Pexpr())
+	{
+		return (*Pexpr())[child_index]->DeriveTableDescriptor();
+	}
+
+	return GetRelationalProperties(child_index)->GetTableDescriptor();
+}
 // Scalar property accessors
 
 CColRefSet *

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
@@ -2030,6 +2030,17 @@ CExpressionHandle::DeriveHasPartialIndexes()
 	return GetRelationalProperties()->HasPartialIndexes();
 }
 
+CTableDescriptor *
+CExpressionHandle::DeriveTableDescriptor()
+{
+	if (NULL != Pexpr())
+	{
+		return Pexpr()->DeriveTableDescriptor();
+	}
+
+	return GetRelationalProperties()->GetTableDescriptor();
+}
+
 // Scalar property accessors
 
 CColRefSet *

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -33,6 +33,7 @@
 #include "gpopt/operators/CLogicalGet.h"
 #include "gpopt/operators/CLogicalDynamicGet.h"
 #include "gpopt/operators/CLogicalNAryJoin.h"
+#include "gpopt/operators/CLogicalSelect.h"
 #include "gpopt/operators/CExpression.h"
 #include "gpopt/operators/CExpressionHandle.h"
 #include "gpopt/operators/CPredicateUtils.h"
@@ -1403,8 +1404,34 @@ CLogical::PtabdescFromTableGet
 			return CLogicalBitmapTableGet::PopConvert(pop)->Ptabdesc();
 		case CLogical::EopLogicalDynamicBitmapTableGet:
 			return CLogicalDynamicBitmapTableGet::PopConvert(pop)->Ptabdesc();
+		case CLogical::EopLogicalSelect:
+			return CLogicalSelect::PopConvert(pop)->Ptabdesc();
 		default:
-			GPOS_ASSERT(false && "Unsupported operator in CLogical::PtabdescFromTableGet");
+			return NULL;
+	}
+}
+
+CColRefArray *
+CLogical::PoutputColsFromTableGet
+	(
+	COperator *pop
+	)
+{
+	GPOS_ASSERT(NULL != pop);
+	switch (pop->Eopid())
+	{
+		case CLogical::EopLogicalGet:
+			return CLogicalGet::PopConvert(pop)->PdrgpcrOutput();
+		case CLogical::EopLogicalDynamicGet:
+			return CLogicalDynamicGet::PopConvert(pop)->PdrgpcrOutput();
+		case CLogical::EopLogicalBitmapTableGet:
+			return CLogicalBitmapTableGet::PopConvert(pop)->PdrgpcrOutput();
+		case CLogical::EopLogicalDynamicBitmapTableGet:
+			return CLogicalDynamicBitmapTableGet::PopConvert(pop)->PdrgpcrOutput();
+		case CLogical::EopLogicalSelect:
+			return CLogicalSelect::PopConvert(pop)->PdrgpcrOutput();
+		default:
+			GPOS_ASSERT(false && "Unsupported operator in CLogical::PoutputColsFromTableGet");
 			return NULL;
 	}
 }

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -1411,31 +1411,6 @@ CLogical::PtabdescFromTableGet
 	}
 }
 
-CColRefArray *
-CLogical::PoutputColsFromTableGet
-	(
-	COperator *pop
-	)
-{
-	GPOS_ASSERT(NULL != pop);
-	switch (pop->Eopid())
-	{
-		case CLogical::EopLogicalGet:
-			return CLogicalGet::PopConvert(pop)->PdrgpcrOutput();
-		case CLogical::EopLogicalDynamicGet:
-			return CLogicalDynamicGet::PopConvert(pop)->PdrgpcrOutput();
-		case CLogical::EopLogicalBitmapTableGet:
-			return CLogicalBitmapTableGet::PopConvert(pop)->PdrgpcrOutput();
-		case CLogical::EopLogicalDynamicBitmapTableGet:
-			return CLogicalDynamicBitmapTableGet::PopConvert(pop)->PdrgpcrOutput();
-		case CLogical::EopLogicalSelect:
-			return CLogicalSelect::PopConvert(pop)->PdrgpcrOutput();
-		default:
-			GPOS_ASSERT(false && "Unsupported operator in CLogical::PoutputColsFromTableGet");
-			return NULL;
-	}
-}
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CLogical::PdrgpcrOutputFromLogicalGet

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -1003,6 +1003,26 @@ CLogical::DeriveFunctionProperties
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CLogical::DeriveTableDescriptor
+//
+//	@doc:
+//		Derive table descriptor for tables used by operator
+//
+//---------------------------------------------------------------------------
+CTableDescriptor *
+CLogical::DeriveTableDescriptor
+	(
+	CMemoryPool *,
+	CExpressionHandle &
+	)
+	const
+{
+	//currently return null unless there is a single table being used. Later we may want
+	//to make this return a set of table descriptors and pass them up all operators
+	return NULL;
+}
+//---------------------------------------------------------------------------
+//	@function:
 //		CLogical::PfpDeriveFromScalar
 //
 //	@doc:

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalCTEConsumer.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalCTEConsumer.cpp
@@ -256,6 +256,19 @@ CLogicalCTEConsumer::DeriveJoinDepth
 	return pexpr->DeriveJoinDepth();
 }
 
+// derive table descriptor
+CTableDescriptor *
+CLogicalCTEConsumer::DeriveTableDescriptor
+	(
+	CMemoryPool *, //mp
+	CExpressionHandle & //exprhdl
+	)
+	const
+{
+	CExpression *pexpr = COptCtxt::PoctxtFromTLS()->Pcteinfo()->PexprCTEProducer(m_id);
+	GPOS_ASSERT(NULL != pexpr);
+	return pexpr->DeriveTableDescriptor();
+}
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalCTEProducer.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalCTEProducer.cpp
@@ -158,6 +158,18 @@ CLogicalCTEProducer::DeriveMaxCard
 	return exprhdl.DeriveMaxCard(0);
 }
 
+CTableDescriptor *
+CLogicalCTEProducer::DeriveTableDescriptor
+	(
+	CMemoryPool *, // mp
+	CExpressionHandle &exprhdl
+	)
+	const
+{
+	// pass on max card of first child
+	return exprhdl.DeriveTableDescriptor(0);
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CLogicalCTEProducer::Matches

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalCTEProducer.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalCTEProducer.cpp
@@ -166,7 +166,7 @@ CLogicalCTEProducer::DeriveTableDescriptor
 	)
 	const
 {
-	// pass on max card of first child
+	// pass on table descriptor of first child
 	return exprhdl.DeriveTableDescriptor(0);
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalSelect.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalSelect.cpp
@@ -39,7 +39,23 @@ CLogicalSelect::CLogicalSelect
 	CMemoryPool *mp
 	)
 	:
-	CLogicalUnary(mp)
+	CLogicalUnary(mp),
+	m_ptabdesc(NULL),
+	m_pdrgpcrOutput(NULL)
+{
+	m_phmPexprPartPred = GPOS_NEW(mp) ExprPredToExprPredPartMap(mp);
+}
+
+CLogicalSelect::CLogicalSelect
+	(
+	CMemoryPool *mp,
+	CTableDescriptor *ptabdesc,
+	 CColRefArray *output_cols
+	)
+	:
+	CLogicalUnary(mp),
+	m_ptabdesc(ptabdesc),
+	m_pdrgpcrOutput(output_cols)
 {
 	m_phmPexprPartPred = GPOS_NEW(mp) ExprPredToExprPredPartMap(mp);
 }
@@ -47,6 +63,8 @@ CLogicalSelect::CLogicalSelect
 CLogicalSelect::~CLogicalSelect()
 {
 	m_phmPexprPartPred->Release();
+	CRefCount::SafeRelease(m_ptabdesc);
+	CRefCount::SafeRelease(m_pdrgpcrOutput);
 }
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalSelect.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalSelect.cpp
@@ -40,8 +40,7 @@ CLogicalSelect::CLogicalSelect
 	)
 	:
 	CLogicalUnary(mp),
-	m_ptabdesc(NULL),
-	m_pdrgpcrOutput(NULL)
+	m_ptabdesc(NULL)
 {
 	m_phmPexprPartPred = GPOS_NEW(mp) ExprPredToExprPredPartMap(mp);
 }
@@ -49,13 +48,11 @@ CLogicalSelect::CLogicalSelect
 CLogicalSelect::CLogicalSelect
 	(
 	CMemoryPool *mp,
-	CTableDescriptor *ptabdesc,
-	 CColRefArray *output_cols
+	CTableDescriptor *ptabdesc
 	)
 	:
 	CLogicalUnary(mp),
-	m_ptabdesc(ptabdesc),
-	m_pdrgpcrOutput(output_cols)
+	m_ptabdesc(ptabdesc)
 {
 	m_phmPexprPartPred = GPOS_NEW(mp) ExprPredToExprPredPartMap(mp);
 }

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalSelect.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalSelect.cpp
@@ -63,8 +63,6 @@ CLogicalSelect::CLogicalSelect
 CLogicalSelect::~CLogicalSelect()
 {
 	m_phmPexprPartPred->Release();
-	CRefCount::SafeRelease(m_ptabdesc);
-	CRefCount::SafeRelease(m_pdrgpcrOutput);
 }
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
@@ -1350,7 +1350,7 @@ CJoinOrderDPv2::PexprExpand()
 		// We need the underlying partition and table row information to properly estimate cardinality for
 		// partition selection. If this is a logical expr that is more complex (eg: cte, nary join), we
 		// will use a default estimate
-		CTableDescriptor *table_desc = CLogical::PtabdescFromTableGet(pexpr_atom->Pop());
+		CTableDescriptor *table_desc = pexpr_atom->DeriveTableDescriptor();
 
 		if (table_desc != NULL)
 		{

--- a/src/backend/gporca/libgpopt/src/xforms/CXformExpandNAryJoinDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformExpandNAryJoinDPv2.cpp
@@ -148,13 +148,16 @@ CXformExpandNAryJoinDPv2::Transform
 	// Retrieve top K join orders from jodp and add as alternatives
 	CExpression *nextJoinOrder = NULL;
 
-	while (NULL != (nextJoinOrder = jodp.GetNextOfTopK()))
+	while (NULL != (nextJoinOrder = jodp.GetNextOfTopK(jodp.m_top_k_expressions)) ||
+		   NULL != (nextJoinOrder = jodp.GetNextOfTopK(jodp.m_top_k_part_expressions)))
 	{
 		CExpression *pexprNormalized = CNormalizer::PexprNormalize(mp, nextJoinOrder);
 
 		nextJoinOrder->Release();
 		pxfres->Add(pexprNormalized);
 	}
+
+
 }
 
 // EOF

--- a/src/backend/gporca/libgpopt/src/xforms/CXformExpandNAryJoinDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformExpandNAryJoinDPv2.cpp
@@ -156,7 +156,6 @@ CXformExpandNAryJoinDPv2::Transform
 		pxfres->Add(pexprNormalized);
 	}
 
-
 }
 
 // EOF

--- a/src/backend/gporca/libgpopt/src/xforms/CXformExpandNAryJoinDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformExpandNAryJoinDPv2.cpp
@@ -148,8 +148,7 @@ CXformExpandNAryJoinDPv2::Transform
 	// Retrieve top K join orders from jodp and add as alternatives
 	CExpression *nextJoinOrder = NULL;
 
-	while (NULL != (nextJoinOrder = jodp.GetNextOfTopK(jodp.m_top_k_expressions)) ||
-		   NULL != (nextJoinOrder = jodp.GetNextOfTopK(jodp.m_top_k_part_expressions)))
+	while (NULL != (nextJoinOrder = jodp.GetNextOfTopK()))
 	{
 		CExpression *pexprNormalized = CNormalizer::PexprNormalize(mp, nextJoinOrder);
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -2892,6 +2892,7 @@ CXformUtils::PexprBuildIndexPlan
 	GPOS_ASSERT_IMP(!fDynamicGet, NULL == ppartcnstrIndex);
 
 	CTableDescriptor *ptabdesc = CLogical::PtabdescFromTableGet(pexprGet->Pop());
+	GPOS_ASSERT(NULL != ptabdesc);
 	CColRefArray *pdrgpcrOutput = NULL;
 	CWStringConst *alias = NULL;
 	ULONG ulPartIndex = gpos::ulong_max;
@@ -3927,6 +3928,7 @@ CXformUtils::PexprSelect2BitmapBoolOp
 	CLogical *popGet = CLogical::PopConvert(pexprRelational->Pop());
 
 	CTableDescriptor *ptabdesc = CLogical::PtabdescFromTableGet(popGet);
+	GPOS_ASSERT(NULL != ptabdesc);
 	const ULONG ulIndices = ptabdesc->IndexCount();
 	if (0 == ulIndices)
 	{

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -2891,7 +2891,7 @@ CXformUtils::PexprBuildIndexPlan
 	BOOL fDynamicGet = (COperator::EopLogicalDynamicGet == op_id);
 	GPOS_ASSERT_IMP(!fDynamicGet, NULL == ppartcnstrIndex);
 
-	CTableDescriptor *ptabdesc = CLogical::PtabdescFromTableGet(pexprGet->Pop());
+	CTableDescriptor *ptabdesc = pexprGet->DeriveTableDescriptor();
 	GPOS_ASSERT(NULL != ptabdesc);
 	CColRefArray *pdrgpcrOutput = NULL;
 	CWStringConst *alias = NULL;
@@ -3927,7 +3927,7 @@ CXformUtils::PexprSelect2BitmapBoolOp
 	CExpression *pexprScalar = (*pexpr)[1];
 	CLogical *popGet = CLogical::PopConvert(pexprRelational->Pop());
 
-	CTableDescriptor *ptabdesc = CLogical::PtabdescFromTableGet(popGet);
+	CTableDescriptor *ptabdesc = pexprRelational->DeriveTableDescriptor();
 	GPOS_ASSERT(NULL != ptabdesc);
 	const ULONG ulIndices = ptabdesc->IndexCount();
 	if (0 == ulIndices)

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -1256,7 +1256,7 @@ CStatisticsUtils::DeriveStatsForBitmapTableGet
 {
 	GPOS_ASSERT(CLogical::EopLogicalBitmapTableGet == expr_handle.Pop()->Eopid() ||
 				CLogical::EopLogicalDynamicBitmapTableGet == expr_handle.Pop()->Eopid());
-	CTableDescriptor *table_descriptor = CLogical::PtabdescFromTableGet(expr_handle.Pop());
+	CTableDescriptor *table_descriptor = expr_handle.DeriveTableDescriptor();
 
 	// the index of the condition
 	ULONG child_cond_index = 0;


### PR DESCRIPTION
Orca's DP algorithms currently generate logical alternatives based only on cardinality; they do not take into account motions/partition selectors as these are physical properties handled later in the optimization process. Since DPv2 doesn't generate all possible alternatives for the optimization stage, we end up generating alternatives that do not support partition selection or can only place poor partition selectors.

This PR introduces partition knowledge into the DPv2 algorithm. If there is a possible partition selector, it will generate an alternative that considers it, in addition to the previous alternatives.

We introduce new properties, m_contain_PS  to indicate whether a SExpressionInfo contains a PS for a particular expression. We consider an expression to have a possible partition selector if the join expression columns and the partition table's partition key overlap. If they do, we mark this expression as containing a PS for a particular PT.

We consider a good PS one which is selective. Eg:
```
- DynamicTableScan
- PartitionSelector
   -TableSelector
     - SomePredicate
```

would be selective. However, if there is no selective predicate, we do not consider this as a promising PS.

For now, we add just a single alternative that satisfies this property and only consider linear trees.

This still has a few TODOs I'd like to fix, namely cleaning up `PtabdescFromTableGet()`
 and `PoutputColsFromTableGet()`, tuning the internal broadcast cost more, and adding some test cases, but I'd like to get feedback on general algorithm changes we may want to make first. 