### PR TITLE
Dispatch transaction snapshot in CdbDispatchSetCommand()

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1688,8 +1688,14 @@ exec_simple_query(const char *query_string)
 
 		/*
 		 * Set up a snapshot if parse analysis/planning will need one.
+		 *
+		 * Greenplum exception: CdbDispatchSetCommand() dispatches SET commands
+		 * to idle segments, give the idle segments a chance to get the
+		 * dispatched snapshot in this case.
 		 */
-		if (analyze_requires_snapshot(parsetree))
+		if (analyze_requires_snapshot(parsetree) ||
+			(nodeTag(parsetree) == T_VariableSetStmt &&
+			 ((VariableSetStmt *)parsetree)->kind != VAR_SET_MULTI))
 		{
 			PushActiveSnapshot(GetTransactionSnapshot());
 			snapshot_set = true;

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1688,14 +1688,8 @@ exec_simple_query(const char *query_string)
 
 		/*
 		 * Set up a snapshot if parse analysis/planning will need one.
-		 *
-		 * Greenplum exception: CdbDispatchSetCommand() dispatches SET commands
-		 * to idle segments, give the idle segments a chance to get the
-		 * dispatched snapshot in this case.
 		 */
-		if (analyze_requires_snapshot(parsetree) ||
-			(nodeTag(parsetree) == T_VariableSetStmt &&
-			 ((VariableSetStmt *)parsetree)->kind != VAR_SET_MULTI))
+		if (analyze_requires_snapshot(parsetree))
 		{
 			PushActiveSnapshot(GetTransactionSnapshot());
 			snapshot_set = true;

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -1342,7 +1342,6 @@ PortalRunUtility(Portal portal, Node *utilityStmt,
 	 */
 	if (!(IsA(utilityStmt, TransactionStmt) ||
 		  IsA(utilityStmt, LockStmt) ||
-		  IsA(utilityStmt, VariableSetStmt) ||
 		  IsA(utilityStmt, VariableShowStmt) ||
 		  IsA(utilityStmt, ConstraintsSetStmt) ||
 	/* efficiency hacks from here down */
@@ -1350,7 +1349,19 @@ PortalRunUtility(Portal portal, Node *utilityStmt,
 		  IsA(utilityStmt, ListenStmt) ||
 		  IsA(utilityStmt, NotifyStmt) ||
 		  IsA(utilityStmt, UnlistenStmt) ||
-		  IsA(utilityStmt, CheckPointStmt)))
+		  IsA(utilityStmt, CheckPointStmt) ||
+		  /* 
+		   * Greenplum specific:
+		   * VariableSetStmt need transaction snapshot except SET TRANSACTION ISOLATION
+		   * This is due to VariableSetStmt may contain hook function which read catalog
+		   * table, but Greenplum use DTXCONTET_LOCAL_ONLY to access catalog table, which
+		   * cannot sync the sharedsnapshot on reader gang and cannot bump currentCommandId.
+		   * As a result, we should fetch tranaction snapshot to sync currentCommandId for
+		   * reader gang.
+		   */
+		  (IsA(utilityStmt, VariableSetStmt) &&
+		   ((((VariableSetStmt *)utilityStmt)->kind == VAR_SET_MULTI) ||
+		   strcmp(((VariableSetStmt *)utilityStmt)->name, "transaction_isolation") == 0))))
 	{
 		snapshot = GetTransactionSnapshot();
 		/* If told to, register the snapshot we're using and save in portal */

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -336,3 +336,63 @@ INFO:  iteration:3 unsafe truncate performed
  
 (1 row)
 
+-- test for not dispatching GUCs, which may need updates committed, to idle segments
+BEGIN ISOLATION LEVEL REPEATABLE READ;
+CREATE TABLE guc_gp_test_table (
+        stringu1        name
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'stringu1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT length(stringu1) FROM guc_gp_test_table GROUP BY length(stringu1);
+ length 
+--------
+(0 rows)
+
+DROP ROLE IF EXISTS guc_gp_test_role;
+NOTICE:  role "guc_gp_test_role" does not exist, skipping
+CREATE ROLE guc_gp_test_role;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+SET ROLE guc_gp_test_role;   -- it reported role doesn't exist here
+RESET SESSION AUTHORIZATION;
+DROP ROLE guc_gp_test_role;
+RESET ROLE;
+DROP TABLE guc_gp_test_table;
+END;
+SET search_path to 'public';
+CREATE TABLE guc_gp_t1(c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO guc_gp_t1 SELECT generate_series(1,100),generate_series(51,150);
+CREATE TABLE guc_gp_t2 AS SELECT * FROM guc_gp_t1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+BEGIN;
+CREATE SCHEMA guc_gp;
+CREATE TABLE guc_gp.guc_gp_t3 AS SELECT * FROM guc_gp_t1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE guc_gp.guc_gp_t4 AS SELECT * FROM guc_gp_t1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT sum(guc_gp_t1.c1) FROM guc_gp_t1,guc_gp_t2;
+  sum   
+--------
+ 505000
+(1 row)
+
+SET search_path to 'guc_gp';
+SELECT sum(guc_gp_t3.c1) FROM guc_gp_t3,guc_gp_t4;
+  sum   
+--------
+ 505000
+(1 row)
+
+ROLLBACK;
+SELECT sum(guc_gp_t1.c1) FROM guc_gp_t1,guc_gp_t2;
+  sum   
+--------
+ 505000
+(1 row)
+
+DROP TABLE guc_gp_t1;
+DROP TABLE guc_gp_t2;


### PR DESCRIPTION
CdbDispatchSetCommand() dispatches SET commands to idle segments, which
could not see the changes from a transaction with isolation levels
higher than or equal to repeatable read.

To fix that, dispatch the transaction snapshot in this case and set it
on the idle segments.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change