### PR TITLE
[BACKPORT] Skip foreign table when gpexpand

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -493,3 +493,20 @@ Feature: expand the cluster by adding more segments
         And unset fault inject
         When the user runs gpexpand with a static inputfile for a single-node cluster with mirrors without ret code check
         Then gpexpand should return a return code of 0
+
+    @gpexpand_verify_partition_external_table
+    Scenario: Gpexpand should succeed when partition table contain an external table as child partition
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And the cluster is generated with "1" primaries only
+		And database "gptest" exists
+		And the user create an external table with name "ext_test" in partition table t
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "localhost"
+        When the user runs gpexpand interview to add 3 new segment and 0 new host "ignored.host"
+        Then the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+        Then verify that the cluster has 3 new segments
+        When the user runs gpexpand to redistribute
+        Then the numsegments of table "ext_test" is 4

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -185,6 +185,19 @@ def impl(conetxt, tabname):
         dbconn.execSQL(conn, sql)
         conn.commit()
 
+@given('the user create an external table with name "{tabname}" in partition table t')
+def impl(conetxt, tabname):
+    dbname = 'gptest'
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
+        sql = ("create external table {tabname}(i int, j int) location "
+               "('gpfdist://host.invalid:8000/file') format 'text'").format(tabname=tabname)
+        dbconn.execSQL(conn, sql)
+        sql = "create table t(i int, j int) partition by list(i) (values(2018), values(1218))"
+        dbconn.execSQL(conn, sql)
+        sql = ("alter table t exchange partition for (2018) with table {tabname} without validation").format(tabname=tabname)
+        dbconn.execSQL(conn, sql)
+        conn.commit()
+
 @given('the user executes "{sql}" with named connection "{cname}"')
 def impl(context, cname, sql):
     conn = context.named_conns[cname]

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4677,8 +4677,6 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 				Oid relid = RelationGetRelid(rel);
 				PartStatus ps = rel_part_status(relid);
 
-				ATExternalPartitionCheck(cmd->subtype, rel, recursing);
-
 				if (Gp_role == GP_ROLE_DISPATCH &&
 					rel->rd_cdbpolicy->numsegments == getgpsegmentCount())
 					ereport(ERROR,
@@ -14947,10 +14945,12 @@ ATExecExpandTable(List **wqueue, Relation rel, AlterTableCmd *cmd)
 		bool           iswritable = ext->iswritable;
 
 		relation_close(rel, NoLock);
+		/*
+		 * Skip expanding readable external table, since data is not
+		 * located inside gpdb
+		 */
 		if (!iswritable)
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("unsupported ALTER command for external table")));
+			return;
 	}
 	else
 	{


### PR DESCRIPTION
For non partition table, we will skip gpexpand external tables,
but for partition table, when one of its child parition is a
external table, we error out when gpexpand. This is not a correct
behavior.
Since data of foreign table is located outside gpdb, skip these
tables when gpexpand is enough.

Co-Authored-by: Ning Yu nyu@pivotal.io

(cherry picked from commit b9691eba051c37005ba9f038171cd8849b15cea3)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
