### PR TITLE
Fix wrong results caused by over-eager constraint exclusion

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -1343,6 +1343,15 @@ contain_nonstrict_functions_walker(Node *node, void *context)
 {
 	if (node == NULL)
 		return false;
+
+	/* the functions in predtest.c handle expressions and
+	 * RestrictInfo objects -- so make this function handle
+	 * them too for convenience */
+	if (IsA(node, RestrictInfo))
+	{
+		RestrictInfo *rinfo = (RestrictInfo *) node;
+		return contain_nonstrict_functions_walker((Node*)rinfo->clause, context);
+	}
 	if (IsA(node, Aggref))
 	{
 		/* an aggregate could return non-null with null input */

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -3333,4 +3333,55 @@ select get_selected_parts('explain analyze select * from bar where j is distinct
  [0, 0]
 (1 row)
 
+-- Test for over-eager constraint exclusion, issue #10287
+drop table if exists parttab;
+NOTICE:  table "parttab" does not exist, skipping
+create table parttab (n numeric, t text) partition by list (n)(partition one values ('1'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'n' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "parttab_1_prt_one" for table "parttab"
+insert into parttab values
+	('1', 'one'),
+	('1.0', 'one point zero'),
+	('1.00', 'one point zero zero');
+explain (costs off)
+select * from parttab where length(n::text) = 3;
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on parttab_1_prt_one
+               Filter: (length((n)::text) = 3)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select * from parttab where length(n::text) = 3;
+  n  |       t        
+-----+----------------
+ 1.0 | one point zero
+(1 row)
+
+-- Test for constraint exclusion with NULL tuples, issue #8582
+drop table if exists ta;
+NOTICE:  table "ta" does not exist, skipping
+create table ta(a int check(a = 1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into ta values(null);
+explain (costs off)
+select * from ta where a is null;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on ta
+         Filter: (a IS NULL)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select * from ta where a is null;
+ a 
+---
+  
+(1 row)
+
 RESET ALL;

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -2936,4 +2936,57 @@ select get_selected_parts('explain analyze select * from bar where j is distinct
  [8, 8]
 (1 row)
 
+-- Test for over-eager constraint exclusion, issue #10287
+drop table if exists parttab;
+NOTICE:  table "parttab" does not exist, skipping
+create table parttab (n numeric, t text) partition by list (n)(partition one values ('1'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'n' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "parttab_1_prt_one" for table "parttab"
+insert into parttab values
+	('1', 'one'),
+	('1.0', 'one point zero'),
+	('1.00', 'one point zero zero');
+explain (costs off)
+select * from parttab where length(n::text) = 3;
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Partition Selector for parttab (dynamic scan id: 1)
+               Partitions selected: 1 (out of 1)
+         ->  Dynamic Seq Scan on parttab (dynamic scan id: 1)
+               Filter: (length((n)::text) = 3)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select * from parttab where length(n::text) = 3;
+  n  |       t        
+-----+----------------
+ 1.0 | one point zero
+(1 row)
+
+-- Test for constraint exclusion with NULL tuples, issue #8582
+drop table if exists ta;
+NOTICE:  table "ta" does not exist, skipping
+create table ta(a int check(a = 1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into ta values(null);
+explain (costs off)
+select * from ta where a is null;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on ta
+         Filter: (a IS NULL)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select * from ta where a is null;
+ a 
+---
+  
+(1 row)
+
 RESET ALL;


### PR DESCRIPTION
When checking relation exclusion by constraints, GPDB performs further
checks that if the predicate is of format expr=constant, try to evaluate
the clause by replacing every occurrence of expr with the constant. This
works in some cases but not for all cases.

This PR fixes this issue #10287 by constraining the input types of
predicate to be types that we know we're safe with. For now we only use
integer.

This PR also fixes issue #8582 by checking if the restrictinfo_list
contains any nonstrict construct, so it can behavior correctly for NULL
tuples.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
