### PR TITLE
Fix assert failure in cdbcomponent_getCdbComponents()

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -711,7 +711,8 @@ cdbcomponent_getCdbComponents()
 	}
 	PG_CATCH();
 	{
-		FtsNotifyProber();
+		if (Gp_role == GP_ROLE_DISPATCH)
+			FtsNotifyProber();
 
 		PG_RE_THROW();
 	}


### PR DESCRIPTION
It could be called in utility mode, however we should avoid calling into
FtsNotifyProber() for such case. Ideally we could do that if we access the
master node and postgres is not in single mode, but it seems that we do not that
need.

Here is the stack of the issue I encountered.

0  0x0000003397e32625 in raise () from /lib64/libc.so.6
1  0x0000003397e33e05 in abort () from /lib64/libc.so.6
2  0x0000000000b39844 in ExceptionalCondition (conditionName=0xeebac0 "!(Gp_role == GP_ROLE_DISPATCH)", errorType=0xeebaaf "FailedAssertion",
    fileName=0xeeba67 "cdbfts.c", lineNumber=101) at assert.c:66
3  0x0000000000bffb1e in FtsNotifyProber () at cdbfts.c:101
4  0x0000000000c389a4 in cdbcomponent_getCdbComponents () at cdbutil.c:714
5  0x0000000000c26e3a in gp_pgdatabase__ (fcinfo=0x7ffd7b009c10) at cdbpgdatabase.c:74
6  0x000000000076dbd6 in ExecMakeTableFunctionResult (funcexpr=0x3230fc0, econtext=0x3230988, argContext=0x3232b68, expectedDesc=0x3231df8, randomAccess=0 '\000',
	    operatorMemKB=32768) at execQual.c:2275
......
18 0x00000000009afeb2 in exec_simple_query (query_string=0x316ce20 "select * from gp_pgdatabase") at postgres.c:1778