### PR TITLE
Correct plan of general & segmentGeneral path with volatiole functions.

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -2389,6 +2389,13 @@ create_motion_path_for_upddel(PlannerInfo *root, Index rti, GpPolicy *policy,
 	}
 	else if (policyType == POLICYTYPE_REPLICATED)
 	{
+		/*
+		 * The statement that update or delete on replicated table has to
+		 * be dispatched to each segment and executed on each segment. Thus
+		 * the targetlist cannot contain volatile functions.
+		 */
+		if (contain_volatile_functions((Node *) (subpath->pathtarget->exprs)))
+			elog(ERROR, "could not devise a plan.");
 	}
 	else
 		elog(ERROR, "unrecognized policy type %u", policyType);
@@ -2493,6 +2500,58 @@ create_split_update_path(PlannerInfo *root, Index rti, GpPolicy *policy, Path *s
 	return subpath;
 }
 
+/*
+ * turn_volatile_seggen_to_singleqe
+ *
+ * This function is the key tool to build correct plan
+ * for general or segmentgeneral locus paths that contain
+ * volatile functions.
+ *
+ * If we find such a pattern:
+ *    1. if we are update or delete statement on replicated table
+ *       simply reject the query
+ *    2. if it is general locus, simply change it to singleQE
+ *    3. if it is segmentgeneral, use a motion to bring it to
+ *       singleQE and then create a projection path
+ *
+ * If we do not find the pattern, simply return the input path.
+ *
+ * The last parameter of this function is the part that we want to
+ * check volatile functions.
+ */
+Path *
+turn_volatile_seggen_to_singleqe(PlannerInfo *root, Path *path, Node *node)
+{
+	if ((CdbPathLocus_IsSegmentGeneral(path->locus) || CdbPathLocus_IsGeneral(path->locus)) &&
+		(contain_volatile_functions(node) || IsA(path, LimitPath)))
+	{
+		CdbPathLocus     singleQE;
+		Path            *mpath;
+		ProjectionPath  *ppath;
+
+		if (root->upd_del_replicated_table > 0 &&
+			bms_is_member(root->upd_del_replicated_table,
+						  path->parent->relids))
+			elog(ERROR, "could not devise a plan");
+
+		if (CdbPathLocus_IsGeneral(path->locus))
+		{
+			CdbPathLocus_MakeSingleQE(&(path->locus),
+									  getgpsegmentCount());
+			return path;
+		}
+
+		CdbPathLocus_MakeSingleQE(&singleQE,
+								  CdbPathLocus_NumSegments(path->locus));
+		mpath = cdbpath_create_motion_path(root, path, NIL, false, singleQE);
+		ppath =  create_projection_path_with_quals(root, mpath->parent, mpath,
+												   mpath->pathtarget, NIL, false);
+		ppath->force = true;
+		return (Path *) ppath;
+	}
+	else
+		return path;
+}
 
 static SplitUpdatePath *
 make_splitupdate_path(PlannerInfo *root, Path *subpath, Index rti)

--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -690,14 +690,36 @@ cdbpathlocus_join(JoinType jointype, CdbPathLocus a, CdbPathLocus b)
 	 * If one rel is replicated, result stays with the other rel,
 	 * but need to ensure the result is on the common segments.
 	 */
-	if (CdbPathLocus_IsSegmentGeneral(a) ||
-		CdbPathLocus_IsReplicated(a))
+	if (CdbPathLocus_IsReplicated(a))
 	{
 		b.numsegments = CdbPathLocus_CommonSegments(a, b);
 		return b;
 	}
-	if (CdbPathLocus_IsSegmentGeneral(b) ||
-		CdbPathLocus_IsReplicated(b))
+	if (CdbPathLocus_IsReplicated(b))
+	{
+		a.numsegments = CdbPathLocus_CommonSegments(a, b);
+		return a;
+	}
+
+	/*
+	 * If one rel is segmentgeneral, result stays with the other rel,
+	 * but need to ensure the result is on the common segments.
+	 *
+	 * NB: the code check SegmentGeneral and replicated is quite similar,
+	 * but we have to put check-segmentgeneral below. Consider one
+	 * is segmentgeneral and the other is replicated, only by this order
+	 * we can be sure that this function never return a locus of
+	 * Replicated.
+	 * update a replicated table join with a partitioned locus table will
+	 * reach here.
+	 */
+
+	if (CdbPathLocus_IsSegmentGeneral(a))
+	{
+		b.numsegments = CdbPathLocus_CommonSegments(a, b);
+		return b;
+	}
+	if (CdbPathLocus_IsSegmentGeneral(b))
 	{
 		a.numsegments = CdbPathLocus_CommonSegments(a, b);
 		return a;

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -1533,6 +1533,7 @@ create_projection_plan(PlannerInfo *root, ProjectionPath *best_path)
 	 * not using.)
 	 */
 	if (!best_path->cdb_restrict_clauses &&
+		!best_path->force &&
 		(is_projection_capable_path(best_path->subpath) ||
 		 tlist_same_exprs(tlist, subplan->targetlist)))
 	{

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -1124,6 +1124,18 @@ contain_volatile_functions_walker(Node *node, void *context)
 {
 	if (node == NULL)
 		return false;
+
+	/*
+	 * We need to handle RestrictInfo, a case that uses this
+	 * is that replicated table with a volatile restriction.
+	 * We have to find the pattern and turn it into singleQE.
+	 */
+	if (IsA(node, RestrictInfo))
+	{
+		RestrictInfo * info = (RestrictInfo *) node;
+		return contain_volatile_functions_walker((Node*)info->clause, context);
+	}
+
 	/* Check for volatile functions in node itself */
 	if (check_functions_in_node(node, contain_volatile_functions_checker,
 								context))

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3389,7 +3389,26 @@ create_nestloop_path(PlannerInfo *root,
 												 rowidexpr_id);
 	}
 
-	return (Path *) pathnode;
+	/*
+	 * Greenplum specific behavior:
+	 * If we find the join locus is general or segmentgeneral,
+	 * we should check the joinqual, if it contains volatile functions
+	 * we have to turn the join path to singleQE.
+	 *
+	 * NB: we do not add this logic in the above create_unique_rowid_path
+	 * code block, the reason is:
+	 *   create_unique_rowid_path is a technique to implement semi join
+	 *   using normal join, it can only happens for sublink query:
+	 *   1. if the sublink query contains volatile target list or havingQual
+	 *      it cannot be pulled up in pull_up_subquery, so it will be a
+	 *      subselect and be handled in the function set_subquery_pathlist
+	 *   2. if the sublink query contains volatile functions in joinqual
+	 *      or where clause, it will be handled in set_rel_pathlist and
+	 *      here.
+	 */
+	return turn_volatile_seggen_to_singleqe(root,
+											(Path *) pathnode,
+											(Node *) (pathnode->joinrestrictinfo));
 }
 
 /*
@@ -3561,8 +3580,13 @@ create_mergejoin_path(PlannerInfo *root,
 												 pathnode->jpath.innerjoinpath->parent->relids,
 												 rowidexpr_id);
 	}
-	else
-		return (Path *) pathnode;
+
+	/*
+	 * See the comments at the end of create_nestloop_path.
+	 */
+	return turn_volatile_seggen_to_singleqe(root,
+											(Path *) pathnode,
+											(Node *) (pathnode->jpath.joinrestrictinfo));
 }
 
 /*
@@ -3713,8 +3737,13 @@ create_hashjoin_path(PlannerInfo *root,
 												 pathnode->jpath.innerjoinpath->parent->relids,
 												 rowidexpr_id);
 	}
-	else
-		return (Path *) pathnode;
+
+	/*
+	 * See the comments at the end of create_nestloop_path.
+	 */
+	return turn_volatile_seggen_to_singleqe(root,
+											(Path *) pathnode,
+											(Node *) (pathnode->jpath.joinrestrictinfo));
 }
 
 /*
@@ -4914,8 +4943,12 @@ adjust_modifytable_subpaths(PlannerInfo *root, CmdType operation,
  * 'limitCount' is the actual LIMIT expression, or NULL
  * 'offset_est' is the estimated value of the OFFSET expression
  * 'count_est' is the estimated value of the LIMIT expression
+ *
+ * Greenplum specific change: the return type is changed to Path
+ * because at the end of function, we need to check if it is
+ * segment general locus and may create other kind of path.
  */
-LimitPath *
+Path *
 create_limit_path(PlannerInfo *root, RelOptInfo *rel,
 				  Path *subpath,
 				  Node *limitOffset, Node *limitCount,
@@ -4993,7 +5026,12 @@ create_limit_path(PlannerInfo *root, RelOptInfo *rel,
 			pathnode->path.rows = 1;
 	}
 
-	return pathnode;
+	/*
+	 * Greenplum specific behavior:
+	 * If the limit path's locus is general or segmentgeneral
+	 * we have to make it singleQE.
+	 */
+	return turn_volatile_seggen_to_singleqe(root, (Path *) pathnode, NULL);
 }
 
 

--- a/src/include/cdb/cdbpath.h
+++ b/src/include/cdb/cdbpath.h
@@ -59,5 +59,6 @@ cdbpath_motion_for_join(PlannerInfo    *root,
                         bool            inner_require_existing_order);
 
 extern bool cdbpath_contains_wts(Path *path);
+extern Path * turn_volatile_seggen_to_singleqe(PlannerInfo *root, Path *path, Node *node);
 
 #endif   /* CDBPATH_H */

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -1622,6 +1622,12 @@ typedef struct ProjectionPath
 	Path	   *subpath;		/* path representing input source */
 	bool		dummypp;		/* true if no separate Result is needed */
 
+	/*
+	 * Greenplum specific field:
+	 * If force is true, we always create a Result plannode.
+	 */
+	bool        force;
+
 	List	   *cdb_restrict_clauses;
 
 	/*

--- a/src/include/optimizer/pathnode.h
+++ b/src/include/optimizer/pathnode.h
@@ -282,10 +282,10 @@ extern ModifyTablePath *create_modifytable_path(PlannerInfo *root,
 						List *is_split_updates,
 						List *rowMarks, OnConflictExpr *onconflict,
 						int epqParam);
-extern LimitPath *create_limit_path(PlannerInfo *root, RelOptInfo *rel,
-				  Path *subpath,
-				  Node *limitOffset, Node *limitCount,
-				  int64 offset_est, int64 count_est);
+extern Path *create_limit_path(PlannerInfo *root, RelOptInfo *rel,
+							   Path *subpath,
+							   Node *limitOffset, Node *limitCount,
+							   int64 offset_est, int64 count_est);
 
 extern Path *reparameterize_path(PlannerInfo *root, Path *path,
 					Relids required_outer,

--- a/src/test/regress/expected/bfv_planner_optimizer.out
+++ b/src/test/regress/expected/bfv_planner_optimizer.out
@@ -404,16 +404,16 @@ explain (costs off)
 select * from
 (select a from generate_series(1, 10)a) x, t_hashdist
 where x.a > random();
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
+         Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  Function Scan on generate_series a
-                           Filter: ((a)::double precision > random())
- Optimizer: Postgres query optimizer
+         ->  Result
+               Filter: ((generate_series.generate_series)::double precision > random())
+               ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 ---- join qual
@@ -422,46 +422,47 @@ t_hashdist,
 (select a from generate_series(1, 10) a) x,
 (select a from generate_series(1, 10) a) y
 where x.a + y.a > random();
-                             QUERY PLAN                              
----------------------------------------------------------------------
- Nested Loop
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
-         Join Filter: (((a.a + a_1.a))::double precision > random())
-         ->  Function Scan on generate_series a
-         ->  Function Scan on generate_series a_1
-   ->  Materialize
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               ->  Seq Scan on t_hashdist
- Optimizer: Postgres query optimizer
+         Join Filter: true
+         ->  Seq Scan on t_hashdist
+         ->  Nested Loop
+               Join Filter: (((generate_series_1.generate_series + generate_series.generate_series))::double precision > random())
+               ->  Function Scan on generate_series generate_series_1
+               ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
 ---- sublink & subquery
 explain (costs off) select * from t_hashdist where a > All (select random() from generate_series(1, 10));
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Nested Loop Left Anti Semi (Not-In) Join
-         Join Filter: ((t_hashdist.a)::double precision <= "NotIn_SUBQUERY".random)
+                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  Subquery Scan on "NotIn_SUBQUERY"
-                           ->  Function Scan on generate_series
- Optimizer: Postgres query optimizer
-(9 rows)
+   SubPlan 1
+     ->  Result
+           Filter: ((CASE WHEN (sum((CASE WHEN ((t_hashdist.a)::double precision <= random()) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (random() IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN ((t_hashdist.a)::double precision IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN ((t_hashdist.a)::double precision <= random()) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+           ->  Aggregate
+                 ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
 
 explain (costs off) select * from t_hashdist where a in (select random()::int from generate_series(1, 10));
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                        QUERY PLAN                        
+----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Semi Join
-         Hash Cond: (t_hashdist.a = ((random())::integer))
+         Hash Cond: (t_hashdist.a = (int4(random())))
          ->  Seq Scan on t_hashdist
          ->  Hash
-               ->  Redistribute Motion 1:3  (slice2; segments: 1)
-                     Hash Key: ((random())::integer)
+               ->  Redistribute Motion 1:3  (slice2)
+                     Hash Key: (int4(random()))
                      ->  Function Scan on generate_series
- Optimizer: Postgres query optimizer
+ Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
 -- subplan
@@ -488,80 +489,85 @@ t_hashdist left join (select a from generate_series(1, 10) a) x on t_hashdist.a 
                Output: a.a
                Function Call: generate_series(1, 10)
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=on
 (20 rows)
 
 -- targetlist
 explain (costs off) select * from t_hashdist cross join (select random () from generate_series(1, 10))x;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)
+               ->  Seq Scan on t_hashdist
+         ->  Materialize
+               ->  Result
+                     One-Time Filter: (gp_execution_segment() = 2)
+                     ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+explain (costs off) select * from t_hashdist cross join (select a, sum(random()) from generate_series(1, 10) a group by a) x;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice3; segments: 3)
+               ->  Seq Scan on t_hashdist
+         ->  Materialize
+               ->  Redistribute Motion 1:3  (slice2)
+                     ->  HashAggregate
+                           Group Key: generate_series.generate_series
+                           ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+explain (costs off) select * from t_hashdist cross join (select random() as k, sum(a) from generate_series(1, 10) a group by k) x;
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
-         ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
+         Join Filter: true
+         ->  HashAggregate
+               Group Key: (random())
+               ->  Redistribute Motion 1:3  (slice3)
+                     Hash Key: (random())
                      ->  Function Scan on generate_series
- Optimizer: Postgres query optimizer
-(7 rows)
-
-explain (costs off) select * from t_hashdist cross join (select a, sum(random()) from generate_series(1, 10) a group by a) x;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Nested Loop
-         ->  Seq Scan on t_hashdist
          ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  HashAggregate
-                           Group Key: a.a
-                           ->  Function Scan on generate_series a
- Optimizer: Postgres query optimizer
-(9 rows)
-
-explain (costs off) select * from t_hashdist cross join (select random() as k, sum(a) from generate_series(1, 10) a group by k) x;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Nested Loop
-         ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  HashAggregate
-                           Group Key: random()
-                           ->  Function Scan on generate_series a
- Optimizer: Postgres query optimizer
-(9 rows)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on t_hashdist
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 explain (costs off) select * from t_hashdist cross join (select a, count(1) as s from generate_series(1, 10) a group by a having count(1) > random() order by a) x ;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
+         Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  GroupAggregate
-                           Group Key: a.a
-                           Filter: ((count(1))::double precision > random())
-                           ->  Sort
-                                 Sort Key: a.a
-                                 ->  Function Scan on generate_series a
- Optimizer: Postgres query optimizer
-(12 rows)
+         ->  Result
+               Filter: (((count(1)))::double precision > random())
+               ->  HashAggregate
+                     Group Key: generate_series.generate_series
+                     ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
 
 -- limit
 explain (costs off) select * from t_hashdist cross join (select * from generate_series(1, 10) limit 1) x;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                     QUERY PLAN                     
+----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
+         Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  Limit
-                           ->  Function Scan on generate_series
- Optimizer: Postgres query optimizer
-(8 rows)
+         ->  Limit
+               ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 -- start_ignore
 drop table if exists bfv_planner_x;

--- a/src/test/regress/expected/insert_conflict.out
+++ b/src/test/regress/expected/insert_conflict.out
@@ -771,3 +771,20 @@ select * from twoconstraints;
 
 drop table twoconstraints;
 -- end_ignore
+-- check that modification of replicated tables containing volatile functions is not supported.
+create table rpt_volatile(i int unique) distributed replicated;
+insert into rpt_volatile select i from generate_series(10,20)i;
+-- this should fail
+insert into rpt_volatile as m select x from generate_series(5, 15)x
+  on conflict (i) do update
+  set i = m.i*20 + 5 * random();
+ERROR:  modification of replicated tables containing volatile functions in OnConflictUpdate is not supported
+insert into rpt_volatile as m select x from generate_series(5, 15)x
+  on conflict (i) do update
+  set i = m.i + 20 where m.i > 12 * random();
+ERROR:  modification of replicated tables containing volatile functions in OnConflictUpdate is not supported
+-- this should work
+insert into rpt_volatile as m select x from generate_series(5, 15)x
+  on conflict (i) do update
+  set i = m.i + 20;
+drop table rpt_volatile;

--- a/src/test/regress/expected/qp_functions_in_subquery.out
+++ b/src/test/regress/expected/qp_functions_in_subquery.out
@@ -3360,25 +3360,25 @@ PL/pgSQL function func2_mod_int_stb(integer) line 3 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_110.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
-CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
-PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  query plan with multiple segworker groups is not supported
+HINT:  likely caused by a function that reads or modifies data in a distributed table
+CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_113.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
-CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
-PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  query plan with multiple segworker groups is not supported
+HINT:  likely caused by a function that reads or modifies data in a distributed table
+CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_116.sql
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
-CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
-PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  query plan with multiple segworker groups is not supported
+HINT:  likely caused by a function that reads or modifies data in a distributed table
+CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 -- @description function_in_subqry_withfunc2_118.sql
 begin;
 SELECT * FROM foo, (SELECT func1_read_setint_sql_vol(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  function cannot execute on a QE slice because it accesses relation "qp_funcs_in_subquery.bar"  (seg0 slice1 127.0.1.1:7002 pid=27185)
-CONTEXT:  SQL statement "SELECT d FROM bar WHERE c <> $1"
-PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
+ERROR:  query plan with multiple segworker groups is not supported
+HINT:  likely caused by a function that reads or modifies data in a distributed table
+CONTEXT:  PL/pgSQL function func1_read_setint_sql_vol(integer) line 5 at FOR over SELECT rows
 rollback;
 -- @description function_in_subqry_withfunc2_119.sql
 begin;
@@ -3683,28 +3683,32 @@ rollback;
 -- @description function_in_subqry_withfunc2_150.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_nosql_vol(5))) r order by 1,2,3;
-ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
+ERROR:  query plan with multiple segworker groups is not supported
+HINT:  likely caused by a function that reads or modifies data in a distributed table
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_153.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_sql_int_vol(5))) r order by 1,2,3;
-ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
+ERROR:  query plan with multiple segworker groups is not supported
+HINT:  likely caused by a function that reads or modifies data in a distributed table
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_156.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_read_int_vol(5))) r order by 1,2,3;
-ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
+ERROR:  query plan with multiple segworker groups is not supported
+HINT:  likely caused by a function that reads or modifies data in a distributed table
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;
 -- @description function_in_subqry_withfunc2_158.sql
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_vol(func2_mod_int_vol(5))) r order by 1,2,3;
-ERROR:  function cannot execute on a QE slice because it issues a non-SELECT statement  (seg0 slice1 127.0.1.1:7002 pid=27185)
+ERROR:  query plan with multiple segworker groups is not supported
+HINT:  likely caused by a function that reads or modifies data in a distributed table
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c > $1"
 PL/pgSQL function func1_mod_setint_vol(integer) line 5 at SQL statement
 rollback;

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -708,67 +708,58 @@ create table t_hashdist(a int, b int, c int) distributed by (a);
 create table t_replicate_volatile(a int, b int, c int) distributed replicated;
 ---- pushed down filter
 explain (costs off) select * from t_replicate_volatile, t_hashdist where t_replicate_volatile.a > random();
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                        QUERY PLAN                        
+----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
+         Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  Result
-                           ->  Seq Scan on t_replicate_volatile
-                                 Filter: ((a)::double precision > random())
- Optimizer: Postgres query optimizer
-(9 rows)
+         ->  Seq Scan on t_replicate_volatile
+               Filter: ((a)::double precision > random())
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 -- join qual
 explain (costs off) select * from t_hashdist, t_replicate_volatile x, t_replicate_volatile y where x.a + y.a > random();
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Nested Loop
-   ->  Result
-         ->  Gather Motion 1:1  (slice1; segments: 1)
-               ->  Nested Loop
-                     Join Filter: (((x.a + y.a))::double precision > random())
-                     ->  Seq Scan on t_replicate_volatile x
-                     ->  Materialize
-                           ->  Seq Scan on t_replicate_volatile y
-   ->  Materialize
-         ->  Gather Motion 3:1  (slice2; segments: 3)
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: (((t_replicate_volatile_1.a + t_replicate_volatile.a))::double precision > random())
+         ->  Nested Loop
+               Join Filter: true
                ->  Seq Scan on t_hashdist
- Optimizer: Postgres query optimizer
-(12 rows)
+               ->  Seq Scan on t_replicate_volatile t_replicate_volatile_1
+         ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 -- sublink & subquery
 explain (costs off) select * from t_hashdist where a > All (select random() from t_replicate_volatile);
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Nested Loop Left Anti Semi (Not-In) Join
-         Join Filter: ((t_hashdist.a)::double precision <= "NotIn_SUBQUERY".random)
-         ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  Result
-                           ->  Subquery Scan on "NotIn_SUBQUERY"
-                                 ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
-(10 rows)
+   ->  Seq Scan on t_hashdist
+         Filter: (SubPlan 1)
+         SubPlan 1
+           ->  Result
+                 Filter: ((CASE WHEN (sum((CASE WHEN ((t_hashdist.a)::double precision <= random()) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (random() IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN ((t_hashdist.a)::double precision IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN ((t_hashdist.a)::double precision <= random()) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                 ->  Aggregate
+                       ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 explain (costs off) select * from t_hashdist where a in (select random()::int from t_replicate_volatile);
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Semi Join
-         Hash Cond: (t_hashdist.a = ((random())::integer))
+         Hash Cond: (t_hashdist.a = (int4(random())))
          ->  Seq Scan on t_hashdist
          ->  Hash
-               ->  Redistribute Motion 1:3  (slice2; segments: 1)
-                     Hash Key: ((random())::integer)
-                     ->  Result
-                           ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
-(10 rows)
+               ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 -- subplan
 explain (costs off, verbose) select * from t_hashdist left join t_replicate_volatile on t_hashdist.a > any (select random() from t_replicate_volatile);
@@ -793,105 +784,96 @@ explain (costs off, verbose) select * from t_hashdist left join t_replicate_vola
                ->  Seq Scan on rpt.t_replicate_volatile
                      Output: t_replicate_volatile.a, t_replicate_volatile.b, t_replicate_volatile.c
  Optimizer: Postgres query optimizer
- Settings: enable_seqscan=off, optimizer=off
+ Settings: enable_seqscan=off, optimizer=on
 (20 rows)
 
 -- targetlist
 explain (costs off) select * from t_hashdist cross join (select random () from t_replicate_volatile)x;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                  QUERY PLAN                  
+----------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on t_replicate_volatile
          ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  Result
-                           ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
-(8 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
 
 explain (costs off) select * from t_hashdist cross join (select a, sum(random()) from t_replicate_volatile group by a) x;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                        QUERY PLAN                        
+----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
+         Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  Result
-                           ->  GroupAggregate
-                                 Group Key: t_replicate_volatile.a
-                                 ->  Sort
-                                       Sort Key: t_replicate_volatile.a
-                                       ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
-(12 rows)
+         ->  GroupAggregate
+               Group Key: t_replicate_volatile.a
+               ->  Sort
+                     Sort Key: t_replicate_volatile.a
+                     ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
 
 explain (costs off) select * from t_hashdist cross join (select random() as k, sum(a) from t_replicate_volatile group by k) x;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Nested Loop
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on t_hashdist
-   ->  Materialize
-         ->  Result
-               ->  Gather Motion 1:1  (slice2; segments: 1)
-                     ->  GroupAggregate
-                           Group Key: (random())
-                           ->  Sort
-                                 Sort Key: (random())
-                                 ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
-(12 rows)
-
-explain (costs off) select * from t_hashdist cross join (select a, sum(b) as s from t_replicate_volatile group by a having sum(b) > random() order by a) x ;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                        QUERY PLAN                        
+----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
+         Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  Result
-                           ->  GroupAggregate
-                                 Group Key: t_replicate_volatile.a
-                                 Filter: ((sum(t_replicate_volatile.b))::double precision > random())
-                                 ->  Sort
-                                       Sort Key: t_replicate_volatile.a
-                                       ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
-(13 rows)
+         ->  GroupAggregate
+               Group Key: (random())
+               ->  Sort
+                     Sort Key: (random())
+                     ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+explain (costs off) select * from t_hashdist cross join (select a, sum(b) as s from t_replicate_volatile group by a having sum(b) > random() order by a) x ;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on t_hashdist
+         ->  Result
+               Filter: (((sum(t_replicate_volatile.b)))::double precision > random())
+               ->  GroupAggregate
+                     Group Key: t_replicate_volatile.a
+                     ->  Sort
+                           Sort Key: t_replicate_volatile.a
+                           ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 -- insert
 explain (costs off) insert into t_replicate_volatile select random() from t_replicate_volatile;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Insert on t_replicate_volatile
-   ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Result
-               ->  Seq Scan on t_replicate_volatile t_replicate_volatile_1
- Optimizer: Postgres query optimizer
-(5 rows)
+   ->  Seq Scan on t_replicate_volatile t_replicate_volatile_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
 
 explain (costs off) insert into t_replicate_volatile select random(), a, a from generate_series(1, 10) a;
-                      QUERY PLAN                      
-------------------------------------------------------
+                     QUERY PLAN                     
+----------------------------------------------------
  Insert on t_replicate_volatile
-   ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Subquery Scan on "*SELECT*"
-               ->  Function Scan on generate_series a
- Optimizer: Postgres query optimizer
+   ->  Result
+         ->  Broadcast Motion 1:3  (slice1)
+               ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
 create sequence seq_for_insert_replicated_table;
 explain (costs off) insert into t_replicate_volatile select nextval('seq_for_insert_replicated_table');
-                    QUERY PLAN                     
----------------------------------------------------
+                 QUERY PLAN                 
+--------------------------------------------
  Insert on t_replicate_volatile
-   ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Subquery Scan on "*SELECT*"
+   ->  Result
+         ->  Broadcast Motion 1:3  (slice1)
                ->  Result
- Optimizer: Postgres query optimizer
+ Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
 -- update & delete
@@ -909,28 +891,27 @@ explain (costs off) update t_replicate_volatile set a = random();
 ERROR:  could not devise a plan. (cdbpath.c:2398)
 -- limit
 explain (costs off) insert into t_replicate_volatile select * from t_replicate_volatile limit 1;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Insert on t_replicate_volatile
-   ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Result
-               ->  Limit
-                     ->  Seq Scan on t_replicate_volatile t_replicate_volatile_1
- Optimizer: Postgres query optimizer
-(6 rows)
+   ->  Result
+         ->  Limit
+               ->  Seq Scan on t_replicate_volatile t_replicate_volatile_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
 
 explain (costs off) select * from t_hashdist cross join (select * from t_replicate_volatile limit 1) x;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Nested Loop
-         ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  Result
-                           ->  Limit
-                                 ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
+                      QUERY PLAN                      
+------------------------------------------------------
+ Nested Loop
+   Join Filter: true
+   ->  Limit
+         ->  Gather Motion 1:1  (slice2; segments: 1)
+               ->  Seq Scan on t_replicate_volatile
+   ->  Materialize
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Seq Scan on t_hashdist
+ Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
 -- start_ignore

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -351,6 +351,56 @@ ALTER TABLE foopart SET DISTRIBUTED REPLICATED;
 ALTER TABLE foopart_1_prt_1 SET DISTRIBUTED REPLICATED;
 DROP TABLE foopart;
 
+-- volatile replicated
+-- General and segmentGeneral locus imply that if the corresponding
+-- slice is executed in many different segments should provide the
+-- same result data set. Thus, in some cases, General and segmentGeneral
+-- can be treated like broadcast. But if the segmentGeneral and general
+-- locus path contain volatile functions, they lose the property and
+-- can only be treated as singleQE. The following cases are to check that
+-- we correctly handle all these cases.
+
+-- FIXME: ORCA does not consider this, we need to fix the cases when ORCA
+-- consider this.
+create table t_hashdist(a int, b int, c int) distributed by (a);
+create table t_replicate_volatile(a int, b int, c int) distributed replicated;
+
+---- pushed down filter
+explain (costs off) select * from t_replicate_volatile, t_hashdist where t_replicate_volatile.a > random();
+
+-- join qual
+explain (costs off) select * from t_hashdist, t_replicate_volatile x, t_replicate_volatile y where x.a + y.a > random();
+
+-- sublink & subquery
+explain (costs off) select * from t_hashdist where a > All (select random() from t_replicate_volatile);
+explain (costs off) select * from t_hashdist where a in (select random()::int from t_replicate_volatile);
+
+-- subplan
+explain (costs off, verbose) select * from t_hashdist left join t_replicate_volatile on t_hashdist.a > any (select random() from t_replicate_volatile);
+
+-- targetlist
+explain (costs off) select * from t_hashdist cross join (select random () from t_replicate_volatile)x;
+explain (costs off) select * from t_hashdist cross join (select a, sum(random()) from t_replicate_volatile group by a) x;
+explain (costs off) select * from t_hashdist cross join (select random() as k, sum(a) from t_replicate_volatile group by k) x;
+explain (costs off) select * from t_hashdist cross join (select a, sum(b) as s from t_replicate_volatile group by a having sum(b) > random() order by a) x ;
+
+-- insert
+explain (costs off) insert into t_replicate_volatile select random() from t_replicate_volatile;
+explain (costs off) insert into t_replicate_volatile select random(), a, a from generate_series(1, 10) a;
+create sequence seq_for_insert_replicated_table;
+explain (costs off) insert into t_replicate_volatile select nextval('seq_for_insert_replicated_table');
+-- update & delete
+explain (costs off) update t_replicate_volatile set a = 1 where b > random();
+explain (costs off) update t_replicate_volatile set a = 1 from t_replicate_volatile x where x.a + random() = t_replicate_volatile.b;
+explain (costs off) update t_replicate_volatile set a = 1 from t_hashdist x where x.a + random() = t_replicate_volatile.b;
+explain (costs off) delete from t_replicate_volatile where a < random();
+explain (costs off) delete from t_replicate_volatile using t_replicate_volatile x where t_replicate_volatile.a + x.b < random();
+explain (costs off) update t_replicate_volatile set a = random();
+
+-- limit
+explain (costs off) insert into t_replicate_volatile select * from t_replicate_volatile limit 1;
+explain (costs off) select * from t_hashdist cross join (select * from t_replicate_volatile limit 1) x;
+
 -- start_ignore
 drop schema rpt cascade;
 -- end_ignore


### PR DESCRIPTION
General and segmentGeneral locus imply that if the corresponding slice
is executed in many different segments should provide the same result
data set. Thus, in some cases, General and segmentGeneral can be
treated like broadcast.

But what if the segmentGeneral and general locus path contain volatile
functions? volatile functions, by definition, do not guarantee results
of different invokes. So for such cases, they lose the property and
cannot be treated as *general. Previously, Greenplum planner
does not handle these cases correctly. Limit general or segmentgeneral
path also has such issue.

The fix idea of this commit is: when we find the pattern (a general or
segmentGeneral locus paths contain volatile functions), we create a
motion path above it to turn its locus to singleQE and then create a
projection path. Then the core job becomes how we choose the places to
check:

  1. For a single base rel, we should only check its restriction, this is
     the at bottom of planner, this is at the function set_rel_pathlist
  2. When creating a join path, if the join locus is general or segmentGeneral,
     check its joinqual to see if it contains volatile functions
  3. When handling subquery, we will invoke set_subquery_pathlist function,
     at the end of this function, check the targetlist and havingQual
  4. When creating limit path, the check and change algorithm should also be used
  5. Correctly handle make_subplan

OrderBy clause and Group Clause should be included in targetlist and handled
by the above Step 3.

Also this commit fixes DMLs on replicated table. Update & Delete Statement on
a replicated table is special. These statements have to be dispatched to each
segment to execute. So if they contain volatile functions in their targetList
or where clause, we should reject such statements:

  1. For targetList, we check it at the function create_motion_path_for_upddel
  2. For where clause, they will be handled in the query planner and if we
     find the pattern and want to fix it, do another check if we are updating
     or deleting replicated table, if so reject the statement.

This pr fixes Github Issue: https://github.com/greenplum-db/gpdb/issues/10419

Co-authored-by: Hao Wu <hawu@pivotal.io>

