### PR TITLE
Feature/greenplum db 6 gpupgrade

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -254,6 +254,7 @@ BLD_GPDB_BUILDSET=$($(BLD_ARCH)_GPDB_BUILDSET)
 define BUILD_STEPS
 	@rm -rf $(INSTLOC)
 	cd $(BUILDDIR) && PYGRESQL_LDFLAGS='-Wl,-rpath,\$$$$ORIGIN/../../../lib -Wl,--enable-new-dtags' QUICKLZ_LDFLAGS='-Wl,-rpath,\$$$$ORIGIN/../../lib -Wl,--enable-new-dtags' $(MAKE) $(PARALLEL_MAKE_OPTS) install
+	cd $(BUILDDIR)/src/pl/plpython && $(MAKE) clean && echo 'LDFLAGS += -Wl,-rpath,\$$$$ORIGIN/../../ext/python/lib/ -Wl,--enable-new-dtags' >> Makefile && $(MAKE) $(PARALLEL_MAKE_OPTS) install && cd $(BUILDDIR)
 	#@$(MAKE) greenplum_path INSTLOC=$(INSTLOC)
 	#@$(MAKE) mgmtcopy INSTLOC=$(INSTLOC)
 	@$(MAKE) mkpgbouncer INSTLOC=$(INSTLOC) BUILDDIR=$(BUILDDIR)

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -184,6 +184,8 @@ aix7_ppc_64_CONFIG_ADDITIONS=LDFLAGS="-Wl,-bbigtoc -L/usr/lib/threads"
 CONFIG_ADDITIONS=$($(BLD_ARCH)_CONFIG_ADDITIONS)
 
 CONFIGFLAGS+= $(CONFIG_ADDITIONS)
+CONFIGFLAGS+= --disable-rpath
+CONFIGFLAGS+= LDFLAGS='-Wl,--enable-new-dtags -Wl,-rpath,\$$$$ORIGIN/../lib'
 
 RECONFIG :
 	rm -f Debug/GNUmakefile
@@ -251,7 +253,7 @@ BLD_GPDB_BUILDSET=$($(BLD_ARCH)_GPDB_BUILDSET)
 # set default build steps
 define BUILD_STEPS
 	@rm -rf $(INSTLOC)
-	cd $(BUILDDIR) && $(MAKE) $(PARALLEL_MAKE_OPTS) install
+	cd $(BUILDDIR) && PYGRESQL_LDFLAGS='-Wl,-rpath,\$$$$ORIGIN/../../../lib -Wl,--enable-new-dtags' QUICKLZ_LDFLAGS='-Wl,-rpath,\$$$$ORIGIN/../../lib -Wl,--enable-new-dtags' $(MAKE) $(PARALLEL_MAKE_OPTS) install
 	#@$(MAKE) greenplum_path INSTLOC=$(INSTLOC)
 	#@$(MAKE) mgmtcopy INSTLOC=$(INSTLOC)
 	@$(MAKE) mkpgbouncer INSTLOC=$(INSTLOC) BUILDDIR=$(BUILDDIR)

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -249,12 +249,14 @@ export $(BLD_WHERE_THE_LIBRARY_THINGS_ARE)=$(BLD_LD_LIBRARY_PATH)
 # how much of GPDB to build by platform (default is "full")
 aix7_ppc_64_GPDB_BUILDSET=aix_subset
 BLD_GPDB_BUILDSET=$($(BLD_ARCH)_GPDB_BUILDSET)
+perl_archlibexp:=$(shell perl -MConfig -e 'print $$Config{archlibexp}')
 
 # set default build steps
 define BUILD_STEPS
 	@rm -rf $(INSTLOC)
 	cd $(BUILDDIR) && PYGRESQL_LDFLAGS='-Wl,-rpath,\$$$$ORIGIN/../../../lib -Wl,--enable-new-dtags' QUICKLZ_LDFLAGS='-Wl,-rpath,\$$$$ORIGIN/../../lib -Wl,--enable-new-dtags' $(MAKE) $(PARALLEL_MAKE_OPTS) install
 	cd $(BUILDDIR)/src/pl/plpython && $(MAKE) clean && echo 'LDFLAGS += -Wl,-rpath,\$$$$ORIGIN/../../ext/python/lib/ -Wl,--enable-new-dtags' >> Makefile && $(MAKE) $(PARALLEL_MAKE_OPTS) install && cd $(BUILDDIR)
+	cd $(BUILDDIR)/src/pl/plperl && $(MAKE) clean && echo "LDFLAGS += -Wl,-rpath,$(perl_archlibexp)/CORE -Wl,--enable-new-dtags" >> GNUmakefile && echo "LDFLAGS_SL += -Wl,-rpath,$(perl_archlibexp)/CORE -Wl,--enable-new-dtags" >> GNUmakefile && $(MAKE) $(PARALLEL_MAKE_OPTS) install && cd $(BUILDDIR)
 	#@$(MAKE) greenplum_path INSTLOC=$(INSTLOC)
 	#@$(MAKE) mgmtcopy INSTLOC=$(INSTLOC)
 	@$(MAKE) mkpgbouncer INSTLOC=$(INSTLOC) BUILDDIR=$(BUILDDIR)

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -86,7 +86,7 @@ pygresql:
 	elif [ `uname -s` = 'OpenBSD' ]; then \
 	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC=cc python setup.py build; \
 	else \
-	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python setup.py build; \
+	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" LDFLAGS='$(LDFLAGS) $(PYGRESQL_LDFLAGS)' python setup.py build; \
 	fi
 	mkdir -p $(PYLIB_DIR)/pygresql
 	if [ `uname -s` = 'Darwin' ]; then \

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -31,8 +31,8 @@ fi
 
 cat <<"EOF"
 
-if [ -e "$GPHOME/etc/openssl.cnf" ]; then
-	OPENSSL_CONF="$GPHOME/etc/openssl.cnf"
+if [ -e "${GPHOME}/etc/openssl.cnf" ]; then
+	OPENSSL_CONF="${GPHOME}/etc/openssl.cnf"
 fi
 
 export GPHOME

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -11,7 +11,20 @@ GPHOME="${GPHOME_PATH}"
 
 EOF
 
+if [ -x "${PYTHONHOME}/bin/python" ]; then
+	cat <<-"EOF"
+	PYTHONHOME="${GPHOME}/ext/python"
+	export PYTHONHOME
+
+	PATH="${PYTHONHOME}/bin:${PATH}"
+	LD_LIBRARY_PATH="${PYTHONHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+	EOF
+fi
+
 cat <<"EOF"
+PYTHONPATH="${GPHOME}/lib/python"
+PATH="${GPHOME}/bin:${PATH}"
+LD_LIBRARY_PATH="${GPHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 if [ -e "${GPHOME}/etc/openssl.cnf" ]; then
 	OPENSSL_CONF="${GPHOME}/etc/openssl.cnf"
@@ -19,7 +32,6 @@ fi
 
 export GPHOME
 export PATH
-export PYTHONHOME
 export PYTHONPATH
 export LD_LIBRARY_PATH
 export OPENSSL_CONF

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -1,26 +1,15 @@
 #!/usr/bin/env bash
 
-if [ x$1 != x ] ; then
-    GPHOME_PATH=$1
-else
-    GPHOME_PATH="\`pwd\`"
+if [ -z "$1" ]; then
+  printf "Must specify a value for GPHOME"
+  exit 1
 fi
 
-if [ "$2" = "ISO" ] ; then
-	cat <<-EOF
-		if [ "\${BASH_SOURCE:0:1}" == "/" ]
-		then
-		    GPHOME=\`dirname "\$BASH_SOURCE"\`
-		else
-		    GPHOME=\`pwd\`/\`dirname "\$BASH_SOURCE"\`
-		fi
-	EOF
-else
-	cat <<-EOF
-		GPHOME=${GPHOME_PATH}
-	EOF
-fi
+GPHOME_PATH="$1"
+cat <<EOF
+GPHOME="${GPHOME_PATH}"
 
+EOF
 
 PLAT=`uname -s`
 if [ $? -ne 0 ] ; then
@@ -28,78 +17,28 @@ if [ $? -ne 0 ] ; then
     exit 1
 fi
 
-cat << EOF
-
-# Replace with symlink path if it is present and correct
-if [ -h \${GPHOME}/../greenplum-db ]; then
-    GPHOME_BY_SYMLINK=\`(cd \${GPHOME}/../greenplum-db/ && pwd -P)\`
-    if [ x"\${GPHOME_BY_SYMLINK}" = x"\${GPHOME}" ]; then
-        GPHOME=\`(cd \${GPHOME}/../greenplum-db/ && pwd -L)\`/.
-    fi
-    unset GPHOME_BY_SYMLINK
-fi
-EOF
-
-cat <<EOF
-#setup PYTHONHOME
-if [ -x \$GPHOME/ext/python/bin/python ]; then
-    PYTHONHOME="\$GPHOME/ext/python"
-    export PYTHONHOME
-fi
-EOF
-
-#setup PYTHONPATH
-if [ "x${PYTHONPATH}" == "x" ]; then
-    PYTHONPATH="\$GPHOME/lib/python"
-else
-    PYTHONPATH="\$GPHOME/lib/python:${PYTHONPATH}"
-fi
-cat <<EOF
-PYTHONPATH=${PYTHONPATH}
-EOF
-
-GP_BIN_PATH=\$GPHOME/bin
-GP_LIB_PATH=\$GPHOME/lib
-
-if [ -n "$PYTHONHOME" ]; then
-    GP_BIN_PATH=${GP_BIN_PATH}:\$PYTHONHOME/bin
-    GP_LIB_PATH=${GP_LIB_PATH}:\$PYTHONHOME/lib
-fi
-cat <<EOF
-PATH=${GP_BIN_PATH}:\$PATH
-EOF
-
-cat <<EOF
-LD_LIBRARY_PATH=${GP_LIB_PATH}:\${LD_LIBRARY_PATH-}
-export LD_LIBRARY_PATH
-EOF
-
 # AIX uses yet another library path variable
 # Also, Python on AIX requires special copies of some libraries.  Hence, lib/pware.
 if [ "${PLAT}" = "AIX" ]; then
-cat <<EOF
-PYTHONPATH=\${GPHOME}/ext/python/lib/python2.7:\${PYTHONPATH}
-LIBPATH=\${GPHOME}/lib/pware:\${GPHOME}/lib:\${GPHOME}/ext/python/lib:/usr/lib/threads:\${LIBPATH}
+cat <<"EOF"
+PYTHONPATH="${GPHOME}/ext/python/lib/python2.7:${PYTHONPATH}"
+LIBPATH="${GPHOME}/lib/pware:${GPHOME}/lib:${GPHOME}/ext/python/lib:/usr/lib/threads:${LIBPATH}"
 export LIBPATH
-GP_LIBPATH_FOR_PYTHON=\${GPHOME}/lib/pware
+GP_LIBPATH_FOR_PYTHON="${GPHOME}/lib/pware"
 export GP_LIBPATH_FOR_PYTHON
 EOF
 fi
 
-# openssl configuration file path
-cat <<EOF
-if [ -e \$GPHOME/etc/openssl.cnf ]; then
-OPENSSL_CONF=\$GPHOME/etc/openssl.cnf
-export OPENSSL_CONF
-fi
-EOF
+cat <<"EOF"
 
-cat <<EOF
+if [ -e "$GPHOME/etc/openssl.cnf" ]; then
+	OPENSSL_CONF="$GPHOME/etc/openssl.cnf"
+fi
+
 export GPHOME
 export PATH
-EOF
-
-cat <<EOF
+export PYTHONHOME
 export PYTHONPATH
+export LD_LIBRARY_PATH
+export OPENSSL_CONF
 EOF
-

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -11,24 +11,6 @@ GPHOME="${GPHOME_PATH}"
 
 EOF
 
-PLAT=`uname -s`
-if [ $? -ne 0 ] ; then
-    echo "Error executing uname -s"
-    exit 1
-fi
-
-# AIX uses yet another library path variable
-# Also, Python on AIX requires special copies of some libraries.  Hence, lib/pware.
-if [ "${PLAT}" = "AIX" ]; then
-cat <<"EOF"
-PYTHONPATH="${GPHOME}/ext/python/lib/python2.7:${PYTHONPATH}"
-LIBPATH="${GPHOME}/lib/pware:${GPHOME}/lib:${GPHOME}/ext/python/lib:/usr/lib/threads:${LIBPATH}"
-export LIBPATH
-GP_LIBPATH_FOR_PYTHON="${GPHOME}/lib/pware"
-export GP_LIBPATH_FOR_PYTHON
-EOF
-fi
-
 cat <<"EOF"
 
 if [ -e "${GPHOME}/etc/openssl.cnf" ]; then

--- a/gpcontrib/quicklz/Makefile
+++ b/gpcontrib/quicklz/Makefile
@@ -16,6 +16,12 @@ else
   include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
+# when libquicklz is vendored, it is copied in to GPHOME/lib
+# the quicklz_compressor extension is located in GPHOME/lib/postgresql/
+ifdef QUICKLZ_LDFLAGS
+  LDFLAGS += $(QUICKLZ_LDFLAGS)
+endif
+
 # Install into cdb_init.d, so that the catalog changes performed by initdb,
 # and the compressor is available in all databases.
 .PHONY: install-data


### PR DESCRIPTION
This PR contains a number of changes to how GPDB is built and packaged in order to support upgrading a cluster from GPDB5 to GPDB6.

In order to upgrade a GPDB5 cluster to a GPDB6 cluster, a user needs to have binaries from both GPDB5 and GPDB6 on disk and in a runnable state at the same time. To accomplish this, these commits:

1. Update `greenplum_path.sh` to ignore any `greenplum-db` symlinks
2. Generate a subset of binaries with RPATH/RUNPATH set to a _relative_ path (i.e., use `$ORIGIN`)

For more detail, please see

- [Greenplum Server RPM Packaging Specification: Greenplum Path Layer](https://github.com/greenplum-db/greenplum-database-release/blob/master/Greenplum-Server-RPM-Packaging-Specification.md#greenplum-path-layer)
- [Greenplum Server RPM Packaging Specification: Runtime Linking Layer](https://github.com/greenplum-db/greenplum-database-release/blob/master/Greenplum-Server-RPM-Packaging-Specification.md#runtime-linking-layer)
- Individual commit messages