### PR TITLE
Clean up the internal functions to merge partition stats a bit.

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -4423,8 +4423,9 @@ merge_leaf_stats(VacAttrStatsP stats,
 		void *resultMCV[2];
 
 		mcvpairArray = aggregate_leaf_partition_MCVs(
-			stats->attr->attrelid, stats->attr->attnum, heaptupleStats,
-			relTuples, default_statistics_target, ndistinct, &num_mcv, &rem_mcv,
+			stats->attr->attrelid, stats->attr->attnum,
+			numPartitions, heaptupleStats, relTuples,
+			default_statistics_target, ndistinct, &num_mcv, &rem_mcv,
 			resultMCV);
 		MemoryContextSwitchTo(old_context);
 
@@ -4447,8 +4448,9 @@ merge_leaf_stats(VacAttrStatsP stats,
 
 		void *resultHistogram[1];
 		int num_hist = aggregate_leaf_partition_histograms(
-			stats->attr->attrelid, stats->attr->attnum, heaptupleStats,
-			relTuples, default_statistics_target, mcvpairArray + num_mcv,
+			stats->attr->attrelid, stats->attr->attnum,
+			numPartitions, heaptupleStats, relTuples,
+			default_statistics_target, mcvpairArray + num_mcv,
 			rem_mcv, resultHistogram);
 		MemoryContextSwitchTo(old_context);
 		if (num_hist > 0)

--- a/src/include/cdb/cdbpartition.h
+++ b/src/include/cdb/cdbpartition.h
@@ -125,9 +125,6 @@ extern PartitionNode *RelationBuildPartitionDesc(Relation rel,
 extern PartitionNode *RelationBuildPartitionDescByOid(Oid relid,
 												 bool inctemplate);
 
-extern List *
-rel_get_leaf_children_relids(Oid relid);
-
 extern Oid 
 rel_partition_get_root(Oid relid);
 

--- a/src/include/commands/analyzeutils.h
+++ b/src/include/commands/analyzeutils.h
@@ -35,6 +35,7 @@ typedef struct MCVFreqPair
 /* extern functions called by commands/analyze.c */
 extern MCVFreqPair **aggregate_leaf_partition_MCVs(Oid relationOid,
 												   AttrNumber attnum,
+												   int numPartitions,
 												   HeapTuple *heaptupleStats,
 												   float4 *relTuples,
 												   unsigned int nEntries,
@@ -47,6 +48,7 @@ extern float4 get_rel_reltuples(Oid relid);
 extern int32 get_rel_relpages(Oid relid);
 extern int aggregate_leaf_partition_histograms(Oid relationOid,
 											   AttrNumber attnum,
+											   int nParts,
 											   HeapTuple *heaptupleStats,
 											   float4 *relTuples,
 											   unsigned int nEntries,


### PR DESCRIPTION
aggregate_leaf_partition_MCVs() and aggregate_leaf_partition_histograms()
functions did catalog lookups to count how many leaf partitions a root
table has. Why? Because the caller passes two arrays as inputs, with an
entry for each partition, and the functions need to know how large the
input arrays are. That's overly complicated, of course: the caller can
simply pass the size of the arrays as an argument. That's much more robust
too, I think the current code would crash and burn if the partition
hierarchy was modified concurrently. I'm not sure if that's a live bug, or
if we're holding locks that prevent that, but let's keep things simple in
any case.

This removes the last callers of rel_get_leaf_children_relids() function,
so remove that altogether.
