### PR TITLE
[6X Backport]Fix tupdesc dangling pointer segfault in HashAgg

### DIFF
--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -4160,6 +4160,36 @@ select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
 (0 rows)
 
 drop table ti;
+-- Partitioned table with btree index and hash aggregate should use a correct
+-- memory context for its tuples` descriptor
+drop table if exists dis_tupdesc;
+NOTICE:  table "dis_tupdesc" does not exist, skipping
+create table dis_tupdesc (a int, b int, c int)
+distributed by (a)
+partition by list (b)
+(
+    partition p1 values (1),
+    partition p2 values (2),
+    default partition junk_data
+);
+NOTICE:  CREATE TABLE will create partition "dis_tupdesc_1_prt_p1" for table "dis_tupdesc"
+NOTICE:  CREATE TABLE will create partition "dis_tupdesc_1_prt_p2" for table "dis_tupdesc"
+NOTICE:  CREATE TABLE will create partition "dis_tupdesc_1_prt_junk_data" for table "dis_tupdesc"
+create index dis_tupdesc_idx on dis_tupdesc using btree (c);
+insert into dis_tupdesc select i, i % 3, i % 4 from generate_series (1, 240) as i;
+analyze dis_tupdesc;
+set gp_segments_for_planner = 2;
+set optimizer_segments = 2;
+select distinct b from dis_tupdesc where c >= 2;
+ b 
+---
+ 0
+ 1
+ 2
+(3 rows)
+
+reset gp_segments_for_planner;
+reset optimizer_segments;
 -- MPP-6611, make sure rename works with default partitions
 create table it (i int, j int) partition by range(i) 
 subpartition by range(j) subpartition template(start(1) end(10) every(5))

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -4173,6 +4173,36 @@ select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
 (0 rows)
 
 drop table ti;
+-- Partitioned table with btree index and hash aggregate should use a correct
+-- memory context for its tuples` descriptor
+drop table if exists dis_tupdesc;
+NOTICE:  table "dis_tupdesc" does not exist, skipping
+create table dis_tupdesc (a int, b int, c int)
+distributed by (a)
+partition by list (b)
+(
+    partition p1 values (1),
+    partition p2 values (2),
+    default partition junk_data
+);
+NOTICE:  CREATE TABLE will create partition "dis_tupdesc_1_prt_p1" for table "dis_tupdesc"
+NOTICE:  CREATE TABLE will create partition "dis_tupdesc_1_prt_p2" for table "dis_tupdesc"
+NOTICE:  CREATE TABLE will create partition "dis_tupdesc_1_prt_junk_data" for table "dis_tupdesc"
+create index dis_tupdesc_idx on dis_tupdesc using btree (c);
+insert into dis_tupdesc select i, i % 3, i % 4 from generate_series (1, 240) as i;
+analyze dis_tupdesc;
+set gp_segments_for_planner = 2;
+set optimizer_segments = 2;
+select distinct b from dis_tupdesc where c >= 2;
+ b 
+---
+ 0
+ 1
+ 2
+(3 rows)
+
+reset gp_segments_for_planner;
+reset optimizer_segments;
 -- MPP-6611, make sure rename works with default partitions
 create table it (i int, j int) partition by range(i) 
 subpartition by range(j) subpartition template(start(1) end(10) every(5))

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -2141,6 +2141,26 @@ drop index ti_j_idx;
 select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
 drop table ti;
 
+-- Partitioned table with btree index and hash aggregate should use a correct
+-- memory context for its tuples` descriptor
+drop table if exists dis_tupdesc;
+create table dis_tupdesc (a int, b int, c int)
+distributed by (a)
+partition by list (b)
+(
+    partition p1 values (1),
+    partition p2 values (2),
+    default partition junk_data
+);
+create index dis_tupdesc_idx on dis_tupdesc using btree (c);
+insert into dis_tupdesc select i, i % 3, i % 4 from generate_series (1, 240) as i;
+analyze dis_tupdesc;
+set gp_segments_for_planner = 2;
+set optimizer_segments = 2;
+select distinct b from dis_tupdesc where c >= 2;
+reset gp_segments_for_planner;
+reset optimizer_segments;
+
 -- MPP-6611, make sure rename works with default partitions
 create table it (i int, j int) partition by range(i) 
 subpartition by range(j) subpartition template(start(1) end(10) every(5))


### PR DESCRIPTION
This problem manifests itself with HashAgg on the top of
DynamicIndexScan node and can cause a segmentation fault.

1. A HashAgg node initializes a tuple descriptor for its hash
slot using a reference from input tuples (coming from
DynamicIndexScan through a Sequence node).
2. At the end of every partition index scan in DynamicIndexScan
we unlink and free unused memory chunks and reset partition's
memory context. It causes a total destruction of all objects in
the context including partition index tuple descriptor used in a
HashAgg node.
As a result we get a dangling pointer in HashAgg on switching to
a new index partition during DynamicIndexScan that can cause a
segfault.

Backport commit: 41ce55bf796d76f121ef942ebb3592f8fc0fa907 to 6X.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
