### PR TITLE
6X: gpexpand: cleanup new segments in parallel

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1417,10 +1417,11 @@ class gpexpand:
                                                          , sqlCommandList=statements
                                                          )
                 self.pool.addCommand(execSQLCmd)
-                self.pool.join()
-                ### need to fix self.pool.check_results(). Call getCompletedItems to clear the queue for now.
-                self.pool.check_results()
-                self.pool.getCompletedItems()
+
+        self.pool.join()
+        ### need to fix self.pool.check_results(). Call getCompletedItems to clear the queue for now.
+        self.pool.check_results()
+        self.pool.getCompletedItems()
 
     # --------------------------------------------------------------------------
     def restore_master(self):


### PR DESCRIPTION
When cleaning up the master-only files on the new segments we used to do
the job one by one, when there are tens or hundreds of segments it can
be very slow.

Now we cleanup in parallel.

(cherry picked from commit 857763ae076b70943714ebc2b8d261c2ce4e1be0)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
