### PR TITLE
Docs - Add materialized view info to psql \d reference content

### DIFF
--- a/gpdb-doc/dita/utility_guide/ref/psql.xml
+++ b/gpdb-doc/dita/utility_guide/ref/psql.xml
@@ -450,12 +450,12 @@ testdb=#</codeblock>
         <plentry>
           <pt>\d [<varname>relation_pattern</varname>]  | \d+ [<varname>relation_pattern</varname>]
             | \dS [<varname>relation_pattern</varname>]</pt>
-          <pd>For each relation (table, external table, view, index, sequence, or foreign table) or
-            composite type matching the relation pattern, show all columns, their types, the
-            tablespace (if not the default) and any special attributes such as <codeph>NOT
-              NULL</codeph> or defaults. Associated indexes, constraints, rules, and triggers are
-            also shown. For foreign tables, the associated foreign server is shown as well.<ul
-              id="ul_qda_zxh_no">
+          <pd>For each relation (table, external table, view, materialized view, index, sequence, or
+            foreign table) or composite type matching the relation pattern, show all columns, their
+            types, the tablespace (if not the default) and any special attributes such as
+              <codeph>NOT NULL</codeph> or defaults. Associated indexes, constraints, rules, and
+            triggers are also shown. For foreign tables, the associated foreign server is shown as
+              well.<ul id="ul_qda_zxh_no">
               <li>For some types of relation, <codeph>\d</codeph> shows additional information for
                 each column: column values for sequences, indexed expressions for indexes, and
                 foreign data wrapper options for foreign tables.</li>
@@ -474,8 +474,8 @@ testdb=#</codeblock>
               <li id="kb151095">By default, only user-created objects are shown; supply a pattern or
                 the <codeph>S</codeph> modifier to include system objects. <note>If
                     <codeph>\d</codeph> is used without a pattern argument, it is equivalent to
-                    <codeph>\dtvsE</codeph> which will show a list of all visible tables, views,
-                  sequences, and foreign tables.</note></li>
+                    <codeph>\dtvmsE</codeph> which will show a list of all visible tables, views,
+                  materialized views, sequences, and foreign tables.</note></li>
             </ul></pd>
         </plentry>
         <plentry>
@@ -539,18 +539,19 @@ testdb=#</codeblock>
             description.</pd>
         </plentry>
         <plentry>
-          <pt>\dEistPv[S+] [<varname>external_table | index | sequence | table | parent table |
-              view</varname>] </pt>
+          <pt>\dEimstPv[S+] [<varname>external_table | index | materialized_view | sequence | table
+              | parent table | view</varname>] </pt>
           <pd>This is not the actual command name: the letters <codeph>E</codeph>,
-              <codeph>i</codeph>, <codeph>s</codeph>, <codeph>t</codeph>, <codeph>P</codeph>, and
-              <codeph>v</codeph> stand for external table, index, sequence, table, parent table, and
-            view, respectively. You can specify any or all of these letters, in any order, to obtain
-            a listing of objects of these types. For example, <codeph>\dit</codeph> lists indexes
-            and tables. If <codeph>+</codeph> is appended to the command name, each object is listed
-            with its physical size on disk and its associated description, if any. If a pattern is
-            specified, only objects whose names match the pattern are listed. By default, only
-            user-created objects are shown; supply a pattern or the <codeph>S</codeph> modifier to
-            include system objects.</pd>
+              <codeph>i</codeph>, <codeph>m</codeph>, <codeph>s</codeph>, <codeph>t</codeph>,
+              <codeph>P</codeph>, and <codeph>v</codeph> stand for external table, index,
+            materialized view, sequence, table, parent table, and view, respectively. You can
+            specify any or all of these letters, in any order, to obtain a listing of objects of
+            these types. For example, <codeph>\dit</codeph> lists indexes and tables. If
+              <codeph>+</codeph> is appended to the command name, each object is listed with its
+            physical size on disk and its associated description, if any. If a pattern is specified,
+            only objects whose names match the pattern are listed. By default, only user-created
+            objects are shown; supply a pattern or the <codeph>S</codeph> modifier to include system
+            objects.</pd>
         </plentry>
         <plentry>
           <pt>\des[+] [<varname>foreign_server_pattern</varname>] </pt>


### PR DESCRIPTION
Adapted from postgres 9.4 psql page.