### PR TITLE
Increase retry count for pg_rewind tests' replication promotion and streaming.

### DIFF
--- a/src/bin/pg_rewind/sql/config_test.sh
+++ b/src/bin/pg_rewind/sql/config_test.sh
@@ -98,7 +98,7 @@ STANDBY_PG_CTL_OPTIONS="--gp_dbid=${STANDBY_DBID} -p ${PORT_STANDBY} $PG_CTL_COM
 MASTER_PG_CTL_STOP_MODE="fast"
 
 function wait_for_promotion {
-   retry=150
+   retry=600
    until [ $retry -le 0 ]
    do
       PGOPTIONS=${PGOPTIONS_UTILITY} ${1} -c "select 'promotion is done';" && return 0
@@ -118,7 +118,7 @@ function wait_until_master_is_promoted {
 }
 
 function wait_until_standby_streaming_state {
-   retry=150
+   retry=600
    until [ $retry -le 0 ]
    do
       PGOPTIONS=${PGOPTIONS_UTILITY} $STANDBY_PSQL -c "SELECT state FROM pg_stat_replication;" | grep 'streaming' > /dev/null && return 0


### PR DESCRIPTION
Increase the retry count to prevent test failed. Most of the time, the
failure is because of slow processing.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
