### PR TITLE
[6X Backport]Let FTS mark mirror down if replication keeps crash.

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -135,6 +135,13 @@ int			gp_fts_probe_interval = 60;
 int gp_fts_mark_mirror_down_grace_period = 30;
 
 /*
+ * If primary-mirror replication attempts to connect continuously and exceed
+ * this count, mark the mirror down to prevent wal sync block.
+ * More details please refer to FTSGetReplicationDisconnectTime.
+ */
+int			gp_fts_replication_attempt_count = 10;
+
+/*
  * When we have certain types of failures during gang creation which indicate
  * that a segment is in recovery mode we may be able to retry.
  */

--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -17,11 +17,450 @@
 #include "replication/gp_replication.h"
 #include "replication/walreceiver.h"
 #include "replication/walsender.h"
-#include "replication/walsender_private.h"
+#include "storage/lwlock.h"
 #include "utils/builtins.h"
 
 /* Set at database system is ready to accept connections */
 extern pg_time_t PMAcceptingConnectionsStartTime;
+
+/*
+ * FTSRepStatusCtl is only used for GPDB primary-mirror replication,
+ * so set to a small value for now.
+ */
+uint32 max_replication_status = 1;
+
+/*
+ * Control array for replication status management which used in FTS.
+ * The reason for not using WalSndCtl to track replication status is
+ * the WalSnd is used to track walsender status. And when FTS probe
+ * happens, the WalSnd for a replication may already get freed.
+ */
+FTSReplicationStatusCtlData *FTSRepStatusCtl = NULL;
+
+static void FTSReplicationStatusClearDisconnectTime(FTSReplicationStatus *replication_status);
+static void FTSReplicationStatusClearAttempts(FTSReplicationStatus *replication_status);
+static uint32 FTSReplicationStatusRetrieveAttempts(FTSReplicationStatus *replication_status);
+static pg_time_t FTSReplicationStatusRetrieveDisconnectTime(FTSReplicationStatus *replication_status);
+static void FTSReplicationStatusMarkDisconnect(FTSReplicationStatus *replication_status);
+
+/* Report shared-memory space needed by FTSReplicationStatusShmemInit */
+Size
+FTSReplicationStatusShmemSize(void)
+{
+	Size		size = 0;
+
+	size = offsetof(FTSReplicationStatusCtlData, replications);
+	size = add_size(size, mul_size(max_replication_status, sizeof(FTSReplicationStatus)));
+
+	return size;
+}
+
+/* Allocate and initialize FTSReplicationStatus related shared memory */
+void
+FTSReplicationStatusShmemInit(void)
+{
+	bool		found;
+
+	Assert(FTSReplicationStatusShmemSize() > 0);
+
+	FTSRepStatusCtl = (FTSReplicationStatusCtlData *)
+		ShmemInitStruct("FTSReplicationStatus Ctl", FTSReplicationStatusShmemSize(), &found);
+
+	if (!found)
+	{
+		/* First time through, so initialize */
+		MemSet(FTSRepStatusCtl, 0, FTSReplicationStatusShmemSize());
+
+		for (int i = 0; i < max_replication_status; i++)
+		{
+			FTSReplicationStatus *slot = &FTSRepStatusCtl->replications[i];
+
+			/* everything else is zeroed by the memset above */
+			SpinLockInit(&slot->mutex);
+		}
+	}
+}
+
+/*
+ * FTSReplicationStatusCreateIfNotExist - Init a FTSReplicationStatus for current
+ * replication application. Use application_name to identify the primary-mirror pair.
+ * If FTSReplicationStatus for current application_name already exist, skip
+ * create.
+ *
+ * This function is called under walsender, walsender's application_name is used.
+ */
+void
+FTSReplicationStatusCreateIfNotExist(const char *app_name)
+{
+	FTSReplicationStatus *replication_status = NULL;
+
+	/* FTSRepStatusCtl should be set already. */
+	Assert(FTSRepStatusCtl != NULL);
+
+	/* Use FTSReplicationStatusLock to protect concurrent create/drop */
+	LWLockAcquire(FTSReplicationStatusLock, LW_EXCLUSIVE);
+
+	for (int i = 0; i < max_replication_status; i++)
+	{
+		FTSReplicationStatus *slot = &FTSRepStatusCtl->replications[i];
+
+		if (slot->in_use)
+		{
+			if (strncmp(app_name, NameStr(slot->name), NAMEDATALEN) == 0)
+			{
+				/* FTSReplicationStatus for current application already exists */
+				LWLockRelease(FTSReplicationStatusLock);
+				return;
+			}
+		}
+		else
+		{
+			/*
+			 * Find a free slot, but this does not mean the slot for app_name is not exist.
+			 * Cause the slot may get freed and reused.
+			 */
+			if (replication_status == NULL)
+				replication_status = slot;
+		}
+	}
+
+	/* If find a free slot, create a new FTSReplicationStatus */
+	if (replication_status != NULL)
+	{
+		replication_status->in_use = true;
+		StrNCpy(NameStr(replication_status->name), application_name, NAMEDATALEN);
+		replication_status->con_attempt_count = 0;
+		replication_status->replica_disconnected_at = 0;
+
+		LWLockRelease(FTSReplicationStatusLock);
+		return;
+	}
+
+	/* No need to release LWLock before fatal since abort will release it */
+	ereport(FATAL,
+			(errcode(ERRCODE_TOO_MANY_CONNECTIONS),
+				errmsg("number of requested standby connections "
+					   "exceeds max_replication_status (currently %d)",
+					   max_replication_status)));
+}
+
+/*
+ * FTSReplicationStatusDrop - Drop a FTSReplicationStatus.
+ *
+ * This function is called in FTS probe process, so an app_name is used
+ * to specify which FTSReplicationStatus should be dropped.
+ */
+void
+FTSReplicationStatusDrop(const char* app_name)
+{
+
+	/* FTSRepStatusCtl should be set already. */
+	Assert(FTSRepStatusCtl != NULL);
+
+	/* Use FTSReplicationStatusLock to protect concurrent create/drop */
+	LWLockAcquire(FTSReplicationStatusLock, LW_EXCLUSIVE);
+	for (int i = 0; i < max_replication_status; i++)
+	{
+		FTSReplicationStatus *slot = &FTSRepStatusCtl->replications[i];
+
+		if (slot->in_use &&
+			strcmp(app_name, NameStr(slot->name)) == 0)
+		{
+			slot->in_use = false;
+			MemSet(NameStr(slot->name), 0, NAMEDATALEN);
+		}
+	}
+	LWLockRelease(FTSReplicationStatusLock);
+}
+
+/*
+ * RetrieveFTSReplicationStatus - Get the FTSReplicationStatus from FTSRepStatusCtl.
+ *
+ * FTSReplicationStatusLock should be held before call this function.
+ */
+FTSReplicationStatus *
+RetrieveFTSReplicationStatus(const char *app_name, bool skip_warn)
+{
+	/* FTSRepStatusCtl should be set already. */
+	Assert(FTSRepStatusCtl != NULL);
+	Assert(LWLockHeldByMe(FTSReplicationStatusLock));
+
+	for (int i = 0; i < max_replication_status; i++)
+	{
+		FTSReplicationStatus *slot = &FTSRepStatusCtl->replications[i];
+
+		if (slot->in_use &&
+			strcmp(app_name, NameStr(slot->name)) == 0)
+			return slot;
+	}
+
+	if (!skip_warn)
+		ereport(WARNING,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("FTSReplicationStatus \"%s\" does not exist", app_name)));
+	return NULL;
+}
+
+/*
+ * FTSReplicationStatusMarkDisconnect - Mark current replication's disconnect by
+ * increase the con_attempt_count and set current time as disconnect time.
+ *
+ * This function is called under walsender to mark wal replication disconnected.
+ *
+ * FTSReplicationStatusLock should be held before call this function.
+ */
+static void
+FTSReplicationStatusMarkDisconnect(FTSReplicationStatus *replication_status)
+{
+	if (replication_status == NULL)
+		return;
+
+	/* FTSRepStatusCtl should be set already. */
+	Assert(FTSRepStatusCtl != NULL);
+
+	/* Use FTSReplicationStatusLock to prevent concurrent create/drop */
+	Assert(LWLockHeldByMe(FTSReplicationStatusLock));
+
+	/* Since we need to modify the slot's value, lock the mutex. */
+	SpinLockAcquire(&replication_status->mutex);
+	replication_status->con_attempt_count += 1;
+	replication_status->replica_disconnected_at = (pg_time_t) time(NULL);
+	SpinLockRelease(&replication_status->mutex);
+	elogif(gp_log_fts >= GPVARS_VERBOSITY_VERBOSE, LOG,
+		   "FTSReplicationStatus: Mark replication disconnected. "
+		   "Current attempt count: %d, disconnect at %ld, for application %s",
+		   replication_status->con_attempt_count,
+		   replication_status->replica_disconnected_at,
+		   NameStr(replication_status->name));
+}
+
+/*
+ * FTSReplicationStatusUpdateForWalState - Update replication status for an replication
+ * application and it's WalSndState.
+ *
+ * This function is called under walsender to update replication status.
+ */
+void
+FTSReplicationStatusUpdateForWalState(const char *app_name, WalSndState state)
+{
+	FTSReplicationStatus *replication_status;
+
+	LWLockAcquire(FTSReplicationStatusLock, LW_SHARED);
+
+	replication_status = RetrieveFTSReplicationStatus(app_name, false /*skip_warn*/);
+	/* replication_status must exist */
+	Assert(replication_status);
+
+	if (state == WALSNDSTATE_CATCHUP || state == WALSNDSTATE_STREAMING)
+	{
+		/*
+		 * We can clear the disconnect time once the connection established.
+		 * We only clean the failure count when the wal start streaming, since
+		 * although the connection established, and start to send wal, but there
+		 * still chance to fail. Since the blocked transaction will get released
+		 * only when wal start streaming. More details, see SyncRepReleaseWaiters.
+		 */
+		FTSReplicationStatusClearDisconnectTime(replication_status);
+		/* If current replication start streaming, clear the failure attempt count */
+		if (state == WALSNDSTATE_STREAMING)
+			FTSReplicationStatusClearAttempts(replication_status);
+	}
+	else if (FTSReplicationStatusRetrieveDisconnectTime(replication_status) == 0)
+	{
+		/*
+		 * Mark the replication failure if's it the first time set the failure
+		 * WalSndState. Since if the disconnect time is not 0, we already mark
+		 * the replication failure.
+		 */
+		FTSReplicationStatusMarkDisconnect(replication_status);
+	}
+
+	LWLockRelease(FTSReplicationStatusLock);
+}
+
+/*
+ * FTSReplicationStatusMarkDisconnectForReplication - Mark a replication disconnected
+ * base on replication's application name.
+ *
+ * This function is called under walsender to mark wal replication disconnected.
+ */
+void
+FTSReplicationStatusMarkDisconnectForReplication(const char *app_name)
+{
+	FTSReplicationStatus *replication_status;
+
+	LWLockAcquire(FTSReplicationStatusLock, LW_SHARED);
+
+	replication_status = RetrieveFTSReplicationStatus(app_name, false /* skip_warn */);
+
+	/* replication_status must exist  */
+	Assert(replication_status);
+	FTSReplicationStatusMarkDisconnect(replication_status);
+
+	LWLockRelease(FTSReplicationStatusLock);
+}
+
+/*
+ * FTSReplicationStatusClearAttempts - Clear current replication's continuously
+ * connection attempts since the replication start steaming data.
+ *
+ * This function is called under walsender to mark the replication start
+ * steaming.
+ *
+ * FTSReplicationStatusLock should be held before call this function.
+ */
+static void
+FTSReplicationStatusClearAttempts(FTSReplicationStatus *replication_status)
+{
+	if (replication_status == NULL)
+		return;
+	/* FTSRepStatusCtl should be set already. */
+	Assert(FTSRepStatusCtl != NULL);
+
+	/* Use FTSReplicationStatusLock to prevent concurrent create/drop */
+	Assert(LWLockHeldByMe(FTSReplicationStatusLock));
+
+	/* Since we need to modify the slot's value, lock the mutex. */
+	SpinLockAcquire(&replication_status->mutex);
+	replication_status->con_attempt_count = 0;
+	SpinLockRelease(&replication_status->mutex);
+	elogif(gp_log_fts >= GPVARS_VERBOSITY_VERBOSE, LOG,
+		   "FTSReplicationStatus: Clear replication connection attempts, for application %s",
+		   NameStr(replication_status->name));
+}
+
+/*
+ * FTSReplicationStatusRetrieveAttempts - Retrieve the replication connection attempts
+ * for a replication application.
+ *
+ * This function is called under FTS probe process.
+ *
+ * FTSReplicationStatusLock should be held before call this function.
+ */
+static uint32
+FTSReplicationStatusRetrieveAttempts(FTSReplicationStatus *replication_status)
+{
+	uint32			 	result;
+
+	if (replication_status == NULL)
+		return 0;
+
+	/* FTSRepStatusCtl should be set already. */
+	Assert(FTSRepStatusCtl != NULL);
+
+	/* Use FTSReplicationStatusLock to prevent concurrent create/drop */
+	Assert(LWLockHeldByMe(FTSReplicationStatusLock));
+
+	/* To prevent partial read, lock the mutex. */
+	SpinLockAcquire(&replication_status->mutex);
+	result = replication_status->con_attempt_count;
+	SpinLockRelease(&replication_status->mutex);
+
+	return result;
+}
+
+/*
+ * FTSReplicationStatusClearDisconnectTime - Clear replication disconnect time.
+ *
+ * This function is called under walsender to clear replication disconnect time.
+ *
+ * FTSReplicationStatusLock should be held before call this function.
+ */
+static void
+FTSReplicationStatusClearDisconnectTime(FTSReplicationStatus *replication_status)
+{
+	if (replication_status == NULL)
+		return;
+
+	/* FTSRepStatusCtl should be set already. */
+	Assert(FTSRepStatusCtl != NULL);
+
+	/* Use FTSReplicationStatusLock to prevent concurrent create/drop */
+	Assert(LWLockHeldByMe(FTSReplicationStatusLock));
+
+	/* Since we need to modify the slot's value, lock the mutex. */
+	SpinLockAcquire(&replication_status->mutex);
+	replication_status->replica_disconnected_at = (pg_time_t) 0;
+	SpinLockRelease(&replication_status->mutex);
+	elogif(gp_log_fts >= GPVARS_VERBOSITY_VERBOSE, LOG,
+		   "FTSReplicationStatus: Clear replication disconnect time, for application %s",
+		   NameStr(replication_status->name));
+}
+
+/*
+ * FTSReplicationStatusRetrieveDisconnectTime - Retrieve replication disconnect time.
+ *
+ * This function is called under FTS probe process to retrieve replication disconnect time.
+ *
+ * FTSReplicationStatusLock should be held before call this function.
+ */
+static pg_time_t
+FTSReplicationStatusRetrieveDisconnectTime(FTSReplicationStatus *replication_status)
+{
+	pg_time_t			disconn_time;
+
+	if (replication_status == NULL)
+		return 0;
+
+	/* FTSRepStatusCtl should be set already. */
+	Assert(FTSRepStatusCtl != NULL);
+
+	/* Use FTSReplicationStatusLock to prevent concurrent create/drop */
+	Assert(LWLockHeldByMe(FTSReplicationStatusLock));
+
+	/* Since we need to modify the slot's value, lock the mutex. */
+	SpinLockAcquire(&replication_status->mutex);
+
+	disconn_time = replication_status->replica_disconnected_at;
+
+	SpinLockRelease(&replication_status->mutex);
+
+	return disconn_time;
+}
+
+/* FTSGetReplicationDisconnectTime - used in FTS probe process.
+ *
+ * Detect the primary-mirror replication attempt count.
+ * If the replication keeps crash, we should consider mark
+ * mirror down directly. Since the walsender keeps resarting,
+ * walsender->replica_disconnected_at keeps updated.
+ * So ignore it.
+ *
+ * The reason why we want mark mirror down for this case is because,
+ * when current situation happens, and a transaction try to sync wal
+ * to mirror at the same time, the transaction will block. If walsender
+ * keeps fail, the transaction will block forever.
+ * Please see more details in SyncRepWaitForLSN and SyncRepReleaseWaiters.
+ *
+ * If the FTSReplicationStatus for GP_WALRECEIVER_APPNAME is not exist,
+ * it means the replication has already been stopped.
+ */
+pg_time_t
+FTSGetReplicationDisconnectTime(const char *app_name)
+{
+	pg_time_t			walsender_replica_disconnected_at = 0;
+	uint32				attempt_replication_times = 0;
+	FTSReplicationStatus	   *replication_status = NULL;
+
+	LWLockAcquire(FTSReplicationStatusLock, LW_SHARED);
+	replication_status = RetrieveFTSReplicationStatus(app_name, true /* skip_warn */);
+	if (replication_status)
+	{
+		attempt_replication_times = FTSReplicationStatusRetrieveAttempts(replication_status);
+		if (attempt_replication_times <= gp_fts_replication_attempt_count)
+			walsender_replica_disconnected_at = FTSReplicationStatusRetrieveDisconnectTime(replication_status);
+		else
+		{
+			ereport(LOG,
+					(errmsg("Primary-mirror replication streaming already attempted %d times exceed"
+					" limit gp_fts_replication_attempt_count %d",
+					attempt_replication_times, gp_fts_replication_attempt_count)));
+		}
+	}
+	LWLockRelease(FTSReplicationStatusLock);
+
+	return walsender_replica_disconnected_at;
+}
 
 static bool
 is_mirror_up(WalSnd *walsender)
@@ -41,6 +480,51 @@ is_mirror_up(WalSnd *walsender)
 	return walsender_has_pid && is_communicating_with_mirror;
 }
 
+static bool
+is_probe_retry_needed()
+{
+	pg_time_t			walsender_replica_disconnected_at = 0;
+
+	/*
+	 * Get the walsender disconnect time, if current replication failed too
+	 * many times continuously, the walsender_replica_disconnected_at should
+	 * not take into consider. See more details in FTSGetReplicationDisconnectTime.
+	 */
+	walsender_replica_disconnected_at = FTSGetReplicationDisconnectTime(GP_WALRECEIVER_APPNAME);
+
+	/*
+	 * PMAcceptingConnectionStartTime is process-local variable, set in
+	 * postmaster process and inherited by the FTS handler child
+	 * process. This works because the timestamp is set only once by
+	 * postmaster, and is guaranteed to be set before FTS handler child
+	 * processes can be spawned.
+	 */
+	Assert(PMAcceptingConnectionsStartTime);
+	pg_time_t delta = ((pg_time_t) time(NULL)) -
+		Max(walsender_replica_disconnected_at, PMAcceptingConnectionsStartTime);
+
+	/*
+	 * Report mirror as down, only if it didn't connect for below
+	 * grace period to primary. This helps to avoid marking mirror
+	 * down unnecessarily when restarting primary or due to small n/w
+	 * glitch. During this period, request FTS to probe again.
+	 *
+	 * If the delta is negative, then it's overflowed, meaning it's
+	 * over gp_fts_mark_mirror_down_grace_period since either last
+	 * database accepting connections or last time wal sender
+	 * died. Then, we can safely mark the mirror is down.
+	 */
+	if (delta < gp_fts_mark_mirror_down_grace_period && delta >= 0)
+	{
+		ereport(LOG,
+				(errmsg("requesting fts retry as mirror didn't connect yet but in grace period: " INT64_FORMAT, delta),
+					errdetail("pid zero at time: " INT64_FORMAT " accept connections start time: " INT64_FORMAT,
+							walsender_replica_disconnected_at, PMAcceptingConnectionsStartTime)));
+		return true;
+	}
+	return false;
+}
+
 /*
  * Check the WalSndCtl to obtain if mirror is up or down, if the wal sender is
  * in streaming, and if synchronous replication is enabled or not.
@@ -48,8 +532,6 @@ is_mirror_up(WalSnd *walsender)
 void
 GetMirrorStatus(FtsResponse *response)
 {
-	pg_time_t walsender_replica_disconnected_at = 0;
-
 	response->IsMirrorUp = false;
 	response->IsInSync = false;
 	response->RequestRetry = false;
@@ -69,7 +551,6 @@ GetMirrorStatus(FtsResponse *response)
 			continue;
 		}
 
-		walsender_replica_disconnected_at = walsender->replica_disconnected_at;
 		is_up = is_mirror_up(walsender);
 		is_streaming = (walsender->state == WALSNDSTATE_STREAMING);
 
@@ -79,43 +560,12 @@ GetMirrorStatus(FtsResponse *response)
 		break;
 	}
 
-	if (!response->IsMirrorUp)
-	{
-		/*
-		 * PMAcceptingConnectionStartTime is process-local variable, set in
-		 * postmaster process and inherited by the FTS handler child
-		 * process. This works because the timestamp is set only once by
-		 * postmaster, and is guaranteed to be set before FTS handler child
-		 * processes can be spawned.
-		 */
-		Assert(PMAcceptingConnectionsStartTime);
-		pg_time_t delta = ((pg_time_t) time(NULL)) -
-			Max(walsender_replica_disconnected_at, PMAcceptingConnectionsStartTime);
-
-		/*
-		 * Report mirror as down, only if it didn't connect for below
-		 * grace period to primary. This helps to avoid marking mirror
-		 * down unnecessarily when restarting primary or due to small n/w
-		 * glitch. During this period, request FTS to probe again.
-		 *
-		 * If the delta is negative, then it's overflowed, meaning it's
-		 * over gp_fts_mark_mirror_down_grace_period since either last
-		 * database accepting connections or last time wal sender
-		 * died. Then, we can safely mark the mirror is down.
-		 */
-		if (delta < gp_fts_mark_mirror_down_grace_period && delta >= 0)
-		{
-			ereport(LOG,
-					(errmsg("requesting fts retry as mirror didn't connect yet but in grace period: " INT64_FORMAT, delta),
-					 errdetail("pid zero at time: " INT64_FORMAT " accept connections start time: " INT64_FORMAT,
-							   walsender_replica_disconnected_at, PMAcceptingConnectionsStartTime)));
-			response->RequestRetry = true;
-		}
-	}
-
 	response->IsSyncRepEnabled = WalSndCtl->sync_standbys_defined;
 
 	LWLockRelease(SyncRepLock);
+
+	if (!response->IsMirrorUp)
+		response->RequestRetry = is_probe_retry_needed();
 }
 
 /*
@@ -147,6 +597,8 @@ UnsetSyncStandbysDefined(void)
 		elog(LOG, "signaling configuration reload: setting synchronous_standby_names to ''");
 		DirectFunctionCall1(pg_reload_conf, PointerGetDatum(NULL) /* unused */);
 	}
+
+	FTSReplicationStatusDrop(GP_WALRECEIVER_APPNAME);
 }
 
 Datum

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -90,7 +90,9 @@
 #include "utils/timeout.h"
 #include "utils/timestamp.h"
 #include "utils/faultinjector.h"
+
 #include "cdb/cdbvars.h"
+#include "replication/gp_replication.h"
 
 /*
  * Maximum data payload in a WAL data message.  Must be >= XLOG_BLCKSZ.
@@ -548,6 +550,13 @@ StartReplication(StartReplicationCmd *cmd)
 {
 	StringInfoData buf;
 	XLogRecPtr	FlushPtr;
+
+	/*
+	 * Create FTSReplicationStatus for current application if not created before.
+	 * This is only called for GPDB primary-mirror replication.
+	 */
+	if (MyWalSnd->is_for_gp_walreceiver)
+		FTSReplicationStatusCreateIfNotExist(application_name);
 
 	/*
 	 * We assume here that we're logging enough information in the WAL for
@@ -2102,6 +2111,10 @@ WalSndKill(int code, Datum arg)
 
 	Assert(walsnd != NULL);
 
+	/* Only track failure for GPDB primary-mirror replication */
+	if (MyWalSnd->is_for_gp_walreceiver)
+		FTSReplicationStatusMarkDisconnectForReplication(application_name);
+
 	if (IS_QUERY_DISPATCHER())
 	{
 		/*
@@ -2123,7 +2136,6 @@ WalSndKill(int code, Datum arg)
 			MyWalSnd->xlogCleanUpTo = InvalidXLogRecPtr;
 
 			/* Mark WalSnd struct no longer in use. */
-			MyWalSnd->replica_disconnected_at = (pg_time_t) time(NULL);
 			MyWalSnd->pid = 0;
 
 			SpinLockRelease(&MyWalSnd->mutex);
@@ -2146,7 +2158,6 @@ WalSndKill(int code, Datum arg)
 
 	SpinLockAcquire(&walsnd->mutex);
 	/* Mark WalSnd struct as no longer being in use. */
-	walsnd->replica_disconnected_at = (pg_time_t) time(NULL);
 	walsnd->pid = 0;
 	SpinLockRelease(&walsnd->mutex);
 }
@@ -2874,7 +2885,6 @@ WalSndShmemInit(void)
 
 			SpinLockInit(&walsnd->mutex);
 			InitSharedLatch(&walsnd->latch);
-			walsnd->replica_disconnected_at = (pg_time_t) time(NULL);
 		}
 	}
 }
@@ -2983,11 +2993,17 @@ WalSndSetState(WalSndState state)
 
 	SpinLockAcquire(&walsnd->mutex);
 	walsnd->state = state;
-	if (state == WALSNDSTATE_CATCHUP || state == WALSNDSTATE_STREAMING)
-		walsnd->replica_disconnected_at = 0;
-	else if (walsnd->replica_disconnected_at == 0)
-		walsnd->replica_disconnected_at = (pg_time_t) time(NULL);
 	SpinLockRelease(&walsnd->mutex);
+
+	/*
+	 * If the walsender is not for GPDB primary-mirror replication,
+	 * skip failure stats.
+	 */
+	if (!walsnd->is_for_gp_walreceiver)
+		return;
+
+	/* Update WAL replication status. */
+	FTSReplicationStatusUpdateForWalState(application_name, state);
 }
 
 /*

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -65,6 +65,7 @@
 #include "executor/spi.h"
 #include "utils/workfile_mgr.h"
 #include "utils/session_state.h"
+#include "replication/gp_replication.h"
 
 shmem_startup_hook_type shmem_startup_hook = NULL;
 
@@ -164,6 +165,7 @@ CreateSharedMemoryAndSemaphores(int port)
 		size = add_size(size, ReplicationSlotsShmemSize());
 		size = add_size(size, WalSndShmemSize());
 		size = add_size(size, WalRcvShmemSize());
+		size = add_size(size, FTSReplicationStatusShmemSize());
 		size = add_size(size, BTreeShmemSize());
 		size = add_size(size, SyncScanShmemSize());
 		size = add_size(size, AsyncShmemSize());
@@ -322,6 +324,7 @@ CreateSharedMemoryAndSemaphores(int port)
 	ReplicationSlotsShmemInit();
 	WalSndShmemInit();
 	WalRcvShmemInit();
+	FTSReplicationStatusShmemInit();
 
 #ifdef FAULT_INJECTOR
 	FaultInjector_ShmemInit();

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3733,6 +3733,16 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
+		{"gp_fts_replication_attempt_count", PGC_SIGHUP, GP_ARRAY_TUNING,
+			gettext_noop("Primary-mirror replication connection max continuously attempt count for FTS"),
+			gettext_noop("Used by the fts-probe process.")
+		},
+		&gp_fts_replication_attempt_count,
+		10, 0, 100,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"gp_gang_creation_retry_count", PGC_USERSET, GP_ARRAY_TUNING,
 			gettext_noop("After a gang-creation fails, retry the number of times if failure is retryable."),
 			gettext_noop("A value of zero disables retries."),

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -309,6 +309,7 @@ extern int	gp_fts_probe_retries; /* GUC var - specifies probe number of retries 
 extern int	gp_fts_probe_timeout; /* GUC var - specifies probe timeout for FTS */
 extern int	gp_fts_probe_interval; /* GUC var - specifies polling interval for FTS */
 extern int gp_fts_mark_mirror_down_grace_period;
+extern int	gp_fts_replication_attempt_count; /* GUC var - specifies replication max attempt count for FTS */
 
 extern int gp_gang_creation_retry_count; /* How many retries ? */
 extern int gp_gang_creation_retry_timer; /* How long between retries */

--- a/src/include/replication/gp_replication.h
+++ b/src/include/replication/gp_replication.h
@@ -17,6 +17,61 @@
 #include "fmgr.h"
 
 #include "postmaster/fts.h"
+#include "replication/walsender_private.h"
+#include "storage/shmem.h"
+#include "storage/spin.h"
+
+
+/*
+ * Each GPDB primary-mirror pair has a FTSReplicationStatus in shared memory.
+ *
+ * Mainly used to track replication process for FTS purpose.
+ *
+ * This struct is protected by its 'mutex' spinlock field. The walsender
+ * and FTS probe process will access this struct.
+ */
+typedef struct FTSReplicationStatus
+{
+	NameData    name;			/* The slot's identifier, ie. the replicaton application name */
+	slock_t		mutex;			/* lock, on same cacheline as effective_xmin */
+	bool		in_use;			/* is this slot defined */
+
+	/*
+	 * For GPDB FTS purpose, if the the primary, mirror replication keeps crash
+	 * continuously and attempt to create replication connection too many times,
+	 * FTS should mark the mirror down.
+	 * If the connection established, clear the attempt count to 0.
+	 * See more details in FTSGetReplicationDisconnectTime.
+	 */
+	uint32      con_attempt_count;
+
+	/*
+	 * Records time, either during initialization or due to disconnection.
+	 * This helps to detect time passed since mirror didn't connect.
+	 */
+	pg_time_t   replica_disconnected_at;
+} FTSReplicationStatus;
+
+typedef struct FTSReplicationStatusCtlData
+{
+	/*
+	 * This array should be declared [FLEXIBLE_ARRAY_MEMBER], but for some
+	 * reason you can't do that in an otherwise-empty struct.
+	 */
+	FTSReplicationStatus   replications[1];
+} FTSReplicationStatusCtlData;
+
+extern FTSReplicationStatusCtlData *FTSRepStatusCtl;
+
+extern Size FTSReplicationStatusShmemSize(void);
+extern void FTSReplicationStatusShmemInit(void);
+extern void FTSReplicationStatusCreateIfNotExist(const char *app_name);
+extern void FTSReplicationStatusDrop(const char* app_name);
+
+extern FTSReplicationStatus *RetrieveFTSReplicationStatus(const char *app_name, bool skip_warn);
+extern void FTSReplicationStatusUpdateForWalState(const char *app_name, WalSndState state);
+extern void FTSReplicationStatusMarkDisconnectForReplication(const char *app_name);
+extern pg_time_t FTSGetReplicationDisconnectTime(const char *app_name);
 
 extern void GetMirrorStatus(FtsResponse *response);
 extern void SetSyncStandbysDefined(void);

--- a/src/include/replication/walsender_private.h
+++ b/src/include/replication/walsender_private.h
@@ -68,12 +68,6 @@ typedef struct WalSnd
 	 */
 	XLogRecPtr	xlogCleanUpTo;
 
-	/*
-	 * Records time, either during initialization or due to disconnection.
-	 * This helps to detect time passed since mirror didn't connect.
-	 */
-	pg_time_t   replica_disconnected_at;
-
 	/* Protects shared variables shown above. */
 	slock_t		mutex;
 

--- a/src/include/storage/lwlock.h
+++ b/src/include/storage/lwlock.h
@@ -140,7 +140,8 @@ extern PGDLLIMPORT LWLockPadded *MainLWLockArray;
 #define RelfilenodeGenLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 8].lock)
 #define WorkFileManagerLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 9].lock)
 #define DistributedLogTruncateLock	(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 10].lock)
-#define GP_NUM_INDIVIDUAL_LWLOCKS		10
+#define FTSReplicationStatusLock	(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 11].lock)
+#define GP_NUM_INDIVIDUAL_LWLOCKS		11
 
 /*
  * It would probably be better to allocate separate LWLock tranches

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -192,6 +192,7 @@
 		"gp_fts_probe_interval",
 		"gp_fts_probe_retries",
 		"gp_fts_probe_timeout",
+		"gp_fts_replication_attempt_count",
 		"gp_gang_creation_retry_count",
 		"gp_gang_creation_retry_timer",
 		"gp_global_deadlock_detector_period",

--- a/src/test/isolation2/expected/segwalrep/replication_keeps_crash.out
+++ b/src/test/isolation2/expected/segwalrep/replication_keeps_crash.out
@@ -1,0 +1,122 @@
+-- Tests mark mirror down if replication walsender walreceiver keep
+-- crash continuously.
+--
+-- Primary and mirror both alive, but wal replication crash happens
+-- before start streaming data. And walsender, walreceiver keeps
+-- re-connect continuously, this may block other processes.
+-- GPDB will track the continuously failures for the replication.
+-- If the failure times exceed a limitation, FTS will mark the mirror down
+-- to avoid blocking other queries.
+-- More details please refer to FTSGetReplicationDisconnectTime.
+
+include: helpers/server_helpers.sql;
+CREATE
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
+-- modify fts gucs to speed up the test.
+1: alter system set gp_fts_probe_interval to 10;
+ALTER
+1: alter system set gp_fts_probe_retries to 1;
+ALTER
+1: alter system set gp_fts_replication_attempt_count to 3;
+ALTER
+1: select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+ role | preferred_role | content | mode | status 
+------+----------------+---------+------+--------
+ m    | m              | -1      | s    | u      
+ m    | m              | 0       | s    | u      
+ m    | m              | 1       | s    | u      
+ m    | m              | 2       | s    | u      
+ p    | p              | -1      | n    | u      
+ p    | p              | 0       | s    | u      
+ p    | p              | 1       | s    | u      
+ p    | p              | 2       | s    | u      
+(8 rows)
+
+-- Error out before walsender streaming data
+select gp_inject_fault_infinite('wal_sender_loop', 'error', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Should block in commit (SyncrepWaitForLSN()), waiting for commit
+-- LSN to be flushed on mirror.
+1&: create table mirror_block_t1 (a int) distributed by (a);  <waiting ...>
+
+-- trigger fts to mark mirror down.
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- After gp_fts_replication_attempt_count attempts mirror will be marked down, and syncrep will
+-- be marked off and hence the commit should get unblocked.
+-- Without gp_fts_replication_attempt_count mirror will continuously connect and re-connect and
+-- be in grace period to not be marked down.
+1<:  <... completed>
+CREATE
+
+-- expect: to see the content 0, mirror is mark down
+select content, preferred_role, role, status, mode from gp_segment_configuration where content = 0;
+ content | preferred_role | role | status | mode 
+---------+----------------+------+--------+------
+ 0       | p              | p    | u      | n    
+ 0       | m              | m    | d      | n    
+(2 rows)
+
+select gp_inject_fault('wal_sender_loop', 'reset', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- -- now, let's recover the mirror
+!\retcode gprecoverseg -a  --no-progress;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+ role | preferred_role | content | mode | status 
+------+----------------+---------+------+--------
+ m    | m              | -1      | s    | u      
+ m    | m              | 0       | s    | u      
+ m    | m              | 1       | s    | u      
+ m    | m              | 2       | s    | u      
+ p    | p              | -1      | n    | u      
+ p    | p              | 0       | s    | u      
+ p    | p              | 1       | s    | u      
+ p    | p              | 2       | s    | u      
+(8 rows)
+
+drop table mirror_block_t1;
+DROP
+
+1: alter system reset gp_fts_probe_interval;
+ALTER
+1: alter system reset gp_fts_probe_retries;
+ALTER
+1: alter system reset gp_fts_replication_attempt_count;
+ALTER
+1: select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -187,6 +187,7 @@ test: segwalrep/die_commit_pending_replication
 
 # Tests for FTS
 test: fts_errors
+test: segwalrep/replication_keeps_crash
 test: segwalrep/commit_blocking
 test: segwalrep/fts_unblock_primary
 test: segwalrep/recoverseg_from_file

--- a/src/test/isolation2/sql/segwalrep/replication_keeps_crash.sql
+++ b/src/test/isolation2/sql/segwalrep/replication_keeps_crash.sql
@@ -1,0 +1,62 @@
+-- Tests mark mirror down if replication walsender walreceiver keep
+-- crash continuously.
+--
+-- Primary and mirror both alive, but wal replication crash happens
+-- before start streaming data. And walsender, walreceiver keeps
+-- re-connect continuously, this may block other processes.
+-- GPDB will track the continuously failures for the replication.
+-- If the failure times exceed a limitation, FTS will mark the mirror down
+-- to avoid blocking other queries.
+-- More details please refer to FTSGetReplicationDisconnectTime.
+
+include: helpers/server_helpers.sql;
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+-- modify fts gucs to speed up the test.
+1: alter system set gp_fts_probe_interval to 10;
+1: alter system set gp_fts_probe_retries to 1;
+1: alter system set gp_fts_replication_attempt_count to 3;
+1: select pg_reload_conf();
+
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+
+-- Error out before walsender streaming data
+select gp_inject_fault_infinite('wal_sender_loop', 'error', dbid)
+       from gp_segment_configuration where content=0 and role='p';
+
+-- Should block in commit (SyncrepWaitForLSN()), waiting for commit
+-- LSN to be flushed on mirror.
+1&: create table mirror_block_t1 (a int) distributed by (a);
+
+-- trigger fts to mark mirror down.
+select gp_request_fts_probe_scan();
+
+-- After gp_fts_replication_attempt_count attempts mirror will be marked down, and syncrep will
+-- be marked off and hence the commit should get unblocked.
+-- Without gp_fts_replication_attempt_count mirror will continuously connect and re-connect and
+-- be in grace period to not be marked down.
+1<:
+
+-- expect: to see the content 0, mirror is mark down
+select content, preferred_role, role, status, mode
+from gp_segment_configuration
+where content = 0;
+
+select gp_inject_fault('wal_sender_loop', 'reset', dbid)
+       from gp_segment_configuration where content=0 and role='p';
+
+-- -- now, let's recover the mirror
+!\retcode gprecoverseg -a  --no-progress;
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+
+SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
+
+drop table mirror_block_t1;
+
+1: alter system reset gp_fts_probe_interval;
+1: alter system reset gp_fts_probe_retries;
+1: alter system reset gp_fts_replication_attempt_count;
+1: select pg_reload_conf();


### PR DESCRIPTION
For GPDB FTS, if the primary, mirror replication keeps crash
continuously and attempt to crate replication connection too many times,
FTS should mark the mirror down. Otherwise, it may block other
processes.
If the WAL starts streaming, clear the attempt count to 0. This is because the blocked
transaction can only be released once the WAL in streaming state.

The solution for this is:

1. Use ` FTSReplicationStatus` which under `gp_replication.c`  to track current primary-mirror
replication status. This includes:
    - A continuous failure counter. The counter gets reset once the replication
    starts streaming, or replication restarted.
    - A record of the last disconnect timestamp which is refactored from
    `WalSnd` slot.
    The reason for moving this is: When FTS probe happens, the `WalSnd`
    slot may already get freed. And `WalSnd` slot is designed reusable.
    It's hacky to read value from a freed slot in shared memory.

2. When handling each probe query, `GetMirrorStatus` will check the current
mirror status and the failure count from walsender's application ` FTSReplicationStatus`.
If the count exceeds the limit, the retry test will ignore the last replication
disconnect time since it gets refreshed when new walsender starts. (Since
in the current case, the walsender keeps restart.)

3. On FTS bgworker. If mirror down and retry set to false, mark the mirror
down.

A `gp_fts_replication_attempt_count` GUC is added. When the replication failure count
exceed this GUC, ignore the last replication disconnect time when checking for mirror
probe retry.

The life cycle of a ` FTSReplicationStatus`:
1. It gets created when first enable replication during the replication
start phase. Each replication's sender should have a unique
`application_name`, which also used to specify the replication priority
in multi-mirror env. So ` FTSReplicationStatus` uses the `application_name` mark
itself.

2. The ` FTSReplicationStatus` for replication will exist until FTS detects
failure and stop the replication between primary and mirror. Then
` FTSReplicationStatus` for that `application_name` will be dropped.

Now the `FTSReplicationStatus` is used only for GPDB primary-mirror replication.

(cherry picked from commit 252ba888e70adeb0767dc812fab31888d35cba21)

Reviewed-by: Ashwin Agrawal <aagrawal@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
