### PR TITLE
Reject update/delete statement on replicate table that contains volatile functions

### DIFF
--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -679,6 +679,13 @@ select min(x) from minmaxtest;
    1
 (1 row)
 
+-- Test update on replicate table cannot contain volatile function
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/10226
+create table t_rep_upd_volatile(a int, b int) distributed replicated;
+update t_rep_upd_volatile set a = random();
+ERROR:  update statement on replicate table cannot contain volatile functions
+update t_rep_upd_volatile set a = 1 where b < random();
+ERROR:  update statement on replicate table cannot contain volatile functions
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 4 other objects

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -683,9 +683,11 @@ select min(x) from minmaxtest;
 -- See github issue: https://github.com/greenplum-db/gpdb/issues/10226
 create table t_rep_upd_volatile(a int, b int) distributed replicated;
 update t_rep_upd_volatile set a = random();
-ERROR:  update statement on replicate table cannot contain volatile functions
+ERROR:  update/delete statement on replicated table cannot contain volatile functions
 update t_rep_upd_volatile set a = 1 where b < random();
-ERROR:  update statement on replicate table cannot contain volatile functions
+ERROR:  update/delete statement on replicated table cannot contain volatile functions
+delete from t_rep_upd_volatile where a < random()*10;
+ERROR:  update/delete statement on replicated table cannot contain volatile functions
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 4 other objects

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -342,6 +342,12 @@ insert into minmaxtest select generate_series(1, 10);
 set enable_seqscan=off;
 select min(x) from minmaxtest;
 
+-- Test update on replicate table cannot contain volatile function
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/10226
+create table t_rep_upd_volatile(a int, b int) distributed replicated;
+update t_rep_upd_volatile set a = random();
+update t_rep_upd_volatile set a = 1 where b < random();
+
 -- start_ignore
 drop schema rpt cascade;
 -- end_ignore

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -347,6 +347,7 @@ select min(x) from minmaxtest;
 create table t_rep_upd_volatile(a int, b int) distributed replicated;
 update t_rep_upd_volatile set a = random();
 update t_rep_upd_volatile set a = 1 where b < random();
+delete from t_rep_upd_volatile where a < random()*10;
 
 -- start_ignore
 drop schema rpt cascade;


### PR DESCRIPTION
Greenplum support replicated table and partition table cannot distribute
replicated. So first do a quick check for the length of rtable.
Plan of Update/Delete statement for replicated table has to be dispatched
to each segment and it is just like a procedure(now is the plan) is invoked
many times and it has to produce the same results each time. Some typical
examples are:

  * update t_replicate_table set a = random();
  * update t_replicate_table set a = 1 where b < random();
  * delete from t_replicate_table where a < random();

Here the update/delete statement contains volatile functions, we should
reject them for replicated tables.

See github issue https://github.com/greenplum-db/gpdb/issues/10226 for details.

Co-authored-by: Hao Wu <hawu@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
