### PR TITLE
Use yaml safe_load in gppkg

### DIFF
--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -240,7 +240,7 @@ class Gppkg:
             for cur_file in archive_list:
                 if cur_file.endswith(SPECFILE_NAME):
                     specfile = tarinfo.extractfile(cur_file)
-                    yamlfile = yaml.load(specfile)
+                    yamlfile = yaml.safe_load(specfile)
                     keys = yamlfile.keys()
                     break
 
@@ -1345,7 +1345,7 @@ class BuildGppkg(Operation):
         cur_file = None
 
         with open(specfile) as cur_file:
-            yamlfile = yaml.load(cur_file)
+            yamlfile = yaml.safe_load(cur_file)
 
             tags = yamlfile.keys()
 
@@ -1368,7 +1368,7 @@ class BuildGppkg(Operation):
 
         try:
             with open(specfile) as cur_file:
-                yamlfile = yaml.load(cur_file)
+                yamlfile = yaml.safe_load(cur_file)
 
                 if not self._verify_tags(yamlfile):
                     return False


### PR DESCRIPTION
Commit 21a2cb27b38117cce90c4ff06d8d447842c5acf1, added in PR #10361,
updated yaml and changed yaml.load to yaml.safe_load in gpload.

gppkg uses yaml as well, but references were not updated - this commit
resolves that discrepancy.

Co-authored-by: Tyler Ramer <tramer@vmware.com>
Co-authored-by: Jamie McAtamney <jmcatamney@vmware.com>

