### PR TITLE
Greenplum 5 vendors krb5 1.6.2+vmware.1 

### DIFF
--- a/gpAux/releng/make/dependencies/ivy.sh
+++ b/gpAux/releng/make/dependencies/ivy.sh
@@ -22,7 +22,7 @@ if [ ! -d "${EXT_DIRECTORY}" ]; then
 fi
 
 while read line; do
-    if [[ $line =~ .*"${BUILD_STAGE}->"* && $line =~ ${REVISION} && $line =~ ${MODULE} && $line =~ ${ORG} ]]; then
+    if [[ $line =~ .*"${BUILD_STAGE}->"* && $line =~ "${REVISION}" && $line =~ ${MODULE} && $line =~ ${ORG} ]]; then
         line=`echo $line | cut -f5 -d "="`
         IFS=';' read -ra dependency <<< "$line"
         for i in "${dependency[@]}"; do

--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -18,7 +18,8 @@
       <dependency org="emc"             name="DDBoostSDK"      rev="3.3.0.4-550644" conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="gnu"             name="libstdc"         rev="6.0.22"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse11_x86_64;sles11_x86_64->suse11_x86_64" />
       <dependency org="third-party"     name="ext"             rev="1.1"            conf="win32->win32" />
-      <dependency org="third-party"     name="ext"             rev="gpdb5_ext-3.4"  conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
+      <dependency org="third-party"     name="ext"             rev="gpdb5_ext-3.5"  conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
+      <dependency org="mit"             name="krb5"            rev="1.6.2+vmware.1" conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64" />
       <dependency org="Hyperic"         name="sigar"           rev="1.6.5"          conf="rhel6_x86_64->rhel6_x86_64;rhel7_x86_64->rhel7_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="NetBackup"       name="SDK-7.7"         rev="7.7"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
       <dependency org="R-Project"       name="R"               rev="3.1.0"          conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse10_x86_64;sles11_x86_64->suse10_x86_64" />


### PR DESCRIPTION
since the newly createdmit/krb5/1.6.2+vmware.1 is available in Jfrog, and newly created version of third-party/ext/gpdb5_ext-3.5 no longer contains the unmodified krb5 1.6.2 and  newly created mit/krb5/1.6.2+vmware.1, so those two new artifacts will be downloaded and integrated.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
