### PR TITLE
Limit gxact number on master with MaxBackends.

### DIFF
--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -565,8 +565,10 @@ redoDistributedCommitRecord(TMGXACT_LOG *gxact_log)
 			ereport(FATAL,
 					(errmsg("the limit of %d distributed transactions has been reached",
 							max_tm_gxacts),
-					 errdetail("The global user configuration (GUC) server "
-							   "parameter max_prepared_transactions controls this limit.")));
+					 errdetail("It should not happen. Temporarily increase "
+							   "max_connections (need postmaster reboot) on "
+							   "the postgres (master or standby) to work "
+							   "around this issue and then report a bug")));
 
 		shmCommittedGxactArray[(*shmNumCommittedGxacts)++] = *gxact_log;
 		elog((Debug_print_full_dtm ? LOG : DEBUG5),

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -235,10 +235,16 @@ SharedSnapshotShmemSize(void)
 	slotSize = MAXALIGN(slotSize);
 
 	/*
-	 * We only really need max_prepared_xacts; but for safety we
-	 * multiply that by two (to account for slow de-allocation on
-	 * cleanup, for instance).
+	 * We only really need MaxBackends; but for safety we multiply that by two
+	 * (to account for slow de-allocation on cleanup, for instance).
+	 *
+	 * MaxBackends is only somewhat right.  What we really want here is the
+	 * MaxBackends value from the QD.  But this is at least safe since we know
+	 * we dont need *MORE* than MaxBackends.  But in general MaxBackends on a
+	 * QE is going to be bigger than on a QE by a good bit.  or at least it
+	 * should be.
 	 */
+
 	slotCount = NUM_SHARED_SNAPSHOT_SLOTS;
 
 	size = offsetof(SharedSnapshotStruct, xips);
@@ -276,18 +282,7 @@ CreateSharedSnapshotArray(void)
 
 		sharedSnapshotArray->numSlots = 0;
 
-		/* TODO:  MaxBackends is only somewhat right.  What we really want here
-		 *        is the MaxBackends value from the QD.  But this is at least
-		 *		  safe since we know we dont need *MORE* than MaxBackends.  But
-		 *        in general MaxBackends on a QE is going to be bigger than on a
-		 *		  QE by a good bit.  or at least it should be.
-		 *
-		 * But really, max_prepared_transactions *is* what we want (it
-		 * corresponds to the number of connections allowed on the
-		 * master).
-		 *
-		 * slotCount is initialized in SharedSnapshotShmemSize().
-		 */
+		/* slotCount is initialized in SharedSnapshotShmemSize(). */
 		sharedSnapshotArray->maxSlots = slotCount;
 		sharedSnapshotArray->nextSlot = 0;
 

--- a/src/backend/utils/time/test/sharedsnapshot_test.c
+++ b/src/backend/utils/time/test/sharedsnapshot_test.c
@@ -16,10 +16,10 @@ static void
 test_boundaries_of_CreateSharedSnapshotArray(void **state)
 {
 	/*
-	 * max_prepared_xacts is used to calculate NUM_SHARED_SNAPSHOT_SLOTS. Make
+	 * MaxBackends is used to calculate NUM_SHARED_SNAPSHOT_SLOTS. Make
 	 * it non-zero so that we actually allocate some local snapshot slots.
 	 */
-	max_prepared_xacts = 2;
+	MaxBackends = 2;
 
 	SharedSnapshotStruct 	*fakeSharedSnapshotArray = NULL;
 	LWLockPadded 			*fakeLockBase = NULL;

--- a/src/include/utils/sharedsnapshot.h
+++ b/src/include/utils/sharedsnapshot.h
@@ -67,6 +67,6 @@ extern void readSharedLocalSnapshot_forCursor(Snapshot snapshot, DtxContext dist
 
 extern void AtEOXact_SharedSnapshot(void);
 
-#define NUM_SHARED_SNAPSHOT_SLOTS (2 * max_prepared_xacts)
+#define NUM_SHARED_SNAPSHOT_SLOTS (2 * MaxBackends)
 
 #endif   /* SHAREDSNAPSHOT_H */

--- a/src/test/isolation2/expected/prepare_limit.out
+++ b/src/test/isolation2/expected/prepare_limit.out
@@ -1,0 +1,120 @@
+-- test to verify a bug that causes standby startup fatal with message like
+-- "the limit of xxx distributed transactions has been reached".
+-- Refer comment in https://github.com/greenplum-db/gpdb/issues/9207 for the
+-- context.
+include: helpers/server_helpers.sql;
+CREATE
+
+-- We will reset the value to 250 finally so sanity check the current value here.
+6: show max_prepared_transactions;
+ max_prepared_transactions 
+---------------------------
+ 250                       
+(1 row)
+!\retcode gpconfig -c max_prepared_transactions -v 3 --skipvalidation;
+(exited with code 0)
+!\retcode gpstop -ari;
+(exited with code 0)
+
+5: create table prepare_limit1 (a int);
+CREATE
+5: create table prepare_limit2 (a int);
+CREATE
+5: create table prepare_limit3 (a int);
+CREATE
+5: create table prepare_limit4 (a int);
+CREATE
+
+5: select gp_inject_fault_infinite('dtm_before_insert_forget_comitted', 'suspend', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Note first insert after table create triggers auto_stats and leads to 2pc
+-- transaction.
+
+-- (2) is on seg0
+1&: insert into prepare_limit1 values(2);  <waiting ...>
+2&: insert into prepare_limit2 values(2);  <waiting ...>
+
+-- (1) is on seg1
+3&: insert into prepare_limit3 values(1);  <waiting ...>
+4&: insert into prepare_limit4 values(1);  <waiting ...>
+
+-- wait until these 2pc reach before inserting forget commit.
+5: SELECT gp_wait_until_triggered_fault('dtm_before_insert_forget_comitted', 4, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- wait until standby catches up and replays all xlogs.
+5: select wait_for_replication_replay (-1, 5000);
+ wait_for_replication_replay 
+-----------------------------
+ t                           
+(1 row)
+
+-- reset to make testing continue
+5: select gp_inject_fault('dtm_before_insert_forget_comitted', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+INSERT 1
+2<:  <... completed>
+INSERT 1
+3<:  <... completed>
+INSERT 1
+4<:  <... completed>
+INSERT 1
+
+-- verify that standby is correctly wal streaming.
+5: select state from pg_stat_replication;
+ state     
+-----------
+ streaming 
+(1 row)
+
+-- verify the tuples are on correct segments so the test assumption is
+-- correct. (i.e. tuple 2, 1 are on different segments).
+5: select gp_segment_id, * from prepare_limit1;
+ gp_segment_id | a 
+---------------+---
+ 0             | 2 
+(1 row)
+5: select gp_segment_id, * from prepare_limit2;
+ gp_segment_id | a 
+---------------+---
+ 0             | 2 
+(1 row)
+5: select gp_segment_id, * from prepare_limit3;
+ gp_segment_id | a 
+---------------+---
+ 1             | 1 
+(1 row)
+5: select gp_segment_id, * from prepare_limit4;
+ gp_segment_id | a 
+---------------+---
+ 1             | 1 
+(1 row)
+
+-- cleanup
+5: drop table prepare_limit1;
+DROP
+5: drop table prepare_limit2;
+DROP
+5: drop table prepare_limit3;
+DROP
+5: drop table prepare_limit4;
+DROP
+
+-- Not using gpconfig -r, else it makes max_prepared_transactions be default
+-- (50) and some isolation2 tests will fail due to "too many clients". Hardcode
+-- to 250 which is the default value when demo cluster is created.
+!\retcode gpconfig -c max_prepared_transactions -v 250 --skipvalidation;
+(exited with code 0)
+!\retcode gpstop -ari;
+(exited with code 0)

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -8,10 +8,6 @@
 include: helpers/server_helpers.sql;
 CREATE
 
-create or replace function wait_for_replication_replay (retries int) returns bool as $$ declare i int; /* in func */ result bool; /* in func */ begin /* in func */ i := 0; /* in func */ -- Wait until the mirror (content 0) has replayed up to flush location loop /* in func */ SELECT flush_location = replay_location INTO result from gp_stat_replication where gp_segment_id = 0; /* in func */ if result then /* in func */ return true; /* in func */ end if; /* in func */ 
-if i >= retries then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ i := i + 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
-CREATE
-
 3:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
  role | preferred_role | content | mode | status 
 ------+----------------+---------+------+--------
@@ -509,7 +505,7 @@ VACUUM
 -- Make sure mirror is able to successfully replay all the truncate
 -- records generated and doesn't encounter the "WAL contains
 -- references to invalid pages" PANIC.
-6:SELECT * from wait_for_replication_replay(5000);
+6:SELECT * from wait_for_replication_replay(0, 5000);
  wait_for_replication_replay 
 -----------------------------
  t                           

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,6 +1,9 @@
 test: setup
 
 test: lockmodes
+# Put test prepare_limit near to test lockmodes since both of them reboot the
+# cluster during testing. Usually the 2nd reboot should be faster.
+test: prepare_limit
 test: ao_partition_lock
 test: dml_on_root_locks_all_parts
 

--- a/src/test/isolation2/sql/prepare_limit.sql
+++ b/src/test/isolation2/sql/prepare_limit.sql
@@ -1,0 +1,63 @@
+-- test to verify a bug that causes standby startup fatal with message like
+-- "the limit of xxx distributed transactions has been reached".
+-- Refer comment in https://github.com/greenplum-db/gpdb/issues/9207 for the
+-- context.
+include: helpers/server_helpers.sql;
+
+-- We will reset the value to 250 finally so sanity check the current value here.
+6: show max_prepared_transactions;
+!\retcode gpconfig -c max_prepared_transactions -v 3 --skipvalidation;
+!\retcode gpstop -ari;
+
+5: create table prepare_limit1 (a int);
+5: create table prepare_limit2 (a int);
+5: create table prepare_limit3 (a int);
+5: create table prepare_limit4 (a int);
+
+5: select gp_inject_fault_infinite('dtm_before_insert_forget_comitted', 'suspend', 1);
+
+-- Note first insert after table create triggers auto_stats and leads to 2pc
+-- transaction.
+
+-- (2) is on seg0
+1&: insert into prepare_limit1 values(2);
+2&: insert into prepare_limit2 values(2);
+
+-- (1) is on seg1
+3&: insert into prepare_limit3 values(1);
+4&: insert into prepare_limit4 values(1);
+
+-- wait until these 2pc reach before inserting forget commit.
+5: SELECT gp_wait_until_triggered_fault('dtm_before_insert_forget_comitted', 4, 1);
+
+-- wait until standby catches up and replays all xlogs.
+5: select wait_for_replication_replay (-1, 5000);
+
+-- reset to make testing continue
+5: select gp_inject_fault('dtm_before_insert_forget_comitted', 'reset', 1);
+1<:
+2<:
+3<:
+4<:
+
+-- verify that standby is correctly wal streaming.
+5: select state from pg_stat_replication;
+
+-- verify the tuples are on correct segments so the test assumption is
+-- correct. (i.e. tuple 2, 1 are on different segments).
+5: select gp_segment_id, * from prepare_limit1;
+5: select gp_segment_id, * from prepare_limit2;
+5: select gp_segment_id, * from prepare_limit3;
+5: select gp_segment_id, * from prepare_limit4;
+
+-- cleanup
+5: drop table prepare_limit1;
+5: drop table prepare_limit2;
+5: drop table prepare_limit3;
+5: drop table prepare_limit4;
+
+-- Not using gpconfig -r, else it makes max_prepared_transactions be default
+-- (50) and some isolation2 tests will fail due to "too many clients". Hardcode
+-- to 250 which is the default value when demo cluster is created.
+!\retcode gpconfig -c max_prepared_transactions -v 250 --skipvalidation;
+!\retcode gpstop -ari;

--- a/src/test/isolation2/sql/uao_crash_compaction_column.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_column.sql
@@ -7,29 +7,6 @@
 -- end_matchsubs
 include: helpers/server_helpers.sql;
 
-create or replace function wait_for_replication_replay (retries int) returns bool as
-$$
-declare
-	i int; /* in func */
-	result bool; /* in func */
-begin /* in func */
-	i := 0; /* in func */
-	-- Wait until the mirror (content 0) has replayed up to flush location
-	loop /* in func */
-		SELECT flush_location = replay_location INTO result from gp_stat_replication where gp_segment_id = 0; /* in func */
-		if result then /* in func */
-			return true; /* in func */
-		end if; /* in func */
-
-		if i >= retries then /* in func */
-		   return false; /* in func */
-		end if; /* in func */
-		perform pg_sleep(0.1); /* in func */
-		i := i + 1; /* in func */
-	end loop; /* in func */
-end; /* in func */
-$$ language plpgsql;
-
 3:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
 --
 -- Test to validate crash at different points in AO/CO vacuum.
@@ -167,5 +144,5 @@ where c.role='p' and c.content=0), 'restart');
 -- Make sure mirror is able to successfully replay all the truncate
 -- records generated and doesn't encounter the "WAL contains
 -- references to invalid pages" PANIC.
-6:SELECT * from wait_for_replication_replay(5000);
+6:SELECT * from wait_for_replication_replay(0, 5000);
 6:SELECT gp_inject_fault('fts_probe', 'reset', 1);


### PR DESCRIPTION
    Previously we assign it as max_prepared_xacts. It is used to initialize some
    2pc related shared memory. For example the array shmCommittedGxactArray is
    created with this length and that array is used to collect not-yet "forgotten"
    distributed transactions during master/standby recovery, but the array length
    might be problematic since:

    1. master max_prepared_xacts might be different than segment max_prepared_xacts
    (although the document does not suggest it there is no code to enforce that),
    so the array on master might not be able to accommodate the distributed
    transactions.

    2. Even master max_prepared_xacts is equal to segment max_prepared_xacts as
    usual.  It is possible some distributed transactions use just partial gang so
    the total distributed transactions might be larger (and even much larger) than
    max_prepared_xacts. The document says max_prepared_xacts should be greater than
    max_connections but there is no code to enforce that.

    To fix that we use MaxBackends for the gxact number on master. We may just use
    guc max_connections (MaxBackends includes number for autovacuum workers and bg
    workers additionally besides guc max_connections), but I'm conservatively using
    MaxBackends.  since this issue is annoying - standby can not recover even after
    reboot unless we temporarily increase the guc max_prepared_transactions value.