### PR TITLE
Fix issue 10143, correlated subquery with agg and windowfunc

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1377,10 +1377,15 @@ static Node* grouped_window_mutator(Node *node, void *context)
 					 errmsg("unresolved grouping key in window query"),
 					 errhint("You might need to use explicit aliases and/or to refer to grouping keys in the same way throughout the query.")));
 	}
+	else if (IsA(node, SubLink))
+	{
+		/* put the subquery into Q'' */
+		result = (Node *) var_for_gw_expr(ctx, node, true /* force */);
+	}
 	else
 	{
 		/* Grouping expression; may not find one. */
-		result = (Node*) var_for_gw_expr(ctx, node, false);
+		result = (Node*) var_for_gw_expr(ctx, node, false /* force */);
 	}
 
 

--- a/src/test/regress/expected/bfv_olap.out
+++ b/src/test/regress/expected/bfv_olap.out
@@ -569,6 +569,106 @@ GROUP BY ROLLUP((qty)) order by 1;
      
 (4 rows)
 
+--
+-- Test a query with window function over an aggregate, and a subquery.
+--
+-- Github Issue https://github.com/greenplum-db/gpdb/issues/10143
+create table t1_github_issue_10143(
+  base_ym varchar(6),
+  code varchar(5),
+  name varchar(60)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'base_ym' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_github_issue_10143(
+  base_ym varchar(6),
+  dong varchar(8),
+  code varchar(6),
+  salary numeric(18)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'base_ym' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t1_github_issue_10143 values ('a', 'acode', 'aname');
+insert into t2_github_issue_10143 values ('a', 'adong', 'acode', 1000);
+insert into t2_github_issue_10143 values ('b', 'bdong', 'bcode', 1100);
+set optimizer_trace_fallback = on;
+explain select (select name from t1_github_issue_10143 where code = a.code limit 1) as dongnm
+,sum(sum(a.salary)) over()
+from t2_github_issue_10143 a
+group by a.code;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ WindowAgg  (cost=1.05..2.12 rows=1 width=198)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.05..2.10 rows=1 width=198)
+         ->  Subquery Scan on "Window"  (cost=1.05..2.10 rows=1 width=198)
+               ->  HashAggregate  (cost=1.05..2.09 rows=1 width=198)
+                     Group Key: a.code
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.01..1.03 rows=1 width=60)
+                           Hash Key: a.code
+                           ->  HashAggregate  (cost=1.01..1.01 rows=1 width=60)
+                                 Group Key: a.code
+                                 ->  Seq Scan on t2_github_issue_10143 a  (cost=0.00..1.01 rows=1 width=11)
+                     SubPlan 1  (slice3; segments: 3)
+                       ->  Limit  (cost=0.00..1.03 rows=1 width=6)
+                             ->  Limit  (cost=0.00..1.01 rows=1 width=6)
+                                   ->  Result  (cost=0.00..1.02 rows=1 width=6)
+                                         Filter: ((t1_github_issue_10143.code)::text = (a.code)::text)
+                                         ->  Materialize  (cost=0.00..1.02 rows=1 width=6)
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=6)
+                                                     ->  Seq Scan on t1_github_issue_10143  (cost=0.00..1.01 rows=1 width=6)
+ Optimizer: Postgres query optimizer
+(19 rows)
+
+select (select name from t1_github_issue_10143 where code = a.code limit 1) as dongnm
+,sum(sum(a.salary)) over()
+from t2_github_issue_10143 a
+group by a.code;
+ dongnm | sum  
+--------+------
+        | 2100
+ aname  | 2100
+(2 rows)
+
+select * from (select sum(a.salary) over(), count(*)
+               from t2_github_issue_10143 a
+               group by a.salary) T;
+ sum  | count 
+------+-------
+ 2100 |     1
+ 2100 |     1
+(2 rows)
+
+-- this query currently falls back, needs to be fixed
+select (select rn from (select row_number() over () as rn, name
+                        from t1_github_issue_10143
+                        where code = a.code
+                        group by name) T
+       ) as dongnm
+,sum(sum(a.salary)) over()
+from t2_github_issue_10143 a
+group by a.code;
+ dongnm | sum  
+--------+------
+        | 2100
+      1 | 2100
+(2 rows)
+
+with cte as (select row_number() over (order by code) as rn1, code
+             from t2_github_issue_10143
+             group by code)
+select row_number() over (order by name) as rn2, name
+from t1_github_issue_10143
+group by name
+union all
+select * from cte;
+ rn2 | name  
+-----+-------
+   1 | aname
+   1 | acode
+   2 | bcode
+(3 rows)
+
+reset optimizer_trace_fallback;
 -- CLEANUP
 -- start_ignore
 drop schema bfv_olap cascade;

--- a/src/test/regress/expected/bfv_olap_optimizer.out
+++ b/src/test/regress/expected/bfv_olap_optimizer.out
@@ -1,43 +1,33 @@
 -- Tests for old bugs related to OLAP queries.
-
 -- First create a schema to contain the test tables, and few common test
 -- tables that are shared by several test queries.
 create schema bfv_olap;
 set search_path=bfv_olap;
-
 create table customer
 (
   cn int not null,
   cname text not null,
   cloc text,
-
   primary key (cn)
-
 ) distributed by (cn);
-
 insert into customer values
   ( 1, 'Macbeth', 'Inverness'),
   ( 2, 'Duncan', 'Forres'),
   ( 3, 'Lady Macbeth', 'Inverness'),
   ( 4, 'Witches, Inc', 'Lonely Heath');
-
 create table vendor
 (
   vn int not null,
   vname text not null,
   vloc text,
-
   primary key (vn)
-
 ) distributed by (vn);
-
 insert into vendor values
   ( 10, 'Witches, Inc', 'Lonely Heath'),
   ( 20, 'Lady Macbeth', 'Inverness'),
   ( 30, 'Duncan', 'Forres'),
   ( 40, 'Macbeth', 'Inverness'),
   ( 50, 'Macduff', 'Fife');
-
 create table sale
 (
   cn int not null,
@@ -46,11 +36,8 @@ create table sale
   dt date not null,
   qty int not null,
   prc float not null,
-
   primary key (cn, vn, pn)
-
 ) distributed by (cn,vn,pn);
-
 insert into sale values
   ( 2, 40, 100, '1401-1-1', 1100, 2400),
   ( 1, 10, 200, '1401-3-1', 1, 0),
@@ -64,25 +51,34 @@ insert into sale values
   ( 3, 30, 600, '1401-6-1', 12, 5),
   ( 4, 40, 700, '1401-6-1', 1, 1),
   ( 4, 40, 800, '1401-6-1', 1, 1);
-
-
 --
 -- Test case errors out when we define aggregates without combine functions
 -- and use it as an aggregate derived window function.
 --
-
 -- SETUP
 -- start_ignore
 drop table if exists toy;
+NOTICE:  table "toy" does not exist, skipping
 drop aggregate if exists mysum1(int4);
+NOTICE:  aggregate mysum1(int4) does not exist, skipping
 drop aggregate if exists mysum2(int4);
+NOTICE:  aggregate mysum2(int4) does not exist, skipping
 -- end_ignore
 create table toy(id,val) as select i,i from generate_series(1,5) i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create aggregate mysum1(int4) (sfunc = int4_sum, combinefunc=int8pl, stype=bigint);
 create aggregate mysum2(int4) (sfunc = int4_sum, stype=bigint);
-
 -- TEST
 select id, val, sum(val) over (w), mysum1(val) over (w), mysum2(val) over (w) from toy window w as (order by id rows 2 preceding);
+ id | val | sum | mysum1 | mysum2 
+----+-----+-----+--------+--------
+  1 |   1 |   1 |      1 |      1
+  2 |   2 |   3 |      3 |      3
+  3 |   3 |   6 |      6 |      6
+  4 |   4 |   9 |      9 |      9
+  5 |   5 |  12 |     12 |     12
+(5 rows)
 
 -- CLEANUP
 -- start_ignore
@@ -90,21 +86,23 @@ drop aggregate if exists mysum1(int4);
 drop aggregate if exists mysum2(int4);
 drop table if exists toy;
 -- end_ignore
-
 --
 -- Test case errors out when we define aggregates without preliminary functions and use it as an aggregate derived window function.
 --
-
 -- SETUP
 -- start_ignore
 drop type if exists ema_type cascade;
+NOTICE:  type "ema_type" does not exist, skipping
 drop function if exists ema_adv(t ema_type, v float, x float) cascade;
+ERROR:  type "ema_type" does not exist
 drop function if exists ema_fin(t ema_type) cascade;
+ERROR:  type "ema_type" does not exist
 drop aggregate if exists ema(float, float);
+NOTICE:  aggregate ema(pg_catalog.float8,pg_catalog.float8) does not exist, skipping
 drop table if exists ema_test cascade;
+NOTICE:  table "ema_test" does not exist, skipping
 -- end_ignore
 create type ema_type as (x float, e float);
-
 create function ema_adv(t ema_type, v float, x float)
     returns ema_type
     as $$
@@ -121,7 +119,6 @@ create function ema_adv(t ema_type, v float, x float)
             return t;
         end;
     $$ language plpgsql;
-
 create function ema_fin(t ema_type)
     returns float
     as $$
@@ -129,19 +126,63 @@ create function ema_fin(t ema_type)
            return t.e;
        end;
     $$ language plpgsql;
-
 create aggregate ema(float, float) (
     sfunc = ema_adv,
     stype = ema_type,
     finalfunc = ema_fin,
     initcond = '(,)');
-
 create table ema_test (k int, v float ) distributed by (k);
 insert into ema_test select i, 4*(i::float/20) + 10.0*(1+cos(radians(i*5))) from generate_series(0,19) i(i);
-
 -- TEST
 select k, v, ema(v, 0.9) over (order by k) from ema_test order by k;
+ k  |        v         |       ema        
+----+------------------+------------------
+  0 |               20 |               20
+  1 | 20.1619469809175 | 20.1457522828257
+  2 | 20.2480775301221 | 20.2378450053924
+  3 | 20.2592582628907 | 20.2571169371409
+  4 | 20.1969262078591 | 20.2029452807873
+  5 | 20.0630778703665 | 20.0770646114086
+  6 | 19.8602540378444 | 19.8819350952008
+  7 | 19.5915204428899 |  19.620561908121
+  8 | 19.2604444311898 | 19.2964561788829
+  9 | 18.8710678118655 | 18.9136066485672
+ 10 | 18.4278760968654 | 18.4764491520356
+ 11 | 17.9357643635105 |  17.989832842363
+ 12 |             17.4 | 17.4589832842363
+ 13 |  16.826182617407 | 16.8894626840899
+ 14 | 16.2202014332567 |   16.28712755834
+ 15 | 15.5881904510252 | 15.6580841617567
+ 16 | 14.9364817766693 |  15.008642015178
+ 17 | 14.2715574274766 | 14.3452658862467
+ 18 |             13.6 | 13.6745265886247
+ 19 | 12.9284425725234 | 13.0030509741335
+(20 rows)
+
 select k, v, ema(v, 0.9) over (order by k rows between unbounded preceding and current row) from ema_test order by k;
+ k  |        v         |       ema        
+----+------------------+------------------
+  0 |               20 |               20
+  1 | 20.1619469809175 | 20.1457522828257
+  2 | 20.2480775301221 | 20.2378450053924
+  3 | 20.2592582628907 | 20.2571169371409
+  4 | 20.1969262078591 | 20.2029452807873
+  5 | 20.0630778703665 | 20.0770646114086
+  6 | 19.8602540378444 | 19.8819350952008
+  7 | 19.5915204428899 |  19.620561908121
+  8 | 19.2604444311898 | 19.2964561788829
+  9 | 18.8710678118655 | 18.9136066485672
+ 10 | 18.4278760968654 | 18.4764491520356
+ 11 | 17.9357643635105 |  17.989832842363
+ 12 |             17.4 | 17.4589832842363
+ 13 |  16.826182617407 | 16.8894626840899
+ 14 | 16.2202014332567 |   16.28712755834
+ 15 | 15.5881904510252 | 15.6580841617567
+ 16 | 14.9364817766693 |  15.008642015178
+ 17 | 14.2715574274766 | 14.3452658862467
+ 18 |             13.6 | 13.6745265886247
+ 19 | 12.9284425725234 | 13.0030509741335
+(20 rows)
 
 -- CLEANUP
 -- start_ignore
@@ -151,15 +192,13 @@ drop function if exists ema_fin(t ema_type) cascade;
 drop function if exists ema_adv(t ema_type, v float, x float) cascade;
 drop type if exists ema_type cascade;
 -- end_ignore
-
-
 --
 -- Test with/without group by
 --
-
 -- SETUP
 -- start_ignore
 DROP TABLE IF EXISTS r;
+NOTICE:  table "r" does not exist, skipping
 -- end_ignore
 CREATE TABLE r
 (
@@ -170,36 +209,76 @@ CREATE TABLE r
     e DATE
 ) DISTRIBUTED BY (a,b);
 ALTER TABLE r ADD CONSTRAINT PKEY PRIMARY KEY (b);
-
+NOTICE:  updating distribution policy to match new primary key
 --TEST
 SELECT MAX(a) AS m FROM r GROUP BY b ORDER BY m;
+ m 
+---
+(0 rows)
+
 SELECT MAX(a) AS m FROM r GROUP BY a ORDER BY m;
+ m 
+---
+(0 rows)
+
 SELECT MAX(a) AS m FROM r GROUP BY b;
+ m 
+---
+(0 rows)
 
 -- ORDER BY clause includes some grouping column or not
 SELECT MAX(a) AS m FROM R GROUP BY b ORDER BY m,b;
+ m 
+---
+(0 rows)
+
 SELECT MAX(a) AS m FROM R GROUP BY b,e ORDER BY m,b,e;
+ m 
+---
+(0 rows)
+
 SELECT MAX(a) AS m FROM R GROUP BY b,e ORDER BY m;
+ m 
+---
+(0 rows)
 
 -- ORDER BY 1 or more columns
 SELECT MAX(a),d,e AS m FROM r GROUP BY b,d,e ORDER BY m,e,d;
+ max | d | m 
+-----+---+---
+(0 rows)
+
 SELECT MIN(a),d,e AS m FROM r GROUP BY b,e,d ORDER BY e,d;
+ min | d | m 
+-----+---+---
+(0 rows)
+
 SELECT MAX(a) AS m FROM r GROUP BY b,c,d,e ORDER BY e,d;
+ m 
+---
+(0 rows)
+
 SELECT MAX(a) AS m FROM r GROUP BY b,e ORDER BY e;
+ m 
+---
+(0 rows)
+
 SELECT MAX(e) AS m FROM r GROUP BY b ORDER BY m;
+ m 
+---
+(0 rows)
 
 -- CLEANUP
 -- start_ignore
 DROP TABLE IF EXISTS r;
 -- end_ignore
-
 --
 -- ORDER BY clause includes some grouping column or not
 --
-
 -- SETUP
 -- start_ignore
 DROP TABLE IF EXISTS dm_calendar;
+NOTICE:  table "dm_calendar" does not exist, skipping
 -- end_ignore
 CREATE TABLE dm_calendar (
     calendar_id bigint NOT NULL,
@@ -236,23 +315,23 @@ CREATE TABLE dm_calendar (
     month_number numeric(10,0)
 ) DISTRIBUTED BY (calendar_id);
 ALTER TABLE ONLY dm_calendar ADD CONSTRAINT dm_calendar_pkey PRIMARY KEY (calendar_id);
-
 --TEST
 SELECT "year_id" as id , min("year_name") as a  from (select "year_id" as "year_id" , min("year_name") as "year_name" from  "dm_calendar" group by "year_id") "dm_calendar3" group by "year_id" order by a ASC ;
+ id | a 
+----+---
+(0 rows)
 
 -- CLEANUP
 -- start_ignore
 DROP TABLE IF EXISTS dm_calendar;
 -- end_ignore
-
-
 --
 -- Test with/without group by with primary key as dist key
 --
-
 -- SETUP
 -- start_ignore
 drop table if exists t;
+NOTICE:  table "t" does not exist, skipping
 -- end_ignore
 create table t
 (
@@ -263,18 +342,16 @@ create table t
     e date
 ) distributed by (b);
 alter table t ADD CONSTRAINT pkey primary key (b);
-
 -- TEST
 SELECT MAX(a) AS m FROM t GROUP BY b ORDER BY m;
+ m 
+---
+(0 rows)
 
 -- CLEANUP
 -- start_ignore
 drop table if exists t;
 -- end_ignore
-
-
-
-
 --
 -- Passing through distribution matching type in default implementation
 --
@@ -285,15 +362,29 @@ rank() over (partition by sale.cn order by vn)
 from sale, customer
 where sale.cn = customer.cn
 order by 1, 2;
-
+    cname     | rank 
+--------------+------
+ Duncan       |    1
+ Duncan       |    2
+ Lady Macbeth |    1
+ Lady Macbeth |    1
+ Lady Macbeth |    3
+ Macbeth      |    1
+ Macbeth      |    2
+ Macbeth      |    3
+ Macbeth      |    3
+ Macbeth      |    5
+ Witches, Inc |    1
+ Witches, Inc |    1
+(12 rows)
 
 --
 -- Optimizer query crashing for logical window with no window functions
 --
-
 -- SETUP
 create table mpp23240(a int, b int, c int, d int, e int, f int);
-
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- TEST
 select a, b,
        case 1
@@ -305,24 +396,50 @@ select a, b,
           5
        end as sum1
 from (select * from mpp23240 where f > 10) x;
+ a | b | sum1 
+---+---+------
+(0 rows)
 
 -- CLEANUP
 -- start_ignore
 drop table mpp23240;
 -- end_ignore
-
-
 --
 -- Test for the bug reported at https://github.com/greenplum-db/gpdb/issues/2236
 --
 create table test1 (x int, y int, z double precision);
 insert into test1 select a, b, a*10 + b from generate_series(1, 5) a, generate_series(1, 5) b;
-
 select sum(z) over (partition by x) as sumx, sum(z) over (partition by y) as sumy from test1;
+ sumx | sumy 
+------+------
+   65 |  155
+   65 |  160
+   65 |  165
+   65 |  170
+   65 |  175
+  115 |  155
+  115 |  160
+  115 |  165
+  115 |  170
+  115 |  175
+  165 |  155
+  165 |  160
+  165 |  165
+  165 |  170
+  165 |  175
+  215 |  155
+  215 |  160
+  215 |  165
+  215 |  170
+  215 |  175
+  265 |  155
+  265 |  160
+  265 |  165
+  265 |  170
+  265 |  175
+(25 rows)
 
 drop table test1;
-
-
 --
 -- This failed at one point because of an over-zealous syntax check, with
 -- "window functions not allowed in WHERE clause" error.
@@ -331,7 +448,10 @@ select sum(g) from generate_series(1, 5) g
 where g in (
   select rank() over (order by x) from generate_series(1,5) x
 );
-
+ sum 
+-----
+  15
+(1 row)
 
 --
 -- This caused a crash in ROLLUP planning at one point.
@@ -340,12 +460,57 @@ SELECT sale.vn
 FROM sale,vendor
 WHERE sale.vn=vendor.vn
 GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
+ vn 
+----
+ 40
+   
+   
+ 20
+   
+   
+ 30
+   
+   
+   
+ 10
+ 40
+   
+   
+ 50
+   
+   
+ 30
+   
+   
+ 40
+   
+   
+   
+   
+   
+   
+ 30
+   
+ 50
+   
+ 30
+ 40
+   
+(34 rows)
 
 SELECT DISTINCT sale.vn
 FROM sale,vendor
 WHERE sale.vn=vendor.vn
 GROUP BY ROLLUP( (sale.dt,sale.cn),(sale.pn),(sale.vn));
-
+ vn 
+----
+ 10
+ 20
+ 30
+ 40
+ 50
+   
+(6 rows)
 
 --
 -- Another ROLLUP query, that hit a bug in setting up the planner-generated
@@ -355,7 +520,15 @@ SELECT sale.vn, rank() over (partition by sale.vn)
 FROM vendor, sale
 WHERE sale.vn=vendor.vn
 GROUP BY ROLLUP( sale.vn);
-
+ vn | rank 
+----+------
+    |    1
+ 10 |    1
+ 20 |    1
+ 30 |    1
+ 40 |    1
+ 50 |    1
+(6 rows)
 
 --
 -- Test window function with constant PARTITION BY
@@ -363,6 +536,11 @@ GROUP BY ROLLUP( sale.vn);
 CREATE TABLE testtab (a int4);
 insert into testtab values (1), (2);
 SELECT count(*) OVER (PARTITION BY 1) AS count FROM testtab;
+ count 
+-------
+     2
+     2
+(2 rows)
 
 -- Another variant, where the PARTITION BY is not a literal, but the
 -- planner can deduce that it's a constant through equivalence classes.
@@ -371,6 +549,9 @@ FROM (
   SELECT a, count(*) OVER (PARTITION BY a) FROM (VALUES (1,1)) AS foo(a)
 ) AS sup(c, d)
 WHERE c = 87 ;
+ ?column? 
+----------
+(0 rows)
 
 --
 -- This used to crash, and/or produce incorrect results. The culprit was that a Hash Agg
@@ -380,7 +561,13 @@ WHERE c = 87 ;
 SELECT sale.qty
 FROM sale
 GROUP BY ROLLUP((qty)) order by 1;
-
+ qty  
+------
+    1
+   12
+ 1100
+     
+(4 rows)
 
 --
 -- Test a query with window function over an aggregate, and a subquery.
@@ -391,33 +578,65 @@ create table t1_github_issue_10143(
   code varchar(5),
   name varchar(60)
 );
-
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'base_ym' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table t2_github_issue_10143(
   base_ym varchar(6),
   dong varchar(8),
   code varchar(6),
   salary numeric(18)
 );
-
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'base_ym' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into t1_github_issue_10143 values ('a', 'acode', 'aname');
 insert into t2_github_issue_10143 values ('a', 'adong', 'acode', 1000);
 insert into t2_github_issue_10143 values ('b', 'bdong', 'bcode', 1100);
-
 set optimizer_trace_fallback = on;
-
 explain select (select name from t1_github_issue_10143 where code = a.code limit 1) as dongnm
 ,sum(sum(a.salary)) over()
 from t2_github_issue_10143 a
 group by a.code;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ WindowAgg  (cost=0.00..1324055.31 rows=1 width=16)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324055.31 rows=1 width=16)
+         ->  Result  (cost=0.00..1324055.31 rows=1 width=16)
+               ->  Result  (cost=0.00..1324055.31 rows=1 width=16)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=14)
+                           Group Key: t2_github_issue_10143.code
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=11)
+                                 Sort Key: t2_github_issue_10143.code
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=11)
+                                       Hash Key: t2_github_issue_10143.code
+                                       ->  Seq Scan on t2_github_issue_10143  (cost=0.00..431.00 rows=1 width=11)
+                     SubPlan 1  (slice3; segments: 3)
+                       ->  Limit  (cost=0.00..431.00 rows=1 width=6)
+                             ->  Result  (cost=0.00..431.00 rows=1 width=6)
+                                   Filter: ((t1_github_issue_10143.code)::text = (t2_github_issue_10143.code)::text)
+                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=12)
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                               ->  Seq Scan on t1_github_issue_10143  (cost=0.00..431.00 rows=1 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(19 rows)
 
 select (select name from t1_github_issue_10143 where code = a.code limit 1) as dongnm
 ,sum(sum(a.salary)) over()
 from t2_github_issue_10143 a
 group by a.code;
+ dongnm | sum  
+--------+------
+        | 2100
+ aname  | 2100
+(2 rows)
 
 select * from (select sum(a.salary) over(), count(*)
                from t2_github_issue_10143 a
                group by a.salary) T;
+ sum  | count 
+------+-------
+ 2100 |     1
+ 2100 |     1
+(2 rows)
 
 -- this query currently falls back, needs to be fixed
 select (select rn from (select row_number() over () as rn, name
@@ -428,6 +647,13 @@ select (select rn from (select row_number() over () as rn, name
 ,sum(sum(a.salary)) over()
 from t2_github_issue_10143 a
 group by a.code;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Query-to-DXL Translation: No variable entry found due to incorrect normalization of query
+ dongnm | sum  
+--------+------
+        | 2100
+      1 | 2100
+(2 rows)
 
 with cte as (select row_number() over (order by code) as rn1, code
              from t2_github_issue_10143
@@ -437,11 +663,15 @@ from t1_github_issue_10143
 group by name
 union all
 select * from cte;
+ rn2 | name  
+-----+-------
+   1 | aname
+   1 | acode
+   2 | bcode
+(3 rows)
 
 reset optimizer_trace_fallback;
-
 -- CLEANUP
 -- start_ignore
 drop schema bfv_olap cascade;
 -- end_ignore
-


### PR DESCRIPTION
This is a port of part of PR https://github.com/greenplum-db/gpdb/pull/10306.

This fixes https://github.com/greenplum-db/gpdb/issues/10143.

According to asubramanya, porting the entire
https://github.com/greenplum-db/gpdb/pull/10306 would have led to lots
of failures.

The fix places subqueries in the target list into the lower scope when separating groupby from window queries. We know that the subquery won't contain any window functions, because SQL does not allow that, so it is safe to do. Placing the subquery into the lower scope means that any outer references in the subquery that refer to the original scope Q are still valid, because the new lower scope Q'' will have the same target list. That was the bug in the pre-existing code: When we put the subquery in the upper scope Q', outer refs in the subquery had incorrect varno and varattno entries, since Query Q' has a different target list.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
