### PR TITLE
[6X backport] gpcheckcat: fix gpcheckcat vpinfo issue

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2443,7 +2443,7 @@ class checkAOSegVpinfoThread(execThread):
                 qry = "SELECT count(*) FROM pg_attribute WHERE attrelid=%d AND attnum > 0;" % (relid)
                 attr_count = self.db.query(qry).getresult()[0][0]
 
-                qry = "SELECT distinct(length(vpinfo)) FROM pg_aoseg.%s WHERE xmax = 0;" % (segrelname)
+                qry = "SELECT distinct(length(vpinfo)) FROM pg_aoseg.%s WHERE state = 1;" % (segrelname)
                 vpinfo_curs = self.db.query(qry)
                 nrows = vpinfo_curs.ntuples()
                 if nrows == 0:

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -500,13 +500,14 @@ Feature: gpcheckcat tests
 
     Scenario: gpcheckcat should report vpinfo inconsistent error 
         Given database "vpinfo_inconsistent_db" is dropped and recreated
-        And there is a "co" table "public.co_vpinfo" in "vpinfo_inconsistent_db" with data
-        When the user runs "gpcheckcat vpinfo_inconsistent_db"
-        Then gpcheckcat should return a return code of 0
-        When an attribute of table "co_vpinfo" in database "vpinfo_inconsistent_db" is deleted on segment with content id "0"
-        Then psql should return a return code of 0
-        When the user runs "gpcheckcat -R aoseg_table vpinfo_inconsistent_db" 
-        Then gpcheckcat should print "Failed test\(s\) that are not reported here: aoseg_table" to stdout
+          And there is a "co" table "public.co_vpinfo" in "vpinfo_inconsistent_db" with data
+         When the user runs "gpcheckcat vpinfo_inconsistent_db"
+         Then gpcheckcat should return a return code of 0
+         When an attribute of table "co_vpinfo" in database "vpinfo_inconsistent_db" is deleted on segment with content id "0"
+         Then psql should return a return code of 0
+         When the user runs "gpcheckcat -R aoseg_table vpinfo_inconsistent_db" 
+         Then gpcheckcat should print "Failed test\(s\) that are not reported here: aoseg_table" to stdout
+          And the user runs "dropdb vpinfo_inconsistent_db"
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster


### PR DESCRIPTION
The entry in aocsseg table might be compacted and waiting for drop, so we
should use 'state' to filter the unused entry.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
