### PR TITLE
Raise an error if the OnConflictUpdate contains mutable functions for replicated tables

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -120,7 +120,8 @@ static void setQryDistributionPolicy(ParseState *pstate, IntoClause *into, Query
 
 static bool checkCanOptSelectLockingClause(SelectStmt *stmt);
 static bool queryNodeSearch(Node *node, void *context);
-static void sanity_check_on_conflict_update_set_distkey(Oid relid, List *onconflict_set);
+static void sanity_check_on_conflict_update_set_distkey(GpPolicy  *policy, List *onconflict_set);
+static void sanity_check_on_conflict_update(Oid relid, List *on_conflict_set, Node *on_conflict_where);
 
 /*
  * parse_analyze
@@ -917,8 +918,9 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 	 * This fixes the github issue: https://github.com/greenplum-db/gpdb/issues/9444
 	 */
 	if (isOnConflictUpdate)
-		sanity_check_on_conflict_update_set_distkey(rte->relid,
-													qry->onConflict->onConflictSet);
+		sanity_check_on_conflict_update(rte->relid,
+													qry->onConflict->onConflictSet,
+													qry->onConflict->onConflictWhere);
 
 	/*
 	 * If we have a RETURNING clause, we need to add the target relation to
@@ -3506,12 +3508,11 @@ queryNodeSearch(Node *node, void *context)
 }
 
 static void
-sanity_check_on_conflict_update_set_distkey(Oid relid, List *onconflict_set)
+sanity_check_on_conflict_update_set_distkey(GpPolicy  *policy, List *onconflict_set)
 {
 	ListCell  *lc;
 	Bitmapset *dist_cols = NULL;
 	Bitmapset *conflict_update_cols = NULL;
-	GpPolicy  *policy = GpPolicyFetch(relid);
 
 	for (int i = 0; i < policy->nattrs; i++)
 		dist_cols = bms_add_member(dist_cols, policy->attrs[i]);
@@ -3528,5 +3529,26 @@ sanity_check_on_conflict_update_set_distkey(Oid relid, List *onconflict_set)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("modification of distribution columns in OnConflictUpdate is not supported")));
+	}
+}
+
+static void
+sanity_check_on_conflict_update(Oid relid, List *on_conflict_set, Node *on_conflict_where)
+{
+	GpPolicy  *policy = GpPolicyFetch(relid);
+	switch (policy->ptype)
+	{
+		case POLICYTYPE_PARTITIONED:
+			sanity_check_on_conflict_update_set_distkey(policy, on_conflict_set);
+			break;
+		case POLICYTYPE_REPLICATED:
+			if (contain_mutable_functions((Node*)on_conflict_set) ||
+				contain_mutable_functions(on_conflict_where))
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("modification of replicated tables containing mutable functions in OnConflictUpdate is not supported")));
+			break;
+		default:
+			break;
 	}
 }

--- a/src/test/regress/expected/insert_conflict.out
+++ b/src/test/regress/expected/insert_conflict.out
@@ -771,3 +771,20 @@ select * from twoconstraints;
 
 drop table twoconstraints;
 -- end_ignore
+-- check that modification of replicated tables containing mutable functions is not supported.
+create table rpt_mutable(i int unique) distributed replicated;
+insert into rpt_mutable select i from generate_series(10,20)i;
+-- this should fail
+insert into rpt_mutable as m select x from generate_series(5, 15)x
+  on conflict (i) do update
+  set i = m.i*20 + 5 * random();
+ERROR:  modification of replicated tables containing mutable functions in OnConflictUpdate is not supported
+insert into rpt_mutable as m select x from generate_series(5, 15)x
+  on conflict (i) do update
+  set i = m.i + 20 where m.i > 12 * random();
+ERROR:  modification of replicated tables containing mutable functions in OnConflictUpdate is not supported
+-- this should work
+insert into rpt_mutable as m select x from generate_series(5, 15)x
+  on conflict (i) do update
+  set i = m.i + 20;
+drop table rpt_mutable;

--- a/src/test/regress/sql/insert_conflict.sql
+++ b/src/test/regress/sql/insert_conflict.sql
@@ -434,3 +434,19 @@ insert into twoconstraints values(2, '((0,0),(1,2))')
 select * from twoconstraints;
 drop table twoconstraints;
 -- end_ignore
+
+-- check that modification of replicated tables containing mutable functions is not supported.
+create table rpt_mutable(i int unique) distributed replicated;
+insert into rpt_mutable select i from generate_series(10,20)i;
+-- this should fail
+insert into rpt_mutable as m select x from generate_series(5, 15)x
+  on conflict (i) do update
+  set i = m.i*20 + 5 * random();
+insert into rpt_mutable as m select x from generate_series(5, 15)x
+  on conflict (i) do update
+  set i = m.i + 20 where m.i > 12 * random();
+-- this should work
+insert into rpt_mutable as m select x from generate_series(5, 15)x
+  on conflict (i) do update
+  set i = m.i + 20;
+drop table rpt_mutable;


### PR DESCRIPTION
OnConflictUpdate is allowed for replicate tables, but the on_conflict_set
clause and on_conflict_where clause may cause the replicated table
inconsistent if they contain mutable functions.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
