### PR TITLE
BACKPORT 6X: Fix flaky test terminate_in_gang_creation

### DIFF
--- a/src/test/isolation2/expected/terminate_in_gang_creation.out
+++ b/src/test/isolation2/expected/terminate_in_gang_creation.out
@@ -113,6 +113,9 @@ SELECT gp_wait_until_triggered_fault('fts_probe', 1, dbid) FROM gp_segment_confi
 CHECKPOINT;
 CHECKPOINT
 
+-- not recycle idle QEs to avoid the flaky test where restarting primary takes a long time.
+11: SET gp_vmem_idle_resource_timeout TO 0;
+SET
 11: CREATE TABLE foo (c1 int, c2 int) DISTRIBUTED BY (c1);
 CREATE
 -- ORCA optimizes value scan so there is no additional reader gang in below INSERT.
@@ -135,6 +138,8 @@ DETAIL:  lock [0,1260] AccessShareLock 0. Probably because writer gang is gone s
 INSERT 2
 11: DROP TABLE foo;
 DROP
+11: RESET gp_vmem_idle_resource_timeout;
+RESET
 
 SELECT gp_inject_fault('fts_probe', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
  gp_inject_fault 

--- a/src/test/isolation2/sql/terminate_in_gang_creation.sql
+++ b/src/test/isolation2/sql/terminate_in_gang_creation.sql
@@ -73,6 +73,8 @@ SELECT gp_wait_until_triggered_fault('fts_probe', 1, dbid)
 -- Prevent below pg_ctl restart timeout although the timeout should be enough.
 CHECKPOINT;
 
+-- not recycle idle QEs to avoid the flaky test where restarting primary takes a long time.
+11: SET gp_vmem_idle_resource_timeout TO 0;
 11: CREATE TABLE foo (c1 int, c2 int) DISTRIBUTED BY (c1);
 -- ORCA optimizes value scan so there is no additional reader gang in below INSERT.
 11: SET optimizer = off;
@@ -82,6 +84,7 @@ SELECT pg_ctl(datadir, 'restart', 'immediate')
 11: INSERT INTO foo values(2),(1);
 11: INSERT INTO foo values(2),(1);
 11: DROP TABLE foo;
+11: RESET gp_vmem_idle_resource_timeout;
 
 SELECT gp_inject_fault('fts_probe', 'reset', dbid)
 FROM gp_segment_configuration WHERE role='p' AND content=-1;


### PR DESCRIPTION
The test case restarts all primaries and expects the old session
would fail for the next query since gangs are cached.
But the restart may last more than 18s which is the max idle
time QEs could exist. In this case, the new query in the old
session will just fetch a new gang without expected errors.
Just set gp_vmem_idle_resource_timeout to 0 to fix this flaky test.

Reviewed-by: Paul Guo <pguo@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
