### PR TITLE
Fix pulling up EXPR sublinks

### DIFF
--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -894,6 +894,28 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
  abc | 1 | 2 | xyz
 (3 rows)
 
+-- subquery contains quals of form 'function(outervar, innervar1) = innvervar2'
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=17)
+   ->  Seq Scan on csq_pullup t0  (cost=0.00..1.01 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         SubPlan 1
+           ->  Aggregate  (cost=1.05..1.06 rows=1 width=8)
+                 ->  Result  (cost=0.00..1.04 rows=1 width=0)
+                       Filter: ((t0.n + t1.n) = (t1.i)::numeric)
+                       ->  Materialize  (cost=0.00..1.03 rows=1 width=9)
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=9)
+                                   ->  Seq Scan on csq_pullup t1  (cost=0.00..1.01 rows=1 width=9)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+ t | n | i | v 
+---+---+---+---
+(0 rows)
+
 --
 -- NOT EXISTS CSQs to joins
 --

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -847,6 +847,29 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
  abc | 1 | 2 | xyz
 (3 rows)
 
+-- subquery contains quals of form 'function(outervar, innervar1) = innvervar2'
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+   ->  Result  (cost=0.00..5172.20 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
+         SubPlan 1
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       Filter: ((csq_pullup.n + csq_pullup_1.n) = (csq_pullup_1.i)::numeric)
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=9)
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=9)
+                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=9)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+(12 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+ t | n | i | v 
+---+---+---+---
+(0 rows)
+
 --
 -- NOT EXISTS CSQs to joins
 --

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -348,6 +348,11 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
 
+-- subquery contains quals of form 'function(outervar, innervar1) = innvervar2'
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+
 
 --
 -- NOT EXISTS CSQs to joins


### PR DESCRIPTION
Currently GPDB tries to pull up EXPR sublinks to inner joins. For query

select * from foo where foo.a >
    (select avg(bar.a) from bar where foo.b = bar.b);

GPDB would transform it to:

select * from foo inner join
    (select bar.b, avg(bar.a) as avg from bar group by bar.b) sub
on foo.b = sub.b and foo.a > sub.avg;

To do that, GPDB needs to recurse through the quals in sub-select and
extract quals of form 'outervar = innervar' and then build new
SortGroupClause items and TargetEntry items based on these quals for
sub-select.

But for quals of form 'function(outervar, innervar1) = innvervar2', GPDB
handles them incorrectly and will cause wrong results issues as
described in issue #9615.

This patch fixes this issue by treating these kinds of quals as not
compatible correlated and thus the sub-select would not be converted to
join.

Reviewed-by: Heikki Linnakangas <hlinnakangas@pivotal.io>
Reviewed-by: Asim R P <apraveen@pivotal.io>
(cherry picked from commit dcdc6c0b34bd7184f780f6e2f79f337937435476)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
