### PR TITLE
Fix dbid inconsistency on spread mirroring

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1436,7 +1436,7 @@ CREATE_SEGMENT () {
 
 REGISTER_MIRRORS () {
 		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
-		for I in "${QE_MIRROR_ARRAY[@]}"
+		for I in "${QE_MIRROR_ARRAY_SORTED_ON_CONTENT_ID[@]}"
 		do
 			SET_VAR $I
 			dbid=`env PGOPTIONS="-c gp_role=utility" $PSQL -p $MASTER_PORT -d "${DEFAULTDB}" -X -A -t -c "select pg_catalog.gp_add_segment_mirror(${GP_CONTENT}::int2, '${GP_HOSTNAME}', '${GP_HOSTADDRESS}', ${GP_PORT}, '${GP_DIR}');" 2>/dev/null` >> $LOG_FILE 2>&1
@@ -1444,7 +1444,7 @@ REGISTER_MIRRORS () {
 			MIRRORS_UPDATED_DBID=(${MIRRORS_UPDATED_DBID[@]} ${GP_HOSTADDRESS}~${GP_PORT}~${GP_DIR}~${dbid}~${GP_CONTENT})
 		done
 
-		QE_MIRROR_ARRAY=(${MIRRORS_UPDATED_DBID[@]})
+		QE_MIRROR_ARRAY_SORTED_ON_CONTENT_ID=(${MIRRORS_UPDATED_DBID[@]})
 		LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 


### PR DESCRIPTION
This commit fixes an inaccuracy from [4bfa1f9872b08d7b5f62348926f31fffcfcdb1a8](https://github.com/greenplum-db/gpdb/commit/4bfa1f9872b08d7b5f62348926f31fffcfcdb1a8).
Mirror registration passes through several steps at the moment:

1. CREATE_QE_ARRAY (QE_MIRROR_ARRAY is ordered by content)
2. ARRAY_REORDER (QE_MIRROR_ARRAY is ordered by port)
3. CREATE_ARRAY_SORTED_ON_CONTENT_ID (form QE_MIRROR_ARRAY_SORTED_ON_CONTENT_ID
   on a base of QE_MIRROR_ARRAY)
4. REGISTER_MIRRORS (walk through QE_MIRROR_ARRAY, register mirrors with
   pg_catalog.gp_add_segment_mirror on master's gp_segment_configuration
   and update QE_MIRROR_ARRAY with returned dbids)
5. CREATE_SEGMENT (walk through QE_MIRROR_ARRAY_SORTED_ON_CONTENT_ID with old
   dbids and create mirrors on segment hosts with pg_basebackup)

The problem is in a step 4 - we update the wrong array (QE_MIRROR_ARRAY instead of QE_MIRROR_ARRAY_SORTED_ON_CONTENT_ID). Because of that we get inconsistency between mirror dbids on gp_segment_configuration and internal.auto.conf files. This can cause inoperable cluster state in some situations when we promote a failed primary from a mirror with wrong dbids (FTS can't solve this issue).

This PR should be back ported to 6X_STABLE.

