### PR TITLE
Silence useless NOTICEs emitted by gpcheckcat.

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2606,7 +2606,7 @@ def inconsistentEntryQuery(max_content, catname, pkey, columns, castcols):
 
               -- distribute catalog table from master, so that we can avoid to gather
               CREATE TEMPORARY TABLE _tmp_master ON COMMIT DROP AS
-                  SELECT gp_segment_id segid, {columns} FROM {catalog};
+                  SELECT gp_segment_id AS segid, {columns} FROM {catalog} DISTRIBUTED BY (segid);
               SELECT {columns}, array_agg(gp_segment_id order by gp_segment_id) as segids
               FROM
               (
@@ -2727,7 +2727,7 @@ def duplicateEntryQuery(catname, pkey):
 
           -- distribute catalog table from master, so that we can avoid to gather
           CREATE TEMPORARY TABLE _tmp_master ON COMMIT DROP AS
-              SELECT gp_segment_id segid, {pkey} FROM {catalog};
+              SELECT gp_segment_id AS segid, {pkey} FROM {catalog} DISTRIBUTED BY (segid);
           SELECT {pkey}, total, array_agg(segid order by segid) as segids
           FROM (
               SELECT segid, {pkey}, count(*) as total


### PR DESCRIPTION
These NOTICEs:

    Connected as user 'heikki' to database 'postgres', port '5432', gpdb version '7.0'
    -------------------------------------------------------------------
    Batch size: 4
    Performing test 'duplicate'
    NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
    HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
    NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
    HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
    ...
    NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
    HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
    Total runtime for test 'duplicate': 0:00:06.83

    SUMMARY REPORT: PASSED
    ===================================================================
    Completed 1 test(s) on database 'postgres' at 2020-06-25 11:49:19 with elapsed time 0:00:06
    Found no catalog issue

They're useless chatter. Add explicit DISTRIBUTED BY to the CREATE TABLE AS
commands to silence them.
