### PR TITLE
docs - add information for SSL with standby master

### DIFF
--- a/gpdb-doc/dita/admin_guide/client_auth.xml
+++ b/gpdb-doc/dita/admin_guide/client_auth.xml
@@ -318,22 +318,24 @@ max_prepared_transactions=100
               certificate authority (CA) should be used in production, so the client can verify the
               identity of the server. Either a global or local CA can be used. If all the clients
               are local to the organization, a local CA is recommended.</p></li>
-          <li>Ensure Greenplum Database can access <filepath>server.key</filepath> and
-              <filepath>server.crt</filepath>. When starting in SSL mode, the Greenplum Database
-            master looks for <filepath>server.key</filepath> and <filepath>server.crt</filepath>. As
-            the default, Greenplum Database does not start if the files are not in the master data
-            directory (<codeph>$MASTER_DATA_DIRECTORY</codeph>). Also, if you use other SSL
-            authentication files such as <codeph>root.crt</codeph> (trusted certificate
-            authorities), the files must be on the master host.<p>If Greenplum Database master
-              mirroring is enabled with SSL client authentication, SSL authentication files must be
-              on the of both the master host and standby master host, otherwise Greenplum Database
-              will not start. The SSL files should not be located in the default directory
-                <codeph>$MASTER_DATA_DIRECTORY</codeph>. If an <codeph>initstandby</codeph>
-              operation is performed, the contents of <codeph>$MASTER_DATA_DIRECTORY</codeph> is
-              copied to the standby master and the incorrect SSL key, and cert files ( the master
-              files, and not the standby master files) will prevent standby master start up.
-              </p><p>You can specify a different directory for the location of the SSL server files
-              with the <codeph>postgresql.conf</codeph> parameters <codeph>sslcert</codeph>,
+          <li>Ensure that Greenplum Database can access <filepath>server.key</filepath> and
+              <filepath>server.crt</filepath>, and any additional authentication files such as
+              <codeph>root.crt</codeph> (for trusted certificate authorities). When starting in SSL
+            mode, the Greenplum Database master looks for <filepath>server.key</filepath> and
+              <filepath>server.crt</filepath>. As the default, Greenplum Database does not start if
+            the files are not in the master data directory
+            (<codeph>$MASTER_DATA_DIRECTORY</codeph>). Also, if you use other SSL authentication
+            files such as <codeph>root.crt</codeph> (trusted certificate authorities), the files
+            must be on the master host.<p>If Greenplum Database master mirroring is enabled with SSL
+              client authentication, SSL authentication files must be on both the master host and
+              standby master host and <i>should not be placed</i> in the default directory
+                <codeph>$MASTER_DATA_DIRECTORY</codeph>. When master mirroring is enabled, an
+                <codeph>initstandby</codeph> operation copies the contents of the
+                <codeph>$MASTER_DATA_DIRECTORY</codeph> from the master to the standby master and
+              the incorrect SSL key, and cert files (the master files, and not the standby master
+              files) will prevent standby master start up. </p><p>You can specify a different
+              directory for the location of the SSL server files with the
+                <codeph>postgresql.conf</codeph> parameters <codeph>sslcert</codeph>,
                 <codeph>sslkey</codeph>, <codeph>sslrootcert</codeph>, and <codeph>sslcrl</codeph>.
               For more information about the parameters, see <xref
                 href="../security-guide/topics/Authenticate.xml#topic_fzv_wb2_jr"/> in the

--- a/gpdb-doc/dita/admin_guide/client_auth.xml
+++ b/gpdb-doc/dita/admin_guide/client_auth.xml
@@ -318,20 +318,32 @@ max_prepared_transactions=100
               certificate authority (CA) should be used in production, so the client can verify the
               identity of the server. Either a global or local CA can be used. If all the clients
               are local to the organization, a local CA is recommended.</p></li>
-          <li>The <filepath>server.key</filepath> and <filepath>server.crt</filepath> have been
-            added to the master data directory on both the master host and standby master host. When
-            starting in SSL mode, the Greenplum Database master looks for
-              <filepath>server.key</filepath> and <filepath>server.crt</filepath>. Greenplum
-            Database does not start if the files are not in the master data directory of both the
-            master host and standby master host. <p>Also, if you use other SSL authentication files
-              such as <codeph>root.crt</codeph> (trusted certificate authorities), the files must be
-              on both the master host and standby master host.</p></li>
+          <li>Ensure Greenplum Database can access <filepath>server.key</filepath> and
+              <filepath>server.crt</filepath>. When starting in SSL mode, the Greenplum Database
+            master looks for <filepath>server.key</filepath> and <filepath>server.crt</filepath>. As
+            the default, Greenplum Database does not start if the files are not in the master data
+            directory (<codeph>$MASTER_DATA_DIRECTORY</codeph>). Also, if you use other SSL
+            authentication files such as <codeph>root.crt</codeph> (trusted certificate
+            authorities), the files must be on the master host.<p>If Greenplum Database master
+              mirroring is enabled with SSL client authentication, SSL authentication files must be
+              on the of both the master host and standby master host, otherwise Greenplum Database
+              will not start. The SSL files should not be located in the default directory
+                <codeph>$MASTER_DATA_DIRECTORY</codeph>. If an <codeph>initstandby</codeph>
+              operation is performed, the contents of <codeph>$MASTER_DATA_DIRECTORY</codeph> is
+              copied to the standby master and the incorrect SSL key, and cert files ( the master
+              files, and not the standby master files) will prevent standby master start up.
+              </p><p>You can specify a different directory for the location of the SSL server files
+              with the <codeph>postgresql.conf</codeph> parameters <codeph>sslcert</codeph>,
+                <codeph>sslkey</codeph>, <codeph>sslrootcert</codeph>, and <codeph>sslcrl</codeph>.
+              For more information about the parameters, see <xref
+                href="../security-guide/topics/Authenticate.xml#topic_fzv_wb2_jr"/> in the
+                <cite>Security Configuration Guide</cite>. </p></li>
         </ul> Greenplum Database can be started with SSL enabled by setting the server configuration
         parameter <codeph>ssl=on</codeph> in the <codeph>postgresql.conf</codeph> file on the master
         and standby master hosts. This <codeph>gpconfig</codeph> command sets the
         parameter:<codeblock>gpconfig -c ssl -m on -v off</codeblock></p>
       <p>Setting the parameter requires a server restart. This command restarts the system:
-          <codeph>gpstop -ra -M fast</codeph>.</p>
+          <codeph>gpstop -ra</codeph>.</p>
     </body>
     <topic id="topic6" xml:lang="en">
       <title>Creating a Self-signed Certificate without a Passphrase for Testing Only</title>

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -556,11 +556,11 @@ Hostssl testdb all 192.168.0.0/16 cert map=gpuser
             <li><codeph>root.crl</codeph> - Certificates revoked by certificate authorities.</li>
           </ul></p>
         <p>If Greenplum Database master mirroring is enabled with SSL client authentication, the SSL
-          server files should not be located in the <codeph>$MASTER_DATA_DIRECTORY</codeph>. If an
-            <codeph>initstandby</codeph> operation is performed, the contents of
-            <codeph>$MASTER_DATA_DIRECTORY</codeph> is copied to the standby master and the
-          incorrect SSL key, and cert files ( the master files, and not the standby master files)
-          will prevent standby master start up. </p>
+          server files <i>should not be placed</i> in the default directory
+            <codeph>$MASTER_DATA_DIRECTORY</codeph>. If an <codeph>initstandby</codeph> operation is
+          performed, the contents of <codeph>$MASTER_DATA_DIRECTORY</codeph> is copied from the
+          master to the standby master and the incorrect SSL key, and cert files (the master files,
+          and not the standby master files) will prevent standby master start up. </p>
         <p>You can specify a different directory for the location of the SSL server files with the
             <codeph>postgresql.conf</codeph> parameters <codeph>sslcert</codeph>,
             <codeph>sslkey</codeph>, <codeph>sslrootcert</codeph>, and <codeph>sslcrl</codeph>.</p>

--- a/gpdb-doc/dita/security-guide/topics/Authenticate.xml
+++ b/gpdb-doc/dita/security-guide/topics/Authenticate.xml
@@ -537,76 +537,91 @@ Hostssl testdb all 192.168.0.0/16 cert map=gpuser
               <i>overrides</i> any ciphers string specified in <codeph>/etc/openssl.cnf</codeph>.
               The default value <codeph>ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH</codeph> enables all
               ciphers except for ADH, LOW, EXP, and MD5 ciphers, and prioritizes ciphers by their
-                strength.<note>With TLS 1.2 some ciphers in MEDIUM and HIGH strength still use NULL
-                encryption (no encryption for transport), which the default
-                  <codeph>ssl_ciphers</codeph> string allows. To bypass NULL ciphers with TLS 1.2
-                use a string such as <codeph>TLSv1.2:!eNULL:!aNULL</codeph>.</note></li>
+              strength.
+              <note>With TLS 1.2 some ciphers in MEDIUM and HIGH strength still use NULL encryption
+                (no encryption for transport), which the default <codeph>ssl_ciphers</codeph> string
+                allows. To bypass NULL ciphers with TLS 1.2 use a string such as
+                  <codeph>TLSv1.2:!eNULL:!aNULL</codeph>.<p>It is possible to have authentication
+                  without encryption overhead by using <codeph>NULL-SHA</codeph> or
+                    <codeph>NULL-MD5</codeph> ciphers. However, a man-in-the-middle could read and
+                  pass communications between client and server. Also, encryption overhead is
+                  minimal compared to the overhead of authentication. For these reasons, NULL
+                  ciphers should not be used.</p></note></li>
           </ul></p>
-        <p>The following SSL server files can be found in the Master Data Directory: <ul
-            id="ul_gzs_b22_jr">
-            <li><codeph>server.crt</codeph>. Server certificate.</li>
-            <li><codeph>server.key</codeph>. Server private key.</li>
-            <li><codeph>root.crt</codeph>. Trusted certificate authorities.</li>
-            <li><codeph>root.crl</codeph>. Certificates revoked by certificate authorities.</li>
+        <p>The default location for the following SSL server files is the Greenplum Database master
+          data directory (<codeph>$MASTER_DATA_DIRECTORY</codeph>): <ul id="ul_gzs_b22_jr">
+            <li><codeph>server.crt</codeph> - Server certificate.</li>
+            <li><codeph>server.key</codeph> - Server private key.</li>
+            <li><codeph>root.crt</codeph> - Trusted certificate authorities.</li>
+            <li><codeph>root.crl</codeph> - Certificates revoked by certificate authorities.</li>
           </ul></p>
+        <p>If Greenplum Database master mirroring is enabled with SSL client authentication, the SSL
+          server files should not be located in the <codeph>$MASTER_DATA_DIRECTORY</codeph>. If an
+            <codeph>initstandby</codeph> operation is performed, the contents of
+            <codeph>$MASTER_DATA_DIRECTORY</codeph> is copied to the standby master and the
+          incorrect SSL key, and cert files ( the master files, and not the standby master files)
+          will prevent standby master start up. </p>
+        <p>You can specify a different directory for the location of the SSL server files with the
+            <codeph>postgresql.conf</codeph> parameters <codeph>sslcert</codeph>,
+            <codeph>sslkey</codeph>, <codeph>sslrootcert</codeph>, and <codeph>sslcrl</codeph>.</p>
       </section>
       <section id="config_ssl_client_conn">
         <title>Configuring the SSL Client Connection</title>
       </section>
       <p>SSL options:<parml>
-        <plentry>
+          <plentry>
             <pt>sslmode</pt>
             <pd>Specifies the level of protection.<parml>
-          <plentry>
-            <pt>
-              <codeph>require</codeph>
-            </pt>
-            <pd>Only use an SSL connection. If a root CA file is present, verify the certificate in the
-              same way as if <codeph>verify-ca</codeph> was specified.</pd>
+                <plentry>
+                  <pt>
+                    <codeph>require</codeph>
+                  </pt>
+                  <pd>Only use an SSL connection. If a root CA file is present, verify the
+                    certificate in the same way as if <codeph>verify-ca</codeph> was specified.</pd>
+                </plentry>
+                <plentry>
+                  <pt>
+                    <codeph>verify-ca</codeph>
+                  </pt>
+                  <pd>Only use an SSL connection. Verify that the server certificate is issued by a
+                    trusted CA.</pd>
+                </plentry>
+                <plentry>
+                  <pt>
+                    <codeph>verify-full</codeph>
+                  </pt>
+                  <pd>Only use an SSL connection. Verify that the server certificate is issued by a
+                    trusted CA and that the server host name matches that in the certificate.</pd>
+                </plentry>
+              </parml></pd>
           </plentry>
-          <plentry>
-            <pt>
-              <codeph>verify-ca</codeph>
-            </pt>
-            <pd>Only use an SSL connection. Verify that the server certificate is issued by a
-              trusted CA.</pd>
-          </plentry>
-          <plentry>
-            <pt>
-              <codeph>verify-full</codeph>
-            </pt>
-            <pd>Only use an SSL connection. Verify that the server certificate is issued by a
-              trusted CA and that the server host name matches that in the certificate.</pd>
-          </plentry>
-         </parml></pd>
-        </plentry>
           <plentry>
             <pt>sslcert</pt>
             <pd>The file name of the client SSL certificate. The default is
-                <codeph>~/.postgresql/postgresql.crt</codeph>. </pd>
+                <codeph>$MASTER_DATA_DIRECTORY/postgresql.crt</codeph>. </pd>
           </plentry>
           <plentry>
             <pt>sslkey</pt>
             <pd>The secret key used for the client certificate. The default is
-                <codeph>~/.postgresql/postgresql.key</codeph>.</pd>
+                <codeph>$MASTER_DATA_DIRECTORY/postgresql.key</codeph>.</pd>
           </plentry>
           <plentry>
             <pt>sslrootcert</pt>
             <pd>The name of a file containing SSL Certificate Authority certificate(s). The default
-              is <codeph>~/.postgresql/root.crt</codeph>.</pd>
+              is <codeph>$MASTER_DATA_DIRECTORY/root.crt</codeph>.</pd>
           </plentry>
           <plentry>
             <pt>sslcrl</pt>
             <pd>The name of the SSL certificate revocation list. The default is
-                <codeph>~/.postgresql/root.crl</codeph>.</pd>
+                <codeph>$MASTER_DATA_DIRECTORY/root.crl</codeph>.</pd>
           </plentry>
         </parml></p>
       <p>The client connection parameters can be set using the following environment variables:<ul
           id="ul_yph_5g2_jr">
           <li><codeph>sslmode</codeph> – <codeph>PGSSLMODE</codeph></li>
+          <li><codeph>sslcert</codeph> – <codeph>PGSSLCERT</codeph></li>
           <li><codeph>sslkey</codeph> – <codeph>PGSSLKEY</codeph></li>
           <li><codeph>sslrootcert</codeph> – <codeph>PGSSLROOTCERT</codeph></li>
-          <li><codeph>sslcert</codeph> – <codeph>PGSSLCERT</codeph></li>
           <li><codeph>sslcrl</codeph> – <codeph>PGSSLCRL</codeph> </li>
         </ul></p>
     </body>


### PR DESCRIPTION
--SSL file should not be in $MASTER_DATA_DIRECTORY is standby master
is enabled (in both Admin Guide and Security Config Guide.)

Also in the Security Config. Guide
--Add not about not using NULL ciphers
--Correct default directory for SSL files to $MASTER_DATA_DIRECTORY

Link to HTML docs in a temporary GPDB draft doc web site.
Admin. Guide
https://docs-msk-gpdb7-ssl-dev.cfapps.io/7-0/admin_guide/client_auth.html#topic5

Security Config. Guide
https://docs-msk-gpdb7-ssl-dev.cfapps.io/7-0/security-guide/topics/Authenticate.html#topic_fzv_wb2_jr