### PR TITLE
Don't dispatch SET to idle segments, in a transaction

### DIFF
--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -336,3 +336,25 @@ INFO:  iteration:3 unsafe truncate performed
  
 (1 row)
 
+-- test for not dispatching GUCs, which may need updates committed, to idle segments
+BEGIN ISOLATION LEVEL REPEATABLE READ;
+CREATE TABLE guc_gp_test_table (
+        stringu1        name
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'stringu1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT length(stringu1) FROM guc_gp_test_table GROUP BY length(stringu1);
+ length 
+--------
+(0 rows)
+
+DROP ROLE IF EXISTS guc_gp_test_role;
+NOTICE:  role "guc_gp_test_role" does not exist, skipping
+CREATE ROLE guc_gp_test_role;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+SET ROLE guc_gp_test_role;   -- it reported role doesn't exist here
+RESET SESSION AUTHORIZATION;
+DROP ROLE guc_gp_test_role;
+RESET ROLE;
+DROP TABLE guc_gp_test_table;
+END;

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -358,3 +358,41 @@ DROP ROLE guc_gp_test_role;
 RESET ROLE;
 DROP TABLE guc_gp_test_table;
 END;
+SET search_path to 'public';
+CREATE TABLE guc_gp_t1(c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO guc_gp_t1 SELECT generate_series(1,100),generate_series(51,150);
+CREATE TABLE guc_gp_t2 AS SELECT * FROM guc_gp_t1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+BEGIN;
+CREATE SCHEMA guc_gp;
+CREATE TABLE guc_gp.guc_gp_t3 AS SELECT * FROM guc_gp_t1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE guc_gp.guc_gp_t4 AS SELECT * FROM guc_gp_t1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT sum(guc_gp_t1.c1) FROM guc_gp_t1,guc_gp_t2;
+  sum   
+--------
+ 505000
+(1 row)
+
+SET search_path to 'guc_gp';
+SELECT sum(guc_gp_t3.c1) FROM guc_gp_t3,guc_gp_t4;
+  sum   
+--------
+ 505000
+(1 row)
+
+ROLLBACK;
+SELECT sum(guc_gp_t1.c1) FROM guc_gp_t1,guc_gp_t2;
+  sum   
+--------
+ 505000
+(1 row)
+
+DROP TABLE guc_gp_t1;
+DROP TABLE guc_gp_t2;

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -237,3 +237,23 @@ RESET ROLE;
 DROP TABLE guc_gp_test_table;
 
 END;
+
+SET search_path to 'public';
+
+CREATE TABLE guc_gp_t1(c1 int, c2 int);
+INSERT INTO guc_gp_t1 SELECT generate_series(1,100),generate_series(51,150);
+CREATE TABLE guc_gp_t2 AS SELECT * FROM guc_gp_t1;
+
+BEGIN;
+CREATE SCHEMA guc_gp;
+CREATE TABLE guc_gp.guc_gp_t3 AS SELECT * FROM guc_gp_t1;
+CREATE TABLE guc_gp.guc_gp_t4 AS SELECT * FROM guc_gp_t1;
+
+SELECT sum(guc_gp_t1.c1) FROM guc_gp_t1,guc_gp_t2;
+SET search_path to 'guc_gp';
+SELECT sum(guc_gp_t3.c1) FROM guc_gp_t3,guc_gp_t4;
+ROLLBACK;
+
+SELECT sum(guc_gp_t1.c1) FROM guc_gp_t1,guc_gp_t2;
+DROP TABLE guc_gp_t1;
+DROP TABLE guc_gp_t2;

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -219,3 +219,21 @@ $$
 $$ language plpythonu;
 
 select run_all_in_one();
+
+-- test for not dispatching GUCs, which may need updates committed, to idle segments
+BEGIN ISOLATION LEVEL REPEATABLE READ;
+
+CREATE TABLE guc_gp_test_table (
+        stringu1        name
+);
+SELECT length(stringu1) FROM guc_gp_test_table GROUP BY length(stringu1);
+
+DROP ROLE IF EXISTS guc_gp_test_role;
+CREATE ROLE guc_gp_test_role;
+SET ROLE guc_gp_test_role;   -- it reported role doesn't exist here
+RESET SESSION AUTHORIZATION;
+DROP ROLE guc_gp_test_role;
+RESET ROLE;
+DROP TABLE guc_gp_test_table;
+
+END;


### PR DESCRIPTION
Don't do this if we are inside a valid transaction, in which case the
SET may fail because it requires some updates committed.

It will be set after transaction or subtransaction commit if it needs to
be synced, checkout AtEOXact_GUC() and gp_guc_restore_list.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
