### PR TITLE
[6X Backport] gpMgmt: make additional utilities search_path-safe

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -312,16 +312,22 @@ def parseCommandLine():
 def connect(user=None, password=None, host=None, port=None,
             database=None, utilityMode=False):
     '''Connect to DB using parameters in GV'''
-    options = utilityMode and '-c gp_session_role=utility' or None
+    # make search path safe
+    options = '-c search_path='
+    if utilityMode:
+        options += ' -c gp_session_role=utility'
+
     if not user: user = GV.opt['-U']
     if not password: password = GV.opt['-P']
     if not host: host = GV.opt['-h']
     if not port: port = GV.opt['-p']
     if not database: database = GV.dbname
+
     try:
         logger.debug('connecting to %s:%s %s' % (host, port, database))
         db = pg.connect(host=host, port=port, user=user,
                         passwd=password, dbname=database, opt=options)
+
     except pg.InternalError, ex:
         logger.fatal('could not connect to %s: "%s"' %
                      (database, str(ex).strip()))

--- a/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
@@ -5,7 +5,7 @@ from gppylib.db import dbconn
 import pygresql.pg
 
 
-FTS_PROBE_QUERY = 'SELECT gp_request_fts_probe_scan()'
+FTS_PROBE_QUERY = 'SELECT pg_catalog.gp_request_fts_probe_scan()'
 
 class SegmentReconfigurer:
     def __init__(self, logger, worker_pool, timeout):

--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -17,7 +17,8 @@ gpsd_version = '%prog 1.0'
 
 sysnslist = "('pg_toast', 'pg_bitmapindex', 'pg_temp_1', 'pg_catalog', 'information_schema')"
 orca = False
-pgoptions = '-c gp_session_role=utility'
+# make search path safe
+pgoptions = '-c gp_session_role=utility -c search_path='
 
 
 def ResultIter(cursor, arraysize=1000):

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -68,7 +68,8 @@ version = '1.13'
 PATH_PREFIX = '/tmp/'
 PGDUMP_FILE = 'pg_dump_out.sql'
 sysnslist = "('pg_toast', 'pg_bitmapindex', 'pg_catalog', 'information_schema', 'gp_toolkit')"
-pgoptions = '-c gp_session_role=utility'
+# make search path safe
+pgoptions = '-c gp_session_role=utility -c search_path='
 
 class MRQuery(object):
     def __init__(self):


### PR DESCRIPTION
Make some utilities search path safe, so it'll not calling any external
functions that has same name with our built-in functions.

This fix does not guarantee to fix CVE-2018-1058.

Backport from 070d6221c0c4439db9489ac78e01c14fd784e987.

Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>
Co-authored-by: Jacob Champion <pchampion@pivotal.io>
Co-authored-by: Shoaib Lari <slari@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
