### PR TITLE
Fix windows client build missing pyyaml issue

### DIFF
--- a/gpAux/client/install/src/windows/CreatePackage.bat
+++ b/gpAux/client/install/src/windows/CreatePackage.bat
@@ -11,7 +11,8 @@ type nul > %GPDB_INSTALL_PATH%\bin\gppylib\__init__.py
 copy ..\..\..\..\..\gpMgmt\bin\gppylib\gpversion.py %GPDB_INSTALL_PATH%\bin\gppylib\
 perl -pi.bak -e "s,\$Revision\$,%VERSION%," %GPDB_INSTALL_PATH%\bin\gpload.py
 copy ..\..\..\..\..\gpMgmt\bin\gpload.bat %GPDB_INSTALL_PATH%\bin
-copy ..\..\..\..\..\gpMgmt\bin\ext\yaml\* %GPDB_INSTALL_PATH%\lib\python\yaml
+for %%f in (..\..\..\..\..\gpMgmt\bin\pythonSrc\ext\PyYAML-*.tar.gz) do tar -xf %%f
+for /D %%d in (PyYAML-*) do copy %%d\lib\yaml\* %GPDB_INSTALL_PATH%\lib\python\yaml
 perl -p -e "s,__VERSION_PLACEHOLDER__,%VERSION%," greenplum-clients.wxs > greenplum-clients-%VERSION%.wxs
 candle.exe -nologo greenplum-clients-%VERSION%.wxs -out greenplum-clients-%VERSION%.wixobj -dSRCDIR=%GPDB_INSTALL_PATH% -dVERSION=%VERSION%
 light.exe -nologo -sval greenplum-clients-%VERSION%.wixobj -out greenplum-clients-x86_64.msi


### PR DESCRIPTION
Local fork at gpMgmt/bin/ext/yaml was removed by 8d6c305998. Unpack
it from gpMgmt/bin/pythonSrc/ext just like pygresql when making windows
client package.