### PR TITLE
Skip condition expr in CASE statement in subexpression_match

### DIFF
--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6195,3 +6195,43 @@ select a, (select b from bar_gset where foo_gset.a = bar_gset.b) from foo_gset g
 
 drop table foo_gset;
 drop table bar_gset;
+-- GROUPING SETS not support multiple grouping sets contain references to expressions
+-- where one of which subsumes another in the select targetlist
+create table sale(qty int, i int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'qty' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into sale select k, k, k from generate_series(1,10)k;
+-- query should fail
+select (sale.qty)  as a1,(sale.qty) as a2 from sale group by grouping sets((1),(2));
+ERROR:  GROUPING SETS / ROLLUP / CUBE columns ambiguous
+select (sale.qty)  as a1,(sale.qty + 100) as a2 from sale group by grouping sets((1),(2));
+ERROR:  GROUPING SETS / ROLLUP / CUBE columns ambiguous
+-- result expr in CASE statement is in targetlist, so query should fail
+select (sale.qty)  as a1,(case when sale.i = 1 then sale.qty else sale.qty + 1 end) as a2 from sale group by grouping sets((1),(2));
+ERROR:  GROUPING SETS / ROLLUP / CUBE columns ambiguous
+-- condition expr in CASE statement is not in targetlist, so query should succeed
+select (sale.qty)  as a1,(case when sale.qty = 1 then sale.i else sale.i + 1 end) as a2 from sale group by grouping sets((1),(2)) order by a1, a2;
+ a1 | a2 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+  7 |   
+  8 |   
+  9 |   
+ 10 |   
+    |  1
+    |  3
+    |  4
+    |  5
+    |  6
+    |  7
+    |  8
+    |  9
+    | 10
+    | 11
+(20 rows)
+


### PR DESCRIPTION
Grouping extension planner in gpdb5 and gpdb6 does not
correctly support a scenario where multiple grouping sets
containreferences to expressions where one of which subsumes
references to expressions where one of which subsumes another
in the select targetlist. This will lead to columns ambiguous
error. For example:

SELECT (sale.qty)  as a1,(sale.qty) as a2 FROM sale GROUP
BY GROUPING SETS((1),(2));
SELECT (sale.qty)  as a1,(sale.qty + 100) as a2 FROM sale
GROUP BY GROUPING SETS((1),(2));

But when the subsume relationship happens in the condition
expr of CASE expression, it's not in select targetlist. We
should not report columns ambiguous at here. For example:

select (sale.qty) as a1,(case when sale.qty = 1 then sale.i else
sale.i + 1 end) as a2 from sale group by grouping sets((1),(2));

The sale.qty in CASE expression will not appear in targetlist.
Note that the above limitation is removed in the latest gpdb.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
