### PR TITLE
Update psutil from 4.0.0 to 5.7.0

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -111,7 +111,7 @@ subprocess32:
 #
 # PSUTIL
 #
-PSUTIL_VERSION=4.0.0
+PSUTIL_VERSION=5.7.0
 PSUTIL_DIR=psutil-$(PSUTIL_VERSION)
 
 psutil:

--- a/python-dependencies.txt
+++ b/python-dependencies.txt
@@ -7,6 +7,6 @@ logilab-common==0.50.1
 MarkupSafe==1.0
 mock==1.0.1
 parse==1.8.2
-psutil==4.0.0
+psutil==5.7.0
 setuptools==36.6.0
 unittest2==0.5.1


### PR DESCRIPTION
psutil 4.0.0 is quite old, and only lists support for python 3.4. We'll
need support for python 3.6 and 3.8 as we update to python3.

Authored-by: Tyler Ramer <tramer@pivotal.io>

Pipeline: 
https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-update_psutil