### PR TITLE
Change branch for test_gpdb_6X slack command

### DIFF
--- a/src/backend/gporca/concourse/test_orca_pipeline.yml
+++ b/src/backend/gporca/concourse/test_orca_pipeline.yml
@@ -12,7 +12,7 @@ resources:
 - name: gporca-commits-to-test
   type: git
   source:
-    branch: test-gpdb
+    branch: test-gpdb-6X
     uri: https://github.com/greenplum-db/gporca-pipeline-misc
 
 - name: gpdb6-centos7-build


### PR DESCRIPTION
Previously, we used the same slack command for master and 6X. Now we
have separate slack commands, and need to look in separate branches.

