### PR TITLE
[5X backport]Fix a recursive AbortTransaction issue

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsInjectFault.py
+++ b/gpMgmt/bin/gppylib/programs/clsInjectFault.py
@@ -438,6 +438,7 @@ class GpInjectFaultProgram:
                   "finish_prepared_after_record_commit_prepared (inject fault in FinishPreparedTransaction() after recording the commit prepared record), " \
                   "resgroup_assigned_on_master (inject fault in AssignResGroupOnMaster() after slot is assigned), " \
                   "copy_from_high_processed (inject fault to pretend copying from very high number of processed rows), " \
+                  "abort_after_procarray_end (inject fault in AbortTransaction after ProcArrayEndTransaction), " \
 			      "all (affects all faults injected, used for 'status' and 'reset'), ") 
         addTo.add_option("-c", "--ddl_statement", dest="ddlStatement", type="string",
                          metavar="ddlStatement",

--- a/src/backend/cdb/cdblocaldistribxact.c
+++ b/src/backend/cdb/cdblocaldistribxact.c
@@ -85,7 +85,8 @@ LocalDistribXact_ChangeState(PGPROC *proc,
 		break;
 
 	case LOCALDISTRIBXACT_STATE_COMMITTED:
-		if (oldState != LOCALDISTRIBXACT_STATE_ACTIVE)
+		if (oldState != LOCALDISTRIBXACT_STATE_ACTIVE &&
+			oldState != LOCALDISTRIBXACT_STATE_PREPARED)
 			elog(PANIC,
 			     "Expected distributed transaction xid = %u to local element to be in state \"Active\" or \"Commit Delivery\" and "
 			     "found state \"%s\"",
@@ -94,7 +95,8 @@ LocalDistribXact_ChangeState(PGPROC *proc,
 		break;
 
 	case LOCALDISTRIBXACT_STATE_ABORTED:
-		if (oldState != LOCALDISTRIBXACT_STATE_ACTIVE)
+		if (oldState != LOCALDISTRIBXACT_STATE_ACTIVE &&
+			oldState != LOCALDISTRIBXACT_STATE_ABORTED)
 			elog(PANIC,
 			     "Expected distributed transaction xid = %u to local element to be in state \"Active\" or \"Abort Delivery\" and "
 			     "found state \"%s\"",

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -371,6 +371,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault inside dynamic index scan after context reset */
 	_("dynamic_index_scan_context_reset"),
 		/* inject fault when creating new TOAST tables, to modify the chunk size */
+	_("abort_after_procarray_end"),
+		/* inject fault in AbortTransaction after ProcArrayEndTransaction */
 	_("not recognized"),
 };
 
@@ -1082,6 +1084,7 @@ FaultInjector_NewHashEntry(
 			case DecreaseToastMaxChunkSize:
 			case ProcessStartupPacketFault:
 			case DynamicIndexScanContextReset:
+			case AbortAfterProcarrayEnd:
 
 				break;
 			default:

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -252,6 +252,8 @@ typedef enum FaultInjectorIdentifier_e {
 
 	DynamicIndexScanContextReset,
 
+	AbortAfterProcarrayEnd,
+
 	/* INSERT has to be done before that line */
 	FaultInjectorIdMax,
 	

--- a/src/test/isolation2/expected/distributed_transactions.out
+++ b/src/test/isolation2/expected/distributed_transactions.out
@@ -1,0 +1,58 @@
+-- Test error after ProcArrayEndTransaction
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
+-- abort fail on QD
+SELECT gp_inject_fault_new( 'abort_after_procarray_end', 'error', 1);
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+BEGIN;
+BEGIN
+CREATE TABLE test_xact_abort_failure(a int);
+CREATE
+ABORT;
+ERROR:  fault triggered, fault name:'abort_after_procarray_end' fault type:'error'
+SELECT gp_inject_fault_new( 'abort_after_procarray_end', 'reset', 1);
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+
+-- abort fail on QE
+SELECT gp_inject_fault_new( 'abort_after_procarray_end', 'error', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+BEGIN;
+BEGIN
+CREATE TABLE test_xact_abort_failure(a int);
+CREATE
+ABORT;
+ABORT
+SELECT gp_inject_fault_new( 'abort_after_procarray_end', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+
+-- abort fail in local transaction
+SELECT gp_inject_fault_new( 'abort_after_procarray_end', 'error', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+2U: BEGIN;
+BEGIN
+2U: CREATE TABLE test_xact_abort_failure(a int);
+CREATE
+2U: ABORT;
+ERROR:  fault triggered, fault name:'abort_after_procarray_end' fault type:'error'
+SELECT gp_inject_fault_new( 'abort_after_procarray_end', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -130,3 +130,5 @@ test: packcore
 
 # Cancel test
 test: cancel_plpython
+
+test: distributed_transactions

--- a/src/test/isolation2/sql/distributed_transactions.sql
+++ b/src/test/isolation2/sql/distributed_transactions.sql
@@ -1,0 +1,24 @@
+-- Test error after ProcArrayEndTransaction
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+-- abort fail on QD
+SELECT gp_inject_fault_new( 'abort_after_procarray_end', 'error', 1);
+BEGIN;
+CREATE TABLE test_xact_abort_failure(a int);
+ABORT;
+SELECT gp_inject_fault_new( 'abort_after_procarray_end', 'reset', 1);
+
+-- abort fail on QE
+SELECT gp_inject_fault_new( 'abort_after_procarray_end', 'error', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+BEGIN;
+CREATE TABLE test_xact_abort_failure(a int);
+ABORT;
+SELECT gp_inject_fault_new( 'abort_after_procarray_end', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+
+-- abort fail in local transaction
+SELECT gp_inject_fault_new( 'abort_after_procarray_end', 'error', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+2U: BEGIN;
+2U: CREATE TABLE test_xact_abort_failure(a int);
+2U: ABORT;
+SELECT gp_inject_fault_new( 'abort_after_procarray_end', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;


### PR DESCRIPTION
When the error happens after ProcArrayEndTransaction, it will recurse back to
AbortTransaction, we need to make sure it will not generate extra WAL record
and not fail the assertions.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
