### PR TITLE
Fix pgbench --tablespace option.

### DIFF
--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -2454,12 +2454,12 @@ init(bool is_no_vacuum)
 		opts[0] = '\0';
 		if (ddl->declare_fillfactor)
 			snprintf(opts + strlen(opts), sizeof(opts) - strlen(opts),
-					 " with (fillfactor=%d, %s) DISTRIBUTED BY (%s)",
-					 fillfactor, storage_clause, ddl->distributed_col);
+					 " with (fillfactor=%d, %s)",
+					 fillfactor, storage_clause);
 		else
 			snprintf(opts + strlen(opts), sizeof(opts) - strlen(opts),
-					 " with (%s) DISTRIBUTED BY (%s)",
-					 storage_clause, ddl->distributed_col);
+					 " with (%s)",
+					 storage_clause);
 		if (tablespace != NULL)
 		{
 			char	   *escape_tablespace;
@@ -2470,6 +2470,9 @@ init(bool is_no_vacuum)
 					 " tablespace %s", escape_tablespace);
 			PQfreemem(escape_tablespace);
 		}
+		snprintf(opts + strlen(opts), sizeof(opts) - strlen(opts),
+				 " distributed by (%s)",
+				 ddl->distributed_col);
 
 		cols = (scale >= SCALE_32BIT_THRESHOLD) ? ddl->bigcols : ddl->smcols;
 


### PR DESCRIPTION
The CREATE TABLE commands constructed in pgbench had the DISTRIBUTED BY
and TABLESPACE options the wrong way 'round, so that you got a syntax
error. For example:

```
$ pgbench postgres -i --tablespace "pg_default"
creating tables...
ERROR:  syntax error at or near "tablespace"
LINE 1: ...22)) with (appendonly=false) DISTRIBUTED BY (bid) tablespace...
                                                             ^
```
Put the clauses in right order.

We have no test coverage for this at the moment, but PostgreSQL v11 adds
a test for this (commit ed8a7c6fcf). I noticed this while looking at test
failures with the PostgreSQL v12 merge.
