### PR TITLE
[6X backport] Fix flaky test gp_replica_check

### DIFF
--- a/gpcontrib/gp_replica_check/gp_replica_check.c
+++ b/gpcontrib/gp_replica_check/gp_replica_check.c
@@ -26,7 +26,7 @@
 /*
  * How many seconds to wait for checkpoint record to be applied in standby?
  */
-#define NUM_CHECKPOINT_SYNC_TIMEOUT 60
+#define NUM_CHECKPOINT_SYNC_TIMEOUT 600
 
 /*
  * This value is used as divisor to split a sec, used to speficy sleep time


### PR DESCRIPTION
When there is a big lag between primary and mirror replay, gp_replica_check
will fail if the checkpoint is not replayed in about 60 seconds. Extend the
timeout to 600 seconds to reduce the chance of flaky.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
