### PR TITLE
[6X backport]Fix CASE WHEN IS NOT DISTINCT FROM clause incorrect dump.

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -7631,10 +7631,15 @@ get_rule_expr(Node *node, deparse_context *context,
 						if (IsA(arg, DistinctExpr))
 						{
 							DistinctExpr 	*dexpr = (DistinctExpr *) arg;
-							Node			*rhs;
+							Node			*lhs = (Node *) linitial(dexpr->args);
+							Node			*rhs = (Node *) lsecond(dexpr->args);
 
+							if (!IsA(lhs, CaseTestExpr))
+							{
+								get_rule_expr(lhs, context, false);
+								appendStringInfoChar(buf, ' ');
+							}
 							appendStringInfoString(buf, "IS NOT DISTINCT FROM ");
-							rhs = (Node *) lsecond(dexpr->args);
 							get_rule_expr(rhs, context, false);
 						}
 						else

--- a/src/test/regress/expected/case_gp.out
+++ b/src/test/regress/expected/case_gp.out
@@ -17,6 +17,44 @@ INSERT INTO mytable values (1,2,'t'),
   (7,6,'a'),
   (8,7,'t'),
   (9,8,'a');
+DROP VIEW IF EXISTS notdisview;
+NOTICE:  view "notdisview" does not exist, skipping
+CREATE OR REPLACE VIEW notdisview AS
+SELECT
+    CASE
+        WHEN 'test' IS NOT DISTINCT FROM ''::text THEN 'A'::text
+        ELSE 'B'::text
+        END AS t;
+select pg_get_viewdef('notdisview',true);
+                               pg_get_viewdef                               
+----------------------------------------------------------------------------
+  SELECT                                                                   +
+         CASE                                                              +
+             WHEN 'test'::text IS NOT DISTINCT FROM ''::text THEN 'A'::text+
+             ELSE 'B'::text                                                +
+         END AS t;
+(1 row)
+
+DROP VIEW IF EXISTS notdisview2;
+NOTICE:  view "notdisview2" does not exist, skipping
+CREATE OR REPLACE VIEW notdisview2 AS
+SELECT
+    CASE
+        WHEN c::text IS NOT DISTINCT FROM ''::text THEN 'A'::text
+        ELSE 'B'::text
+        END AS t
+    FROM mytable;
+select pg_get_viewdef('notdisview2',true);
+                                pg_get_viewdef                                 
+-------------------------------------------------------------------------------
+  SELECT                                                                      +
+         CASE                                                                 +
+             WHEN mytable.c::text IS NOT DISTINCT FROM ''::text THEN 'A'::text+
+             ELSE 'B'::text                                                   +
+         END AS t                                                             +
+    FROM mytable;
+(1 row)
+
 CREATE OR REPLACE FUNCTION negate(int) RETURNS int 
 AS 'SELECT $1 * (-1)'
 LANGUAGE sql CONTAINS SQL
@@ -340,6 +378,7 @@ LINE 1: SELECT b,c,decode(c,'a',ARRAY[1,2],'e',ARRAY[3,4],'o',ARRAY[...
 -- Clean up
 --
 DROP TABLE mytable CASCADE;
+NOTICE:  drop cascades to view notdisview2
 DROP TABLE products CASCADE;
 NOTICE:  drop cascades to view myview
 DROP TABLE calls_to_blip;

--- a/src/test/regress/sql/case_gp.sql
+++ b/src/test/regress/sql/case_gp.sql
@@ -17,6 +17,25 @@ INSERT INTO mytable values (1,2,'t'),
   (8,7,'t'),
   (9,8,'a');
 
+DROP VIEW IF EXISTS notdisview;
+CREATE OR REPLACE VIEW notdisview AS
+SELECT
+    CASE
+        WHEN 'test' IS NOT DISTINCT FROM ''::text THEN 'A'::text
+        ELSE 'B'::text
+        END AS t;
+select pg_get_viewdef('notdisview',true);
+
+DROP VIEW IF EXISTS notdisview2;
+CREATE OR REPLACE VIEW notdisview2 AS
+SELECT
+    CASE
+        WHEN c::text IS NOT DISTINCT FROM ''::text THEN 'A'::text
+        ELSE 'B'::text
+        END AS t
+    FROM mytable;
+select pg_get_viewdef('notdisview2',true);
+
 CREATE OR REPLACE FUNCTION negate(int) RETURNS int 
 AS 'SELECT $1 * (-1)'
 LANGUAGE sql CONTAINS SQL


### PR DESCRIPTION
The clause 'CASE WHEN (arg1) IS NOT DISTINCT FROM (arg2)' dump will miss
the arg1. For example:
```
CREATE OR REPLACE VIEW xxxtest AS
SELECT
    CASE
    WHEN 'I will disappear' IS NOT DISTINCT FROM ''::text
    THEN 'A'::text
    ELSE 'B'::text
    END AS t;
```
The dump will lose 'I will disappear'.

```
SELECT
    CASE
    WHEN IS NOT DISTINCT FROM ''::text
    THEN 'A'::text
    ELSE 'B'::text
    END AS t;
```

This is backport from 3b2aed6e2313792e4d1dd3072d300f12947b69cb.

Reviewed-by: Paul Guo <paulguo@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
