### PR TITLE
Fix pgupgrade unit tests

### DIFF
--- a/contrib/pg_upgrade/ci/run-test-as-gpadmin.sh
+++ b/contrib/pg_upgrade/ci/run-test-as-gpadmin.sh
@@ -22,7 +22,7 @@ install_gpdb6() {
 
 	pushd "$gpdb6_source_path"
 
-	./configure --disable-orca --prefix="$gpdb6_installation_path" --without-zstd --with-python &&
+	./configure --disable-orca --prefix="$gpdb6_installation_path" --without-zstd --with-python --disable-gpcloud &&
 		make -j 4 -l 4 &&
 		make install
 

--- a/contrib/pg_upgrade/test/unit/Makefile
+++ b/contrib/pg_upgrade/test/unit/Makefile
@@ -27,7 +27,7 @@ override CPPFLAGS += -I$(pg_upgrade_directory) \
 
 test_dependencies = $(CMOCKERY_OBJS)
 
-debugging_flags = -Og -g -fsanitize=address -Wextra -pedantic-errors -Werror
+debugging_flags = -Og -g -Wextra -pedantic-errors -Werror
 
 compile_test = $(CC) $(CFLAGS) $(debugging_flags) $^ $(libpq_pgport) $(LDFLAGS) -o $@ 
 


### PR DESCRIPTION
- Add --disable-gpcloud configure flag as its not required for testing
  pg_upgrade
- Remove -fsanitize=address

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
