### PR TITLE
Disallow to change the distribution policy to REPLICATED for partition table

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4610,7 +4610,13 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 					switch (ps)
 					{
 						case PART_STATUS_NONE:
+							break;
 						case PART_STATUS_ROOT:
+							ldistro = (DistributedBy *)lsecond((List *)cmd->def);
+							if (ldistro && ldistro->ptype == POLICYTYPE_REPLICATED)
+								ereport(ERROR,
+										(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+										 errmsg("can't set the distribution policy of a partition table to REPLICATED")));
 							break;
 						case PART_STATUS_LEAF:
 							Assert(PointerIsValid(cmd->def));

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -668,9 +668,35 @@ fetch next from c1;
 (1 row)
 
 end;
+-- Test MinMax path on replicated table
+create table minmaxtest (x int, y int) distributed replicated;
+create index on minmaxtest (x);
+insert into minmaxtest select generate_series(1, 10);
+set enable_seqscan=off;
+select min(x) from minmaxtest;
+ min 
+-----
+   1
+(1 row)
+
+-- Test replicated on partition table
+-- should fail
+CREATE TABLE foopart (a int4, b int4) DISTRIBUTED REPLICATED PARTITION BY RANGE (a) (START (1) END (10));
+ERROR:  PARTITION BY clause cannot be used with DISTRIBUTED REPLICATED clause
+CREATE TABLE foopart (a int4, b int4) PARTITION BY RANGE (a) (START (1) END (10)) ;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "foopart_1_prt_1" for table "foopart"
+-- should fail
+ALTER TABLE foopart SET DISTRIBUTED REPLICATED;
+ERROR:  can't set the distribution policy of a partition table to REPLICATED
+ALTER TABLE foopart_1_prt_1 SET DISTRIBUTED REPLICATED;
+ERROR:  can't set the distribution policy of "foopart_1_prt_1"
+HINT:  Distribution policy can be set for an entire partitioned table, not for one of its leaf parts or an interior branch.
+DROP TABLE foopart;
 -- start_ignore
 drop schema rpt cascade;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 7 other objects
 DETAIL:  drop cascades to table foo
 drop cascades to table bar
 drop cascades to table baz

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -335,6 +335,22 @@ declare c1 cursor for select * from cursor_update order by c2 for update;
 fetch next from c1;
 end;
 
+-- Test MinMax path on replicated table
+create table minmaxtest (x int, y int) distributed replicated;
+create index on minmaxtest (x);
+insert into minmaxtest select generate_series(1, 10);
+set enable_seqscan=off;
+select min(x) from minmaxtest;
+
+-- Test replicated on partition table
+-- should fail
+CREATE TABLE foopart (a int4, b int4) DISTRIBUTED REPLICATED PARTITION BY RANGE (a) (START (1) END (10));
+CREATE TABLE foopart (a int4, b int4) PARTITION BY RANGE (a) (START (1) END (10)) ;
+-- should fail
+ALTER TABLE foopart SET DISTRIBUTED REPLICATED;
+ALTER TABLE foopart_1_prt_1 SET DISTRIBUTED REPLICATED;
+DROP TABLE foopart;
+
 -- start_ignore
 drop schema rpt cascade;
 -- end_ignore


### PR DESCRIPTION
This patch fixes the issue: https://github.com/greenplum-db/gpdb/issues/10224
Replicated table is not allowed to be a partition table.
So an existing partition table must not be altered its
distribution policy to REPLICATED.

Reported-by: Heikki Linnakangas <hlinnakangas@pivotal.io>
Reviewed-by: Zhenghua Lyu <zlv@pivotal.io>
(cherry picked from commit 78cccb81fa42b0e6ac2e6fbfc646f464f667be28)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
