### PR TITLE
Alter table add column on AOCS table inherits the default storage set…

### DIFF
--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -529,27 +529,46 @@ compresstype_is_valid(char *comptype)
 }
 
 /*
- * Make encoding (compresstype = none, blocksize=...) based on
+ * Make encoding (compresstype = ..., blocksize=...) based on
  * currently configured defaults.
  */
 List *
-default_column_encoding_clause(void)
+default_column_encoding_clause(Relation rel)
 {
-	const StdRdOptions *ao_opts = currentAOStorageOptions();
 	DefElem *e1, *e2, *e3;
-	if (ao_opts->compresstype[0])
-	{
+	const StdRdOptions *ao_opts = currentAOStorageOptions();
+	Form_pg_appendonly appendonly = rel ? rel->rd_appendonly : NULL;
+	char *compresstype = appendonly ? NameStr(appendonly->compresstype) : NULL;
+
+	if (compresstype && compresstype[0])
 		e1 = makeDefElem("compresstype",
-						 (Node *)makeString(pstrdup(ao_opts->compresstype)));
-	}
+				(Node *)makeString(pstrdup(compresstype)));
+	else if (ao_opts->compresstype[0])
+		e1 = makeDefElem("compresstype",
+				(Node *)makeString(pstrdup(ao_opts->compresstype)));
 	else
-	{
 		e1 = makeDefElem("compresstype", (Node *)makeString("none"));
-	}
-	e2 = makeDefElem("blocksize",
-					 (Node *)makeInteger(ao_opts->blocksize));
-	e3 = makeDefElem("compresslevel",
-					 (Node *)makeInteger(ao_opts->compresslevel));
+
+	if (appendonly)
+		e2 = makeDefElem("blocksize",
+				(Node *)makeInteger(appendonly->blocksize));
+	else if (ao_opts->blocksize != 0)
+		e2 = makeDefElem("blocksize",
+				(Node *)makeInteger(ao_opts->blocksize));
+	else
+		e2 = makeDefElem("blocksize",
+				(Node *)makeInteger(AO_DEFAULT_BLOCKSIZE));
+
+	if (appendonly && appendonly->compresslevel != 0)
+		e3 = makeDefElem("compresslevel",
+				(Node *)makeInteger(appendonly->compresslevel));
+	else if (ao_opts->compresslevel != 0)
+		e3 = makeDefElem("compresslevel",
+				(Node *)makeInteger(ao_opts->compresslevel));
+	else
+		e3 = makeDefElem("compresslevel",
+				(Node *)makeInteger(AO_DEFAULT_COMPRESSLEVEL));
+
 	return list_make3(e1, e2, e3);
 }
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -7811,7 +7811,7 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 			c->encoding = TypeNameGetStorageDirective(colDef->typeName);
 			
 			if (!c->encoding)
-				c->encoding = default_column_encoding_clause();
+				c->encoding = default_column_encoding_clause(rel);
 		}
 
 		AddRelationAttributeEncodings(rel, list_make1(c));

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -4657,7 +4657,7 @@ transformAttributeEncoding(List *columns, List *stenc, List *taboptions, bool *f
 					if (te)
 						c->encoding = copyObject(te);
 					else
-						c->encoding = default_column_encoding_clause();
+						c->encoding = default_column_encoding_clause(NULL);
 				}
 			}
 		}

--- a/src/include/catalog/pg_compression.h
+++ b/src/include/catalog/pg_compression.h
@@ -119,7 +119,7 @@ extern void callCompressionValidator(PGFunction func, char *comptype,
 									 Oid typid);
 
 extern bool compresstype_is_valid(char *compresstype);
-extern List *default_column_encoding_clause(void);
+extern List *default_column_encoding_clause(Relation rel);
 extern PGFunction *GetCompressionImplementation(char *comptype);
 extern bool is_storage_encoding_directive(char *name);
 

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -781,3 +781,48 @@ alter table aocs_with_compress drop column b;
 alter table aocs_with_compress set with (reorganize=true);
 -- The following operation must not fail
 alter table aocs_with_compress alter column c type integer;
+-- test case: alter AOCS table add column, the preference of the storage setting is: the encoding clause > table setting > gp_default_storage_options
+CREATE TABLE aocs_alter_add_col(a int) WITH (appendonly=true, orientation=column, compresstype=rle_type, compresslevel=4, blocksize=65536);
+SET gp_default_storage_options ='appendonly=true, orientation=column, compresstype=zlib, compresslevel=2';
+-- use statement encoding 
+ALTER TABLE aocs_alter_add_col ADD COLUMN b int ENCODING(compresstype=zlib, compresslevel=3, blocksize=16384);
+-- use table setting
+ALTER TABLE aocs_alter_add_col ADD COLUMN c int;
+RESET gp_default_storage_options;
+-- use table setting
+ALTER TABLE aocs_alter_add_col ADD COLUMN d int;
+\d+ aocs_alter_add_col
+                                 Append-Only Columnar Table "public.aocs_alter_add_col"
+ Column |  Type   | Modifiers | Storage | Stats target | Compression Type | Compression Level | Block Size | Description 
+--------+---------+-----------+---------+--------------+------------------+-------------------+------------+-------------
+ a      | integer |           | plain   |              | rle_type         | 4                 | 65536      | 
+ b      | integer |           | plain   |              | zlib             | 3                 | 16384      | 
+ c      | integer |           | plain   |              | rle_type         | 4                 | 65536      | 
+ d      | integer |           | plain   |              | rle_type         | 4                 | 65536      | 
+Checksum: t
+Distributed by: (a)
+Options: appendonly=true, orientation=column, compresstype=rle_type, compresslevel=4, blocksize=65536
+
+DROP TABLE aocs_alter_add_col;
+CREATE TABLE aocs_alter_add_col_no_compress(a int) WITH (appendonly=true, orientation=column);
+SET gp_default_storage_options ='appendonly=true, orientation=column, compresstype=zlib, compresslevel=2, blocksize=8192';
+-- use statement encoding
+ALTER TABLE aocs_alter_add_col_no_compress ADD COLUMN b int ENCODING(compresstype=rle_type, compresslevel=3, blocksize=16384);
+-- use gp_default_storage_options
+ALTER TABLE aocs_alter_add_col_no_compress ADD COLUMN c int;
+RESET gp_default_storage_options;
+-- use default value 
+ALTER TABLE aocs_alter_add_col_no_compress ADD COLUMN d int;
+\d+ aocs_alter_add_col_no_compress 
+                           Append-Only Columnar Table "public.aocs_alter_add_col_no_compress"
+ Column |  Type   | Modifiers | Storage | Stats target | Compression Type | Compression Level | Block Size | Description 
+--------+---------+-----------+---------+--------------+------------------+-------------------+------------+-------------
+ a      | integer |           | plain   |              | none             | 0                 | 32768      | 
+ b      | integer |           | plain   |              | rle_type         | 3                 | 16384      | 
+ c      | integer |           | plain   |              | zlib             | 2                 | 32768      | 
+ d      | integer |           | plain   |              | none             | 0                 | 32768      | 
+Checksum: t
+Distributed by: (a)
+Options: appendonly=true, orientation=column
+
+DROP TABLE aocs_alter_add_col_no_compress;

--- a/src/test/regress/sql/alter_table_aocs.sql
+++ b/src/test/regress/sql/alter_table_aocs.sql
@@ -446,3 +446,27 @@ alter table aocs_with_compress set with (reorganize=true);
 -- The following operation must not fail
 alter table aocs_with_compress alter column c type integer;
 
+-- test case: alter AOCS table add column, the preference of the storage setting is: the encoding clause > table setting > gp_default_storage_options
+CREATE TABLE aocs_alter_add_col(a int) WITH (appendonly=true, orientation=column, compresstype=rle_type, compresslevel=4, blocksize=65536);
+SET gp_default_storage_options ='appendonly=true, orientation=column, compresstype=zlib, compresslevel=2';
+-- use statement encoding 
+ALTER TABLE aocs_alter_add_col ADD COLUMN b int ENCODING(compresstype=zlib, compresslevel=3, blocksize=16384);
+-- use table setting
+ALTER TABLE aocs_alter_add_col ADD COLUMN c int;
+RESET gp_default_storage_options;
+-- use table setting
+ALTER TABLE aocs_alter_add_col ADD COLUMN d int;
+\d+ aocs_alter_add_col
+DROP TABLE aocs_alter_add_col;
+
+CREATE TABLE aocs_alter_add_col_no_compress(a int) WITH (appendonly=true, orientation=column);
+SET gp_default_storage_options ='appendonly=true, orientation=column, compresstype=zlib, compresslevel=2, blocksize=8192';
+-- use statement encoding
+ALTER TABLE aocs_alter_add_col_no_compress ADD COLUMN b int ENCODING(compresstype=rle_type, compresslevel=3, blocksize=16384);
+-- use gp_default_storage_options
+ALTER TABLE aocs_alter_add_col_no_compress ADD COLUMN c int;
+RESET gp_default_storage_options;
+-- use default value 
+ALTER TABLE aocs_alter_add_col_no_compress ADD COLUMN d int;
+\d+ aocs_alter_add_col_no_compress 
+DROP TABLE aocs_alter_add_col_no_compress;


### PR DESCRIPTION
…tings

When alter table add a column to AOCS table, the newly added column should
inherits the compresstype, compresslevel and blocksize of the relation.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
