### PR TITLE
Enable to disable fault injector manually

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -3073,6 +3073,7 @@ gpdb::RunStaticPartitionSelection
 	return NULL;
 }
 
+#ifdef FAULT_INJECTOR
 FaultInjectorType_e
 gpdb::InjectFaultInOptTasks
 	(
@@ -3086,6 +3087,7 @@ gpdb::InjectFaultInOptTasks
 	GP_WRAP_END;
 	return FaultInjectorTypeNotSpecified;
 }
+#endif
 
 gpos::ULONG
 gpdb::CountLeafPartTables

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -670,8 +670,10 @@ namespace gpdb {
 	// static partition selection given a PartitionSelector node
 	SelectedParts *RunStaticPartitionSelection(PartitionSelector *ps);
 
+#ifdef FAULT_INJECTOR
 	// simple fault injector used by COptTasks.cpp to inject GPDB fault
 	FaultInjectorType_e InjectFaultInOptTasks(const char* fault_name);
+#endif
 
 	// return the number of leaf partition for a given table oid
 	gpos::ULONG CountLeafPartTables(Oid oidRelation);


### PR DESCRIPTION
Most of the code that uses fault injector is in the preprocess block.
But the function gpdb::InjectFaultInOptTasks() isn't guarded by
the macro FAULT_INJECTOR.
See issue: https://github.com/greenplum-db/gpdb/issues/10341

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
