### PR TITLE
[6X Backport] Fix flaky test for replication_keeps_crash.

### DIFF
--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -291,10 +291,13 @@ FTSReplicationStatusMarkDisconnectForReplication(const char *app_name)
 
 	LWLockAcquire(FTSReplicationStatusLock, LW_SHARED);
 
-	replication_status = RetrieveFTSReplicationStatus(app_name, false /* skip_warn */);
+	/*
+	 * FTS may already mark the mirror down and free the replication status.
+	 * For this case, a NULL pointer will return.
+	 */
+	replication_status = RetrieveFTSReplicationStatus(app_name, true /* skip_warn */);
 
-	/* replication_status must exist  */
-	Assert(replication_status);
+	/* if replication_status is NULL, do nothing */
 	FTSReplicationStatusMarkDisconnect(replication_status);
 
 	LWLockRelease(FTSReplicationStatusLock);

--- a/src/test/isolation2/expected/segwalrep/replication_keeps_crash.out
+++ b/src/test/isolation2/expected/segwalrep/replication_keeps_crash.out
@@ -18,8 +18,6 @@ CREATE
 -- modify fts gucs to speed up the test.
 1: alter system set gp_fts_probe_interval to 10;
 ALTER
-1: alter system set gp_fts_probe_retries to 1;
-ALTER
 1: alter system set gp_fts_replication_attempt_count to 3;
 ALTER
 1: select pg_reload_conf();
@@ -51,6 +49,12 @@ select gp_inject_fault_infinite('wal_sender_loop', 'error', dbid) from gp_segmen
 -- Should block in commit (SyncrepWaitForLSN()), waiting for commit
 -- LSN to be flushed on mirror.
 1&: create table mirror_block_t1 (a int) distributed by (a);  <waiting ...>
+
+select gp_wait_until_triggered_fault('wal_sender_loop', 1, dbid) from gp_segment_configuration where role='p' and content=0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
 
 -- trigger fts to mark mirror down.
 select gp_request_fts_probe_scan();
@@ -110,8 +114,6 @@ drop table mirror_block_t1;
 DROP
 
 1: alter system reset gp_fts_probe_interval;
-ALTER
-1: alter system reset gp_fts_probe_retries;
 ALTER
 1: alter system reset gp_fts_replication_attempt_count;
 ALTER

--- a/src/test/isolation2/sql/segwalrep/replication_keeps_crash.sql
+++ b/src/test/isolation2/sql/segwalrep/replication_keeps_crash.sql
@@ -15,7 +15,6 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 
 -- modify fts gucs to speed up the test.
 1: alter system set gp_fts_probe_interval to 10;
-1: alter system set gp_fts_probe_retries to 1;
 1: alter system set gp_fts_replication_attempt_count to 3;
 1: select pg_reload_conf();
 
@@ -28,6 +27,8 @@ select gp_inject_fault_infinite('wal_sender_loop', 'error', dbid)
 -- Should block in commit (SyncrepWaitForLSN()), waiting for commit
 -- LSN to be flushed on mirror.
 1&: create table mirror_block_t1 (a int) distributed by (a);
+
+select gp_wait_until_triggered_fault('wal_sender_loop', 1, dbid) from gp_segment_configuration where role='p' and content=0;
 
 -- trigger fts to mark mirror down.
 select gp_request_fts_probe_scan();
@@ -57,6 +58,5 @@ SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration
 drop table mirror_block_t1;
 
 1: alter system reset gp_fts_probe_interval;
-1: alter system reset gp_fts_probe_retries;
 1: alter system reset gp_fts_replication_attempt_count;
 1: select pg_reload_conf();


### PR DESCRIPTION
Find an assertion that may not match when mark mirror down happens before
walsender exit, which will free the replication status before walsender
exit and try to record disconnect info. Which lead the segment crash
and starts to recover.

Also, remove the set `gp_fts_probe_retries to 1` which may cause FTS probe failed
under some extremes environment.
This was first added to reduce the test time. Since reduce the `gp_fts_replication_attempt_count` also
save the test time, so skip alter `gp_fts_probe_retries`.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
