### PR TITLE
gpexpand support readability

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -38,7 +38,7 @@ try:
     from gppylib.operations.utils import ParallelOperation
     from gppylib.parseutils import line_reader, check_values, canonicalize_address
     from gppylib.heapchecksum import HeapChecksum
-    from gppylib.commands.pg import PgBaseBackup
+    from gppylib.commands.pg import PgBaseBackup, Thread
     from gppylib.mainUtils import ExceptionNoStackTraceNeeded
 
 except ImportError, e:
@@ -1589,7 +1589,7 @@ class gpexpand:
     quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
     c.oid as tableoid,
     NULL as root_partition_name,
-    2 as rank,
+    1 as rank,
     pe.writable is not null as external_writable,
     '%s' as undone_status,
     NULL as expansion_started,
@@ -1655,31 +1655,34 @@ WHERE
            Change all leaf partition's policy back to old policy with a mandatory
            data movement.
         """
-        src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(n.nspname) || '.' || quote_ident(c.relname))"
+        src_size_sql = """SELECT 
+        SUM(pg_relation_size(quote_ident(partitionschemaname) || '.' || quote_ident(partitiontablename))) 
+        FROM pg_partitions
+        WHERE schemaname = n.nspname AND tablename = c.relname"""
+        src_bytes_str = "0" if self.options.simple_progress else "( %s )" % src_size_sql
+        # expand leaf partition in parallel
         sql = """
 SELECT
     current_database(),
-    quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
+    quote_ident(p.partitionschemaname)||'.'||quote_ident(p.partitiontablename) as fq_name,
     c.oid as tableoid,
-    quote_ident(n.nspname) || '.' || quote_ident(c.relname) as root_partition_name,
+    quote_ident(p.schemaname) || '.' || quote_ident(p.tablename) as root_partition_name,
     2 as rank,
     false as external_writable,
     '%s' as undone_status,
     NULL as expansion_started,
     NULL as expansion_finished,
     %s as source_bytes
-FROM
-    pg_class c,
-    pg_namespace n,
-    pg_partition p,
-    gp_distribution_policy d
+FROM 
+    pg_partitions p, pg_class c, pg_namespace n 
 WHERE
-    c.relnamespace = n.oid
-    AND p.parrelid = c.oid
-    AND d.localoid = c.oid
-    AND parlevel = 0
+    c.relnamespace = n.oid 
+    AND p.partitionschemaname = n.nspname 
+    AND p.partitiontablename = c.relname 
+    AND c.relstorage not in ('x', 'f') 
+    AND NOT c.relhassubclass
 ORDER BY fq_name, tableoid desc
-                  """ % (undone_status, src_bytes_str)
+        """ % (undone_status, src_bytes_str)
         self.logger.debug(sql)
         table_conn = self.connect_database(dbname)
 
@@ -1724,13 +1727,14 @@ ORDER BY fq_name, tableoid desc
         self.conn.commit()
 
         # read schema and queue up commands
-        sql = "SELECT * FROM gpexpand.status_detail WHERE status = 'NOT STARTED' ORDER BY rank"
+        sql = "SELECT * FROM gpexpand.status_detail WHERE status = 'NOT STARTED' ORDER BY rank, source_bytes"
         cursor = dbconn.execSQL(self.conn, sql)
+        num_segments_after_expansion = len(self.gparray.segmentPairs)
 
         for row in cursor:
             self.logger.debug(row)
             name = "name"
-            tbl = ExpandTable(options=self.options, row=row)
+            tbl = ExpandTable(options=self.options, row=row, num_segments=num_segments_after_expansion)
             cmd = ExpandCommand(name=name, status_url=self.dburl, table=tbl, options=self.options)
             self.queue.addCommand(cmd)
 
@@ -1836,7 +1840,7 @@ ORDER BY fq_name, tableoid desc
             c = dbconn.connect(self.dburl, encoding='UTF8')
             self.logger.warn('Expansion has not yet completed.  Removing the expansion')
             self.logger.warn('schema now will leave the following tables unexpanded:')
-            unexpanded_tables_sql = "SELECT fq_name FROM gpexpand.status_detail WHERE status = 'NOT STARTED' ORDER BY rank"
+            unexpanded_tables_sql = "SELECT fq_name FROM gpexpand.status_detail WHERE status = 'NOT STARTED' ORDER BY rank, source_bytes"
 
             cursor = dbconn.execSQL(c, unexpanded_tables_sql)
             unexpanded_tables_text = ''.join("\t%s\n" % row[0] for row in cursor)
@@ -1922,9 +1926,13 @@ ORDER BY fq_name, tableoid desc
 
 # -----------------------------------------------
 class ExpandTable():
-    def __init__(self, options, row=None):
+    def __init__(self, options, row=None, num_segments=0):
         self.options = options
         self.is_root_partition = False
+        if num_segments:
+            self.num_segments = num_segments
+        else:
+            logger.warning('numsegments is 0, gpexpand will fail if there is a partition table.')
         if row is not None:
             (self.dbname, self.fq_name, self.table_oid,
              self.root_partition_name,
@@ -1979,21 +1987,163 @@ class ExpandTable():
         dbconn.execSQL(status_conn, sql)
         status_conn.commit()
 
-    def expand(self, table_conn, cancel_flag):
+    # lock root/interior partition tables until all leaf tables expanded
+    def lock_partition_tables(self, status_url, table_url, rootoid):
+        sql = """
+SELECT
+    quote_ident(p.partitionschemaname) ||'.'|| quote_ident(p.partitiontablename) as fq_name
+FROM 
+    pg_partitions p, pg_class c, pg_namespace n 
+WHERE
+    c.relnamespace = n.oid 
+    AND p.partitionschemaname = n.nspname 
+    AND p.partitiontablename = c.relname 
+    AND c.relhassubclass
+    AND quote_ident(p.schemaname)||'.'||quote_ident(p.tablename) = '%s';
+        """ % self.root_partition_name
+        status_conn = dbconn.connect(status_url, encoding='UTF8')
+        table_conn = dbconn.connect(table_url, encoding='UTF8')
+        partition_tables = [self.root_partition_name]
+        curs = dbconn.execSQL(table_conn, sql)
+        rows = curs.fetchall()
+        for row in rows:
+            partition_tables.append(row[0])
+        lock_sql_list = []
+        for table in partition_tables:
+            lock_sql_list.append('LOCK TABLE ONLY %s IN EXCLUSIVE MODE;' % table)
+        lock_sql = '\n'.join(lock_sql_list)
+        lock_check_sql = """SELECT count(1) FROM pg_locks WHERE relation = %s AND locktype = 'relation' 
+                AND mode = 'ExclusiveLock';""" % rootoid
+        # double check
+        lock_count = dbconn.execSQLForSingleton(table_conn, lock_check_sql)
+        if lock_count > 0:
+            status_conn.close()
+            table_conn.close()
+            return
+        logger.info('Locking partition table %s' % self.root_partition_name)
+        dbconn.execSQL(table_conn, lock_sql)
+        # check if all leaf tables expanded
+        check_sql = """SELECT COUNT(1) FROM gpexpand.status_detail WHERE root_partition_name = '%s' 
+        AND status <> '%s'""" % (self.root_partition_name, done_status)
+        while True:
+            time.sleep(3)
+            count = dbconn.execSQLForSingleton(status_conn, check_sql)
+            if count == 0:
+                table_conn.commit()
+                logger.info('Unlocked %s' % self.root_partition_name)
+                if self.options.analyze:
+                    logger.info('Analyzing %s' % self.root_partition_name)
+                    self.analyze_partition_table(table_conn)
+                table_conn.close()
+                status_conn.close()
+                break
+
+    def analyze_partition_table(self, table_conn):
+        tables = list()
+        not_ext_sql = """
+SELECT
+    quote_ident(p.partitionschemaname)||'.'||quote_ident(p.partitiontablename) as partitiontable
+FROM 
+    pg_partitions p, pg_class c, pg_namespace n 
+WHERE 
+    c.relnamespace = n.oid 
+    AND p.partitionschemaname = n.nspname 
+    AND p.partitiontablename = c.relname 
+    AND c.relstorage not in ('x', 'f') 
+    AND NOT c.relhassubclass
+    AND quote_ident(p.schemaname)||'.'||quote_ident(p.tablename) = '%s'
+            """ % self.root_partition_name
+        cursor = None
+        try:
+            cursor = dbconn.execSQL(table_conn, not_ext_sql)
+            for row in list(cursor.fetchall()):
+                tables.append(row[0])
+        except Exception, ex:
+            logger.warn(ex)
+        finally:
+            if cursor:
+                cursor.close()
+        for tab in tables:
+            sql = 'ANALYZE %s' % tab
+            logger.info('Analyzing %s' % (tab.decode('utf-8')))
+            dbconn.execSQL(table_conn, sql)
+            table_conn.commit()
+
+    def update_partition_numsegments(self, table_conn, rootoid):
+        sql = """
+SELECT
+    c.oid as tableoid
+FROM 
+    pg_partitions p, pg_class c, pg_namespace n 
+WHERE
+    c.relnamespace = n.oid 
+    AND p.partitionschemaname = n.nspname 
+    AND p.partitiontablename = c.relname 
+    AND c.relhassubclass
+    AND quote_ident(p.schemaname)||'.'||quote_ident(p.tablename) = '%s';
+        """ % self.root_partition_name
+        tableoids = []
+        curs = dbconn.execSQL(table_conn, sql)
+        rows = curs.fetchall()
+        for row in rows:
+            tableoids.append(int(row[0]))
+        tableoids.append(rootoid)
+
+        for tableoid in tableoids:
+            sql = """UPDATE gp_distribution_policy SET numsegments=%d WHERE numsegments < %d AND localoid=%d; """ % (
+                self.num_segments, self.num_segments, tableoid)
+            dbconn.execSQL(table_conn, sql)
+            table_conn.commit()
+
+    def preprocess_partition_table(self, table_conn, status_conn, status_url, table_url):
+        # find the first leaf partition table
+        sql = """SELECT fq_name FROM gpexpand.status_detail WHERE expansion_started = (SELECT min(expansion_started) 
+                FROM gpexpand.status_detail WHERE root_partition_name = '%s' AND expansion_started IS NOT NULL);
+                """ % self.root_partition_name
+        first_fq_name = dbconn.execSQLForSingleton(status_conn, sql)
+
+        oid_sql = """SELECT '%s'::regclass::oid""" % self.root_partition_name
+        rootoid = dbconn.execSQLForSingleton(table_conn, oid_sql)
+        lock_check_sql = """SELECT count(1) FROM pg_locks WHERE relation = %s AND locktype = 'relation' 
+                AND mode = 'ExclusiveLock';""" % rootoid
+        lock_count = dbconn.execSQLForSingleton(table_conn, lock_check_sql)
+
+        if self.fq_name == first_fq_name:
+            lock_thread = Thread(name='lock partition tables', target=self.lock_partition_tables,
+                                 args=(status_url, table_url, rootoid))
+            lock_thread.start()
+            # wait for the partition table to be locked
+            time.sleep(1)
+            self.update_partition_numsegments(table_conn, rootoid)
+        # lock count is for restarting gpexpand due to interruption
+        elif lock_count == 0:
+            time.sleep(random.randint(1, 5))
+            lock_count = dbconn.execSQLForSingleton(table_conn, lock_check_sql)
+            if lock_count == 0:
+                lock_thread = Thread(name='lock partition tables', target=self.lock_partition_tables,
+                                     args=(status_url, table_url, rootoid))
+                lock_thread.start()
+                time.sleep(1)
+                self.update_partition_numsegments(table_conn, rootoid)
+
+    def expand(self, table_conn, status_conn, cancel_flag, status_url, table_url):
         # for root partition, we want to expand whose partition in one shot
-        # TODO: expand leaf partitions seperately in parallel
         only_str = "" if self.is_root_partition else "ONLY"
         external_str = "EXTERNAL" if self.external_writable else ""
-        sql = 'ALTER %s TABLE %s %s EXPAND TABLE' % (external_str, only_str, self.fq_name)
-
-        logger.info('Expanding %s.%s' % (self.dbname.decode('utf-8'), self.fq_name.decode('utf-8')))
-        logger.debug("Expand SQL: %s" % sql.decode('utf-8'))
 
         # check is atomic in python
         if not cancel_flag:
+            if self.root_partition_name is not None:
+                self.preprocess_partition_table(table_conn, status_conn, status_url, table_url)
+
+            sql = 'ALTER %s TABLE %s %s EXPAND TABLE' % (external_str, only_str, self.fq_name)
+            logger.info('Expanding %s.%s' % (self.dbname.decode('utf-8'), self.fq_name.decode('utf-8')))
+            logger.debug("Expand SQL: %s" % sql.decode('utf-8'))
+
             dbconn.execSQL(table_conn, sql)
             table_conn.commit()
-            if self.options.analyze:
+
+            if self.options.analyze and self.root_partition_name is None:
                 sql = 'ANALYZE %s' % (self.fq_name)
                 logger.info('Analyzing %s' % (self.fq_name.decode('utf-8')))
                 dbconn.execSQL(table_conn, sql)
@@ -2115,7 +2265,7 @@ class ExpandCommand(SQLCommand):
 
         try:
             status_conn = dbconn.connect(self.status_url, encoding='UTF8')
-            table_conn = dbconn.connect(self.table_url, encoding='UTF8')
+            table_conn = dbconn.connect(self.table_url, encoding='UTF8', allowSystemTableMods=True)
         except DatabaseError, ex:
             if self.options.verbose:
                 logger.exception(ex)
@@ -2144,10 +2294,9 @@ class ExpandCommand(SQLCommand):
                 # Set conn for  cancel
                 self.cancel_conn = table_conn
                 start_time = datetime.datetime.now()
-                if not self.options.simple_progress:
-                    self.table.mark_started(status_conn, table_conn, start_time, self.cancel_flag)
+                self.table.mark_started(status_conn, table_conn, start_time, self.cancel_flag)
 
-                table_exp_success = self.table.expand(table_conn, self.cancel_flag)
+                table_exp_success = self.table.expand(table_conn, status_conn, self.cancel_flag, self.status_url, self.table_url)
 
         except Exception, ex:
             if ex.__str__().find('canceling statement due to user request') == -1 and not self.cancel_flag:

--- a/src/test/regress/expected/expand_table_ao.out
+++ b/src/test/regress/expected/expand_table_ao.out
@@ -808,19 +808,16 @@ select gp_segment_id, * from part_t1_1_prt_other_b_2_prt_2_3_prt_others_d;
 (7 rows)
 
 alter table part_t1_1_prt_other_b_2_prt_2_3_prt_others_d expand table;
-ERROR:  cannot expand leaf or interior partition "part_t1_1_prt_other_b_2_prt_2_3_prt_others_d"
-DETAIL:  root/leaf/interior partitions need to have same numsegments
-HINT:  use "ALTER TABLE part_t1 EXPAND TABLE" instead
 select gp_segment_id, * from part_t1_1_prt_other_b_2_prt_2_3_prt_others_d;
  gp_segment_id | a  | b | c | d | e 
 ---------------+----+---+---+---+---
-             0 |  9 | 0 | 1 | 4 | 0
              0 | 29 | 2 | 1 | 4 | 0
              0 | 45 | 0 | 1 | 0 | 0
              0 | 65 | 2 | 1 | 0 | 0
-             1 |  5 | 2 | 1 | 0 | 1
              1 | 69 | 0 | 1 | 4 | 1
              1 | 89 | 2 | 1 | 4 | 1
+             2 |  5 | 2 | 1 | 0 | 1
+             2 |  9 | 0 | 1 | 4 | 0
 (7 rows)
 
 -- try to expand root partition, should success

--- a/src/test/regress/expected/expand_table_aoco.out
+++ b/src/test/regress/expected/expand_table_aoco.out
@@ -790,19 +790,16 @@ select gp_segment_id, * from part_t1_1_prt_other_b_2_prt_2_3_prt_others_d;
 (7 rows)
 
 alter table part_t1_1_prt_other_b_2_prt_2_3_prt_others_d expand table;
-ERROR:  cannot expand leaf or interior partition "part_t1_1_prt_other_b_2_prt_2_3_prt_others_d"
-DETAIL:  root/leaf/interior partitions need to have same numsegments
-HINT:  use "ALTER TABLE part_t1 EXPAND TABLE" instead
 select gp_segment_id, * from part_t1_1_prt_other_b_2_prt_2_3_prt_others_d;
  gp_segment_id | a  | b | c | d | e 
 ---------------+----+---+---+---+---
-             0 |  9 | 0 | 1 | 4 | 0
              0 | 29 | 2 | 1 | 4 | 0
              0 | 45 | 0 | 1 | 0 | 0
              0 | 65 | 2 | 1 | 0 | 0
-             1 |  5 | 2 | 1 | 0 | 1
              1 | 69 | 0 | 1 | 4 | 1
              1 | 89 | 2 | 1 | 4 | 1
+             2 |  5 | 2 | 1 | 0 | 1
+             2 |  9 | 0 | 1 | 4 | 0
 (7 rows)
 
 -- try to expand root partition, should success


### PR DESCRIPTION
Tables in the redistribution state during gpexpand cannot be read or written. For a 350GB column-stored table, the redistribution needs to last more than 1 hour. During this period, queries join with the table cannot be executed.

In addition, if a partition table including external table, gpexpand will fail. You need to manually delete the external table partition and restore the external table after the expansion is completed.

#### commit fix
- In the CTAS phase, the lock is reduced to Exclusive Lock to support table readability.
- Sink the expansion of the partition table to the leaf partition, which can be expanded in parallel, and the external table can be filtered.

It is necessary to ensure that the data can be read correctly during the redistribution, the inserted data will not be lost, and gpexpand can be retried if it fails.

See github issue: [#10114](https://github.com/greenplum-db/gpdb/issues/10114)
