### PR TITLE
Fix wrong results on multiphase aggregation with ORDER BY

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2223,14 +2223,19 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 				 * change the previous root->parse Query node, which makes the
 				 * current sort_pathkeys invalid.
 				 */
+				PlannerInfo *subroot = makeNode(PlannerInfo);
+
+				memcpy(subroot, root, sizeof(PlannerInfo));
+				subroot->eq_classes = NULL;
+
 				if (parse->distinctClause)
 					root->distinct_pathkeys =
-						make_pathkeys_for_sortclauses(root,
+						make_pathkeys_for_sortclauses(subroot,
 													  parse->distinctClause,
 													  result_plan->targetlist);
 				if (parse->sortClause)
 					root->sort_pathkeys =
-						make_pathkeys_for_sortclauses(root,
+						make_pathkeys_for_sortclauses(subroot,
 													  parse->sortClause,
 													  result_plan->targetlist);
 			}

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1664,6 +1664,49 @@ select count(distinct t), count(distinct t2) from int2vectortab;
      4 |     5
 (1 row)
 
+-- Test if the correct EC is used after cdb_grouping_planner changes the parsetree
+drop table if exists t;
+create table t (a int, b int, c int) distributed by(b);
+insert into t select 1, i, i from generate_series(1,10)i;
+analyze t;
+explain (costs off)
+select c, count(*) from t where a = 1 group by 1 order by 1;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Merge Key: t.c
+   ->  Sort
+         Sort Key: t.c
+         ->  GroupAggregate
+               Group Key: t.c
+               ->  Sort
+                     Sort Key: t.c
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: t.c
+                           ->  GroupAggregate
+                                 Group Key: t.c
+                                 ->  Sort
+                                       Sort Key: t.c
+                                       ->  Seq Scan on t
+                                             Filter: (a = 1)
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+select c, count(*) from t where a = 1 group by 1 order by 1;
+ c  | count 
+----+-------
+  1 |     1
+  2 |     1
+  3 |     1
+  4 |     1
+  5 |     1
+  6 |     1
+  7 |     1
+  8 |     1
+  9 |     1
+ 10 |     1
+(10 rows)
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1664,6 +1664,43 @@ select count(distinct t), count(distinct t2) from int2vectortab;
      4 |     5
 (1 row)
 
+-- Test if the correct EC is used after cdb_grouping_planner changes the parsetree
+drop table if exists t;
+create table t (a int, b int, c int) distributed by(b);
+insert into t select 1, i, i from generate_series(1,10)i;
+analyze t;
+explain (costs off)
+select c, count(*) from t where a = 1 group by 1 order by 1;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Merge Key: c
+   ->  GroupAggregate
+         Group Key: c
+         ->  Sort
+               Sort Key: c
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: c
+                     ->  Seq Scan on t
+                           Filter: (a = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select c, count(*) from t where a = 1 group by 1 order by 1;
+ c  | count 
+----+-------
+  1 |     1
+  2 |     1
+  3 |     1
+  4 |     1
+  5 |     1
+  6 |     1
+  7 |     1
+  8 |     1
+  9 |     1
+ 10 |     1
+(10 rows)
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1413,6 +1413,17 @@ select count(*) over (partition by t) from int2vectortab;
 select count(distinct t) from int2vectortab;
 select count(distinct t), count(distinct t2) from int2vectortab;
 
+-- Test if the correct EC is used after cdb_grouping_planner changes the parsetree
+drop table if exists t;
+create table t (a int, b int, c int) distributed by(b);
+
+insert into t select 1, i, i from generate_series(1,10)i;
+analyze t;
+
+explain (costs off)
+select c, count(*) from t where a = 1 group by 1 order by 1;
+select c, count(*) from t where a = 1 group by 1 order by 1;
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;


### PR DESCRIPTION
In the multiphase aggregation logic, cdb_grouping_planner would change
the parsetree, especially the range table list and targetlist. But for
EquivalenceClasses, their expressions are not changed accordingly, and
they are still based on the original range table list. As a result, when
we apply ORDER BY above the multiphase aggregation, in high possibility
we would be using the wrong EC for pathkey.

This PR clones a new root and resets its EC list when re-writing
sort_pathkeys, which is very hacky but works for this case.

Fixes issue #10231

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
