### PR TITLE
docs - update some pxf xrefs, add excludes

### DIFF
--- a/gpdb-doc/book/config.yml
+++ b/gpdb-doc/book/config.yml
@@ -84,4 +84,4 @@ template_variables:
   support_link: <a href="https://github.com/greenplum-db/gpdb/wiki">Wiki</a>
   support_url: https://greenplum.org
 
-broken_link_exclusions: iefix|arrowhead
+broken_link_exclusions: iefix|arrowhead|overview_pxf.html|pxf.html|pxf-cluster.html|pxf_kerbhdfs.html|cfginitstart_pxf.html|init_pxf.html|access_hdfs.html|intro_pxf.html|using_pxf.html|client_instcfg.html|install_java.html

--- a/gpdb-doc/dita/admin_guide/external/pxf-overview.xml
+++ b/gpdb-doc/dita/admin_guide/external/pxf-overview.xml
@@ -2,15 +2,28 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic_u14_wtd_dbb">
   <title>Accessing External Data with PXF</title>
-  <shortdesc>Data managed by your organization may already reside in external sources such as Hadoop, object stores, and other SQL databases. The Greenplum Platform Extension Framework (PXF) provides access to this external data via built-in connectors that map an external data source to a Greenplum Database table definition.</shortdesc>
+  <shortdesc>Data managed by your organization may already reside in external
+    sources such as Hadoop, object stores, and other SQL databases. The
+    Greenplum Platform Extension Framework (PXF) provides access to this
+    external data via built-in connectors that map an external data source to
+    a Greenplum Database table definition.</shortdesc>
   <body>
-    <p>PXF is installed with Hadoop and Object Storage connectors. These connectors enable you to read external data stored in text, Avro, JSON, RCFile, Parquet, SequenceFile, and ORC formats. You can use the JDBC connector to access an external SQL database.</p>
+    <p>PXF is installed with Hadoop and Object Storage connectors. These
+      connectors enable you to read external data stored in text, Avro, JSON,
+      RCFile, Parquet, SequenceFile, and ORC formats. You can use the JDBC
+      connector to access an external SQL database.</p>
     <note>In previous versions of Greenplum Database, you may have used the
       <codeph>gphdfs</codeph> external table protocol to access data stored in Hadoop.
       Greenplum Database version 6.0.0 removes the <codeph>gphdfs</codeph> protocol.
       Use PXF and the <codeph>pxf</codeph> external table protocol to access
       Hadoop in Greenplum Database version 6.x.</note>
-    <p>The Greenplum Platform Extension Framework includes a protocol C library and a Java service. After you configure and initialize PXF, you start a single PXF JVM process on each Greenplum Database segment host. This long-running process concurrently serves multiple query requests.</p>
-    <p>For detailed information about the architecture of and using PXF, refer to the <xref href="../../pxf/overview_pxf.html" type="topic" format="html">Greenplum Platform Extension Framework (PXF)</xref> documentation.</p>
+    <p>The Greenplum Platform Extension Framework includes a C-language extension
+      and a Java service. After you configure and initialize PXF, you start a
+      single PXF JVM process on each Greenplum Database segment host. This long-
+      running process concurrently serves multiple query requests.</p>
+    <p>For detailed information about the architecture of and using PXF, refer
+      to the <xref href="../../../pxf/5-13/overview_pxf.html" type="topic"
+        format="html" scope="external">Greenplum Platform Extension Framework (PXF)</xref>
+      documentation.</p>
   </body>
 </topic>

--- a/gpdb-doc/dita/analytics/overview.xml
+++ b/gpdb-doc/dita/analytics/overview.xml
@@ -88,10 +88,10 @@
             href="https://greenplum.docs.pivotal.io/streaming-server/1-3-6/intro.html" format="html" scope="external"
             >Kafka integration</xref>, extensions for HDFS, Hive, and HBase as well as
           reading/writing data from/to cloud storage, including Amazon S3 objects. Review the
-          capabilities of Greenplum <xref href="https://gpdb.docs.pivotal.io/6-1/pxf/intro_pxf.html"
-            format="html" scope="external">Platform Extension Framework (PXF)</xref>, which provides
-            <i>connectors</i> that enable you to access data stored in sources external to your
-          Greenplum Database deployment.</li>
+          capabilities of the Greenplum <xref href="../admin_guide/external/pxf-overview.xml"
+            >Platform Extension Framework (PXF)</xref>, which provides
+            <i>connectors</i> that enable you to access data stored in sources external
+          to your Greenplum Database deployment.</li>
       <li otherprops="Pivotal">Use familiar and leading BI and advanced analytics software that are ODBC/JDBC compatible, or have native integrations,
         including SAS, IBM Cognos, SAP Analytics Solutions, Qlik, Tableau, Apache Zeppelin, and Jupyter.</li>
       <li>Execute deep learning algorithms using popular frameworks like Keras and TensorFlow in an

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.xml
@@ -212,9 +212,8 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE <varname>table_name</varna
         <plentry>
           <pt>LOCATION <varname>('protocol://[host[:port]]/path/file' [, ...])</varname></pt>
           <pd>If you use the <codeph>pxf</codeph> protocol to access an external data source,
-          refer to the PXF <xref href="../../pxf/intro_pxf.html#create_external_table" format="html">Creating an External Table</xref>
-          documentation for detailed information about
-          the <codeph>pxf</codeph> protocol <codeph>LOCATION</codeph> clause syntax.</pd>
+          refer to <xref href="../../admin_guide/external/g-pxf-protocol.xml"></xref> for
+          information about the <codeph>pxf</codeph> protocol.</pd>
           <pd>If you use the <codeph>s3</codeph> protocol to read or write to S3, refer to <xref
               href="../../admin_guide/external/g-s3-protocol.xml#amazon-emr/section_stk_c2r_kx"/>
             for additional information about the <codeph>s3</codeph> protocol
@@ -322,9 +321,8 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE <varname>table_name</varna
         using a custom format, see "Loading and Unloading Data" in the <cite>Greenplum Database
           Administrator Guide</cite>.</pd>
           <pd>If you use the <codeph>pxf</codeph> protocol to access an external data source,
-          refer to the PXF <xref href="../../pxf/intro_pxf.html#create_external_table" format="html">Creating an External Table</xref>
-          documentation for detailed information about
-          the <codeph>pxf</codeph> protocol <codeph>FORMAT</codeph> clause syntax.</pd>
+          refer to <xref href="../../admin_guide/external/pxf-overview.xml"></xref>
+          for information about using PXF.</pd>
         </plentry>
         <plentry>
           <pt>FORMAT 'CUSTOM' (formatter=<varname>formatter_specification</varname>)</pt>
@@ -333,9 +331,8 @@ CREATE WRITABLE EXTERNAL WEB [TEMPORARY | TEMP] TABLE <varname>table_name</varna
             to the formatter function. The length of the formatter specification, the string
             including <codeph>Formatter=</codeph>, can be up to approximately 50K bytes.</pd>
           <pd>If you use the <codeph>pxf</codeph> protocol to access an external data source,
-          refer to the PXF <xref href="../../pxf/intro_pxf.html#create_external_table" format="html">Creating an External Table</xref>
-          documentation for detailed information about
-          the <codeph>pxf</codeph> protocol <codeph>FORMAT</codeph> clause syntax.</pd>
+          refer to <xref href="../../admin_guide/external/pxf-overview.xml"></xref>
+          for information about using PXF.</pd>
           <pd>For general information about using a custom format, see "Loading and Unloading Data" in the
               <cite>Greenplum Database Administrator Guide</cite>.</pd>
         </plentry>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_PROTOCOL.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_PROTOCOL.xml
@@ -68,10 +68,9 @@
                     <codeph>gpfdist</codeph>, and <codeph>gpfdists</codeph> internally. 
                 See
                     <xref href="../../admin_guide/external/g-s3-protocol.xml#amazon-emr/s3_prereq"/>
-                for information about enabling the <codeph>S3</codeph> protocol. See the <xref
-                    href="../../pxf/overview_pxf.html" type="topic" format="html">Greenplum Platform
-                    Extension Framework (PXF)</xref> documentation for information about configuring
-                the PXF extension and using the <codeph>pxf</codeph> protocol.</p>
+                for information about enabling the <codeph>S3</codeph> protocol. Refer to <xref
+                    href="../../admin_guide/external/g-pxf-protocol.xml" type="topic"></xref> for
+                information about using the <codeph>pxf</codeph> protocol.</p>
             <p>Any shared library that implements a data access protocol must be located in the same
                 location on all Greenplum Database segment hosts. For example, the shared library
                 can be in a location specified by the operating system environment variable

--- a/gpdb-doc/dita/security-guide/topics/SecuringGPDB.xml
+++ b/gpdb-doc/dita/security-guide/topics/SecuringGPDB.xml
@@ -29,7 +29,7 @@
         is secured with Kerberos ("Kerberized"), you must configure Greenplum Database
         and PXF to allow users accessing external tables to authenticate with Kerberos.
         Refer to <xref
-          href="../../pxf/pxf_kerbhdfs.html" scope="peer" format="html">Configuring PXF for Secure HDFS</xref> for the procedure to perform this setup. </p>
+          href="../../../pxf/5-13/pxf_kerbhdfs.html" scope="external" format="html">Configuring PXF for Secure HDFS</xref> for the procedure to perform this setup. </p>
     </section>
     <section>
       <title>Platform Hardening</title>

--- a/gpdb-doc/dita/utility_guide/utility-programs.xml
+++ b/gpdb-doc/dita/utility_guide/utility-programs.xml
@@ -116,10 +116,10 @@
                         <p><xref href="ref/plcontainer.xml#topic1" type="topic" format="dita"/></p>
                         <p><xref href="ref/plcontainer-configuration.xml#topic1" type="topic" format="dita"/></p>
                         <p><xref href="ref/psql.xml#topic1"/><sup otherprops="pivotal">3</sup></p>
-                        <p><xref href="../pxf/ref/pxf.html" format="html" scope="peer"
+                        <p><xref href="../../pxf/5-13/ref/pxf.html" format="html" scope="external"
                             >pxf</xref></p>
-                        <p><xref href="../pxf/ref/pxf-cluster.html" format="html" scope="peer">pxf
-                                cluster</xref></p>
+                        <p><xref href="../../pxf/5-13/ref/pxf-cluster.html" format="html"
+                            scope="external">pxf cluster</xref></p>
                         <p><xref href="ref/reindexdb.xml#topic1"/></p>
                         <p><xref href="ref/vacuumdb.xml#topic1"/></p>
                     </stentry>

--- a/gpdb-doc/dita/utility_guide/utility_guide.ditamap
+++ b/gpdb-doc/dita/utility_guide/utility_guide.ditamap
@@ -63,8 +63,8 @@
             <topicref href="ref/plcontainer.xml"/>
             <topicref href="ref/plcontainer-configuration.xml"/>
             <topicref href="ref/psql.xml"/>
-            <topicref href="../pxf/ref/pxf.html" scope="peer" navtitle="pxf"/>
-            <topicref href="../pxf/ref/pxf-cluster.html" scope="peer" navtitle="pxf cluster"/>
+            <topicref href="../../pxf/5-13/ref/pxf.html" scope="external" navtitle="pxf"/>
+            <topicref href="../../pxf/5-13/ref/pxf-cluster.html" scope="external" navtitle="pxf cluster"/>
             <topicref href="ref/reindexdb.xml"/>
             <topicref href="ref/vacuumdb.xml"/>
         </topicref>


### PR DESCRIPTION
in this PR:
- change some pxf links to xref to the dita landing page
- use relative external links when possible to refer to pxf docs, as they are moving to a new docset located at _greenplumdocsurl_/pxf
- xref to pxf docset version 5-13
- add some link exclusions for open source book
- misc formatting edits
