### PR TITLE
Fix a delimiter bug if external table has delimiter 'OFF'.

### DIFF
--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -236,7 +236,6 @@ typedef struct CopyStateData
 
 	/* Greenplum Database specific variables */
 	bool		escape_off;		/* treat backslashes as non-special? */
-	bool		delim_off;		/* delimiter is set to OFF? */
 	int			first_qe_processed_field;
 	List	   *qd_attnumlist;
 	List	   *qe_attnumlist;
@@ -253,6 +252,8 @@ typedef struct CopyStateData
 
 	/* Information on the connections to QEs. */
 	CdbCopy    *cdbCopy;
+
+	bool		delim_off;		/* delimiter is set to OFF? */
 
 /* end Greenplum Database specific variables */
 } CopyStateData;

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -236,6 +236,7 @@ typedef struct CopyStateData
 
 	/* Greenplum Database specific variables */
 	bool		escape_off;		/* treat backslashes as non-special? */
+	bool		delim_off;		/* delimiter is set to OFF? */
 	int			first_qe_processed_field;
 	List	   *qd_attnumlist;
 	List	   *qe_attnumlist;

--- a/src/test/isolation2/input/external_table.source
+++ b/src/test/isolation2/input/external_table.source
@@ -124,3 +124,23 @@ CREATE EXTERNAL WEB TABLE ext_delim_off ( junk text) execute 'echo hi' on master
 
 -- Query the ext_delim_off table
 SELECT * FROM ext_delim_off;
+
+-- start_ignore
+DROP EXTERNAL TABLE IF EXISTS ext_delimiter_off_text;
+-- end_ignore
+
+-- Create external table(format text) with delimiter off, and a row with 'O'
+CREATE EXTERNAL WEB TABLE ext_delimiter_off_text
+(a text) EXECUTE E'echo O' ON MASTER FORMAT 'text' (delimiter 'OFF') ENCODING 'UTF8';
+
+SELECT * FROM ext_delimiter_off_text;
+
+-- start_ignore
+DROP EXTERNAL TABLE IF EXISTS ext_delimiter_off_csv;
+-- end_ignore
+
+-- Create external table(format csv) with delimiter off, and a row with 'O'
+CREATE EXTERNAL WEB TABLE ext_delimiter_off_csv
+(a text) EXECUTE E'echo O' ON MASTER FORMAT 'csv' (delimiter 'OFF') ENCODING 'UTF8';
+
+SELECT * FROM ext_delimiter_off_csv;

--- a/src/test/isolation2/output/external_table.source
+++ b/src/test/isolation2/output/external_table.source
@@ -204,3 +204,33 @@ SELECT * FROM ext_delim_off;
 ------
  hi   
 (1 row)
+
+GP_IGNORE:-- start_ignore
+GP_IGNORE:DROP EXTERNAL TABLE IF EXISTS ext_delimiter_off_text;
+GP_IGNORE:DROP
+GP_IGNORE:-- end_ignore
+
+-- Create external table(format text) with delimiter off, and a row with 'O'
+CREATE EXTERNAL WEB TABLE ext_delimiter_off_text (a text) EXECUTE E'echo O' ON MASTER FORMAT 'text' (delimiter 'OFF') ENCODING 'UTF8';
+CREATE
+
+SELECT * FROM ext_delimiter_off_text;
+ a 
+---
+ O 
+(1 row)
+
+GP_IGNORE:-- start_ignore
+GP_IGNORE:DROP EXTERNAL TABLE IF EXISTS ext_delimiter_off_csv;
+GP_IGNORE:DROP
+GP_IGNORE:-- end_ignore
+
+-- Create external table(format csv) with delimiter off, and a row with 'O'
+CREATE EXTERNAL WEB TABLE ext_delimiter_off_csv (a text) EXECUTE E'echo O' ON MASTER FORMAT 'csv' (delimiter 'OFF') ENCODING 'UTF8';
+CREATE
+
+SELECT * FROM ext_delimiter_off_csv;
+ a 
+---
+ O 
+(1 row)


### PR DESCRIPTION
Fix a delimiter bug if external table has delimiter 'OFF', and the value of the column is 'O'.

Add a bool flag 'delim_off' for CopyStateData to indicate if delimiter is set to OFF or not.

This PR is to fix: https://github.com/greenplum-db/gpdb/issues/10009 
