### PR TITLE
For Python testing artifacts, introduce combination of Concourse cache and pip --cache-dir.

### DIFF
--- a/concourse/scripts/combine_cli_coverage.bash
+++ b/concourse/scripts/combine_cli_coverage.bash
@@ -27,7 +27,10 @@ read -r COMMIT_SHA < gpdb_src/.git/HEAD
 source ./gpdb_src/concourse/scripts/common.bash
 time install_gpdb
 
-pip install -r ./gpdb_src/gpMgmt/requirements-dev.txt
+# Set PIP Download cache directory
+export PIP_CACHE_DIR=${PWD}/pip-cache-dir
+
+pip --retries 10 install -r ./gpdb_src/gpMgmt/requirements-dev.txt
 
 # Save the JSON_KEY to a file, for later use by gsutil.
 keyfile=secret-key.json

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -60,7 +60,9 @@ function install_python_requirements_on_single_host() {
     # and is run by root user. Therefore, pip install as root user to make items globally
     # available
     local requirements_txt="$1"
-    pip install -r ${requirements_txt}
+
+    export PIP_CACHE_DIR=${PWD}/pip-cache-dir
+    pip --retries 10 install -r ${requirements_txt}
 }
 
 function install_python_requirements_on_multi_host() {
@@ -69,10 +71,13 @@ function install_python_requirements_on_multi_host() {
     # the user flag is required for centos 7
     local requirements_txt="$1"
 
-    pip install --user -r ${requirements_txt}
+    # Set PIP Download cache directory
+    export PIP_CACHE_DIR=/home/gpadmin/pip-cache-dir
+
+    pip --retries 10 install --user -r ${requirements_txt}
     while read -r host; do
        scp ${requirements_txt} "$host":/tmp/requirements.txt
-       ssh $host pip install --user -r /tmp/requirements.txt
+       ssh $host PIP_CACHE_DIR=${PIP_CACHE_DIR} pip --retries 10 install --user -r /tmp/requirements.txt
     done < /tmp/hostfile_all
 }
 

--- a/concourse/scripts/gsutil_sync
+++ b/concourse/scripts/gsutil_sync
@@ -43,7 +43,10 @@ gs_service_key_file = $(pwd)/$keyfile
 EOF
 export BOTO_CONFIG=$(pwd)/boto.cfg
 
-pip install -r ./gpdb_src/gpMgmt/requirements-dev.txt
+# Set PIP Download cache directory
+export PIP_CACHE_DIR="${PWD}/pip-cache-dir"
+
+pip --retries 10 install -r ./gpdb_src/gpMgmt/requirements-dev.txt
 
 # Trim a trailing slash from the source directory if it has one
 SOURCE_DIRECTORY="${1%/}"

--- a/concourse/tasks/behave_gpdb.yml
+++ b/concourse/tasks/behave_gpdb.yml
@@ -11,5 +11,7 @@ params:
   BEHAVE_FLAGS: ""
   BLDWRAP_POSTGRES_CONF_ADDONS: ""
   TEST_NAME: ""
+caches:
+  - path: pip-cache-dir
 run:
   path: gpdb_src/concourse/scripts/behave_gpdb.bash

--- a/concourse/tasks/gpMgmt_check_gpdb.yml
+++ b/concourse/tasks/gpMgmt_check_gpdb.yml
@@ -10,3 +10,5 @@ params:
   TEST_OS: ""
 run:
   path: gpdb_src/concourse/scripts/gpMgmt_check_gpdb.bash
+caches:
+  - path: pip-cache-dir

--- a/concourse/tasks/run_behave_on_ccp_cluster.yml
+++ b/concourse/tasks/run_behave_on_ccp_cluster.yml
@@ -5,6 +5,8 @@ inputs:
  - name: cluster_env_files
 outputs:
  - name: coverage
+caches:
+  - path: pip-cache-dir
 run:
   path: bash
   args:
@@ -76,6 +78,9 @@ run:
         if [ -d \$MASTER_DATA_DIRECTORY ]; then gpstart -a; fi
     "
 
+    while read -r host; do
+        scp -qr "pip-cache-dir" $host:pip-cache-dir
+    done < cluster_env_files/hostfile_all
 
     ssh -t mdw "
         source /home/gpadmin/gpdb_src/concourse/scripts/common.bash
@@ -87,6 +92,12 @@ run:
 
         $CUSTOM_ENV bash /home/gpadmin/gpdb_src/concourse/scripts/run_behave_test.sh \"$BEHAVE_FLAGS\"
     "
+
+    # Refresh the Concourse container cache with the updated contents
+    # from the CCP mdw node.
+
+    rm -rf "pip-cache-dir/http"
+    scp -qr mdw:pip-cache-dir/http "pip-cache-dir"
 
     # collect coverage
     while read -r host; do


### PR DESCRIPTION
For the Python testing artifacts used by the CLI tools, utilize the
Concourse cached directories feature to create and use a pip cache dir
shared between task runs.

**Be aware**, the cache is scoped to the worker the task is run on. We do
not get a cache hit when subsequent builds run on different workers.

**Notes**
* The environment variable PIP_CACHE_DIR is used to store the cache
directory.

* Add "--retries 10" to Behave test dependency pip install commands.