### PR TITLE
Fix uninitialized variable in pgrowlocks

### DIFF
--- a/contrib/pgrowlocks/pgrowlocks.c
+++ b/contrib/pgrowlocks/pgrowlocks.c
@@ -74,7 +74,6 @@ pgrowlocks(PG_FUNCTION_ARGS)
 	AttInMetadata *attinmeta;
 	Datum		result;
 	MyData	   *mydata;
-	Relation	rel;
 
 	if (SRF_IS_FIRSTCALL())
 	{
@@ -82,6 +81,7 @@ pgrowlocks(PG_FUNCTION_ARGS)
 		RangeVar   *relrv;
 		MemoryContext oldcontext;
 		AclResult	aclresult;
+		Relation	rel;
 
 		funcctx = SRF_FIRSTCALL_INIT();
 		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
@@ -129,7 +129,7 @@ pgrowlocks(PG_FUNCTION_ARGS)
 		/* must hold a buffer lock to call HeapTupleSatisfiesUpdate */
 		LockBuffer(scan->rs_cbuf, BUFFER_LOCK_SHARE);
 
-		htsu = HeapTupleSatisfiesUpdate(rel, tuple,
+		htsu = HeapTupleSatisfiesUpdate(mydata->rel, tuple,
 										GetCurrentCommandId(false),
 										scan->rs_cbuf);
 		xmax = HeapTupleHeaderGetRawXmax(tuple->t_data);


### PR DESCRIPTION
I encounter the following When I build master branch on Ubuntu 16.04 with gcc 6.3.0.

```
pgrowlocks.c: In function ‘pgrowlocks’:
pgrowlocks.c:132:8: error: ‘rel’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   htsu = HeapTupleSatisfiesUpdate(rel, tuple,
   ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           GetCurrentCommandId(false),
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
           scan->rs_cbuf);
           ~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
<builtin>: recipe for target 'pgrowlocks.o' failed
make[1]: *** [pgrowlocks.o] Error 1
make[1]: Leaving directory '/home/japin/greenplum-db/gpdb/contrib/pgrowlocks'
Makefile:102: recipe for target 'all-pgrowlocks-recurse' failed
make: *** [all-pgrowlocks-recurse] Error 2
```

This commit fix this bug.