### PR TITLE
Force to update checkpoint timeline id in control data after promotio…

### DIFF
--- a/src/bin/pg_rewind/sql/config_test.sh
+++ b/src/bin/pg_rewind/sql/config_test.sh
@@ -109,6 +109,10 @@ function wait_for_promotion {
    exit 1
 }
 
+function standby_checkpoint {
+   PGOPTIONS=${PGOPTIONS_UTILITY} ${STANDBY_PSQL} -c "checkpoint;"
+}
+
 function wait_until_standby_is_promoted {
     wait_for_promotion "${STANDBY_PSQL}"
 }

--- a/src/bin/pg_rewind/sql/run_test.sh
+++ b/src/bin/pg_rewind/sql/run_test.sh
@@ -115,6 +115,11 @@ fi
 # For a local test, source node need to be stopped as well.
 if [ $TEST_SUITE == "local" ]; then
 	pg_ctl -w -D $TEST_STANDBY stop -m fast >>$log_path 2>&1
+else
+	# Force a checkpoint to update the source timline id in pg_control data,
+	# else pg_rewind will quit without recovery if the timline is is not
+	# updated because it is same as the one on the target.
+	standby_checkpoint >>$log_path 2>&1
 fi
 
 # At this point, the rewind processing is ready to run.


### PR DESCRIPTION
…n and before pg_rewind.

After promotion there is a checkpoint but not an immediate one, so the
checkpoint timeline id in pg_control data might not be updated in time when
running pg_rewind which depends on that to decide the necessity of incremental
recovery.  Let's run checkpoint after promotion in tests so that later
pg_rewind will not bypass the incremental recovery.

This should be able to fix some long-existing annoying flaky pg_rewind tests.

