### PR TITLE
Check whether the directory exists when deleting the tablespace

### DIFF
--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1119,11 +1119,21 @@ remove_symlink:
 	else
 	{
 		link_target_dir[rllen] = '\0';
-		if(directory_is_empty(link_target_dir) && rmdir(link_target_dir) < 0)
-			ereport(redo ? LOG : ERROR,
-				(errcode_for_file_access(),
-					errmsg("could not remove directory \"%s\": %m",
-						link_target_dir)));
+		if (access(link_target_dir, F_OK) != 0)
+		{
+			ereport(redo? LOG : ERROR,
+					(errcode_for_file_access(),
+							errmsg("could not open directory \"%s\": %m",
+								   link_target_dir)));
+		}
+		else
+		{
+			if(directory_is_empty(link_target_dir) && rmdir(link_target_dir) < 0)
+				ereport(redo ? LOG : ERROR,
+						(errcode_for_file_access(),
+								errmsg("could not remove directory \"%s\": %m",
+									   link_target_dir)));
+		}
 	}
 
 

--- a/src/test/regress/input/gp_tablespace.source
+++ b/src/test/regress/input/gp_tablespace.source
@@ -205,3 +205,10 @@ SELECT COUNT(*) FROM tblspc_otherloc_heap;
 
 DROP TABLE tblspc_otherloc_heap;
 DROP TABLESPACE testspace_otherloc;
+
+CREATE TABLESPACE testspace_dir_empty LOCATION '@testtablespace@';
+CREATE TABLE t_dir_empty(a int);
+\! rm -rf @testtablespace@/*;
+DROP TABLE IF EXISTS t_dir_empty;
+DROP TABLESPACE testspace_dir_empty;
+

--- a/src/test/regress/output/gp_tablespace.source
+++ b/src/test/regress/output/gp_tablespace.source
@@ -380,3 +380,8 @@ SELECT COUNT(*) FROM tblspc_otherloc_heap;
 
 DROP TABLE tblspc_otherloc_heap;
 DROP TABLESPACE testspace_otherloc;
+CREATE TABLESPACE testspace_dir_empty LOCATION '@testtablespace@';
+CREATE TABLE t_dir_empty(a int);
+\! rm -rf @testtablespace@/*;
+DROP TABLE IF EXISTS t_dir_empty;
+DROP TABLESPACE testspace_dir_empty;


### PR DESCRIPTION
If the directory of tablespace does not exist, we should got a
error on commit transaction. But error on commit transaction will
cause a panic. So the directory of tablespace should be checked
so that we can avoid panic.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
