### PR TITLE
Used dictionary to form connection string in minirepro

### DIFF
--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -330,9 +330,16 @@ def main():
 
     # setup the connection info tuple with options
     connectionInfo = (host, port, user, db)
-    connectionString = ':'.join([host, port, db, user, '', pgoptions, ''])
+    connectionDict = {
+            'host': host,
+            'port': port,
+            'database': db,
+            'user': user,
+            'options': pgoptions,
+            }
+
     print "Connecting to database: host=%s, port=%s, user=%s, db=%s ..." % connectionInfo
-    conn = pgdb.connect(connectionString)
+    conn = pgdb.connect(**connectionDict)
     cursor = conn.cursor()
 
     # get server version, which is dumped to minirepro output file


### PR DESCRIPTION
The approach of using a connection string is fragile in the event of an
update to pygresql or missing values, as demonstrated by errors after
update of pygresql in f5758021be347aea069c3ef930bae6354a2dd8db

Instead, we'll use a named value as arguments to pgdb.connect(),
following the example of dbconn.py

Addresses https://github.com/greenplum-db/gpdb/issues/10435 

Authored-by: Tyler Ramer <tramer@vmware.com>

