### PR TITLE
Fix vacuum on temporary AO table

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -70,7 +70,7 @@ AOCSCompaction_DropSegmentFile(Relation aorel, int segno)
 			   "segno %d",
 			   pseudoSegNo);
 
-		fd = OpenAOSegmentFile(aorel, filenamepath, pseudoSegNo, 0);
+		fd = OpenAOSegmentFile(aorel, filenamepath, 0);
 		if (fd >= 0)
 		{
 			TruncateAOSegmentFile(fd, aorel, pseudoSegNo, 0);
@@ -133,7 +133,7 @@ AOCSSegmentFileTruncateToEOF(Relation aorel, int segno, AOCSVPInfo *vpinfo)
 			   fileSegNo,
 			   segeof);
 
-		fd = OpenAOSegmentFile(aorel, filenamepath, fileSegNo, segeof);
+		fd = OpenAOSegmentFile(aorel, filenamepath, segeof);
 		if (fd >= 0)
 		{
 			TruncateAOSegmentFile(fd, aorel, fileSegNo, segeof);

--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -140,24 +140,13 @@ MakeAOSegmentFileName(Relation rel,
 File
 OpenAOSegmentFile(Relation rel, 
 				  char *filepathname, 
-				  int32	segmentFileNum,
 				  int64	logicalEof)
-{	
-	char	   *dbPath;
-	char		path[MAXPGPATH];
+{
 	int			fileFlags = O_RDWR | PG_BINARY;
 	File		fd;
 
-	dbPath = GetDatabasePath(rel->rd_node.dbNode, rel->rd_node.spcNode);
-
-	if (segmentFileNum == 0)
-		snprintf(path, MAXPGPATH, "%s/%u", dbPath, rel->rd_node.relNode);
-	else
-		snprintf(path, MAXPGPATH, "%s/%u.%u", dbPath, rel->rd_node.relNode, segmentFileNum);
-
 	errno = 0;
-
-	fd = PathNameOpenFile(path, fileFlags, 0600);
+	fd = PathNameOpenFile(filepathname, fileFlags, 0600);
 	if (fd < 0)
 	{
 		if (logicalEof == 0 && errno == ENOENT)
@@ -168,8 +157,6 @@ OpenAOSegmentFile(Relation rel,
 				 errmsg("could not open Append-Only segment file \"%s\": %m",
 						filepathname)));
 	}
-	pfree(dbPath);
-
 	return fd;
 }
 
@@ -478,7 +465,7 @@ truncate_ao_perFile(const int segno, void *ctx)
 
 	sprintf(segPathSuffixPosition, ".%u", segno);
 
-	fd = OpenAOSegmentFile(aorel, segPath, segno, 0);
+	fd = OpenAOSegmentFile(aorel, segPath, 0);
 
 	if (fd >= 0)
 	{

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -75,7 +75,7 @@ AppendOnlyCompaction_DropSegmentFile(Relation aorel, int segno)
 	/* Open and truncate the relation segfile */
 	MakeAOSegmentFileName(aorel, segno, -1, &fileSegNo, filenamepath);
 
-	fd = OpenAOSegmentFile(aorel, filenamepath, fileSegNo, 0);
+	fd = OpenAOSegmentFile(aorel, filenamepath, 0);
 	if (fd >= 0)
 	{
 		TruncateAOSegmentFile(fd, aorel, fileSegNo, 0);
@@ -235,7 +235,7 @@ AppendOnlySegmentFileTruncateToEOF(Relation aorel, int segno, int64 segeof)
 		   segno,
 		   segeof);
 
-	fd = OpenAOSegmentFile(aorel, filenamepath, fileSegNo, segeof);
+	fd = OpenAOSegmentFile(aorel, filenamepath, segeof);
 	if (fd >= 0)
 	{
 		TruncateAOSegmentFile(fd, aorel, fileSegNo, segeof);

--- a/src/include/access/aomd.h
+++ b/src/include/access/aomd.h
@@ -37,7 +37,6 @@ extern void MakeAOSegmentFileName(
 
 extern File OpenAOSegmentFile(Relation rel,
 				  char *filepathname,
-				  int32 segmentFileNum,
 				  int64	logicalEof);
 
 extern void CloseAOSegmentFile(File fd);

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -423,8 +423,8 @@ insert into temp_tenk_aocs5(unique1, unique2) values (99998888, 99998888);
 update temp_tenk_aocs5 set unique2 = 99998889 where unique2 = 99998888;
 delete from temp_tenk_aocs5 where unique2 = 99998889;
 select count(*) from temp_tenk_aocs5;
-truncate table temp_tenk_aocs5;
 vacuum analyze temp_tenk_aocs5;
+truncate table temp_tenk_aocs5;
 \d temp_tenk_aocs5
 insert into temp_tenk_aocs5(unique1, unique2) values (99998888, 99998888);
 select unique1 from temp_tenk_aocs5;

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -446,7 +446,7 @@ insert into ao select i, 2, 'a' from generate_series(1, 20) i;
 select distinct j from ao where j > -1 and j < 3 order by j;
 
 -- TEMP TABLES w/ INDEXES
-create temp table temp_tenk_ao5 with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+create temp table temp_tenk_ao5 with (appendonly=true, compresstype=zlib, compresslevel=1)
     as select * from tenk_ao5 distributed by (unique1);
 create index temp_even_index on temp_tenk_ao5 (even);
 select count(*) from temp_tenk_ao5;
@@ -455,8 +455,8 @@ insert into temp_tenk_ao5(unique1, unique2) values (99998888, 99998888);
 update temp_tenk_ao5 set unique2 = 99998889 where unique2 = 99998888;
 delete from temp_tenk_ao5 where unique2 = 99998889;
 select count(*) from temp_tenk_ao5;
-truncate table temp_tenk_ao5;
 vacuum analyze temp_tenk_ao5;
+truncate table temp_tenk_ao5;
 \d temp_tenk_ao5
 insert into temp_tenk_ao5(unique1, unique2) values (99998888, 99998888);
 select unique1 from temp_tenk_ao5;
@@ -464,7 +464,7 @@ select unique1 from temp_tenk_ao5;
 -- TEMP TABLES w/ COMMIT DROP AND USING PREPARE
 begin;
 prepare tenk_ao5_prep(int4) as select * from tenk_ao5 where unique1 > 8000;
-create temp table tenk_ao5_temp_drop with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+create temp table tenk_ao5_temp_drop with (appendonly=true, compresstype=zlib, compresslevel=1)
     on commit drop as execute tenk_ao5_prep(8095);
 select count(*) from tenk_ao5_temp_drop;
 commit;
@@ -472,7 +472,7 @@ select count(*) from tenk_ao5_temp_drop;
 
 -- TEMP TABLES w/ COMMIT DELETE ROWS
 begin;
-create temp table tenk_ao5_temp_delete_rows with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+create temp table tenk_ao5_temp_delete_rows with (appendonly=true, compresstype=zlib, compresslevel=1)
     on commit delete rows as select * from tenk_ao5 where unique1 > 8000 distributed by (unique1);
 select count(*) from tenk_ao5_temp_delete_rows;
 commit;
@@ -480,7 +480,7 @@ select count(*) from tenk_ao5_temp_delete_rows;
 
 -- TEMP TABLES w/ COMMIT PRESERVE ROWS
 begin;
-create temp table tenk_ao5_temp_pres_rows with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+create temp table tenk_ao5_temp_pres_rows with (appendonly=true, compresstype=zlib, compresslevel=1)
     on commit preserve rows as select * from tenk_ao5 where unique1 > 8000 distributed by (unique1);
 select count(*) from tenk_ao5_temp_pres_rows;
 commit;

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -858,8 +858,8 @@ select count(*) from temp_tenk_aocs5;
  10000
 (1 row)
 
-truncate table temp_tenk_aocs5;
 vacuum analyze temp_tenk_aocs5;
+truncate table temp_tenk_aocs5;
 \d temp_tenk_aocs5
 Append-Only Columnar Table "pg_temp_274.temp_tenk_aocs5"
    Column    |  Type   | Modifiers 

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -925,7 +925,7 @@ select distinct j from ao where j > -1 and j < 3 order by j;
 (3 rows)
 
 -- TEMP TABLES w/ INDEXES
-create temp table temp_tenk_ao5 with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+create temp table temp_tenk_ao5 with (appendonly=true, compresstype=zlib, compresslevel=1)
     as select * from tenk_ao5 distributed by (unique1);
 create index temp_even_index on temp_tenk_ao5 (even);
 select count(*) from temp_tenk_ao5;
@@ -949,10 +949,10 @@ select count(*) from temp_tenk_ao5;
      0
 (1 row)
 
-truncate table temp_tenk_ao5;
 vacuum analyze temp_tenk_ao5;
+truncate table temp_tenk_ao5;
 \d temp_tenk_ao5
-Append-Only Columnar Table "pg_temp_274.temp_tenk_ao5"
+Append-Only Table "pg_temp_15.temp_tenk_ao5"
    Column    |  Type   | Modifiers 
 -------------+---------+-----------
  unique1     | integer | 
@@ -971,6 +971,9 @@ Append-Only Columnar Table "pg_temp_274.temp_tenk_ao5"
  stringu1    | name    | 
  stringu2    | name    | 
  string4     | name    | 
+Compression Type: zlib
+Compression Level: 1
+Block Size: 32768
 Checksum: t
 Indexes:
     "temp_even_index" btree (even)
@@ -986,7 +989,7 @@ select unique1 from temp_tenk_ao5;
 -- TEMP TABLES w/ COMMIT DROP AND USING PREPARE
 begin;
 prepare tenk_ao5_prep(int4) as select * from tenk_ao5 where unique1 > 8000;
-create temp table tenk_ao5_temp_drop with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+create temp table tenk_ao5_temp_drop with (appendonly=true, compresstype=zlib, compresslevel=1)
     on commit drop as execute tenk_ao5_prep(8095);
 select count(*) from tenk_ao5_temp_drop;
  count 
@@ -1001,7 +1004,7 @@ LINE 1: select count(*) from tenk_ao5_temp_drop;
                              ^
 -- TEMP TABLES w/ COMMIT DELETE ROWS
 begin;
-create temp table tenk_ao5_temp_delete_rows with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+create temp table tenk_ao5_temp_delete_rows with (appendonly=true, compresstype=zlib, compresslevel=1)
     on commit delete rows as select * from tenk_ao5 where unique1 > 8000 distributed by (unique1);
 select count(*) from tenk_ao5_temp_delete_rows;
  count 
@@ -1018,7 +1021,7 @@ select count(*) from tenk_ao5_temp_delete_rows;
 
 -- TEMP TABLES w/ COMMIT PRESERVE ROWS
 begin;
-create temp table tenk_ao5_temp_pres_rows with (appendonly=true, orientation=column, compresstype=zlib, compresslevel=1)
+create temp table tenk_ao5_temp_pres_rows with (appendonly=true, compresstype=zlib, compresslevel=1)
     on commit preserve rows as select * from tenk_ao5 where unique1 > 8000 distributed by (unique1);
 select count(*) from tenk_ao5_temp_pres_rows;
  count 


### PR DESCRIPTION
The path constructed in `OpenAOSegmentFile()` didn't take into account
"t_" semantic of filename. Ideally, the correct filename is passed to
function, so no need to construct the same.

Would be better if can move `MakeAOSegmentFileName()` inside
`OpenAOSegmentFile()`, as all callers call it except
`truncate_ao_perFile()`, which doesn't fit that model.

This needs to be back-ported to 6X_STABLE as issue exists there too.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
