### PR TITLE
Document steps for installing pygresql for OSS database build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: cpp
 cache: ccache
 
 git:
-  submodules: false
+  submodules: true
 
 addons:
     apt:
@@ -124,8 +124,6 @@ before_install:
 
 install:
     - pip install --user --upgrade pip
-    - pip install --user --pre psutil
-    - pip install --user lockfile
     - pip install --user setuptools
 
 ## ----------------------------------------------------------------------

--- a/README.CentOS.bash
+++ b/README.CentOS.bash
@@ -25,6 +25,12 @@ sudo yum install -y \
     xerces-c-devel \
     zlib-devel
 
+# Needed for pygresql, or you can source greenplum_path.sh after compiling database and pip install python-dependencies then
+sudo yum install -y \
+    postgresql \
+    postgresql-devel
+
+
 sudo pip install conan
 sudo pip install -r python-dependencies.txt
 sudo pip install -r python-developer-dependencies.txt

--- a/README.ubuntu.bash
+++ b/README.ubuntu.bash
@@ -36,6 +36,7 @@ apt-get install -y \
   python-lockfile \
   python-pip \
   python-psutil \
+  python-pygresql \
   python-yaml \
   zlib1g-dev
 

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -55,11 +55,11 @@ SERVER_SBIN=$(SERVER_SRC)/../sbin
 LIB_DIR=$(SRC)/lib
 PYLIB_DIR=$(SRC)/ext
 
-core: pygresql subprocess32
+core: subprocess32
 	python gpconfig_modules/parse_guc_metadata.py $(DESTDIR)$(prefix)
 
 ifneq "$(wildcard $(CURDIR)/pythonSrc/ext/*.tar.gz)" ""
-install: installdirs installprograms core lockfile psutil
+install: installdirs installprograms core lockfile psutil pygresql
 else
 install: installdirs installprograms core
 endif


### PR DESCRIPTION
PyGreSQL may now be installed via pip or via Ubuntu apt.

Authored-by: Tyler Ramer <tramer@pivotal.io>

