### PR TITLE
6X_Stable back port: For Python testing artifacts, introduce combination of Concourse cache and PIP_CACHE_DIR

### DIFF
--- a/concourse/tasks/behave_gpdb.yml
+++ b/concourse/tasks/behave_gpdb.yml
@@ -11,3 +11,5 @@ params:
   BLDWRAP_POSTGRES_CONF_ADDONS: ""
 run:
   path: gpdb_src/concourse/scripts/behave_gpdb.bash
+caches:
+  - path: pip-cache-dir

--- a/concourse/tasks/gpMgmt_check_gpdb.yml
+++ b/concourse/tasks/gpMgmt_check_gpdb.yml
@@ -9,3 +9,5 @@ params:
   TEST_OS: ""
 run:
   path: gpdb_src/concourse/scripts/gpMgmt_check_gpdb.bash
+caches:
+  - path: pip-cache-dir

--- a/concourse/tasks/run_behave_on_ccp_cluster.yml
+++ b/concourse/tasks/run_behave_on_ccp_cluster.yml
@@ -2,6 +2,8 @@ platform: linux
 inputs:
  - name: ccp_src
  - name: cluster_env_files
+caches:
+ - path: pip-cache-dir
 run:
   path: bash
   args:
@@ -76,9 +78,19 @@ run:
         if [ -d \$MASTER_DATA_DIRECTORY ]; then gpstart -a; fi
     "
 
+    while read -r host; do
+        scp -qr "pip-cache-dir" $host:pip-cache-dir
+    done < cluster_env_files/hostfile_all
+
     ssh -t mdw "
         source /home/gpadmin/gpdb_src/concourse/scripts/common.bash
         install_python_requirements_on_multi_host /home/gpadmin/gpdb_src/gpMgmt/requirements-dev.txt
 
         $CUSTOM_ENV bash /home/gpadmin/gpdb_src/concourse/scripts/run_behave_test.sh \"$BEHAVE_FLAGS\"
     "
+
+    # Refresh the Concourse container cache with the updated contents
+    # from the CCP mdw node.
+
+    rm -rf "pip-cache-dir/http"
+    scp -qr mdw:pip-cache-dir/http "pip-cache-dir"


### PR DESCRIPTION
For the Python testing artifacts used by the CLI tools, utilize the
Concourse cached directories feature to create and use a pip cache dir
shared between task runs.

Be aware, the cache is scoped to the worker the task is run on. We do
not get a cache hit when subsequent builds run on different workers.

**Notes**

* The environment variable PIP_CACHE_DIR is used to store the cache directory.
* Add "--retries 10" to Behave test dependency pip install commands.

The PR for the master branch: https://github.com/greenplum-db/gpdb/pull/10296