### PR TITLE
6X Backport: Properly mark null return from combine functions

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -1359,7 +1359,7 @@ spill_hash_table(AggState *aggstate)
 	/* Book keeping. */
 	hashtable->is_spilling = true;
 
-	Assert(hashtable->nbuckets > spill_set->num_spill_files);
+	Assert(hashtable->nbuckets >= spill_set->num_spill_files);
 
 	/*
 	 * Write each spill file. Write the last spill file first, since it will

--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -47,6 +47,7 @@ struct BatchFileInfo
 	int64 total_bytes;
 	int64 ntuples;
 	BufFile *wfile;
+	bool suspended;
 };
 
 /*
@@ -1160,6 +1161,7 @@ getSpillFile(workfile_set *work_set, SpillSet *set, int file_no, int *p_alloc_si
 		/* Initialize to NULL in case the create function below throws an exception */
 		spill_file->file_info->wfile = NULL; 
 		spill_file->file_info->wfile = BufFileCreateTempInSet(work_set, false /* interXact */);
+		spill_file->file_info->suspended = false;
 		BufFilePledgeSequential(spill_file->file_info->wfile);	/* allow compression */
 
 		elog(HHA_MSG_LVL, "HashAgg: create %d level batch file %d",
@@ -1192,7 +1194,9 @@ suspendSpillFiles(SpillSet *spill_set)
 		if (spill_file->file_info &&
 			spill_file->file_info->wfile != NULL)
 		{
+			Assert(spill_file->file_info->suspended == false);
 			BufFileSuspend(spill_file->file_info->wfile);
+			spill_file->file_info->suspended = true;
 
 			freed_size += FREEABLE_BATCHFILE_METADATA;
 
@@ -1231,7 +1235,8 @@ closeSpillFile(AggState *aggstate, SpillSet *spill_set, int file_no)
 		BufFileClose(spill_file->file_info->wfile);
 		spill_file->file_info->wfile = NULL;
 		freedspace += (BATCHFILE_METADATA - sizeof(BatchFileInfo));
-		
+		if (spill_file->file_info->suspended)
+			freedspace -= FREEABLE_BATCHFILE_METADATA;
 	}
 	if (spill_file->file_info)
 	{
@@ -1868,7 +1873,9 @@ agg_hash_reload(AggState *aggstate)
 
 	if (spill_file->file_info->wfile != NULL)
 	{
+		Assert(spill_file->file_info->suspended);
 		BufFileResume(spill_file->file_info->wfile);
+		spill_file->file_info->suspended = false;
 		hashtable->mem_for_metadata  += FREEABLE_BATCHFILE_METADATA;
 	}
 

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -3109,7 +3109,11 @@ numeric_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (NumericAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)
@@ -3200,7 +3204,11 @@ numeric_avg_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (NumericAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)
@@ -3712,7 +3720,11 @@ numeric_poly_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (PolyNumAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)
@@ -3952,7 +3964,11 @@ int8_avg_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (PolyNumAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)

--- a/src/test/regress/expected/gp_hashagg.out
+++ b/src/test/regress/expected/gp_hashagg.out
@@ -49,6 +49,7 @@ select grp,sum(v) from hashagg_test where id1 = 1 and id2 = 1 and day between '1
  there |   6
 (2 rows)
 
+reset gp_hashagg_streambottom;
 -- Test a window-aggregate (median) with a join where the join column
 -- is further constrained by a constant. And the constant is of different
 -- type (int4, while the column is bigint). We had a bug at one point
@@ -131,4 +132,156 @@ select nohash_int from hashagg_test2 group by nohash_int;
  8
  9
 (10 rows)
+
+reset enable_sort;
+-- We had a bug in the following combine functions where if the combine function
+-- returned a NULL, it didn't set fcinfo->isnull = true. This led to a segfault
+-- when we would spill in the final stage of a two-stage agg inside the serial
+-- function.
+CREATE TABLE test_combinefn_null (a int8, b int, c char(32000));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO test_combinefn_null SELECT i, (i | 7), i::text FROM generate_series(1, 1024) i;
+ANALYZE test_combinefn_null;
+SET statement_mem='2MB';
+set enable_sort=off;
+-- Test int8_avg_combine()
+SELECT $$
+SELECT
+sum(a) FILTER (WHERE false)
+FROM test_combinefn_null
+GROUP BY b
+HAVING max(c) = '31'
+$$ AS qry \gset
+EXPLAIN (COSTS OFF, VERBOSE) :qry;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: (pg_catalog.sum((sum(test_combinefn_null.a) FILTER (WHERE false)))), test_combinefn_null.b
+   ->  HashAggregate
+         Output: pg_catalog.sum((sum(test_combinefn_null.a) FILTER (WHERE false))), test_combinefn_null.b
+         Group Key: test_combinefn_null.b
+         Filter: (max((max(test_combinefn_null.c))) = '31'::bpchar)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Output: test_combinefn_null.b, (sum(test_combinefn_null.a) FILTER (WHERE false)), (max(test_combinefn_null.c))
+               Hash Key: test_combinefn_null.b
+               ->  HashAggregate
+                     Output: test_combinefn_null.b, sum(test_combinefn_null.a) FILTER (WHERE false), max(test_combinefn_null.c)
+                     Group Key: test_combinefn_null.b
+                     ->  Seq Scan on public.test_combinefn_null
+                           Output: test_combinefn_null.a, test_combinefn_null.b, test_combinefn_null.c
+ Optimizer: Postgres query optimizer
+ Settings: enable_indexscan=off, enable_seqscan=on, enable_sort=off
+(16 rows)
+
+:qry;
+ sum 
+-----
+    
+(1 row)
+
+-- Test numeric_poly_combine()
+SELECT $$
+SELECT
+var_pop(a::int) FILTER (WHERE false)
+FROM test_combinefn_null
+GROUP BY b
+HAVING max(c) = '31'
+$$ AS qry \gset
+EXPLAIN (COSTS OFF, VERBOSE) :qry;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: (pg_catalog.var_pop((var_pop((test_combinefn_null.a)::integer) FILTER (WHERE false)))), test_combinefn_null.b
+   ->  HashAggregate
+         Output: pg_catalog.var_pop((var_pop((test_combinefn_null.a)::integer) FILTER (WHERE false))), test_combinefn_null.b
+         Group Key: test_combinefn_null.b
+         Filter: (max((max(test_combinefn_null.c))) = '31'::bpchar)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Output: test_combinefn_null.b, (var_pop((test_combinefn_null.a)::integer) FILTER (WHERE false)), (max(test_combinefn_null.c))
+               Hash Key: test_combinefn_null.b
+               ->  HashAggregate
+                     Output: test_combinefn_null.b, var_pop((test_combinefn_null.a)::integer) FILTER (WHERE false), max(test_combinefn_null.c)
+                     Group Key: test_combinefn_null.b
+                     ->  Seq Scan on public.test_combinefn_null
+                           Output: test_combinefn_null.a, test_combinefn_null.b, test_combinefn_null.c
+ Optimizer: Postgres query optimizer
+ Settings: enable_indexscan=off, enable_seqscan=on, enable_sort=off
+(16 rows)
+
+:qry;
+ var_pop 
+---------
+        
+(1 row)
+
+-- Test numeric_avg_combine()
+SELECT $$
+SELECT
+sum(a::numeric) FILTER (WHERE false)
+FROM test_combinefn_null
+GROUP BY b
+HAVING max(c) = '31'
+$$ AS qry \gset
+EXPLAIN (COSTS OFF, VERBOSE) :qry;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: (pg_catalog.sum((sum((test_combinefn_null.a)::numeric) FILTER (WHERE false)))), test_combinefn_null.b
+   ->  HashAggregate
+         Output: pg_catalog.sum((sum((test_combinefn_null.a)::numeric) FILTER (WHERE false))), test_combinefn_null.b
+         Group Key: test_combinefn_null.b
+         Filter: (max((max(test_combinefn_null.c))) = '31'::bpchar)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Output: test_combinefn_null.b, (sum((test_combinefn_null.a)::numeric) FILTER (WHERE false)), (max(test_combinefn_null.c))
+               Hash Key: test_combinefn_null.b
+               ->  HashAggregate
+                     Output: test_combinefn_null.b, sum((test_combinefn_null.a)::numeric) FILTER (WHERE false), max(test_combinefn_null.c)
+                     Group Key: test_combinefn_null.b
+                     ->  Seq Scan on public.test_combinefn_null
+                           Output: test_combinefn_null.a, test_combinefn_null.b, test_combinefn_null.c
+ Optimizer: Postgres query optimizer
+ Settings: enable_indexscan=off, enable_seqscan=on, enable_sort=off
+(16 rows)
+
+:qry;
+ sum 
+-----
+    
+(1 row)
+
+-- Test numeric_combine()
+SELECT $$
+SELECT
+var_pop(a::numeric) FILTER (WHERE false)
+FROM test_combinefn_null
+GROUP BY b
+HAVING max(c) = '31'
+$$ AS qry \gset
+EXPLAIN (COSTS OFF, VERBOSE) :qry;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: (pg_catalog.var_pop((var_pop((test_combinefn_null.a)::numeric) FILTER (WHERE false)))), test_combinefn_null.b
+   ->  HashAggregate
+         Output: pg_catalog.var_pop((var_pop((test_combinefn_null.a)::numeric) FILTER (WHERE false))), test_combinefn_null.b
+         Group Key: test_combinefn_null.b
+         Filter: (max((max(test_combinefn_null.c))) = '31'::bpchar)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Output: test_combinefn_null.b, (var_pop((test_combinefn_null.a)::numeric) FILTER (WHERE false)), (max(test_combinefn_null.c))
+               Hash Key: test_combinefn_null.b
+               ->  HashAggregate
+                     Output: test_combinefn_null.b, var_pop((test_combinefn_null.a)::numeric) FILTER (WHERE false), max(test_combinefn_null.c)
+                     Group Key: test_combinefn_null.b
+                     ->  Seq Scan on public.test_combinefn_null
+                           Output: test_combinefn_null.a, test_combinefn_null.b, test_combinefn_null.c
+ Optimizer: Postgres query optimizer
+ Settings: enable_indexscan=off, enable_seqscan=on, enable_sort=off
+(16 rows)
+
+:qry;
+ var_pop 
+---------
+        
+(1 row)
 

--- a/src/test/regress/sql/gp_hashagg.sql
+++ b/src/test/regress/sql/gp_hashagg.sql
@@ -27,7 +27,7 @@ select grp,sum(v) from hashagg_test where id1 = 1 and id2 = 1 and day between '1
 set enable_seqscan=on;
 select grp,sum(v) from hashagg_test where id1 = 1 and id2 = 1 and day between '1/1/2006' and '1/31/2006' group by grp order by sum(v) desc;
 
-
+reset gp_hashagg_streambottom;
 -- Test a window-aggregate (median) with a join where the join column
 -- is further constrained by a constant. And the constant is of different
 -- type (int4, while the column is bigint). We had a bug at one point
@@ -89,3 +89,59 @@ set enable_sort=off;
 -- use a Sort + Group, because nohash_int type is not hashable.
 select normal_int from hashagg_test2 group by normal_int;
 select nohash_int from hashagg_test2 group by nohash_int;
+
+reset enable_sort;
+
+-- We had a bug in the following combine functions where if the combine function
+-- returned a NULL, it didn't set fcinfo->isnull = true. This led to a segfault
+-- when we would spill in the final stage of a two-stage agg inside the serial
+-- function.
+CREATE TABLE test_combinefn_null (a int8, b int, c char(32000));
+INSERT INTO test_combinefn_null SELECT i, (i | 7), i::text FROM generate_series(1, 1024) i;
+ANALYZE test_combinefn_null;
+SET statement_mem='2MB';
+set enable_sort=off;
+
+-- Test int8_avg_combine()
+SELECT $$
+SELECT
+sum(a) FILTER (WHERE false)
+FROM test_combinefn_null
+GROUP BY b
+HAVING max(c) = '31'
+$$ AS qry \gset
+EXPLAIN (COSTS OFF, VERBOSE) :qry;
+:qry;
+
+-- Test numeric_poly_combine()
+SELECT $$
+SELECT
+var_pop(a::int) FILTER (WHERE false)
+FROM test_combinefn_null
+GROUP BY b
+HAVING max(c) = '31'
+$$ AS qry \gset
+EXPLAIN (COSTS OFF, VERBOSE) :qry;
+:qry;
+
+-- Test numeric_avg_combine()
+SELECT $$
+SELECT
+sum(a::numeric) FILTER (WHERE false)
+FROM test_combinefn_null
+GROUP BY b
+HAVING max(c) = '31'
+$$ AS qry \gset
+EXPLAIN (COSTS OFF, VERBOSE) :qry;
+:qry;
+
+-- Test numeric_combine()
+SELECT $$
+SELECT
+var_pop(a::numeric) FILTER (WHERE false)
+FROM test_combinefn_null
+GROUP BY b
+HAVING max(c) = '31'
+$$ AS qry \gset
+EXPLAIN (COSTS OFF, VERBOSE) :qry;
+:qry;


### PR DESCRIPTION
This is a backport of PR: #9946
