### PR TITLE
Move slack command trigger repo

### DIFF
--- a/src/backend/gporca/concourse/test_orca_pipeline.yml
+++ b/src/backend/gporca/concourse/test_orca_pipeline.yml
@@ -13,7 +13,8 @@ resources:
   type: git
   source:
     branch: test-gpdb-6X
-    uri: https://github.com/greenplum-db/gporca-pipeline-misc
+    private_key: {{slack-trigger-git-key}}
+    uri: {{slack-trigger-git-remote}}
 
 - name: gpdb6-centos7-build
   type: docker-image


### PR DESCRIPTION
We've moved the repo that holds trigger commits to a private repo since
there wasn't anything interesting there.
