### PR TITLE
Improve handling of target lists of window queries

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2279,23 +2279,6 @@ gpdb::MutateQueryTree
 	return NULL;
 }
 
-List *
-gpdb::MutateRangeTable
-	(
-	List *rtable,
-	Node *(*mutator) (),
-	void *context,
-	int flags
-	)
-{
-	GP_WRAP_START;
-	{
-		return range_table_mutator(rtable, mutator, context, flags);
-	}
-	GP_WRAP_END;
-	return NIL;
-}
-
 bool
 gpdb::RelPartIsRoot
 	(

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -921,28 +921,6 @@ CQueryMutators::FlatCopyAggref
 	return new_aggref;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CQueryMutators::FlatCopyAggref
-//
-//	@doc:
-//		Make a copy of the aggref (minus the arguments)
-//---------------------------------------------------------------------------
-WindowFunc *
-CQueryMutators::FlatCopyWindowFunc
-(
- WindowFunc *old_windowfunc
- )
-{
-	WindowFunc *new_windowfunc = MakeNode(WindowFunc);
-
-	*new_windowfunc = *old_windowfunc;
-	new_windowfunc->args = NIL;
-
-	return new_windowfunc;
-}
-
-
 // Increment the levels up of outer references
 Var *
 CQueryMutators::IncrLevelsUpIfOuterRef

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -1688,7 +1688,7 @@ CTranslatorQueryToDXL::TranslateWindowToDXL
 
 				StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
 			}
-			else if (CTranslatorUtils::IsWindowSpec(target_entry, window_clause))
+			else if (CTranslatorUtils::IsReferencedInWindowSpec(target_entry, window_clause))
 			{
 				// add computed column used in window specification needed in the output columns
 				// to the child's project list
@@ -1743,7 +1743,7 @@ CTranslatorQueryToDXL::TranslateWindowToDXL
 		}
 		else if (!IsA(target_entry->expr, Var))
 		{
-			GPOS_ASSERT(CTranslatorUtils::IsWindowSpec(target_entry, window_clause));
+			GPOS_ASSERT(CTranslatorUtils::IsReferencedInWindowSpec(target_entry, window_clause));
 			// computed columns used in the window specification
 			new_child_project_list_dxlnode->AddChild(project_elem_dxlnode);
 		}

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1674,7 +1674,7 @@ CTranslatorUtils::GetWindowSpecTargetEntry
 	ForEach (target_entry_cell, target_list_subset)
 	{
 		TargetEntry *cur_target_entry = (TargetEntry*) lfirst(target_entry_cell);
-		if (IsWindowSpec(cur_target_entry, window_clause_list))
+		if (IsReferencedInWindowSpec(cur_target_entry, window_clause_list))
 		{
 			gpdb::GPDBFree(target_list_subset);
 			return cur_target_entry;
@@ -1720,7 +1720,7 @@ CTranslatorUtils::IsWindowSpec
 //		Check if the TargetEntry is a used in the window specification
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorUtils::IsWindowSpec
+CTranslatorUtils::IsReferencedInWindowSpec
 	(
 	const TargetEntry *target_entry,
 	List *window_clause_list

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1690,34 +1690,8 @@ CTranslatorUtils::GetWindowSpecTargetEntry
 
 
 //---------------------------------------------------------------------------
-//	@function:
-//		CTranslatorUtils::IsWindowSpec
-//
-//	@doc:
-//		Check if the expression has a matching target entry that is a window spec
-//---------------------------------------------------------------------------
-BOOL
-CTranslatorUtils::IsWindowSpec
-	(
-	Node *node,
-	List *window_clause_list,
-	List *target_list
-	)
-{
-	GPOS_ASSERT(NULL != node);
-	
-	TargetEntry *window_spec = GetWindowSpecTargetEntry(node, window_clause_list, target_list);
-
-	return (NULL != window_spec);
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CTranslatorUtils::IsWindowSpec
-//
-//	@doc:
-//		Check if the TargetEntry is a used in the window specification
+// CTranslatorUtils::IsReferencedInWindowSpec
+// Check if the TargetEntry is a used in a window specification
 //---------------------------------------------------------------------------
 BOOL
 CTranslatorUtils::IsReferencedInWindowSpec

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -507,9 +507,6 @@ namespace gpdb {
 	// modify a query or an expression tree
 	Node *MutateQueryOrExpressionTree(Node *node, Node *(*mutator)(), void *context, int flags);
 
-	// the part of MutateQueryTree that processes a query's rangetable
-	List *MutateRangeTable(List *rtable, Node *(*mutator)(), void *context, int flags);
-
 	// check whether the part with the given oid is the root of a partition table
 	bool RelPartIsRoot(Oid relid);
 	

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -498,7 +498,7 @@ namespace gpdb {
 	// query or expression tree walker
 	bool WalkQueryOrExpressionTree(Node *node, bool(*walker)(), void *context, int flags);
 
-	// modify a query tree
+	// modify the components of a Query tree
 	Query *MutateQueryTree(Query *query, Node *(*mutator)(), void *context, int flags);
 
 	// modify an expression tree

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -53,7 +53,7 @@ namespace gpdxl
 	class CQueryMutators
 	{
 		typedef Node *(*MutatorWalkerFn) ();
-		typedef BOOL (*FallbackWalkerFn) ();
+		typedef BOOL (*ExprWalkerFn) ();
 
 		typedef struct SContextGrpbyPlMutator
 		{
@@ -232,7 +232,7 @@ namespace gpdxl
 
 			// traverse the expression and fix the levels up of any CTE
 			static
-			Node *RunFixCTELevelsUpMutator(Node *node, SContextIncLevelsupMutator *context);
+			BOOL RunFixCTELevelsUpWalker(Node *node, SContextIncLevelsupMutator *context);
 
 			// mutate the grouping columns, fix levels up when necessary
 			static

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -68,7 +68,7 @@ namespace gpdxl
 				// original query
 				Query *m_query;
 
-				// the new target list of the group by (derived) query
+				// the new target list of the group by or window (lower) query
 				List *m_lower_table_tlist;
 
 				// the current query level

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -69,7 +69,7 @@ namespace gpdxl
 				Query *m_query;
 
 				// the new target list of the group by (derived) query
-				List *m_derived_table_tlist;
+				List *m_lower_table_tlist;
 
 				// the current query level
 				ULONG m_current_query_level;
@@ -95,7 +95,7 @@ namespace gpdxl
 					m_mp(mp),
 					m_mda(mda),
 					m_query(query),
-					m_derived_table_tlist(derived_table_tlist),
+					m_lower_table_tlist(derived_table_tlist),
 					m_current_query_level(0),
 					m_agg_levels_up(gpos::ulong_max),
 					m_is_mutating_agg_arg(false),
@@ -192,7 +192,7 @@ namespace gpdxl
 
 			// flatten expressions in window operation project list
 			static
-			Query *NormalizeWindowProjList(CMemoryPool *mp, CMDAccessor *md_accessor, const Query *query);
+			Query *NormalizeWindowProjList(CMemoryPool *mp, CMDAccessor *md_accessor, const Query *original_query);
 
 			// traverse the project list to extract all window functions in an arbitrarily complex project element
 			static
@@ -261,7 +261,7 @@ namespace gpdxl
 
 			// make the input query into a derived table and return a new root query
 			static
-			Query *ConvertToDerivedTable(const Query *query, BOOL should_fix_target_list, BOOL should_fix_having_qual);
+			Query *ConvertToDerivedTable(const Query *original_query, BOOL should_fix_target_list, BOOL should_fix_having_qual);
 
 			// eliminate distinct clause
 			static

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -80,9 +80,6 @@ namespace gpdxl
 				// indicate whether we are mutating the argument of an aggregate
 				BOOL m_is_mutating_agg_arg;
 
-				// indicate whether we are mutating the argument of a window function
-				BOOL m_is_mutating_window_arg;
-
 				// ctor
 				SContextGrpbyPlMutator
 					(
@@ -98,8 +95,7 @@ namespace gpdxl
 					m_lower_table_tlist(derived_table_tlist),
 					m_current_query_level(0),
 					m_agg_levels_up(gpos::ulong_max),
-					m_is_mutating_agg_arg(false),
-					m_is_mutating_window_arg(false)
+					m_is_mutating_agg_arg(false)
 				{
 				}
 
@@ -199,10 +195,6 @@ namespace gpdxl
 			// make a copy of the aggref (minus the arguments)
 			static
 			Aggref *FlatCopyAggref(Aggref *aggref);
-
-			// make a copy of the window function (minus the arguments)
-			static
-			WindowFunc *FlatCopyWindowFunc (WindowFunc *old_windowfunc);
 
 			// create a new entry in the derived table and return its corresponding var
 			static

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -166,12 +166,6 @@ namespace gpdxl
 
 				} CContextTLWalker;
 
-		private:
-
-			// check if the cte levels up needs to be corrected
-			static
-			BOOL NeedsLevelsUpCorrection(SContextIncLevelsupMutator *context, Index cte_levels_up);
-
 		public:
 
 			// fall back during since the target list refers to a attribute which algebrizer at this point cannot resolve

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -285,7 +285,7 @@ namespace gpdxl
 			BOOL IsSortingColumn(const TargetEntry *target_entry, List *sort_clause_list); 
 			// check to see if the target list entry is used in the window reference
 			static
-			BOOL IsWindowSpec(const TargetEntry *target_entry, List *window_clause_list);
+			BOOL IsReferencedInWindowSpec(const TargetEntry *target_entry, List *window_clause_list);
 
 			// extract a matching target entry that is a window spec
 			static

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -291,10 +291,6 @@ namespace gpdxl
 			static
 			TargetEntry *GetWindowSpecTargetEntry(Node *node, List *window_clause_list, List *target_list);
 
-			// check if the expression has a matching target entry that is a window spec
-			static
-			BOOL IsWindowSpec(Node *node, List *window_clause_list, List *target_list);
-
 			// create a scalar const value expression for the given int8 value
 			static
 			CDXLNode *CreateDXLProjElemFromInt8Const(CMemoryPool *mp, CMDAccessor *md_accessor, INT val);

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -6613,6 +6613,34 @@ select (select rank() over(partition by orca_w2.a) from orca_w3 where a = orca_w
    1 |   3
 (9 rows)
 
+-- correlated subquery in target list
+select (select a+1 from (select a from orca_w2 where orca_w1.a=orca_w2.a) sq(a)) as one, row_number() over(partition by orca_w1.a) as two from orca_w1;
+ one | two 
+-----+-----
+     |   1
+   3 |   1
+   4 |   1
+(3 rows)
+
+-- correlated subquery in target list, mismatching varattnos
+select (select a+1 from (select a from orca_w2 where sq2.a=orca_w2.a) sq1(a)) as one, row_number() over(partition by sq2.a) as two from (select 1,1,1,a from orca_w1) sq2(x,y,z,a);
+ one | two 
+-----+-----
+   3 |   1
+   4 |   1
+     |   1
+(3 rows)
+
+-- cte in scalar subquery
+with x as (select a, b from orca_w1)
+select (select count(*) from x) as one, rank() over(partition by a) as rank_within_parent from x order by a desc;
+ one | rank_within_parent 
+-----+--------------------
+   3 |                  1
+   3 |                  1
+   3 |                  1
+(3 rows)
+
 -- window function in subquery inside target list with outer ref in order clause
 select (select rank() over(order by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
  one | two 

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -6637,6 +6637,34 @@ select (select rank() over(partition by orca_w2.a) from orca_w3 where a = orca_w
    1 |   3
 (9 rows)
 
+-- correlated subquery in target list
+select (select a+1 from (select a from orca_w2 where orca_w1.a=orca_w2.a) sq(a)) as one, row_number() over(partition by orca_w1.a) as two from orca_w1;
+ one | two 
+-----+-----
+   3 |   1
+   4 |   1
+     |   1
+(3 rows)
+
+-- correlated subquery in target list, mismatching varattnos
+select (select a+1 from (select a from orca_w2 where sq2.a=orca_w2.a) sq1(a)) as one, row_number() over(partition by sq2.a) as two from (select 1,1,1,a from orca_w1) sq2(x,y,z,a);
+ one | two 
+-----+-----
+     |   1
+   3 |   1
+   4 |   1
+(3 rows)
+
+-- cte in scalar subquery
+with x as (select a, b from orca_w1)
+select (select count(*) from x) as one, rank() over(partition by a) as rank_within_parent from x order by a desc;
+ one | rank_within_parent 
+-----+--------------------
+   3 |                  1
+   3 |                  1
+   3 |                  1
+(3 rows)
+
 -- window function in subquery inside target list with outer ref in order clause
 select (select rank() over(order by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
  one | two 

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -308,6 +308,16 @@ select (select a from orca_w3 where a = orca_w1.a) as one from orca_w1 where orc
 -- window function in subquery inside target list with outer ref in partition clause
 select (select rank() over(partition by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
 
+-- correlated subquery in target list
+select (select a+1 from (select a from orca_w2 where orca_w1.a=orca_w2.a) sq(a)) as one, row_number() over(partition by orca_w1.a) as two from orca_w1;
+
+-- correlated subquery in target list, mismatching varattnos
+select (select a+1 from (select a from orca_w2 where sq2.a=orca_w2.a) sq1(a)) as one, row_number() over(partition by sq2.a) as two from (select 1,1,1,a from orca_w1) sq2(x,y,z,a);
+
+-- cte in scalar subquery
+with x as (select a, b from orca_w1)
+select (select count(*) from x) as one, rank() over(partition by a) as rank_within_parent from x order by a desc;
+
 -- window function in subquery inside target list with outer ref in order clause
 select (select rank() over(order by orca_w2.a) from orca_w3 where a = orca_w1.a) as one, row_number() over(partition by orca_w1.a) as two from orca_w1, orca_w2 order by orca_w1.a;
 


### PR DESCRIPTION
Fixing two bugs related to handling queries with window functions and refactoring the related code.

ORCA can't handle expressions on window functions like `rank() over() - 1` in a target list. To avoid these, we split `Query` blocks that contain them into two. The new lower `Query` computes the window functions, the new upper `Query` computes the expressions.

We use three mutators and walkers to help with this process:

1. Increase the `varlevelsup` of outer references in the new lower `Query`, since we now inserted a new scope above it.
2. Split expressions on window functions into the window functions (for the lower scope) and expressions with a `Var` substituted for the `WindowFunc` (for the upper scope). Also adjust the `varattno` for `Var`s that now appear in the upper scope.
3. Increase the `ctelevelsup` for any `RangeTblEntry`s in the lower scope.

The bugs we saw were related to these mutators. The second one didn't recurse correctly into the required types of subqueries, the third one didn't always increment the query level correctly. The refactor hopefully will simplify this code somewhat. For details, see individual commit messages.

Note: In the 6X_STABLE branch, we currently have a temporary check that triggers a fallback to planner when we see window queries with outer refs in them. When this code gets merged into 6X, we will remove the temporary check. See https://github.com/greenplum-db/gpdb/pull/10265.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
