### PR TITLE
Fix flaky test exttab1 and pxf_fdw

### DIFF
--- a/gpcontrib/pxf_fdw/expected/pxf_fdw_foreign_table.out
+++ b/gpcontrib/pxf_fdw/expected/pxf_fdw_foreign_table.out
@@ -73,7 +73,7 @@ CREATE FOREIGN TABLE pxf_fdw_test_table_with_newline (id int, name text)
 --
 CREATE FOREIGN TABLE pxf_fdw_test_table_with_fill_missing_fields (id int, name text)
     SERVER pxf_fdw_test_server
-    OPTIONS ( resource '/path/to/resource', fill_missing_fields '');
+    OPTIONS ( resource '/path/to/resource', fill_missing_fields 'true');
 --
 -- Table creation succeeds if force_null is provided on column definition
 --
@@ -246,7 +246,7 @@ ALTER FOREIGN TABLE pxf_fdw_test_table_with_newline
 -- Table alteration succeeds when fill_missing_fields is provided
 --
 ALTER FOREIGN TABLE pxf_fdw_test_table_with_fill_missing_fields
-    OPTIONS ( SET fill_missing_fields '' );
+    OPTIONS ( SET fill_missing_fields 'true' );
 --
 -- Table alteration succeeds when force_null is provided on column definition
 --

--- a/gpcontrib/pxf_fdw/sql/pxf_fdw_foreign_table.sql
+++ b/gpcontrib/pxf_fdw/sql/pxf_fdw_foreign_table.sql
@@ -80,7 +80,7 @@ CREATE FOREIGN TABLE pxf_fdw_test_table_with_newline (id int, name text)
 --
 CREATE FOREIGN TABLE pxf_fdw_test_table_with_fill_missing_fields (id int, name text)
     SERVER pxf_fdw_test_server
-    OPTIONS ( resource '/path/to/resource', fill_missing_fields '');
+    OPTIONS ( resource '/path/to/resource', fill_missing_fields 'true');
 
 --
 -- Table creation succeeds if force_null is provided on column definition
@@ -269,7 +269,7 @@ ALTER FOREIGN TABLE pxf_fdw_test_table_with_newline
 -- Table alteration succeeds when fill_missing_fields is provided
 --
 ALTER FOREIGN TABLE pxf_fdw_test_table_with_fill_missing_fields
-    OPTIONS ( SET fill_missing_fields '' );
+    OPTIONS ( SET fill_missing_fields 'true' );
 
 --
 -- Table alteration succeeds when force_null is provided on column definition

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1521,7 +1521,7 @@ ProcessCopyOptions(CopyState cstate,
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("conflicting or redundant options")));
-			cstate->fill_missing = intVal(defel->arg);
+			cstate->fill_missing = defGetBoolean(defel);
 		}
 		else if (strcmp(defel->defname, "newline") == 0)
 		{


### PR DESCRIPTION
The flaky case happens when select an external table with option
"fill missing fields". By gdb the qe, this value is not false
on QE sometimes. When ProcessCopyOptions, we use intVal(defel->arg)
to parse the boolean value, which is not correct. Using defGetBoolean
to replace it.
Also fix a pxf_fdw test case, which should set fill_missing_fields to true
explicitly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
