### PR TITLE
Make cdbpullup_missingVarWalker also consider PlaceHolderVar.

### DIFF
--- a/src/backend/cdb/cdbpullup.c
+++ b/src/backend/cdb/cdbpullup.c
@@ -476,7 +476,11 @@ cdbpullup_missingVarWalker(Node *node, void *targetlist)
 	if (!node)
 		return false;
 
-	if (IsA(node, Var))
+	/*
+	 * Should also consider PlaceHolderVar in the targetlist.
+	 * See github issue: https://github.com/greenplum-db/gpdb/issues/10315
+	 */
+	if (IsA(node, Var) || IsA(node, PlaceHolderVar))
 	{
 		if (!targetlist)
 			return true;

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1601,3 +1601,44 @@ select * from fix_param_a left join fix_param_b on
  20 | 20 | 20 | 20
 (20 rows)
 
+-- Test targetlist contains placeholder var
+-- When creating a redistributed motion with hash keys,
+-- Greenplum planner will invoke `cdbpullup_findEclassInTargetList`.
+-- The following test case contains non-strict function `coalesce`
+-- in the subquery at nullable-side of outerjoin and thus will
+-- have PlaceHolderVar in targetlist. The case is to test if
+-- function `cdbpullup_findEclassInTargetList` handles PlaceHolderVar
+-- correct.
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/10315
+create table t_issue_10315 ( id1 int, id2 int );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_issue_10315 select i,i from generate_series(1, 2)i;
+insert into t_issue_10315 select i,null from generate_series(1, 2)i;
+insert into t_issue_10315 select null,i from generate_series(1, 2)i;
+select *  from
+( select coalesce( bq.id1 ) id1, coalesce ( bq.id2 ) id2
+        from ( select r.id1, r.id2 from t_issue_10315 r group by r.id1, r.id2 ) bq  ) t
+full join ( select r.id1, r.id2 from t_issue_10315 r group by r.id1, r.id2 ) bq_all
+on t.id1 = bq_all.id1  and t.id2 = bq_all.id2
+full join ( select r.id1, r.id2 from t_issue_10315 r group by r.id1, r.id2 ) tq_all
+on (coalesce(t.id1) = tq_all.id1  and t.id2 = tq_all.id2) ;
+ id1 | id2 | id1 | id2 | id1 | id2 
+-----+-----+-----+-----+-----+-----
+   2 |   2 |   2 |   2 |   2 |   2
+   2 |     |     |     |     |    
+     |   1 |     |     |     |    
+     |   2 |     |     |     |    
+     |     |     |   2 |     |    
+     |     |     |   1 |     |    
+     |     |   2 |     |     |    
+     |     |   1 |     |     |    
+     |     |     |     |     |   2
+     |     |     |     |     |   1
+     |     |     |     |   2 |    
+   1 |   1 |   1 |   1 |   1 |   1
+   1 |     |     |     |     |    
+     |     |     |     |   1 |    
+(14 rows)
+
+drop table t_issue_10315;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1588,3 +1588,44 @@ select * from fix_param_a left join fix_param_b on
  20 | 20 | 20 | 20
 (20 rows)
 
+-- Test targetlist contains placeholder var
+-- When creating a redistributed motion with hash keys,
+-- Greenplum planner will invoke `cdbpullup_findEclassInTargetList`.
+-- The following test case contains non-strict function `coalesce`
+-- in the subquery at nullable-side of outerjoin and thus will
+-- have PlaceHolderVar in targetlist. The case is to test if
+-- function `cdbpullup_findEclassInTargetList` handles PlaceHolderVar
+-- correct.
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/10315
+create table t_issue_10315 ( id1 int, id2 int );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_issue_10315 select i,i from generate_series(1, 2)i;
+insert into t_issue_10315 select i,null from generate_series(1, 2)i;
+insert into t_issue_10315 select null,i from generate_series(1, 2)i;
+select *  from
+( select coalesce( bq.id1 ) id1, coalesce ( bq.id2 ) id2
+        from ( select r.id1, r.id2 from t_issue_10315 r group by r.id1, r.id2 ) bq  ) t
+full join ( select r.id1, r.id2 from t_issue_10315 r group by r.id1, r.id2 ) bq_all
+on t.id1 = bq_all.id1  and t.id2 = bq_all.id2
+full join ( select r.id1, r.id2 from t_issue_10315 r group by r.id1, r.id2 ) tq_all
+on (coalesce(t.id1) = tq_all.id1  and t.id2 = tq_all.id2) ;
+ id1 | id2 | id1 | id2 | id1 | id2 
+-----+-----+-----+-----+-----+-----
+   2 |   2 |   2 |   2 |   2 |   2
+   2 |     |     |     |     |    
+     |   1 |     |     |     |    
+     |   2 |     |     |     |    
+     |     |     |   2 |     |    
+     |     |     |   1 |     |    
+     |     |   2 |     |     |    
+     |     |   1 |     |     |    
+     |     |     |     |     |   2
+     |     |     |     |     |   1
+     |     |     |     |   2 |    
+   1 |   1 |   1 |   1 |   1 |   1
+   1 |     |     |     |     |    
+     |     |     |     |   1 |    
+(14 rows)
+
+drop table t_issue_10315;

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -742,3 +742,28 @@ select * from fix_param_a left join fix_param_b on
 	fix_param_a.i = fix_param_b.i and fix_param_b.j in
 		(select j from fix_param_c where fix_param_b.i = fix_param_c.i)
 	order by 1;
+
+-- Test targetlist contains placeholder var
+-- When creating a redistributed motion with hash keys,
+-- Greenplum planner will invoke `cdbpullup_findEclassInTargetList`.
+-- The following test case contains non-strict function `coalesce`
+-- in the subquery at nullable-side of outerjoin and thus will
+-- have PlaceHolderVar in targetlist. The case is to test if
+-- function `cdbpullup_findEclassInTargetList` handles PlaceHolderVar
+-- correct.
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/10315
+create table t_issue_10315 ( id1 int, id2 int );
+
+insert into t_issue_10315 select i,i from generate_series(1, 2)i;
+insert into t_issue_10315 select i,null from generate_series(1, 2)i;
+insert into t_issue_10315 select null,i from generate_series(1, 2)i;
+
+select *  from
+( select coalesce( bq.id1 ) id1, coalesce ( bq.id2 ) id2
+        from ( select r.id1, r.id2 from t_issue_10315 r group by r.id1, r.id2 ) bq  ) t
+full join ( select r.id1, r.id2 from t_issue_10315 r group by r.id1, r.id2 ) bq_all
+on t.id1 = bq_all.id1  and t.id2 = bq_all.id2
+full join ( select r.id1, r.id2 from t_issue_10315 r group by r.id1, r.id2 ) tq_all
+on (coalesce(t.id1) = tq_all.id1  and t.id2 = tq_all.id2) ;
+
+drop table t_issue_10315;


### PR DESCRIPTION
When planner adds a redistribute motion above this subplan, planner
will invoke `cdbpullup_findEclassInTargetList` to make sure the
distkey can be computed based on subplan's targetlist. When the distkey
is an expression based on some PlaceholderVar elements in targetlist,
the function `cdbpullup_missingVarWalker` does not handle it correctly.

For example, when distkey is:

```sql
CoalesceExpr [coalescetype=23 coalescecollid=0 location=586]
        [args]
                PlaceHolderVar [phrels=0x00000040 phid=1 phlevelsup=0]
                        [phexpr]
                                CoalesceExpr [coalescetype=23 coalescecollid=0 location=49]
                                        [args] Var [varno=6 varattno=1 vartype=23 varnoold=6 varoattno=1]
```

and targetlist is:

```
TargetEntry [resno=1]
        Var [varno=2 varattno=1 vartype=23 varnoold=2 varoattno=1]
TargetEntry [resno=2]
        Var [varno=2 varattno=2 vartype=23 varnoold=2 varoattno=2]
TargetEntry [resno=3]
        PlaceHolderVar [phrels=0x00000040 phid=1 phlevelsup=0]
                [phexpr]
                        CoalesceExpr [coalescetype=23 coalescecollid=0 location=49]
                                [args] Var [varno=6 varattno=1 vartype=23 varnoold=6 varoattno=1]
TargetEntry [resno=4]
        PlaceHolderVar [phrels=0x00000040 phid=2 phlevelsup=0]
                [phexpr]
                        CoalesceExpr [coalescetype=23 coalescecollid=0 location=78]
                                [args] Var [varno=6 varattno=2 vartype=23 varnoold=6 varoattno=2]
```

Previously only consider Var leads to `cdbpullup_missingVarWalker` fail.

See Github issue: https://github.com/greenplum-db/gpdb/issues/10315 for
details.

This commit fixes the issue by considering PlaceHolderVar in function
`cdbpullup_missingVarWalker`.
