### PR TITLE
pg_upgrade: Add check to identify foreign key constraint on root

### DIFF
--- a/contrib/pg_upgrade/test/integration/expected/upgraded_foreign_key_constraint.out
+++ b/contrib/pg_upgrade/test/integration/expected/upgraded_foreign_key_constraint.out
@@ -1,0 +1,24 @@
+SELECT * FROM mfk;
+ a 
+---
+ 1 
+ 2 
+(2 rows)
+SELECT * FROM pt;
+ a 
+---
+ 1 
+ 2 
+(2 rows)
+SELECT * FROM pt_another;
+ a 
+---
+ 1 
+ 2 
+(2 rows)
+SELECT * FROM non_pt;
+ a 
+---
+ 1 
+ 2 
+(2 rows)

--- a/contrib/pg_upgrade/test/integration/gpdb5_schedule
+++ b/contrib/pg_upgrade/test/integration/gpdb5_schedule
@@ -13,3 +13,4 @@ test: different_name_index_backed_constraint
 test: mismatched_partition_schemas
 test: vacuum_freeze_tables
 test: indexes
+test: foreign_key_constraint

--- a/contrib/pg_upgrade/test/integration/gpdb6_schedule
+++ b/contrib/pg_upgrade/test/integration/gpdb6_schedule
@@ -5,3 +5,4 @@ test: upgraded_partitioned_heap_table_with_differently_aligned_dropped_columns
 test: upgraded_partitioned_heap_table_with_differently_aligned_varlen_dropped_columns
 test: upgraded_vacuum_freeze_tables
 test: upgraded_indexes
+test: upgraded_foreign_key_constraint

--- a/contrib/pg_upgrade/test/integration/input/foreign_key_constraint.source
+++ b/contrib/pg_upgrade/test/integration/input/foreign_key_constraint.source
@@ -1,0 +1,18 @@
+CREATE TABLE mfk(a int unique);
+INSERT INTO mfk SELECT i FROM generate_series(1,2)i;
+CREATE TABLE pt(a int references mfk(a)) PARTITION BY RANGE(a) (START(1) END(3) EVERY(2));
+INSERT INTO pt SELECT i FROM generate_series(1,2)i;
+
+CREATE TABLE pt_another(a int references mfk(a)) PARTITION BY RANGE(a) (START(1) END(3) EVERY(2));
+INSERT INTO pt_another SELECT i FROM generate_series(1,2)i;
+
+CREATE TABLE non_pt(a int references mfk(a));
+INSERT INTO non_pt SELECT i FROM generate_series(1,2)i;
+
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+
+! /bin/cat foreign_key_constraints.txt;
+
+-- DROP the foreign key constraints
+ALTER TABLE public.pt DROP CONSTRAINT pt_fkey CASCADE;
+ALTER TABLE public.pt_another DROP CONSTRAINT pt_another_fkey CASCADE;

--- a/contrib/pg_upgrade/test/integration/output/foreign_key_constraint.source
+++ b/contrib/pg_upgrade/test/integration/output/foreign_key_constraint.source
@@ -1,0 +1,46 @@
+CREATE TABLE mfk(a int unique);
+CREATE
+INSERT INTO mfk SELECT i FROM generate_series(1,2)i;
+INSERT 2
+CREATE TABLE pt(a int references mfk(a)) PARTITION BY RANGE(a) (START(1) END(3) EVERY(2));
+CREATE
+INSERT INTO pt SELECT i FROM generate_series(1,2)i;
+INSERT 2
+
+CREATE TABLE pt_another(a int references mfk(a)) PARTITION BY RANGE(a) (START(1) END(3) EVERY(2));
+CREATE
+INSERT INTO pt_another SELECT i FROM generate_series(1,2)i;
+INSERT 2
+
+CREATE TABLE non_pt(a int references mfk(a));
+CREATE
+INSERT INTO non_pt SELECT i FROM generate_series(1,2)i;
+INSERT 2
+
+! ./gpdb6/bin/pg_upgrade --mode=dispatcher --old-gp-dbid=1 --new-gp-dbid=1 --check --old-bindir=@upgrade_test_path@/gpdb5/bin --new-bindir=@upgrade_test_path@/gpdb6/bin --old-datadir=@upgrade_test_path@/gpdb5-data/qddir/demoDataDir-1 --new-datadir=@upgrade_test_path@/gpdb6-data/qddir/demoDataDir-1 --old-port=@old_port@;
+Performing Consistency Checks on Old Live Server
+------------------------------------------------
+Checking cluster versions                                   ok
+Creating a dump of all tablespace metadata.                 ok
+Checking for foreign key constraints on root partitions     fatal
+
+Your installation contains foreign key constraint on root 
+partition tables. These constraints need to be dropped before 
+proceeding to upgrade. A list of foreign key constraints is 
+in the file:
+	foreign_key_constraints.txt
+
+Failure, exiting
+
+
+! /bin/cat foreign_key_constraints.txt;
+Database: upgradetest
+  pt_fkey on relation public.pt
+  pt_another_fkey on relation public.pt_another
+
+
+-- DROP the foreign key constraints
+ALTER TABLE public.pt DROP CONSTRAINT pt_fkey CASCADE;
+ALTER
+ALTER TABLE public.pt_another DROP CONSTRAINT pt_another_fkey CASCADE;
+ALTER

--- a/contrib/pg_upgrade/test/integration/sql/upgraded_foreign_key_constraint.sql
+++ b/contrib/pg_upgrade/test/integration/sql/upgraded_foreign_key_constraint.sql
@@ -1,0 +1,4 @@
+SELECT * FROM mfk;
+SELECT * FROM pt;
+SELECT * FROM pt_another;
+SELECT * FROM non_pt;


### PR DESCRIPTION
partitions

If a root partition contains a foreign key constraint, pg_dump will
create the DDL in the below format:
```
CREATE TABLE public.pt (
    a integer
)
DISTRIBUTED BY (a) PARTITION BY RANGE(a)
( START (1) END (3) EVERY (2) WITH (tablename='pt_1_prt_1', appendonly=false ) );

ALTER TABLE ONLY public.pt
    ADD CONSTRAINT pt_fkey FOREIGN KEY (a) REFERENCES public.mfk(a);
```

When the ALTER statement is executed, the below error is observed:
```
ERROR:  can't add a constraint to "pt"; it is a partitioned table or part thereof
```

Foreign key constraint on root partitions must be dropped before
upgrading the cluster.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
