### PR TITLE
resgroup: fix the cpu value of the per host status view

### DIFF
--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -1843,7 +1843,7 @@ CREATE VIEW gp_toolkit.gp_resgroup_status_per_host AS
         s.rsgname
       , s.groupid
       , c.hostname
-      , sum((s.cpu                       )::text::numeric) AS cpu
+      , round(avg((s.cpu)::text::numeric), 2) AS cpu
       , sum((s.memory->'used'            )::text::integer) AS memory_used
       , sum((s.memory->'available'       )::text::integer) AS memory_available
       , sum((s.memory->'quota_used'      )::text::integer) AS memory_quota_used


### PR DESCRIPTION
Resource group we does not distinguish the per segment cpu usage, the
cpu usage reported by a segment is actually the total cpu usage of all
the segments on the host.  This is by design, not a bug.  However, in
the gp_toolkit.gp_resgroup_status_per_host view it reports the cpu usage
as the sum of all the segments on the same host, so the reported per
host cpu usage is actually N times of the actual usage, where N is the
count of the segments on that host.

Fixed by reporting the avg() instead of the sum().

Tests are not provided as the resgroup/resgroup_views did not verify cpu
usages since the beginning, because the cpu usage is unstable on
pipelines.  However, I have verified manually.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
