### PR TITLE
[5X Backport]Fix CASE WHEN IS NOT DISTINCT FROM clause incorrect dump.

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -4597,7 +4597,11 @@ get_rule_expr(Node *node, deparse_context *context,
 							Node			*lhs = (Node *) linitial(dexpr->args);
 							Node			*rhs = (Node *) lsecond(dexpr->args);
 
-							if (!IsA(lhs, CaseTestExpr))
+							/*
+							 * If lhs contains CaseTestExpr node as placeholder, we should
+							 * omit the lhs for dump
+							 */
+							if (!IsA(strip_implicit_coercions(lhs), CaseTestExpr))
 							{
 								get_rule_expr(lhs, context, false);
 								appendStringInfoChar(buf, ' ');

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -4594,10 +4594,15 @@ get_rule_expr(Node *node, deparse_context *context,
 						if (IsA(arg, DistinctExpr))
 						{
 							DistinctExpr 	*dexpr = (DistinctExpr *) arg;
-							Node			*rhs;
+							Node			*lhs = (Node *) linitial(dexpr->args);
+							Node			*rhs = (Node *) lsecond(dexpr->args);
 
-							appendStringInfo(buf, "IS NOT DISTINCT FROM ");
-							rhs = (Node *) lsecond(dexpr->args);
+							if (!IsA(lhs, CaseTestExpr))
+							{
+								get_rule_expr(lhs, context, false);
+								appendStringInfoChar(buf, ' ');
+							}
+							appendStringInfoString(buf, "IS NOT DISTINCT FROM ");
 							get_rule_expr(rhs, context, false);
 						}
 						else

--- a/src/test/binary_swap/test_binary_swap_pre.sql
+++ b/src/test/binary_swap/test_binary_swap_pre.sql
@@ -7,6 +7,7 @@
 -- test suite. Ignore by removing the view.
 \c regression;
 DROP VIEW IF EXISTS locktest_segments;
+DROP VIEW IF EXISTS notdisview;
 
 \c isolation2test;
 DROP VIEW IF EXISTS locktest_segments;

--- a/src/test/regress/expected/case_gp.out
+++ b/src/test/regress/expected/case_gp.out
@@ -17,6 +17,44 @@ INSERT INTO mytable values 	(1,2,'t'),
 							(7,6,'a'),
 							(8,7,'t'),
 							(9,8,'a');
+DROP VIEW IF EXISTS notdisview;
+NOTICE:  view "notdisview" does not exist, skipping
+CREATE OR REPLACE VIEW notdisview AS
+SELECT
+    CASE
+        WHEN 'test' IS NOT DISTINCT FROM ''::text THEN 'A'::text
+        ELSE 'B'::text
+        END AS t;
+select pg_get_viewdef('notdisview',true);
+                               pg_get_viewdef                               
+----------------------------------------------------------------------------
+  SELECT                                                                   +
+         CASE                                                              +
+             WHEN 'test'::text IS NOT DISTINCT FROM ''::text THEN 'A'::text+
+             ELSE 'B'::text                                                +
+         END AS t;
+(1 row)
+
+DROP VIEW IF EXISTS notdisview2;
+NOTICE:  view "notdisview2" does not exist, skipping
+CREATE OR REPLACE VIEW notdisview2 AS
+SELECT
+    CASE
+        WHEN c::text IS NOT DISTINCT FROM ''::text THEN 'A'::text
+        ELSE 'B'::text
+        END AS t
+    FROM mytable;
+select pg_get_viewdef('notdisview2',true);
+                                pg_get_viewdef                                 
+-------------------------------------------------------------------------------
+  SELECT                                                                      +
+         CASE                                                                 +
+             WHEN mytable.c::text IS NOT DISTINCT FROM ''::text THEN 'A'::text+
+             ELSE 'B'::text                                                   +
+         END AS t                                                             +
+    FROM mytable;
+(1 row)
+
 CREATE OR REPLACE FUNCTION negate(int) RETURNS int 
 AS 'SELECT $1 * (-1)'
 LANGUAGE sql CONTAINS SQL
@@ -337,6 +375,7 @@ ERROR:  CASE types integer and integer[] cannot be matched
 -- Clean up
 --
 DROP TABLE mytable CASCADE;
+NOTICE:  drop cascades to view notdisview2
 DROP TABLE products CASCADE;
 NOTICE:  drop cascades to rule _RETURN on view myview
 NOTICE:  drop cascades to view myview

--- a/src/test/regress/expected/case_gp.out
+++ b/src/test/regress/expected/case_gp.out
@@ -21,17 +21,17 @@ DROP VIEW IF EXISTS notdisview;
 NOTICE:  view "notdisview" does not exist, skipping
 CREATE OR REPLACE VIEW notdisview AS
 SELECT
-    CASE
+    CASE 'a'::text = 'test'::text
         WHEN 'test' IS NOT DISTINCT FROM ''::text THEN 'A'::text
         ELSE 'B'::text
         END AS t;
 select pg_get_viewdef('notdisview',true);
                                pg_get_viewdef                               
 ----------------------------------------------------------------------------
-  SELECT                                                                   +
-         CASE                                                              +
-             WHEN 'test'::text IS NOT DISTINCT FROM ''::text THEN 'A'::text+
-             ELSE 'B'::text                                                +
+  SELECT                                                                    
+         CASE 'a'::text = 'test'::text                                      
+             WHEN 'test'::text IS NOT DISTINCT FROM ''::text THEN 'A'::text 
+             ELSE 'B'::text                                                 
          END AS t;
 (1 row)
 
@@ -47,12 +47,36 @@ SELECT
 select pg_get_viewdef('notdisview2',true);
                                 pg_get_viewdef                                 
 -------------------------------------------------------------------------------
-  SELECT                                                                      +
-         CASE                                                                 +
-             WHEN mytable.c::text IS NOT DISTINCT FROM ''::text THEN 'A'::text+
-             ELSE 'B'::text                                                   +
-         END AS t                                                             +
+  SELECT                                                                       
+         CASE                                                                  
+             WHEN mytable.c::text IS NOT DISTINCT FROM ''::text THEN 'A'::text 
+             ELSE 'B'::text                                                    
+         END AS t                                                              
     FROM mytable;
+(1 row)
+
+CREATE TABLE mytable2 (
+    key character varying(20) NOT NULL,
+    key_value character varying(50)
+) DISTRIBUTED BY (key);
+DROP VIEW IF EXISTS notdisview3;
+NOTICE:  view "notdisview3" does not exist, skipping
+CREATE OR REPLACE VIEW notdisview3 AS
+SELECT
+    CASE mytable2.key_value
+        WHEN IS NOT DISTINCT FROM 'NULL'::text THEN 'now'::text::date
+        ELSE to_date(mytable2.key_value::text, 'YYYYMM'::text)
+        END AS t
+    FROM mytable2;
+select pg_get_viewdef('notdisview3',true);
+                              pg_get_viewdef                               
+---------------------------------------------------------------------------
+  SELECT                                                                   
+         CASE mytable2.key_value                                           
+             WHEN IS NOT DISTINCT FROM 'NULL'::text THEN 'now'::text::date 
+             ELSE to_date(mytable2.key_value::text, 'YYYYMM'::text)        
+         END AS t                                                          
+    FROM mytable2;
 (1 row)
 
 CREATE OR REPLACE FUNCTION negate(int) RETURNS int 
@@ -375,6 +399,7 @@ ERROR:  CASE types integer and integer[] cannot be matched
 -- Clean up
 --
 DROP TABLE mytable CASCADE;
+NOTICE:  drop cascades to rule _RETURN on view notdisview2
 NOTICE:  drop cascades to view notdisview2
 DROP TABLE products CASCADE;
 NOTICE:  drop cascades to rule _RETURN on view myview

--- a/src/test/regress/sql/case_gp.sql
+++ b/src/test/regress/sql/case_gp.sql
@@ -17,6 +17,25 @@ INSERT INTO mytable values (1,2,'t'),
   (8,7,'t'),
   (9,8,'a');
 
+DROP VIEW IF EXISTS notdisview;
+CREATE OR REPLACE VIEW notdisview AS
+SELECT
+    CASE
+        WHEN 'test' IS NOT DISTINCT FROM ''::text THEN 'A'::text
+        ELSE 'B'::text
+        END AS t;
+select pg_get_viewdef('notdisview',true);
+
+DROP VIEW IF EXISTS notdisview2;
+CREATE OR REPLACE VIEW notdisview2 AS
+SELECT
+    CASE
+        WHEN c::text IS NOT DISTINCT FROM ''::text THEN 'A'::text
+        ELSE 'B'::text
+        END AS t
+    FROM mytable;
+select pg_get_viewdef('notdisview2',true);
+
 CREATE OR REPLACE FUNCTION negate(int) RETURNS int 
 AS 'SELECT $1 * (-1)'
 LANGUAGE sql CONTAINS SQL

--- a/src/test/regress/sql/case_gp.sql
+++ b/src/test/regress/sql/case_gp.sql
@@ -20,7 +20,7 @@ INSERT INTO mytable values (1,2,'t'),
 DROP VIEW IF EXISTS notdisview;
 CREATE OR REPLACE VIEW notdisview AS
 SELECT
-    CASE
+    CASE 'a'::text = 'test'::text
         WHEN 'test' IS NOT DISTINCT FROM ''::text THEN 'A'::text
         ELSE 'B'::text
         END AS t;
@@ -35,6 +35,21 @@ SELECT
         END AS t
     FROM mytable;
 select pg_get_viewdef('notdisview2',true);
+
+CREATE TABLE mytable2 (
+    key character varying(20) NOT NULL,
+    key_value character varying(50)
+) DISTRIBUTED BY (key);
+
+DROP VIEW IF EXISTS notdisview3;
+CREATE OR REPLACE VIEW notdisview3 AS
+SELECT
+    CASE mytable2.key_value
+        WHEN IS NOT DISTINCT FROM 'NULL'::text THEN 'now'::text::date
+        ELSE to_date(mytable2.key_value::text, 'YYYYMM'::text)
+        END AS t
+    FROM mytable2;
+select pg_get_viewdef('notdisview3',true);
 
 CREATE OR REPLACE FUNCTION negate(int) RETURNS int 
 AS 'SELECT $1 * (-1)'


### PR DESCRIPTION
The clause 'CASE WHEN (arg1) IS NOT DISTINCT FROM (arg2)' dump will miss
the arg1. For example:
```
CREATE OR REPLACE VIEW xxxtest AS
SELECT
    CASE
    WHEN 'I will disappear' IS NOT DISTINCT FROM ''::text
    THEN 'A'::text
    ELSE 'B'::text
    END AS t;
```
The dump will lose 'I will disappear'.

```
SELECT
    CASE
    WHEN IS NOT DISTINCT FROM ''::text
    THEN 'A'::text
    ELSE 'B'::text
    END AS t;
```

I dig into commit a453004, if left-hand argument for `IS NOT DISTINCT
FROM` contains any `CaseTestExpr` node, the left-hand arg should be
omit. `CaseTestExpr` is a placeholder for CASE expression.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
