### PR TITLE
Fix Orca optimizer search stage couldn't measure elapsed time correctly

### DIFF
--- a/src/backend/gporca/libgpopt/src/engine/CEngine.cpp
+++ b/src/backend/gporca/libgpopt/src/engine/CEngine.cpp
@@ -1713,7 +1713,7 @@ CEngine::ProcessTraceFlags()
 
 		at.Os()
 			<< std::endl << "[OPT]: stage "<< m_ulCurrSearchStage << " completed in "
-			<< PssCurrent()->UlElapsedTime() << " msec, ";
+			<< PssCurrent()->UlElapsedTime() << "ms, ";
 			if (NULL == PssCurrent()->PexprBest())
 			{
 				at.Os() << " no plan was found";

--- a/src/backend/gporca/libgpopt/src/search/CSearchStage.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CSearchStage.cpp
@@ -41,6 +41,11 @@ CSearchStage::CSearchStage
 
 	// include all implementation rules in any search strategy
 	m_xforms->Union(CXformFactory::Pxff()->PxfsImplementation());
+
+	if (GPOS_FTRACE(EopttracePrintOptimizationStatistics))
+	{
+		m_timer.Restart();
+	}
 }
 
 


### PR DESCRIPTION
Previously, CTimerUser didn't initialize timer, so the elapsed time provided by
Orca was not meaningful, sometimes confusing.

When traceflag T101012 is turned on, we can see the following trace message:
```
[OPT]: Memo (stage 0): [20 groups, 0 duplicate groups, 44 group expressions, 4 activated xforms]
[OPT]: stage 0 completed in 860087 msec,  plan with cost 1028.470667 was found
[OPT]: <Begin Xforms - stage 0>
......
[OPT]: <End Xforms - stage 0>
[OPT]: Search terminated at stage 1/1
[OPT]: Total Optimization Time: 67ms
```
As shown above, the stage 0 elapsed timer is much greater than the total
optimization time, which is obviously incorrect.

