### PR TITLE
Re-enable test segwalrep/dtx_recovery_wait_lsn

### DIFF
--- a/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
+++ b/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
@@ -26,9 +26,8 @@ CREATE
 --------------------------
  Success:                 
 (1 row)
-2&: select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, dbid) from gp_segment_configuration where content=0 and role='p';  <waiting ...>
 1&: insert into t_wait_lsn select generate_series(1,12);  <waiting ...>
-2<:  <... completed>
+2: select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, dbid) from gp_segment_configuration where content=0 and role='p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
@@ -72,6 +71,7 @@ CREATE
 -- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
 -- end_matchsubs
 3: select 1;
+PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -152,18 +152,9 @@ server closed the connection unexpectedly
 -------
  12    
 (1 row)
--- start_matchsubs
--- m/File \"\.\/sql_isolation_testcase\.py\", line \d+/
--- s/File \"\.\/sql_isolation_testcase\.py\", line \d+/File \"\.\/sql_isolation_testcase\.py\", line xxx/
--- end_matchsubs
 4: drop table t_wait_lsn;
 DROP
-4q: ... <quitting>
-Traceback (most recent call last):
-  File "./sql_isolation_testcase.py", line 123, in <module>
-    executor.process_isolation_file(sys.stdin, sys.stdout)
-  File "./sql_isolation_testcase.py", line 123, in process_isolation_file
-    process.stop()
-  File "./sql_isolation_testcase.py", line 123, in stop
-    raise Exception("Should not finish test case while waiting for results")
-Exception: Should not finish test case while waiting for results
+1<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.

--- a/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
+++ b/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
@@ -152,14 +152,18 @@ server closed the connection unexpectedly
 -------
  12    
 (1 row)
+-- start_matchsubs
+-- m/File \"\.\/sql_isolation_testcase\.py\", line \d+/
+-- s/File \"\.\/sql_isolation_testcase\.py\", line \d+/File \"\.\/sql_isolation_testcase\.py\", line xxx/
+-- end_matchsubs
 4: drop table t_wait_lsn;
 DROP
 4q: ... <quitting>
 Traceback (most recent call last):
-  File "./sql_isolation_testcase.py", line 718, in <module>
+  File "./sql_isolation_testcase.py", line 123, in <module>
     executor.process_isolation_file(sys.stdin, sys.stdout)
-  File "./sql_isolation_testcase.py", line 510, in process_isolation_file
+  File "./sql_isolation_testcase.py", line 123, in process_isolation_file
     process.stop()
-  File "./sql_isolation_testcase.py", line 138, in stop
+  File "./sql_isolation_testcase.py", line 123, in stop
     raise Exception("Should not finish test case while waiting for results")
 Exception: Should not finish test case while waiting for results

--- a/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
+++ b/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
@@ -7,12 +7,17 @@ CREATE
 -- in-progress two-phase transactions.
 -- The FTS process should be able to continue probe and 'sync off' the mirror
 -- while the 'dtx recovery' process is hanging recovering distributed transactions.
-!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
--- start_ignore
-20200123:08:10:59:395805 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-c gp_fts_probe_retries -v 2 --masteronly'
 
--- end_ignore
-(exited with code 0)
+-- modify fts gucs to speed up the test.
+1: alter system set gp_fts_probe_interval to 10;
+ALTER
+1: alter system set gp_fts_probe_retries to 1;
+ALTER
+1: select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
 
 1: create or replace function wait_until_standby_in_state(targetstate text) returns void as $$ declare replstate text; /* in func */ begin loop select state into replstate from pg_stat_replication; /* in func */ exit when replstate = targetstate; /* in func */ perform pg_sleep(0.1); /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
 CREATE
@@ -26,7 +31,7 @@ CREATE
 --------------------------
  Success:                 
 (1 row)
-1&: insert into t_wait_lsn select generate_series(1,12);  <waiting ...>
+1&: insert into t_wait_lsn values(2),(1);  <waiting ...>
 2: select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, dbid) from gp_segment_configuration where content=0 and role='p';
  gp_wait_until_triggered_fault 
 -------------------------------
@@ -83,11 +88,14 @@ server closed the connection unexpectedly
                              
 (1 row)
 
--- wait for FTS to 'sync off' the mirror, meanwhile, dtx recovery process will restart repeatedly
+-- wait for FTS to 'sync off' the mirror, meanwhile, dtx recovery process will
+-- restart repeatedly.
+-- the query should succeed finally since dtx recovery process is able to quit.
+-- this's what we want to test.
 4: select count(*) from t_wait_lsn;
  count 
 -------
- 12    
+ 2     
 (1 row)
 
 !\retcode gprecoverseg -a;
@@ -140,20 +148,24 @@ server closed the connection unexpectedly
  OK                                   
 (1 row)
 
-!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
--- start_ignore
-20200123:08:12:04:396100 gpconfig:09c5497cf854:gpadmin-[INFO]:-completed successfully with parameters '-c gp_fts_probe_retries -v 2 --masteronly'
-
--- end_ignore
-(exited with code 0)
-
 4: select count(*) from t_wait_lsn;
  count 
 -------
- 12    
+ 2     
 (1 row)
 4: drop table t_wait_lsn;
 DROP
+
+4: alter system reset gp_fts_probe_interval;
+ALTER
+4: alter system reset gp_fts_probe_retries;
+ALTER
+4: select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+
 1<:  <... completed>
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally

--- a/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
+++ b/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
@@ -98,6 +98,11 @@ server closed the connection unexpectedly
  2     
 (1 row)
 
+1<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
 !\retcode gprecoverseg -a;
 -- start_ignore
 20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Starting gprecoverseg with args: -a
@@ -165,8 +170,3 @@ ALTER
 ----------------
  t              
 (1 row)
-
-1<:  <... completed>
-server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -194,8 +194,7 @@ test: segwalrep/twophase_tolerance_with_mirror_promotion
 test: segwalrep/failover_with_many_records
 test: segwalrep/dtm_recovery_on_standby
 test: segwalrep/commit_blocking_on_standby
-# Removed due to test failures during isolation2 refactor. Needs to be re-written to not rely on python exception in isolation2
-# test: segwalrep/dtx_recovery_wait_lsn
+test: segwalrep/dtx_recovery_wait_lsn
 test: pg_basebackup
 test: pg_basebackup_with_tablespaces
 test: fts_manual_probe

--- a/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
+++ b/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
@@ -61,5 +61,9 @@ $$ language plpgsql;
 !\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
 
 4: select count(*) from t_wait_lsn;
+-- start_matchsubs
+-- m/File \"\.\/sql_isolation_testcase\.py\", line \d+/
+-- s/File \"\.\/sql_isolation_testcase\.py\", line \d+/File \"\.\/sql_isolation_testcase\.py\", line xxx/
+-- end_matchsubs
 4: drop table t_wait_lsn;
 4q:

--- a/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
+++ b/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
@@ -6,7 +6,11 @@ include: helpers/server_helpers.sql;
 -- in-progress two-phase transactions. 
 -- The FTS process should be able to continue probe and 'sync off' the mirror
 -- while the 'dtx recovery' process is hanging recovering distributed transactions.
-!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
+
+-- modify fts gucs to speed up the test.
+1: alter system set gp_fts_probe_interval to 10;
+1: alter system set gp_fts_probe_retries to 1;
+1: select pg_reload_conf();
 
 1: create or replace function wait_until_standby_in_state(targetstate text)
 returns void as $$
@@ -25,7 +29,7 @@ $$ language plpgsql;
 
 -- suspend segment 0 before performing 'COMMIT PREPARED'
 2: select gp_inject_fault_infinite('finish_prepared_start_of_function', 'suspend', dbid) from gp_segment_configuration where content=0 and role='p';
-1&: insert into t_wait_lsn select generate_series(1,12);
+1&: insert into t_wait_lsn values(2),(1);
 2: select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, dbid) from gp_segment_configuration where content=0 and role='p';
 
 -- let walreceiver on mirror 0 skip WAL flush
@@ -50,15 +54,21 @@ $$ language plpgsql;
 -- wait for master finish crash recovery
 -1U: select wait_until_standby_in_state('streaming');
 
--- wait for FTS to 'sync off' the mirror, meanwhile, dtx recovery process will restart repeatedly 
+-- wait for FTS to 'sync off' the mirror, meanwhile, dtx recovery process will
+-- restart repeatedly.
+-- the query should succeed finally since dtx recovery process is able to quit.
+-- this's what we want to test.
 4: select count(*) from t_wait_lsn;
 
 !\retcode gprecoverseg -a;
 -- loop while segments come in sync
 4: select wait_until_all_segments_synchronized();
 
-!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
-
 4: select count(*) from t_wait_lsn;
 4: drop table t_wait_lsn;
+
+4: alter system reset gp_fts_probe_interval;
+4: alter system reset gp_fts_probe_retries;
+4: select pg_reload_conf();
+
 1<:

--- a/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
+++ b/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
@@ -60,6 +60,8 @@ $$ language plpgsql;
 -- this's what we want to test.
 4: select count(*) from t_wait_lsn;
 
+1<:
+
 !\retcode gprecoverseg -a;
 -- loop while segments come in sync
 4: select wait_until_all_segments_synchronized();
@@ -70,5 +72,3 @@ $$ language plpgsql;
 4: alter system reset gp_fts_probe_interval;
 4: alter system reset gp_fts_probe_retries;
 4: select pg_reload_conf();
-
-1<:

--- a/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
+++ b/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
@@ -25,9 +25,8 @@ $$ language plpgsql;
 
 -- suspend segment 0 before performing 'COMMIT PREPARED'
 2: select gp_inject_fault_infinite('finish_prepared_start_of_function', 'suspend', dbid) from gp_segment_configuration where content=0 and role='p';
-2&: select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, dbid) from gp_segment_configuration where content=0 and role='p';
 1&: insert into t_wait_lsn select generate_series(1,12);
-2<:
+2: select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, dbid) from gp_segment_configuration where content=0 and role='p';
 
 -- let walreceiver on mirror 0 skip WAL flush
 2: select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid) from gp_segment_configuration where content=0 and role='m';
@@ -61,9 +60,5 @@ $$ language plpgsql;
 !\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
 
 4: select count(*) from t_wait_lsn;
--- start_matchsubs
--- m/File \"\.\/sql_isolation_testcase\.py\", line \d+/
--- s/File \"\.\/sql_isolation_testcase\.py\", line \d+/File \"\.\/sql_isolation_testcase\.py\", line xxx/
--- end_matchsubs
 4: drop table t_wait_lsn;
-4q:
+1<:


### PR DESCRIPTION
It was disabled in 791f3b01ddc29ef002735307c485b8f08105444c.  Because there is
concern about the change of the line number in sql_isolation_testcase.py in the
test answer file. Using init file to mask the line change in
sql_isolation_testcase.py to ease the concern.
