### PR TITLE
Fix pulling up EXPR sublinks

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -276,55 +276,39 @@ InitConvertSubqueryToJoinContext(ConvertSubqueryToJoinContext *ctx)
 static bool
 IsCorrelatedOpExpr(OpExpr *opexp, Expr **innerExpr)
 {
-	Assert(opexp);
-	Assert(list_length(opexp->args) > 1);
-	Assert(innerExpr);
+	Expr	   *e1;
+	Expr	   *e2;
 
 	if (list_length(opexp->args) != 2)
-	{
 		return false;
-	}
 
-	Expr	   *e1 = (Expr *) list_nth(opexp->args, 0);
-	Expr	   *e2 = (Expr *) list_nth(opexp->args, 1);
+	e1 = (Expr *) list_nth(opexp->args, 0);
+	e2 = (Expr *) list_nth(opexp->args, 1);
 
-	/**
+	/*
 	 * One of the vars must be outer, and other must be inner.
-	 *
-	 * If both sides of the condition referring to outer variable,
-	 * then fail to extract the innerExpr.
 	 */
-	if (contain_vars_of_level((Node *) e1, 1) && contain_vars_of_level((Node *) e2, 1))
+	if (contain_vars_of_level((Node *) e1, 1) &&
+			!contain_vars_of_level((Node *) e1, 0) &&
+			contain_vars_of_level((Node *) e2, 0) &&
+			!contain_vars_of_level((Node *) e2, 1))
 	{
-		return false;
+		*innerExpr = (Expr *) copyObject(e2);
+
+		return true;
 	}
 
-	Expr	   *tOuterExpr = NULL;
-	Expr	   *tInnerExpr = NULL;
-
-	if (contain_vars_of_level((Node *) e1, 1))
+	if (contain_vars_of_level((Node *) e1, 0) &&
+			!contain_vars_of_level((Node *) e1, 1) &&
+			contain_vars_of_level((Node *) e2, 1) &&
+			!contain_vars_of_level((Node *) e2, 0))
 	{
-		tOuterExpr = (Expr *) copyObject(e1);
-		tInnerExpr = (Expr *) copyObject(e2);
-	}
-	else if ((contain_vars_of_level((Node *) e2, 1)))
-	{
-		tOuterExpr = (Expr *) copyObject(e2);
-		tInnerExpr = (Expr *) copyObject(e1);
-	}
+		*innerExpr = (Expr *) copyObject(e1);
 
-	/**
-	 * It is correlated only if we found an outer var and inner expr
-	 */
-
-	if (tOuterExpr && contain_vars_of_level((Node *) tInnerExpr, 0))
-	{
-		*innerExpr = tInnerExpr;
 		return true;
 	}
 
 	return false;
-
 }
 
 /**
@@ -545,11 +529,14 @@ SubqueryToJoinWalker(Node *node, ConvertSubqueryToJoinContext *context)
 
 		if (considerOpExpr)
 		{
+			TargetEntry *tle;
 
-			TargetEntry *tle = makeTargetEntry(copyObject(innerExpr),
-										list_length(context->targetList) + 1,
+			tle = makeTargetEntry(innerExpr,
+											   list_length(context->targetList) + 1,
 											   NULL,
 											   false);
+			tle->ressortgroupref = list_length(context->targetList) + 1;
+			context->targetList = lappend(context->targetList, tle);
 
 			if (context->extractGrouping)
 			{
@@ -558,13 +545,12 @@ SubqueryToJoinWalker(Node *node, ConvertSubqueryToJoinContext *context)
 				gc->sortop = sortOp;
 				gc->tleSortGroupRef = list_length(context->groupClause) + 1;
 				context->groupClause = lappend(context->groupClause, gc);
-				tle->ressortgroupref = list_length(context->targetList) + 1;
 			}
 
-			context->targetList = lappend(context->targetList, tle);
 			context->joinQual = make_and_qual(context->joinQual, (Node *) opexp);
 
-			AssertImply(context->extractGrouping, list_length(context->groupClause) == list_length(context->targetList));
+			AssertImply(context->extractGrouping,
+					list_length(context->groupClause) == list_length(context->targetList));
 
 			return;
 		}

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -883,6 +883,28 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
  abc | 1 | 2 | xyz
 (3 rows)
 
+-- subquery contains quals of form 'function(outervar, innervar1) = innvervar2'
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=17)
+   ->  Seq Scan on csq_pullup t0  (cost=0.00..1.01 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         SubPlan 1
+           ->  Aggregate  (cost=1.05..1.06 rows=1 width=8)
+                 ->  Result  (cost=0.00..1.04 rows=1 width=0)
+                       Filter: ((t0.n + t1.n) = (t1.i)::numeric)
+                       ->  Materialize  (cost=0.00..1.03 rows=1 width=9)
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=9)
+                                   ->  Seq Scan on csq_pullup t1  (cost=0.00..1.01 rows=1 width=9)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+ t | n | i | v 
+---+---+---+---
+(0 rows)
+
 --
 -- NOT EXISTS CSQs to joins
 --

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -874,6 +874,29 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
  abc | 1 | 2 | xyz
 (3 rows)
 
+-- subquery contains quals of form 'function(outervar, innervar1) = innvervar2'
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+   ->  Result  (cost=0.00..5172.20 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
+         SubPlan 1
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       Filter: ((csq_pullup.n + csq_pullup_1.n) = (csq_pullup_1.i)::numeric)
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=9)
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=9)
+                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=9)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+(12 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+ t | n | i | v 
+---+---+---+---
+(0 rows)
+
 --
 -- NOT EXISTS CSQs to joins
 --

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -347,6 +347,11 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
 
+-- subquery contains quals of form 'function(outervar, innervar1) = innvervar2'
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+
 
 --
 -- NOT EXISTS CSQs to joins


### PR DESCRIPTION
Currently GPDB tries to pull up EXPR sublinks to inner joins. For query

select * from foo where foo.a >
    (select avg(bar.a) from bar where foo.b = bar.b);

GPDB would transform it to:

select * from foo inner join
    (select bar.b, avg(bar.a) as avg from bar group by bar.b) sub
on foo.b = sub.b and foo.a > sub.avg;

To do that, GPDB needs to recurse through the quals in sub-select and
extract quals of form 'outervar = innervar' and then build new
SortGroupClause items and TargetEntry items based on these quals for
sub-select.

But for quals of form 'function(outervar, innervar1) = innvervar2', GPDB
handles them incorrectly and will cause wrong results issues as
described in issue #9615.

This patch fixes this issue by treating these kinds of quals as not
compatible correlated and thus the sub-select would not be converted to
join.

Reviewed-by: Heikki Linnakangas <hlinnakangas@pivotal.io>
Reviewed-by: Asim R P <apraveen@pivotal.io>
(cherry picked from commit dcdc6c0b34bd7184f780f6e2f79f337937435476)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
