### PR TITLE
Set GPHOME to GPDB installation directory when sourcing greenplum_path

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -1059,9 +1059,9 @@ greenplum_path:
 	mkdir -p $(INSTLOC)
 ifeq ($(BLD_ARCH),$(filter $(BLD_ARCH),ubuntu1604_amd64))
 	# python is not vendored in the enterpise builds of Ubuntu 16.04
-	$(BUILDDIR)/gpMgmt/bin/generate-greenplum-path.sh $(INSTLOC) no > $(INSTLOC)/greenplum_path.sh
+	$(BUILDDIR)/gpMgmt/bin/generate-greenplum-path.sh no > $(INSTLOC)/greenplum_path.sh
 else
-	$(BUILDDIR)/gpMgmt/bin/generate-greenplum-path.sh $(INSTLOC) yes > $(INSTLOC)/greenplum_path.sh
+	$(BUILDDIR)/gpMgmt/bin/generate-greenplum-path.sh yes > $(INSTLOC)/greenplum_path.sh
 endif
 
 copylicense:

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
 
-if [ -z "$1" ]; then
-  printf "Must specify a value for GPHOME"
-  exit 1
-fi
+SET_PYTHONHOME="${1:-no}"
 
-SET_PYTHONHOME="${2:-no}"
-
-GPHOME_PATH="$1"
-cat <<EOF
-GPHOME="${GPHOME_PATH}"
-
+cat <<"EOF"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+GPDB_DIR=$(readlink "${SCRIPT_DIR}" || basename "${SCRIPT_DIR}")
+GPHOME=$(dirname "${SCRIPT_DIR}")/"${GPDB_DIR}"
 EOF
 
 if [ "${SET_PYTHONHOME}" = "yes" ]; then

--- a/gpMgmt/bin/test-generate-greenplum-path.bash
+++ b/gpMgmt/bin/test-generate-greenplum-path.bash
@@ -2,23 +2,13 @@
 
 set -e
 
-echo "set GPHOME with first argument"
-./generate-greenplum-path.sh /foo | grep -q 'GPHOME="/foo"'
-
 echo "set PYTHONHOME if second argument is 'yes'"
-./generate-greenplum-path.sh /foo yes | grep -q 'PYTHONHOME="${GPHOME}/ext/python"'
+./generate-greenplum-path.sh yes | grep -q 'PYTHONHOME="${GPHOME}/ext/python"'
 
 echo "do not set PYTHONHOME if second argument is not 'yes'"
-[ $(./generate-greenplum-path.sh /foo no | grep -c PYTHONHOME) -eq 0 ]
+[ $(./generate-greenplum-path.sh no | grep -c PYTHONHOME) -eq 0 ]
 
 echo "do not set PYTHONHOME if second argument is missing"
-[ $(./generate-greenplum-path.sh /foo | grep -c PYTHONHOME) -eq 0 ]
-
-echo "error out if no argument is given"
-if ./generate-greenplum-path.sh; then
-  echo "should not have passed"
-  exit 1
-fi
-./generate-greenplum-path.sh | grep -q "Must specify a value for GPHOME"
+[ $(./generate-greenplum-path.sh | grep -c PYTHONHOME) -eq 0 ]
 
 echo "ALL TEST PASSED"


### PR DESCRIPTION
The current implementation has the RPM packages modifying greenplum_path.sh to update GPHOME upon installation using the following implemetation:

```
# Set GPHOME to the installation prefix
  sed -i -e "1 s~^\(GPHOME=\).*~\1${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}~" "${RPM_INSTALL_PREFIX}/greenplum-db-%{gpdb_version}/greenplum_path.sh"
```
Because the greenplum_path.sh is listed as a configuration file in the RPM, the file is saved with every installation regardless of whether a user has not modified the configuration file. 


Co-authored-by: Ning Wu <ningw@vmware.com>
Co-authored-by: Tingfang Bao <baotingfang@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
