### PR TITLE
Detect if vendoring python in gpdb package

### DIFF
--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -11,7 +11,7 @@ GPHOME="${GPHOME_PATH}"
 
 EOF
 
-if [ -x "${PYTHONHOME}/bin/python" ]; then
+if [ -n "${PYTHONHOME}" ] && [ -x "${PYTHONHOME}/bin/python" ]; then
 	cat <<-"EOF"
 	PYTHONHOME="${GPHOME}/ext/python"
 	export PYTHONHOME


### PR DESCRIPTION
   Update `generate-greenplum-path.sh` script to detect if included python. 
   We corrected the python path located in the Greenplum package.

[#173567726]

Co-authored-by: Tingfang Bao <baotingfang@gmail.com>
Co-authored-by: Ning Wu <ningw@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
