### PR TITLE
gpcheckcat: add the check of vpinfo consistency

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2425,6 +2425,90 @@ def checkTableMissingEntry(cat):
         myprint(qry)
 
 
+class checkAOSegVpinfoThread(execThread):
+    def __init__(self, cfg, db):
+        execThread.__init__(self, cfg, db, None)
+
+    def run(self):
+        aoseg_query = """
+           SELECT a.relname, a.relid, a.segrelid, cl.relname
+           FROM (SELECT p.relid, p.segrelid, c.relname FROM pg_appendonly p LEFT JOIN pg_class c ON p.relid = c.oid WHERE p.columnstore = true) a
+           LEFT JOIN pg_class cl ON a.segrelid = cl.oid;
+        """
+
+        try:
+            # Read the list of aoseg tables from the database
+            curs = self.db.query(aoseg_query)
+
+            for relname, relid, segrelid, segrelname in curs.getresult():
+                qry = "SELECT count(*) FROM pg_attribute WHERE attrelid=%d AND attnum > 0;" % (relid)
+                attr_count = self.db.query(qry).single()[0]
+
+                qry = "SELECT distinct(length(vpinfo)) FROM pg_aoseg.%s where xmax = 0;" % (segrelname)
+                vpinfo_curs = self.db.query(qry)
+                nrows = len(vpinfo_curs)
+                if nrows == 0:
+                    continue
+                elif nrows > 1:
+                    GV.checkStatus = False
+                    setError(ERROR_NOREPAIR)
+                    logger.info('[FAIL] inconsistent vpinfo')
+                    logger.error("found {nrows} vpinfo(s) with different length in 'pg_aoseg.{segrelname}' of table '{relname}' on segment {content}"
+                                 .format(nrows = nrows,
+                                         segrelname = segrelname,
+                                         relname = relname,
+                                         content = self.cfg['content']))
+                    logger.error(qry)
+                    continue
+
+                vpinfo_length = vpinfo_curs.single()[0]
+
+                # vpinfo is bytea type, the length of the first 3 fields is 12 bytes, and the size of AOCSVPInfoEntry is 16
+                # typedef struct AOCSVPInfo
+                # {
+                # 	int32		_len;
+                # 	int32		version;
+                # 	int32		nEntry;
+                #
+                # 	AOCSVPInfoEntry entry[1];
+                # } AOCSVPInfo;
+                vpinfo_attr_count = (vpinfo_length - 12) / 16
+                if vpinfo_attr_count != attr_count:
+                    GV.checkStatus = False
+                    setError(ERROR_NOREPAIR)
+                    logger.info('[FAIL] inconsistent vpinfo')
+                    logger.error("vpinfo in 'pg_aoseg.{segrelname}' of table '{relname}' contains {vpinfo_attr_count} attributes, while pg_attribute has {attr_count} attributes on segment {content}"
+                                 .format(segrelname = segrelname,
+                                         relname = relname,
+                                         vpinfo_attr_count = vpinfo_attr_count,
+                                         attr_count = attr_count,
+                                         content = self.cfg['content']))
+                    logger.error(qry)
+        except Exception, e:
+            GV.checkStatus = False
+            self.error = e
+
+def checkAOSegVpinfo():
+    threads = []
+    i = 1
+    # parallelise check
+    for dbid in GV.cfg:
+        cfg = GV.cfg[dbid]
+        db_connection = connect2(cfg)
+        thread = checkAOSegVpinfoThread(cfg, db_connection)
+        thread.start()
+        logger.debug('launching check thread %s for dbid %i' %
+                     (thread.getName(), dbid))
+        threads.append(thread)
+
+        if (i % GV.opt['-B']) == 0:
+            processThread(threads)
+            threads = []
+
+        i += 1
+
+    processThread(threads)
+
 # -------------------------------------------------------------------------------
 
 # Exclude these tuples from the catalog table scan
@@ -2969,6 +3053,14 @@ all_checks = {
             "order": 14,
             "online": True
         },
+    "aoseg_table":
+        {
+            "description": "Check that vpinfo in aoseg table is consistent with pg_attribute",
+            "fn": lambda: checkAOSegVpinfo(),
+            "version": 'main',
+            "order": 15,
+            "online": False
+        }
 }
 
 

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -498,6 +498,16 @@ Feature: gpcheckcat tests
           And the user runs "dropdb gpcheckcat_orphans"
           And the path "repair_dir" is removed from current working directory
 
+    Scenario: gpcheckcat should report vpinfo inconsistent error 
+        Given database "vpinfo_inconsistent_db" is dropped and recreated
+        And there is a "co" table "public.co_vpinfo" in "vpinfo_inconsistent_db" with data
+        When the user runs "gpcheckcat vpinfo_inconsistent_db"
+        Then gpcheckcat should return a return code of 0
+        When an attribute of table "co_vpinfo" in database "vpinfo_inconsistent_db" is deleted on segment with content id "0"
+        Then psql should return a return code of 0
+        When the user runs "gpcheckcat -R aoseg_table vpinfo_inconsistent_db" 
+        Then gpcheckcat should print "Failed test\(s\) that are not reported here: aoseg_table" to stdout
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1623,6 +1623,7 @@ def impl(context, filename):
 
 
 @then('an attribute of table "{table}" in database "{dbname}" is deleted on segment with content id "{segid}"')
+@when('an attribute of table "{table}" in database "{dbname}" is deleted on segment with content id "{segid}"')
 def impl(context, table, dbname, segid):
     local_cmd = 'psql %s -t -c "SELECT port,hostname FROM gp_segment_configuration WHERE content=%s and role=\'p\';"' % (
     dbname, segid)


### PR DESCRIPTION
column 'vpinfo' in pg_aoseg.pg_aocsseg_xxx record the 'eof' of each attribute
in the AOCS table, the number of attributes in 'vpinfo' should be the same as
the number of attributes in 'pg_attribute'

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
