### PR TITLE
Conditionally set the PYTHONHOME in greenplum-path.sh

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -350,7 +350,6 @@ define BUILD_STEPS
 	else \
 	  cd $(BUILDDIR) && $(MAKE) $(PARALLEL_MAKE_OPTS) install; \
 	fi \
-	#@$(MAKE) greenplum_path INSTLOC=$(INSTLOC)
 	#@$(MAKE) mgmtcopy INSTLOC=$(INSTLOC)
 	@$(MAKE) mkpgbouncer INSTLOC=$(INSTLOC) BUILDDIR=$(BUILDDIR)
 	@$(MAKE) mkpgbench INSTLOC=$(INSTLOC) BUILDDIR=$(BUILDDIR)
@@ -360,6 +359,7 @@ define BUILD_STEPS
 	fi
 	@$(MAKE) copydocs INSTLOC=$(INSTLOC)
 	@$(MAKE) copylibs INSTLOC=$(INSTLOC)
+	@$(MAKE) greenplum_path INSTLOC=$(INSTLOC)
 	@$(MAKE) clients INSTLOC=$(INSTLOC) CLIENTINSTLOC=$(CLIENTINSTLOC)
 	@$(MAKE) set_scripts_version INSTLOC=$(CLIENTINSTLOC)
 	@$(MAKE) loaders INSTLOC=$(INSTLOC) LOADERSINSTLOC=$(LOADERSINSTLOC)
@@ -1057,8 +1057,7 @@ endif
 
 greenplum_path:
 	mkdir -p $(INSTLOC)
-	unset LIBPATH; \
-	  releng/generate-greenplum-path.sh $(INSTLOC) > $(INSTLOC)/greenplum_path.sh
+	$(BUILDDIR)/gpMgmt/bin/generate-greenplum-path.sh $(INSTLOC) yes > $(INSTLOC)/greenplum_path.sh
 
 copylicense:
 	for proddir in $(INSTLOC) $(CLIENTINSTLOC) $(LOADERSINSTLOC); do \

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -276,6 +276,7 @@ solarisTest:
 
 .PHONY: installcheck-bash
 installcheck-bash:
+	./test-generate-greenplum-path.bash
 	./test/suite.bash
 
 .PHONY: installcheck

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -5,13 +5,15 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
+SET_PYTHONHOME="${2:-no}"
+
 GPHOME_PATH="$1"
 cat <<EOF
 GPHOME="${GPHOME_PATH}"
 
 EOF
 
-if [ -x "${PYTHONHOME}/bin/python" ]; then
+if [ "${SET_PYTHONHOME}" = "yes" ]; then
 	cat <<-"EOF"
 	PYTHONHOME="${GPHOME}/ext/python"
 	export PYTHONHOME

--- a/gpMgmt/bin/test-generate-greenplum-path.bash
+++ b/gpMgmt/bin/test-generate-greenplum-path.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "set GPHOME with first argument"
+./generate-greenplum-path.sh /foo | grep -q 'GPHOME="/foo"'
+
+echo "set PYTHONHOME if second argument is 'yes'"
+./generate-greenplum-path.sh /foo yes | grep -q 'PYTHONHOME="${GPHOME}/ext/python"'
+
+echo "do not set PYTHONHOME if second argument is not 'yes'"
+[ $(./generate-greenplum-path.sh /foo no | grep -c PYTHONHOME) -eq 0 ]
+
+echo "do not set PYTHONHOME if second argument is missing"
+[ $(./generate-greenplum-path.sh /foo | grep -c PYTHONHOME) -eq 0 ]
+
+echo "error out if no argument is given"
+if ./generate-greenplum-path.sh; then
+  echo "should not have passed"
+  exit 1
+fi
+./generate-greenplum-path.sh | grep -q "Must specify a value for GPHOME"
+
+echo "ALL TEST PASSED"


### PR DESCRIPTION
- generate-greenplum-path.sh use second parameter yes to generate
  PYTHONHOME
- ONLY gpAux need to run this script with second parameter yes, since
  in GPDB5 we always vendor python.
- developer build on their box won't be impacted by this change, since
  regular build doesn't have second parameter, hence PYTHONHOME will be
  skipped.
- We added test-generate-greeplum-path.bash to verify the correctness of
the script.

Note: This PR is related to PR https://github.com/greenplum-db/gpdb/pull/10409

[#173567726]

Authored-by: Tingfang Bao <baotingfang@gmail.com>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
