### PR TITLE
Mark mirror down if replication keeps crash.

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -137,7 +137,7 @@ int gp_fts_mark_mirror_down_grace_period = 30;
 
 /*
  * If primary-mirror replication attempts to connect continuously and exceed
- * this count, mark the mirror down dirextly.
+ * this count, mark the mirror down.
  */
 int			gp_fts_replication_attempt_count = 10;
 

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -136,6 +136,12 @@ int			gp_fts_probe_interval = 60;
 int gp_fts_mark_mirror_down_grace_period = 30;
 
 /*
+ * If primary-mirror replication attempts to connect continuously and exceed
+ * this count, mark the mirror down dirextly.
+ */
+int			gp_fts_replication_attempt_count = 10;
+
+/*
  * When we have certain types of failures during gang creation which indicate
  * that a segment is in recovery mode we may be able to retry.
  */

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -300,6 +300,7 @@ HandleFtsWalRepSyncRepOff(void)
 	ereport(LOG,
 			(errmsg("turning off synchronous wal replication due to FTS request")));
 	UnsetSyncStandbysDefined();
+	ReplicationSlotClearAttemptCount(INTERNAL_WAL_REPLICATION_SLOT_NAME);
 	GetMirrorStatus(&response);
 
 	SendFtsResponse(&response, FTS_MSG_SYNCREP_OFF);
@@ -333,7 +334,10 @@ CreateReplicationSlotOnPromote(const char *name)
 		ReplicationSlotCreate(name, false, RS_PERSISTENT);
 	}
 	else
+	{
 		ereport(LOG, (errmsg("replication slot %s exists", name)));
+		ReplicationSlotClearAttemptCount(name);
+	}
 
 	/*
 	 * Only on promote signal replication slot is created on mirror. If

--- a/src/backend/fts/test/ftsmessagehandler_test.c
+++ b/src/backend/fts/test/ftsmessagehandler_test.c
@@ -105,6 +105,9 @@ test_HandleFtsWalRepSyncRepOff(void **state)
 
 	will_be_called(UnsetSyncStandbysDefined);
 
+	expect_value(ReplicationSlotClearAttemptCount, name, INTERNAL_WAL_REPLICATION_SLOT_NAME);
+	will_be_called(ReplicationSlotClearAttemptCount);
+
 	/* since this function doesn't have any logic, the test just verified the message type */
 	expectSendFtsResponse(FTS_MSG_SYNCREP_OFF, &mockresponse);
 	

--- a/src/backend/replication/slot.c
+++ b/src/backend/replication/slot.c
@@ -571,7 +571,7 @@ ReplicationSlotMarkDirty(void)
 
 /*
  * For GPDB FTS purpose, retrieve how many replication connection attempts
- * to crate replication connection.
+ * to create replication connection.
  */
 uint32
 ReplicationSlotRetrieveAttemptCount(const char *name)

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3560,6 +3560,16 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
+		{"gp_fts_replication_attempt_count", PGC_SIGHUP, GP_ARRAY_TUNING,
+			gettext_noop("Primary-mirror replication connection max continuously attempt count for FTS"),
+			gettext_noop("Used by the fts-probe process.")
+		},
+		&gp_fts_replication_attempt_count,
+		10, 0, 100,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"gp_gang_creation_retry_count", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("After a gang-creation fails, retry the number of times if failure is retryable."),
 			gettext_noop("A value of zero disables retries."),

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -247,7 +247,8 @@ extern int	gp_snapshotadd_timeout; /* GUC var - timeout specifier for snapshot-c
 extern int	gp_fts_probe_retries; /* GUC var - specifies probe number of retries for FTS */
 extern int	gp_fts_probe_timeout; /* GUC var - specifies probe timeout for FTS */
 extern int	gp_fts_probe_interval; /* GUC var - specifies polling interval for FTS */
-extern int gp_fts_mark_mirror_down_grace_period;
+extern int	gp_fts_mark_mirror_down_grace_period;
+extern int	gp_fts_replication_attempt_count; /* GUC var - specifies replication max attempt count for FTS */
 
 extern int gp_gang_creation_retry_count; /* How many retries ? */
 extern int gp_gang_creation_retry_timer; /* How long between retries */

--- a/src/include/replication/slot.h
+++ b/src/include/replication/slot.h
@@ -98,7 +98,7 @@ typedef struct ReplicationSlot
 
 	/*
 	 * For GPDB FTS purpose, if the the primary, mirror replication keeps crash
-	 * continuously and attempt to crate replication connection too many times,
+	 * continuously and attempt to create replication connection too many times,
 	 * FTS should mark the mirror down.
 	 * If the connection established, clear the attempt count to 0.
 	 */

--- a/src/include/replication/slot.h
+++ b/src/include/replication/slot.h
@@ -97,6 +97,14 @@ typedef struct ReplicationSlot
 	bool		dirty;
 
 	/*
+	 * For GPDB FTS purpose, if the the primary, mirror replication keeps crash
+	 * continuously and attempt to crate replication connection too many times,
+	 * FTS should mark the mirror down.
+	 * If the connection established, clear the attempt count to 0.
+	 */
+	pg_atomic_uint32	con_attempt_count;
+
+	/*
 	 * For logical decoding, it's extremely important that we never remove any
 	 * data that's still needed for decoding purposes, even after a crash;
 	 * otherwise, decoding will produce wrong answers.  Ordinary streaming
@@ -169,6 +177,9 @@ extern void ReplicationSlotAcquire(const char *name);
 extern void ReplicationSlotRelease(void);
 extern void ReplicationSlotSave(void);
 extern void ReplicationSlotMarkDirty(void);
+
+extern uint32 ReplicationSlotRetrieveAttemptCount(const char *name);
+extern void ReplicationSlotClearAttemptCount(const char *name);
 
 /* misc stuff */
 extern bool ReplicationSlotValidateName(const char *name, int elevel);

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -191,6 +191,7 @@
 		"gp_fts_probe_interval",
 		"gp_fts_probe_retries",
 		"gp_fts_probe_timeout",
+		"gp_fts_replication_attempt_count",
 		"gp_gang_creation_retry_count",
 		"gp_gang_creation_retry_timer",
 		"gp_global_deadlock_detector_period",

--- a/src/test/isolation2/expected/segwalrep/replication_keeps_crash.out
+++ b/src/test/isolation2/expected/segwalrep/replication_keeps_crash.out
@@ -1,0 +1,87 @@
+-- Tests mark mirror down if replication walsender walreceiver keep
+-- crash continuously.
+--
+-- Primary and mirror both alive, but wal replication crash happens
+-- before start streaming data. And walsender, walreceiver keeps
+-- re-connect continuously, this may block other processes.
+-- Mark the mirror down to resolve it.
+
+include: helpers/server_helpers.sql;
+CREATE
+
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+ role | preferred_role | content | mode | status 
+------+----------------+---------+------+--------
+ m    | m              | -1      | s    | u      
+ m    | m              | 0       | s    | u      
+ m    | m              | 1       | s    | u      
+ m    | m              | 2       | s    | u      
+ p    | p              | -1      | n    | u      
+ p    | p              | 0       | s    | u      
+ p    | p              | 1       | s    | u      
+ p    | p              | 2       | s    | u      
+(8 rows)
+
+-- Error out before walsender streaming data
+select gp_inject_fault_infinite('wal_sender_loop', 'error', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Should block in commit (SyncrepWaitForLSN()), waiting for commit
+-- LSN to be flushed on mirror.
+1&: create table mirror_block_t1 (a int) distributed by (a);  <waiting ...>
+
+-- trigger failover
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+1<:  <... completed>
+CREATE
+
+-- expect: to see the content 0, mirror is mark down
+select content, preferred_role, role, status, mode from gp_segment_configuration where content = 0;
+ content | preferred_role | role | status | mode 
+---------+----------------+------+--------+------
+ 0       | p              | p    | u      | n    
+ 0       | m              | m    | d      | n    
+(2 rows)
+
+select gp_inject_fault('wal_sender_loop', 'reset', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- -- now, let's fully recover the mirror
+!\retcode gprecoverseg -aF  --no-progress;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+ role | preferred_role | content | mode | status 
+------+----------------+---------+------+--------
+ m    | m              | -1      | s    | u      
+ m    | m              | 0       | s    | u      
+ m    | m              | 1       | s    | u      
+ m    | m              | 2       | s    | u      
+ p    | p              | -1      | n    | u      
+ p    | p              | 0       | s    | u      
+ p    | p              | 1       | s    | u      
+ p    | p              | 2       | s    | u      
+(8 rows)
+
+drop table mirror_block_t1;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -184,6 +184,7 @@ test: segwalrep/die_commit_pending_replication
 
 # Tests for FTS
 test: fts_errors
+test: segwalrep/replication_keeps_crash
 test: segwalrep/commit_blocking
 test: segwalrep/fts_unblock_primary
 test: segwalrep/recoverseg_from_file

--- a/src/test/isolation2/sql/segwalrep/replication_keeps_crash.sql
+++ b/src/test/isolation2/sql/segwalrep/replication_keeps_crash.sql
@@ -1,0 +1,42 @@
+-- Tests mark mirror down if replication walsender walreceiver keep
+-- crash continuously.
+--
+-- Primary and mirror both alive, but wal replication crash happens
+-- before start streaming data. And walsender, walreceiver keeps
+-- re-connect continuously, this may block other processes.
+-- Mark the mirror down to resolve it.
+
+include: helpers/server_helpers.sql;
+
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+
+-- Error out before walsender streaming data
+select gp_inject_fault_infinite('wal_sender_loop', 'error', dbid)
+       from gp_segment_configuration where content=0 and role='p';
+
+-- Should block in commit (SyncrepWaitForLSN()), waiting for commit
+-- LSN to be flushed on mirror.
+1&: create table mirror_block_t1 (a int) distributed by (a);
+
+-- trigger failover
+select gp_request_fts_probe_scan();
+
+1<:
+
+-- expect: to see the content 0, mirror is mark down
+select content, preferred_role, role, status, mode
+from gp_segment_configuration
+where content = 0;
+
+select gp_inject_fault('wal_sender_loop', 'reset', dbid)
+       from gp_segment_configuration where content=0 and role='p';
+
+-- -- now, let's fully recover the mirror
+!\retcode gprecoverseg -aF  --no-progress;
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+
+drop table mirror_block_t1;


### PR DESCRIPTION
For GPDB FTS, if the primary, mirror replication keeps crash
continuously and attempt to crate replication connection too many times,
FTS should mark the mirror down. Otherwise, it may block other processes.
If the connection established, clear the attempt count to 0.

The solution for this is:
1. Use replication slot to track current continuously failure times for its primary-mirror replication.
    - the count gets reset once the replication starts streaming, or restarted.

2. When handling each probe query, `GetMirrorStatus` will check the current mirror status and the failure count from its replication slot. If the count exceeds the limit, the retry test will ignore the last replication connection time since it gets refreshed when new walsender starts.(since in current case, the walsender keeps restart.)

3. On FTS bgworker. If mirror down and retry set to false, mark the mirror down.

From the replication slot, it has two main usages:
1. For logical replication. https://www.postgresql.org/docs/current/logical-replication.html
2. Replication slots provide an automated way to ensure that the master does not remove WAL segments until they have been received by all standbys. https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION-SLOTS

So, use the replication slot to track replication failure times between standby seems not so bad?

We can not record the continuously failure for replication in FTS is because FTS only retrieves the mirror status from walsender. But walsender get restarted after a failure. There's no way to count the failure if the FTS sleeps and waits for the next probe. Since during the FTS sleep period, replication may be normal, start streaming, and crash again when the next FTS probe happens.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
