### PR TITLE
Fix the limit clause applying on the SegmentGeneral/General locus

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -4941,7 +4941,7 @@ create_limit_path(PlannerInfo *root, RelOptInfo *rel,
 		if (CdbPathLocus_IsGeneral(subpath->locus))
 			locus.numsegments = getgpsegmentCount();
 		Assert(locus.numsegments > 0);
-		subpath = cdbpath_create_motion_path(root, subpath, NIL, false, locus);
+		subpath = cdbpath_create_motion_path(root, subpath, subpath->pathkeys, false, locus);
 	}
 
 	pathnode->path.pathtype = T_Limit;

--- a/src/test/regress/expected/limit_gp.out
+++ b/src/test/regress/expected/limit_gp.out
@@ -189,3 +189,119 @@ select array(select b from t_limit_all order by b asc limit all) t;
 (1 row)
 
 drop table t_limit_all;
+-- Check LIMIT on a subquery with General/SegmentGeneral locus
+create table t_rpt(i int) distributed replicated;
+create table t_rpt2(i int) distributed replicated;
+create table t_prt(i int) distributed by(i);
+create table t_prt2(i int) distributed by(i);
+-- This PR only fixes the issue for Postgres optimizer
+-- The fix for ORCA should remove the comment and lines changing the optimizer
+set optimizer = off;
+explain insert into t_rpt select i from t_rpt2;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Insert on t_rpt  (cost=0.00..1063.00 rows=32100 width=4)
+   ->  Seq Scan on t_rpt2  (cost=0.00..1063.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+explain insert into t_rpt select i from t_rpt2 limit 2;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Insert on t_rpt  (cost=1063.00..1063.10 rows=2 width=4)
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=1063.00..1063.10 rows=6 width=4)
+         ->  Limit  (cost=1063.00..1063.00 rows=2 width=4)
+               ->  Seq Scan on t_rpt2  (cost=0.00..1063.00 rows=96300 width=4)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+explain insert into t_rpt select i from t_rpt2 order by i limit 2;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Insert on t_rpt  (cost=2266.75..2266.85 rows=2 width=4)
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=2266.75..2266.85 rows=6 width=4)
+         ->  Limit  (cost=2266.75..2266.75 rows=2 width=4)
+               ->  Sort  (cost=2026.00..2266.75 rows=96300 width=4)
+                     Sort Key: t_rpt2.i
+                     ->  Seq Scan on t_rpt2  (cost=0.00..1063.00 rows=96300 width=4)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain insert into t_rpt select i from t_prt;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Insert on t_rpt  (cost=0.00..4915.00 rows=96300 width=4)
+   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..4915.00 rows=96300 width=4)
+         ->  Seq Scan on t_prt  (cost=0.00..1063.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain insert into t_rpt select i from t_prt limit 2;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Insert on t_rpt  (cost=106.30..106.46 rows=2 width=4)
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=106.30..106.46 rows=6 width=4)
+         ->  Limit  (cost=106.30..106.36 rows=2 width=4)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=106.30..106.36 rows=2 width=4)
+                     ->  Limit  (cost=106.30..106.32 rows=1 width=4)
+                           ->  Seq Scan on t_prt  (cost=0.00..1063.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain insert into t_prt select i from t_prt2;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Insert on t_prt  (cost=0.00..1063.00 rows=32100 width=4)
+   ->  Seq Scan on t_prt2  (cost=0.00..1063.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+explain insert into t_prt select i from t_prt2 limit 2;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Insert on t_prt  (cost=106.30..106.42 rows=1 width=4)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=106.30..106.42 rows=2 width=4)
+         Hash Key: t_prt2.i
+         ->  Limit  (cost=106.30..106.36 rows=2 width=4)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=106.30..106.36 rows=2 width=4)
+                     ->  Limit  (cost=106.30..106.32 rows=1 width=4)
+                           ->  Seq Scan on t_prt2  (cost=0.00..1063.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+explain insert into t_prt select i from t_rpt2;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Insert on t_prt  (cost=0.00..2989.00 rows=32100 width=4)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..2989.00 rows=96300 width=4)
+         Hash Key: t_rpt2.i
+         ->  Seq Scan on t_rpt2  (cost=0.00..1063.00 rows=96300 width=4)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+explain insert into t_prt select i from t_rpt2 limit 2;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Insert on t_prt  (cost=1063.00..1063.06 rows=1 width=4)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=1063.00..1063.06 rows=2 width=4)
+         Hash Key: t_rpt2.i
+         ->  Limit  (cost=1063.00..1063.00 rows=2 width=4)
+               ->  Seq Scan on t_rpt2  (cost=0.00..1063.00 rows=96300 width=4)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+explain insert into t_prt select i from t_rpt2 order by i limit 2;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Insert on t_prt  (cost=2026.00..2026.07 rows=1 width=4)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=2026.00..2026.07 rows=2 width=4)
+         Hash Key: t_rpt2.i
+         ->  Limit  (cost=2026.00..2026.01 rows=2 width=4)
+               ->  Sort  (cost=2026.00..2266.75 rows=96300 width=4)
+                     Sort Key: t_rpt2.i
+                     ->  Seq Scan on t_rpt2  (cost=0.00..1063.00 rows=96300 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+reset optimizer;
+drop table t_rpt, t_rpt2, t_prt, t_prt2;

--- a/src/test/regress/expected/limit_gp_optimizer.out
+++ b/src/test/regress/expected/limit_gp_optimizer.out
@@ -185,3 +185,119 @@ select array(select b from t_limit_all order by b asc limit all) t;
 (1 row)
 
 drop table t_limit_all;
+-- Check LIMIT on a subquery with General/SegmentGeneral locus
+create table t_rpt(i int) distributed replicated;
+create table t_rpt2(i int) distributed replicated;
+create table t_prt(i int) distributed by(i);
+create table t_prt2(i int) distributed by(i);
+-- This PR only fixes the issue for Postgres optimizer
+-- The fix for ORCA should remove the comment and lines changing the optimizer
+set optimizer = off;
+explain insert into t_rpt select i from t_rpt2;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Insert on t_rpt  (cost=0.00..1063.00 rows=32100 width=4)
+   ->  Seq Scan on t_rpt2  (cost=0.00..1063.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+explain insert into t_rpt select i from t_rpt2 limit 2;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Insert on t_rpt  (cost=1063.00..1063.10 rows=2 width=4)
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=1063.00..1063.10 rows=6 width=4)
+         ->  Limit  (cost=1063.00..1063.00 rows=2 width=4)
+               ->  Seq Scan on t_rpt2  (cost=0.00..1063.00 rows=96300 width=4)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+explain insert into t_rpt select i from t_rpt2 order by i limit 2;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Insert on t_rpt  (cost=2266.75..2266.85 rows=2 width=4)
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=2266.75..2266.85 rows=6 width=4)
+         ->  Limit  (cost=2266.75..2266.75 rows=2 width=4)
+               ->  Sort  (cost=2026.00..2266.75 rows=96300 width=4)
+                     Sort Key: t_rpt2.i
+                     ->  Seq Scan on t_rpt2  (cost=0.00..1063.00 rows=96300 width=4)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain insert into t_rpt select i from t_prt;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Insert on t_rpt  (cost=0.00..4915.00 rows=96300 width=4)
+   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..4915.00 rows=96300 width=4)
+         ->  Seq Scan on t_prt  (cost=0.00..1063.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain insert into t_rpt select i from t_prt limit 2;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Insert on t_rpt  (cost=106.30..106.46 rows=2 width=4)
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=106.30..106.46 rows=6 width=4)
+         ->  Limit  (cost=106.30..106.36 rows=2 width=4)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=106.30..106.36 rows=2 width=4)
+                     ->  Limit  (cost=106.30..106.32 rows=1 width=4)
+                           ->  Seq Scan on t_prt  (cost=0.00..1063.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain insert into t_prt select i from t_prt2;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Insert on t_prt  (cost=0.00..1063.00 rows=32100 width=4)
+   ->  Seq Scan on t_prt2  (cost=0.00..1063.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+explain insert into t_prt select i from t_prt2 limit 2;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Insert on t_prt  (cost=106.30..106.42 rows=1 width=4)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=106.30..106.42 rows=2 width=4)
+         Hash Key: t_prt2.i
+         ->  Limit  (cost=106.30..106.36 rows=2 width=4)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=106.30..106.36 rows=2 width=4)
+                     ->  Limit  (cost=106.30..106.32 rows=1 width=4)
+                           ->  Seq Scan on t_prt2  (cost=0.00..1063.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+explain insert into t_prt select i from t_rpt2;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Insert on t_prt  (cost=0.00..2989.00 rows=32100 width=4)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..2989.00 rows=96300 width=4)
+         Hash Key: t_rpt2.i
+         ->  Seq Scan on t_rpt2  (cost=0.00..1063.00 rows=96300 width=4)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+explain insert into t_prt select i from t_rpt2 limit 2;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Insert on t_prt  (cost=1063.00..1063.06 rows=1 width=4)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=1063.00..1063.06 rows=2 width=4)
+         Hash Key: t_rpt2.i
+         ->  Limit  (cost=1063.00..1063.00 rows=2 width=4)
+               ->  Seq Scan on t_rpt2  (cost=0.00..1063.00 rows=96300 width=4)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+explain insert into t_prt select i from t_rpt2 order by i limit 2;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Insert on t_prt  (cost=2266.75..2266.81 rows=1 width=4)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=2266.75..2266.81 rows=2 width=4)
+         Hash Key: t_rpt2.i
+         ->  Limit  (cost=2266.75..2266.75 rows=2 width=4)
+               ->  Sort  (cost=2026.00..2266.75 rows=96300 width=4)
+                     Sort Key: t_rpt2.i
+                     ->  Seq Scan on t_rpt2  (cost=0.00..1063.00 rows=96300 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+reset optimizer;
+drop table t_rpt, t_rpt2, t_prt, t_prt2;

--- a/src/test/regress/sql/limit_gp.sql
+++ b/src/test/regress/sql/limit_gp.sql
@@ -66,3 +66,28 @@ select array(select b from t_limit_all order by b asc limit all) t;
 select array(select b from t_limit_all order by b asc limit all) t;
 
 drop table t_limit_all;
+
+-- Check LIMIT on a subquery with General/SegmentGeneral locus
+create table t_rpt(i int) distributed replicated;
+create table t_rpt2(i int) distributed replicated;
+create table t_prt(i int) distributed by(i);
+create table t_prt2(i int) distributed by(i);
+
+-- This PR only fixes the issue for Postgres optimizer
+-- The fix for ORCA should remove the comment and lines changing the optimizer
+set optimizer = off;
+explain insert into t_rpt select i from t_rpt2;
+explain insert into t_rpt select i from t_rpt2 limit 2;
+explain insert into t_rpt select i from t_rpt2 order by i limit 2;
+explain insert into t_rpt select i from t_prt;
+explain insert into t_rpt select i from t_prt limit 2;
+
+explain insert into t_prt select i from t_prt2;
+explain insert into t_prt select i from t_prt2 limit 2;
+explain insert into t_prt select i from t_rpt2;
+explain insert into t_prt select i from t_rpt2 limit 2;
+explain insert into t_prt select i from t_rpt2 order by i limit 2;
+
+reset optimizer;
+drop table t_rpt, t_rpt2, t_prt, t_prt2;
+


### PR DESCRIPTION
When creating a limit path on the top of a subpath, which is
unorder and with SegmentGeneral/General locus, the locus type
of the Limit path should be no longer SegmentGeneral/General.
Because it may produce different output on different segments.
For example:
```
gpadmin=# explain insert into rpt select i from rpt2 limit 1;
                                  QUERY PLAN
------------------------------------------------------------------------------
 Insert on rpt  (cost=0.00..431.03 rows=1 width=4)
   ->  Result  (cost=0.00..431.00 rows=1 width=8)
         ->  Limit  (cost=0.00..431.00 rows=1 width=4)
               ->  Seq Scan on rpt rpt2  (cost=0.00..431.00 rows=10 width=4)
```
The table `rpt` and `rpt2` are replicated tables. The subquery
`select i from rpt2 limit 1;` may be different on different segments,
which will lead the replicated table to an inconsistent state.

With this patch, the subquery is executed only on one segment, and
the result is broadcasted to all segments. The plan is:
```
gpadmin=# explain insert into rpt select i from rpt2 limit 1;
                                        QUERY PLAN
-------------------------------------------------------------------------------------------
 Insert on rpt  (cost=1063.00..1063.05 rows=1 width=4)
   ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=1063.00..1063.05 rows=3 width=4)
         ->  Limit  (cost=1063.00..1063.00 rows=1 width=4)
               ->  Seq Scan on rpt2  (cost=0.00..1063.00 rows=96300 width=4)
```

Co-authored-by: Zhenghua Lyu zlv@pivotal.io

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
