### PR TITLE
Fix flakiness of "select 1" output after master reset due to injected…

### DIFF
--- a/src/test/isolation2/expected/crash_recovery.out
+++ b/src/test/isolation2/expected/crash_recovery.out
@@ -76,8 +76,13 @@ CHECKPOINT
 -----------------
  Success:        
 (1 row)
+-- verify master panic happens. The PANIC message does not emit sometimes so
+-- mask it.
+-- start_matchsubs
+-- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- end_matchsubs
 1:select 1;
-PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
+++ b/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
@@ -57,15 +57,16 @@ CHECKPOINT
 -----------------
  Success:        
 (1 row)
--- start_ignore
--- We ignore the output here because PANIC output is intermittent and is
--- unrelated to this test. Test simply cares to trigger fault.
+-- verify master panic happens. The PANIC message does not emit sometimes so
+-- mask it.
+-- start_matchsubs
+-- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- end_matchsubs
 1:select 1;
-PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
--- end_ignore
 
 2<:  <... completed>
 server closed the connection unexpectedly

--- a/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
+++ b/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
@@ -65,8 +65,13 @@ CREATE
 -----------------
  Success:        
 (1 row)
+-- verify master panic happens. The PANIC message does not emit sometimes so
+-- mask it.
+-- start_matchsubs
+-- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- end_matchsubs
 3: select 1;
-PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/sql/crash_recovery.sql
+++ b/src/test/isolation2/sql/crash_recovery.sql
@@ -29,6 +29,12 @@
 
 -- trigger crash
 1:select gp_inject_fault('before_read_command', 'panic', 1);
+-- verify master panic happens. The PANIC message does not emit sometimes so
+-- mask it.
+-- start_matchsubs
+-- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- end_matchsubs
 1:select 1;
 
 2<:

--- a/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
+++ b/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
@@ -20,11 +20,13 @@
 1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 1, 1);
 -- trigger crash
 1:select gp_inject_fault('before_read_command', 'panic', 1);
--- start_ignore
--- We ignore the output here because PANIC output is intermittent and is
--- unrelated to this test. Test simply cares to trigger fault.
+-- verify master panic happens. The PANIC message does not emit sometimes so
+-- mask it.
+-- start_matchsubs
+-- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- end_matchsubs
 1:select 1;
--- end_ignore
 
 2<:
 

--- a/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
+++ b/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
@@ -40,6 +40,12 @@ $$ language plpgsql;
 3: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE content=0 AND role = 'm';
 -- trigger master reset
 3: select gp_inject_fault('before_read_command', 'panic', 1);
+-- verify master panic happens. The PANIC message does not emit sometimes so
+-- mask it.
+-- start_matchsubs
+-- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- end_matchsubs
 3: select 1;
 
 -- wait for master finish crash recovery


### PR DESCRIPTION
… panic fault before_read_command

Several tests inject panic in before_read_command to trigger master reset.
Previous we run "select 1" after the fault inject query to verify, but the
output is not deterministic sometimes. i.e. sometimes we do not see the line

PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'

This was actually observed in test crash_recovery_redundant_dtx per commit
message and test comment.  It ignores the output of "select 1", but probably
we still want the output to verify the fault is encountered.

It's still mysterious why sometimes the PANIC message is missing. I spent some
time on digging but reckon that I can not root cause in short time. One guess
is that the PANIC message was although sent to the frontend in errfinish() but
the kernel buffer-ed data was dropped after abort() due to ereport(PANIC);
Another guess is something wrong related to libpq protocol (not saying it's a
libpq bug).  In any case, it does not deserve much time to work on the tests
only, so simply mask the PANIC message to make the test result deterministic
and also not affect the test purpose.