### PR TITLE
[5X backport] gpcheckcat: fix gpcheckcat vpinfo issue

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -3051,7 +3051,7 @@ class checkAOSegVpinfoThread(execThread):
                 qry = "SELECT count(*) FROM pg_attribute WHERE attrelid=%d AND attnum > 0;" % (relid)
                 attr_count = self.db.query(qry).getresult()[0][0]
 
-                qry = "SELECT distinct(length(vpinfo)) FROM pg_aoseg.%s WHERE xmax = 0;" % (segrelname)
+                qry = "SELECT distinct(length(vpinfo)) FROM pg_aoseg.%s WHERE state = 1;" % (segrelname)
                 vpinfo_curs = self.db.query(qry)
                 nrows = vpinfo_curs.ntuples()
                 if nrows == 0:

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -13,6 +13,17 @@ Feature: gpcheckcat tests
         Then gpcheckcat should return a return code of 0
         And the user runs "dropdb all_good"
 
+    Scenario: gpcheckcat should report vpinfo inconsistent error 
+        Given database "vpinfo_inconsistent_db" is dropped and recreated
+        And there is a "co" table "public.co_vpinfo" in "vpinfo_inconsistent_db" with data
+        When the user runs "gpcheckcat vpinfo_inconsistent_db"
+        Then gpcheckcat should return a return code of 0
+        When an attribute of table "co_vpinfo" in database "vpinfo_inconsistent_db" is deleted on segment with content id "0"
+        Then psql should return a return code of 0
+        When the user runs "gpcheckcat -R aoseg_table vpinfo_inconsistent_db" 
+        Then gpcheckcat should print "Failed test\(s\) that are not reported here: aoseg_table" to stdout
+        And the user runs "dropdb vpinfo_inconsistent_db"
+
     @leak
     Scenario: gpcheckcat should drop leaked schemas
         Given database "leak_db" is dropped and recreated
@@ -429,13 +440,3 @@ Feature: gpcheckcat tests
         And the user runs "psql persistent_db -c "select gp_delete_persistent_relation_node_entry(ctid) from (select ctid from gp_persistent_relation_node where relfilenode_oid=(select relfilenode from pg_class where relname = 'myheaptable3')) as unwanted;""
         When the user runs "gpcheckcat -R persistent persistent_db"
         Then gpcheckcat should print "Failed test\(s\) that are not reported here: persistent" to stdout
-
-    Scenario: gpcheckcat should report vpinfo inconsistent error 
-        Given database "vpinfo_inconsistent_db" is dropped and recreated
-        And there is a "co" table "public.co_vpinfo" in "vpinfo_inconsistent_db" with data
-        When the user runs "gpcheckcat vpinfo_inconsistent_db"
-        Then gpcheckcat should return a return code of 0
-        When an attribute of table "co_vpinfo" in database "vpinfo_inconsistent_db" is deleted on segment with content id "0"
-        Then psql should return a return code of 0
-        When the user runs "gpcheckcat -R aoseg_table vpinfo_inconsistent_db" 
-        Then gpcheckcat should print "Failed test\(s\) that are not reported here: aoseg_table" to stdout


### PR DESCRIPTION
The entry in aocsseg table might be compacted and waiting for drop, so we
should use 'state' to filter the unused entry.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
