### PR TITLE
Fix DNS lookup issue for pure IPv6 addresses in URLs

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1292,8 +1292,6 @@ getDnsCachedAddress(char *name, int port, int elevel, bool use_cache)
 		if (((!use_cache && !hostinfo[0]) || (use_cache && e == NULL))
 			&& addrs->ai_family == AF_INET6)
 		{
-			char		hostinfo[NI_MAXHOST];
-
 			addr = addrs;
 			/* Get a text representation of the IP address */
 			pg_getnameinfo_all((struct sockaddr_storage *) addr->ai_addr, addr->ai_addrlen,


### PR DESCRIPTION
* Problem:
getDnsCachedAddress() always returns empty string if the hostname only
has IPv6 addresses

* Root cause:
Array hostinfo[] is redeclared in code section for IPv6, so the real
lookup result never returns.

* How to reproduce:
You can reproduce this issue even you don't have pure IPv6 environment
1. Assign a IPv6 address for your default net device
   sudo ip -6 addr add 2401::1234/128 dev ${netdev}
2. Add the address to /etc/hosts with a dummy hostname, for example
   2401::1234/128	ipv6host
3. Create external table using the dummy hostname
   create external table test_ext_ipv6(a int) location('gpfdist://ipv6host:8080/data_file') format 'csv';
4. Launch gpfdist
5. Run test SQL
   select * from test_ext_ipv6
   Then an error will be reported with an empty address in url:
   ERROR:  connection with gpfdist failed for "gpfdist://ipv6host:8080/data_file", effective url: "http://:8080/data_file"

The patch is tested manually.

Co-authored-by: Peifeng Qiu <pqiu@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
