### PR TITLE
Disallow the replicated table inherit or to be inherited

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -13555,6 +13555,13 @@ ATExecAddInherit(Relation child_rel, Node *node, LOCKMODE lockmode)
 
 	Assert(PointerIsValid(node));
 
+	/* 1. Replicated table cannot inherit a parent */
+	if (child_rel->rd_cdbpolicy &&
+		child_rel->rd_cdbpolicy->ptype == POLICYTYPE_REPLICATED)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("Replicated table cannot inherit a parent")));
+
 	if (IsA(node, InheritPartitionCmd))
 	{
 		parent = ((InheritPartitionCmd *) node)->parent;
@@ -13572,6 +13579,12 @@ ATExecAddInherit(Relation child_rel, Node *node, LOCKMODE lockmode)
 	 */
 	parent_rel = heap_openrv(parent, ShareUpdateExclusiveLock);
 
+	/* 2. Replicated table cannot be inherited */
+	if (parent_rel->rd_cdbpolicy &&
+		parent_rel->rd_cdbpolicy->ptype == POLICYTYPE_REPLICATED)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("Replicated table cannot be inherited")));
 	/*
 	 * Must be owner of both parent and child -- child was checked by
 	 * ATSimplePermissions call in ATPrepCmd

--- a/src/test/regress/expected/inherit.out
+++ b/src/test/regress/expected/inherit.out
@@ -1753,3 +1753,30 @@ select * from cnullparent where f1 = 2;
 
 drop table cnullparent cascade;
 NOTICE:  drop cascades to table cnullchild
+-- Test that replicated table can't inherit a parent table, and it also
+-- can't be inherited by a child table.
+-- 1. Replicated table can't inherit a parent table.
+CREATE TABLE parent (t text) DISTRIBUTED BY (t);
+-- This is not allowed: should fail
+CREATE TABLE child () INHERITS (parent) DISTRIBUTED REPLICATED;
+ERROR:  INHERITS clause cannot be used with DISTRIBUTED REPLICATED clause
+CREATE TABLE child (t text) DISTRIBUTED REPLICATED;
+-- should fail
+ALTER TABLE child INHERIT parent;
+ERROR:  Replicated table cannot inherit a parent
+DROP TABLE child, parent;
+-- 2. Replicated table can't be inherited
+CREATE TABLE parent (t text) DISTRIBUTED REPLICATED;
+-- should fail
+CREATE TABLE child () INHERITS (parent) DISTRIBUTED REPLICATED;
+ERROR:  INHERITS clause cannot be used with DISTRIBUTED REPLICATED clause
+CREATE TABLE child () INHERITS (parent) DISTRIBUTED BY (t);
+ERROR:  cannot inherit from replicated table "parent" to create table "child"
+DETAIL:  An inheritance hierarchy cannot contain a mixture of distributed and non-distributed tables.
+CREATE TABLE child (t text) DISTRIBUTED REPLICATED;
+ALTER TABLE child INHERIT parent;
+ERROR:  Replicated table cannot inherit a parent
+CREATE TABLE child2(t text) DISTRIBUTED BY (t);
+ALTER TABLE child2 INHERIT parent;
+ERROR:  Replicated table cannot be inherited
+DROP TABLE child, child2, parent;

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -1771,3 +1771,30 @@ select * from cnullparent where f1 = 2;
 
 drop table cnullparent cascade;
 NOTICE:  drop cascades to table cnullchild
+-- Test that replicated table can't inherit a parent table, and it also
+-- can't be inherited by a child table.
+-- 1. Replicated table can't inherit a parent table.
+CREATE TABLE parent (t text) DISTRIBUTED BY (t);
+-- This is not allowed: should fail
+CREATE TABLE child () INHERITS (parent) DISTRIBUTED REPLICATED;
+ERROR:  INHERITS clause cannot be used with DISTRIBUTED REPLICATED clause
+CREATE TABLE child (t text) DISTRIBUTED REPLICATED;
+-- should fail
+ALTER TABLE child INHERIT parent;
+ERROR:  Replicated table cannot inherit a parent
+DROP TABLE child, parent;
+-- 2. Replicated table can't be inherited
+CREATE TABLE parent (t text) DISTRIBUTED REPLICATED;
+-- should fail
+CREATE TABLE child () INHERITS (parent) DISTRIBUTED REPLICATED;
+ERROR:  INHERITS clause cannot be used with DISTRIBUTED REPLICATED clause
+CREATE TABLE child () INHERITS (parent) DISTRIBUTED BY (t);
+ERROR:  cannot inherit from replicated table "parent" to create table "child"
+DETAIL:  An inheritance hierarchy cannot contain a mixture of distributed and non-distributed tables.
+CREATE TABLE child (t text) DISTRIBUTED REPLICATED;
+ALTER TABLE child INHERIT parent;
+ERROR:  Replicated table cannot inherit a parent
+CREATE TABLE child2(t text) DISTRIBUTED BY (t);
+ALTER TABLE child2 INHERIT parent;
+ERROR:  Replicated table cannot be inherited
+DROP TABLE child, child2, parent;

--- a/src/test/regress/sql/inherit.sql
+++ b/src/test/regress/sql/inherit.sql
@@ -605,3 +605,29 @@ insert into cnullchild values(null);
 select * from cnullparent;
 select * from cnullparent where f1 = 2;
 drop table cnullparent cascade;
+
+-- Test that replicated table can't inherit a parent table, and it also
+-- can't be inherited by a child table.
+-- 1. Replicated table can't inherit a parent table.
+CREATE TABLE parent (t text) DISTRIBUTED BY (t);
+-- This is not allowed: should fail
+CREATE TABLE child () INHERITS (parent) DISTRIBUTED REPLICATED;
+
+CREATE TABLE child (t text) DISTRIBUTED REPLICATED;
+-- should fail
+ALTER TABLE child INHERIT parent;
+DROP TABLE child, parent;
+
+-- 2. Replicated table can't be inherited
+CREATE TABLE parent (t text) DISTRIBUTED REPLICATED;
+-- should fail
+CREATE TABLE child () INHERITS (parent) DISTRIBUTED REPLICATED;
+CREATE TABLE child () INHERITS (parent) DISTRIBUTED BY (t);
+
+CREATE TABLE child (t text) DISTRIBUTED REPLICATED;
+ALTER TABLE child INHERIT parent;
+
+CREATE TABLE child2(t text) DISTRIBUTED BY (t);
+ALTER TABLE child2 INHERIT parent;
+
+DROP TABLE child, child2, parent;


### PR DESCRIPTION
Currently, replicated tables are not allowed to inherit a parent
table. But ALTER TABLE .. INHERIT can pass around the restriction.

On the other hand, a replicated table is allowed to be inherited
by a hash distributed table. It makes things much complicated.
When the parent table is declared as a replicated table inherited by
a hash distributed table, its data on the parent is replicated
but the data on the child is hash distributed. When running
`select * from parent;`, the generated plan is:
```
gpadmin=# explain select * from parent;
                                 QUERY PLAN
-----------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.42 rows=14 width=6)
   ->  Append  (cost=0.00..4.14 rows=5 width=6)
         ->  Result  (cost=0.00..1.20 rows=4 width=7)
               One-Time Filter: (gp_execution_segment() = 1)
               ->  Seq Scan on parent  (cost=0.00..1.10 rows=4 width=7)
         ->  Seq Scan on child  (cost=0.00..3.04 rows=2 width=4)
 Optimizer: Postgres query optimizer
(7 rows)
```
It's not particularly useful for the parent table to be replicated.
So, we disallow the replicated table to be inherited.

Reported-by: Heikki Linnakangas <hlinnakangas@pivotal.io>
Reviewed-by: Hubert Zhang <hzhang@pivotal.io>
(cherry picked from commit dc4b839e121ce90bbdc8b94d3d373a41e9acf2ec)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
