### PR TITLE
Feature/greenplum db 5 gpupgrade

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -338,6 +338,7 @@ sol10_sparc_32_GPDB_BUILDSET=partial
 win64_GPDB_BUILDSET=partial
 win32_GPDB_BUILDSET=partial
 BLD_GPDB_BUILDSET=$($(BLD_ARCH)_GPDB_BUILDSET)
+perl_archlibexp:=$(shell perl -MConfig -e 'print $$Config{archlibexp}')
 
 # set default build steps
 define BUILD_STEPS
@@ -345,6 +346,7 @@ define BUILD_STEPS
 	if [ "$(findstring rhel,$(BLD_ARCH))" = "rhel" ]; then \
 	  cd $(BUILDDIR) && PYGRESQL_LDFLAGS='-Wl,-rpath,\$$$$ORIGIN/../../../lib -Wl,--enable-new-dtags' $(MAKE) $(PARALLEL_MAKE_OPTS) install; \
 	  cd $(BUILDDIR)/src/pl/plpython && $(MAKE) clean && echo 'LDFLAGS += -Wl,-rpath,\$$$$ORIGIN/../../ext/python/lib/ -Wl,--enable-new-dtags' >> Makefile && echo 'LDFLAGS_SL += -Wl,-rpath,\$$$$ORIGIN/../../ext/python/lib/ -Wl,--enable-new-dtags' >> Makefile && $(MAKE) $(PARALLEL_MAKE_OPTS) install && cd $(BUILDDIR) ; \
+	  cd $(BUILDDIR)/src/pl/plperl && $(MAKE) clean && echo "LDFLAGS += -Wl,-rpath,$(perl_archlibexp)/CORE -Wl,--enable-new-dtags" >> GNUmakefile && echo "LDFLAGS_SL += -Wl,-rpath,$(perl_archlibexp)/CORE -Wl,--enable-new-dtags" >> GNUmakefile && $(MAKE) $(PARALLEL_MAKE_OPTS) install && cd $(BUILDDIR) ; \
 	else \
 	  cd $(BUILDDIR) && $(MAKE) $(PARALLEL_MAKE_OPTS) install; \
 	fi \

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -253,7 +253,9 @@ ifdef ADDON_DIR
 CONFIGFLAGS+=ADDON_DIR=$(ADDON_DIR)
 endif
 
-ifneq "$(findstring $(BLD_ARCH),rhel6 rhel7)" ""
+# if $BLD_ARCH is rhel6_x86_64 of rhel7_x86_64
+# compile with relative rpath
+ifeq "$(findstring rhel,$(BLD_ARCH))" "rhel"
 CONFIGFLAGS+= --disable-rpath
 CONFIGFLAGS+= LDFLAGS='-Wl,--enable-new-dtags -Wl,-rpath,\$$$$ORIGIN/../lib'
 CONFIGFLAGS+= LDFLAGS_SL='-Wl,--enable-new-dtags -Wl,-rpath,\$$$$ORIGIN/../lib'
@@ -340,10 +342,10 @@ BLD_GPDB_BUILDSET=$($(BLD_ARCH)_GPDB_BUILDSET)
 # set default build steps
 define BUILD_STEPS
 	@rm -rf $(INSTLOC)
-	if [ "$(findstring $(BLD_ARCH),rhel6 rhel7)" = "" ]; then \
-	  cd $(BUILDDIR) && $(MAKE) $(PARALLEL_MAKE_OPTS) install; \
-	else \
+	if [ "$(findstring rhel,$(BLD_ARCH))" = "rhel" ]; then \
 	  cd $(BUILDDIR) && PYGRESQL_LDFLAGS='-Wl,-rpath,\$$$$ORIGIN/../../../lib -Wl,--enable-new-dtags' $(MAKE) $(PARALLEL_MAKE_OPTS) install; \
+	else \
+	  cd $(BUILDDIR) && $(MAKE) $(PARALLEL_MAKE_OPTS) install; \
 	fi \
 	#@$(MAKE) greenplum_path INSTLOC=$(INSTLOC)
 	#@$(MAKE) mgmtcopy INSTLOC=$(INSTLOC)

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -344,6 +344,7 @@ define BUILD_STEPS
 	@rm -rf $(INSTLOC)
 	if [ "$(findstring rhel,$(BLD_ARCH))" = "rhel" ]; then \
 	  cd $(BUILDDIR) && PYGRESQL_LDFLAGS='-Wl,-rpath,\$$$$ORIGIN/../../../lib -Wl,--enable-new-dtags' $(MAKE) $(PARALLEL_MAKE_OPTS) install; \
+	  cd $(BUILDDIR)/src/pl/plpython && $(MAKE) clean && echo 'LDFLAGS += -Wl,-rpath,\$$$$ORIGIN/../../ext/python/lib/ -Wl,--enable-new-dtags' >> Makefile && echo 'LDFLAGS_SL += -Wl,-rpath,\$$$$ORIGIN/../../ext/python/lib/ -Wl,--enable-new-dtags' >> Makefile && $(MAKE) $(PARALLEL_MAKE_OPTS) install && cd $(BUILDDIR) ; \
 	else \
 	  cd $(BUILDDIR) && $(MAKE) $(PARALLEL_MAKE_OPTS) install; \
 	fi \

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -253,6 +253,12 @@ ifdef ADDON_DIR
 CONFIGFLAGS+=ADDON_DIR=$(ADDON_DIR)
 endif
 
+ifneq "$(findstring $(BLD_ARCH),rhel6 rhel7)" ""
+CONFIGFLAGS+= --disable-rpath
+CONFIGFLAGS+= LDFLAGS='-Wl,--enable-new-dtags -Wl,-rpath,\$$$$ORIGIN/../lib'
+CONFIGFLAGS+= LDFLAGS_SL='-Wl,--enable-new-dtags -Wl,-rpath,\$$$$ORIGIN/../lib'
+endif
+
 RECONFIG :
 	rm -f Debug/GNUmakefile
 	rm -f Release/GNUmakefile
@@ -334,7 +340,11 @@ BLD_GPDB_BUILDSET=$($(BLD_ARCH)_GPDB_BUILDSET)
 # set default build steps
 define BUILD_STEPS
 	@rm -rf $(INSTLOC)
-	cd $(BUILDDIR) && $(MAKE) $(PARALLEL_MAKE_OPTS) install
+	if [ "$(findstring $(BLD_ARCH),rhel6 rhel7)" = "" ]; then \
+	  cd $(BUILDDIR) && $(MAKE) $(PARALLEL_MAKE_OPTS) install; \
+	else \
+	  cd $(BUILDDIR) && PYGRESQL_LDFLAGS='-Wl,-rpath,\$$$$ORIGIN/../../../lib -Wl,--enable-new-dtags' $(MAKE) $(PARALLEL_MAKE_OPTS) install; \
+	fi \
 	#@$(MAKE) greenplum_path INSTLOC=$(INSTLOC)
 	#@$(MAKE) mgmtcopy INSTLOC=$(INSTLOC)
 	@$(MAKE) mkpgbouncer INSTLOC=$(INSTLOC) BUILDDIR=$(BUILDDIR)

--- a/gpAux/releng/make/dependencies/ivy.sh
+++ b/gpAux/releng/make/dependencies/ivy.sh
@@ -22,7 +22,7 @@ if [ ! -d "${EXT_DIRECTORY}" ]; then
 fi
 
 while read line; do
-    if [[ $line =~ .*"${BUILD_STAGE}->"* && $line =~ ${REVISION} && $line =~ ${MODULE} && $line =~ ${ORG} ]]; then
+    if [[ $line =~ .*"${BUILD_STAGE}->"* && $line =~ "${REVISION}" && $line =~ ${MODULE} && $line =~ ${ORG} ]]; then
         line=`echo $line | cut -f5 -d "="`
         IFS=';' read -ra dependency <<< "$line"
         for i in "${dependency[@]}"; do

--- a/gpAux/releng/make/dependencies/ivy.xml
+++ b/gpAux/releng/make/dependencies/ivy.xml
@@ -18,7 +18,8 @@
       <dependency org="emc"             name="DDBoostSDK"      rev="3.3.0.4-550644" conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="gnu"             name="libstdc"         rev="6.0.22"         conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse11_x86_64;sles11_x86_64->suse11_x86_64" />
       <dependency org="third-party"     name="ext"             rev="1.1"            conf="win32->win32" />
-      <dependency org="third-party"     name="ext"             rev="gpdb5_ext-3.4"  conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
+      <dependency org="third-party"     name="ext"             rev="gpdb5_ext-3.5"  conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
+      <dependency org="mit"             name="krb5"            rev="1.6.2+vmware.1" conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64" />
       <dependency org="Hyperic"         name="sigar"           rev="1.6.5"          conf="rhel6_x86_64->rhel6_x86_64;rhel7_x86_64->rhel7_x86_64;suse11_x86_64->sles11_x86_64;sles11_x86_64->sles11_x86_64" />
       <dependency org="NetBackup"       name="SDK-7.7"         rev="7.7"            conf="rhel7_x86_64->rhel5_x86_64;rhel6_x86_64->rhel5_x86_64" />
       <dependency org="R-Project"       name="R"               rev="3.1.0"          conf="rhel7_x86_64->rhel6_x86_64;rhel6_x86_64->rhel6_x86_64;suse11_x86_64->suse10_x86_64;sles11_x86_64->suse10_x86_64" />

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -64,7 +64,7 @@ pygresql:
 	elif [ "$(BLD_ARCH)" = 'aix7_ppc_64' ]; then \
 	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python_64 setup.py build; \
 	else \
-	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python setup.py build; \
+	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" LDFLAGS='$(LDFLAGS) $(PYGRESQL_LDFLAGS)' python setup.py build; \
 	fi
 	mkdir -p $(PYLIB_DIR)/pygresql
 	if [ `uname -s` = 'Darwin' ]; then \

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -1,93 +1,28 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [ x$1 != x ] ; then
-    GPHOME_PATH=$1
-else
-    GPHOME_PATH="\`pwd\`"
+if [ -z "$1" ]; then
+  printf "Must specify a value for GPHOME"
+  exit 1
 fi
 
-if [ "$2" = "ISO" ] ; then
-	cat <<-EOF
-		if [ "\${BASH_SOURCE:0:1}" == "/" ]
-		then
-		    GPHOME=\`dirname "\$BASH_SOURCE"\`
-		else
-		    GPHOME=\`pwd\`/\`dirname "\$BASH_SOURCE"\`
-		fi
-	EOF
-else
-	cat <<-EOF
-		GPHOME=${GPHOME_PATH}
-	EOF
-fi
-
-
-PLAT=`uname -s`
-if [ $? -ne 0 ] ; then
-    echo "Error executing uname -s"
-    exit 1
-fi
-
-cat << EOF
-
-# Replace with symlink path if it is present and correct
-if [ -h \${GPHOME}/../greenplum-db ]; then
-    GPHOME_BY_SYMLINK=\`(cd \${GPHOME}/../greenplum-db/ && pwd -P)\`
-    if [ x"\${GPHOME_BY_SYMLINK}" = x"\${GPHOME}" ]; then
-        GPHOME=\`(cd \${GPHOME}/../greenplum-db/ && pwd -L)\`/.
-    fi
-    unset GPHOME_BY_SYMLINK
-fi
-EOF
-
+GPHOME_PATH="$1"
 cat <<EOF
-#setup PYTHONHOME
-if [ -x \$GPHOME/ext/python/bin/python ]; then
-    PYTHONHOME="\$GPHOME/ext/python"
-fi
-EOF
+GPHOME="${GPHOME_PATH}"
 
-#setup PYTHONPATH
-if [ "x${PYTHONPATH}" == "x" ]; then
-    PYTHONPATH="\$GPHOME/lib/python"
-else
-    PYTHONPATH="\$GPHOME/lib/python:${PYTHONPATH}"
-fi
-cat <<EOF
-PYTHONPATH=${PYTHONPATH}
-EOF
-
-GP_BIN_PATH=\$GPHOME/bin
-GP_LIB_PATH=\$GPHOME/lib
-
-if [ -n "$PYTHONHOME" ]; then
-    GP_BIN_PATH=${GP_BIN_PATH}:\$PYTHONHOME/bin
-    GP_LIB_PATH=${GP_LIB_PATH}:\$PYTHONHOME/lib
-fi
-cat <<EOF
-PATH=${GP_BIN_PATH}:\$PATH
-EOF
-
-cat <<EOF
-LD_LIBRARY_PATH=${GP_LIB_PATH}:\${LD_LIBRARY_PATH-}
-export LD_LIBRARY_PATH
-EOF
+PYTHONHOME="${GPHOME}/ext/python"
+PYTHONPATH="${GPHOME}/lib/python"
+PATH="${GPHOME}/bin:${PYTHONHOME}/bin:${PATH}"
+LD_LIBRARY_PATH="${GPHOME}/lib:${PYTHONHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 # openssl configuration file path
-cat <<EOF
-OPENSSL_CONF=\$GPHOME/etc/openssl.cnf
-EOF
+if [ -e "$GPHOME/etc/openssl.cnf" ]; then
+	OPENSSL_CONF="$GPHOME/etc/openssl.cnf"
+fi
 
-cat <<EOF
 export GPHOME
 export PATH
-EOF
-
-cat <<EOF
-export PYTHONPATH
 export PYTHONHOME
-EOF
-
-cat <<EOF
+export PYTHONPATH
+export LD_LIBRARY_PATH
 export OPENSSL_CONF
 EOF

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -14,9 +14,8 @@ PYTHONPATH="${GPHOME}/lib/python"
 PATH="${GPHOME}/bin:${PYTHONHOME}/bin:${PATH}"
 LD_LIBRARY_PATH="${GPHOME}/lib:${PYTHONHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-# openssl configuration file path
-if [ -e "$GPHOME/etc/openssl.cnf" ]; then
-	OPENSSL_CONF="$GPHOME/etc/openssl.cnf"
+if [ -e "${GPHOME}/etc/openssl.cnf" ]; then
+	OPENSSL_CONF="${GPHOME}/etc/openssl.cnf"
 fi
 
 export GPHOME

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -9,10 +9,22 @@ GPHOME_PATH="$1"
 cat <<EOF
 GPHOME="${GPHOME_PATH}"
 
-PYTHONHOME="${GPHOME}/ext/python"
+EOF
+
+if [ -x "${PYTHONHOME}/bin/python" ]; then
+	cat <<-"EOF"
+	PYTHONHOME="${GPHOME}/ext/python"
+	export PYTHONHOME
+
+	PATH="${PYTHONHOME}/bin:${PATH}"
+	LD_LIBRARY_PATH="${PYTHONHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+	EOF
+fi
+
+cat <<"EOF"
 PYTHONPATH="${GPHOME}/lib/python"
-PATH="${GPHOME}/bin:${PYTHONHOME}/bin:${PATH}"
-LD_LIBRARY_PATH="${GPHOME}/lib:${PYTHONHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+PATH="${GPHOME}/bin:${PATH}"
+LD_LIBRARY_PATH="${GPHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 if [ -e "${GPHOME}/etc/openssl.cnf" ]; then
 	OPENSSL_CONF="${GPHOME}/etc/openssl.cnf"
@@ -20,7 +32,6 @@ fi
 
 export GPHOME
 export PATH
-export PYTHONHOME
 export PYTHONPATH
 export LD_LIBRARY_PATH
 export OPENSSL_CONF


### PR DESCRIPTION
This PR contains a number of changes to how GPDB is built and packaged in order to support upgrading a cluster from GPDB5 to GPDB6.

In order to upgrade a GPDB5 cluster to a GPDB6 cluster, a user needs to have binaries from both GPDB5 and GPDB6 on disk and in a runnable state at the same time. To accomplish this, these commits:

1. Update `greenplum_path.sh` to ignore any `greenplum-db` symlinks
2. Generate a subset of binaries with RPATH/RUNPATH set to a _relative_ path (i.e., use `$ORIGIN`)

For more detail, please see

- [Greenplum Server RPM Packaging Specification: Greenplum Path Layer](https://github.com/greenplum-db/greenplum-database-release/blob/master/Greenplum-Server-RPM-Packaging-Specification.md#greenplum-path-layer)
- [Greenplum Server RPM Packaging Specification: Runtime Linking Layer](https://github.com/greenplum-db/greenplum-database-release/blob/master/Greenplum-Server-RPM-Packaging-Specification.md#runtime-linking-layer)
- Individual commit messages