### PR TITLE
enable demo_cluster.sh to handle symlinks

### DIFF
--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -178,8 +178,6 @@ if [ -z "${GPHOME}" ]; then
     echo "  file in your Greenplum installation directory."
     echo ""
     exit 1
-else
-    GPSEARCH=$GPHOME
 fi
 
 cat <<-EOF
@@ -210,16 +208,16 @@ cat <<-EOF
 
 EOF
 
-GPPATH=`find $GPSEARCH -name gpstart| tail -1`
+GPPATH=`find -H $GPHOME -name gpstart| tail -1`
 RETVAL=$?
 
 if [ "$RETVAL" -ne 0 ]; then
-    echo "Error attempting to find Greenplum executables in $GPSEARCH"
+    echo "Error attempting to find Greenplum executables in $GPHOME"
     exit 1
 fi
 
 if [ ! -x "$GPPATH" ]; then
-    echo "No executables found for Greenplum installation in $GPSEARCH"
+    echo "No executables found for Greenplum installation in $GPHOME"
     exit 1
 fi
 GPPATH=`dirname $GPPATH`


### PR DESCRIPTION
Enable demo_cluster.sh to handle symlinks which is useful when GPDB is installed using RPMs and a demo cluster is desired.

_Note:_ If this is merged, backports to 6X and 5X are needed.

[Test pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/kalen_demo_cluster_symlinks_Master)