### PR TITLE
Fix flaky test case 'gpcopy'

### DIFF
--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1176,17 +1176,12 @@ COPY copy_from_same_txn FROM stdin;
 \.
 COMMIT;
 
--- Test that issuing a cancel requests during COPY aborts the processing before
--- the entire contents has been copied out. The hardcoded rowcount 57190 is the
--- number of rows in the lineitem table.
+-- Test that COPY can be aborted by cancel request after the COPY is dispatched.
 
 SELECT gp_inject_fault('cdb_copy_start_after_dispatch', 'reset', 1);
 SELECT gp_inject_fault('cdb_copy_start_after_dispatch', 'interrupt', 1);
 
 COPY lineitem TO '/tmp/aborted.data';
-CREATE TABLE lineitem_aborted (LIKE lineitem);
-COPY lineitem_aborted FROM '/tmp/aborted.data';
-SELECT count(*) < 57190 FROM lineitem_aborted;
 
 SELECT gp_inject_fault('cdb_copy_start_after_dispatch', 'reset', 1);
 

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1436,9 +1436,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 COPY copy_from_same_txn FROM stdin;
 COMMIT;
--- Test that issuing a cancel requests during COPY aborts the processing before
--- the entire contents has been copied out. The hardcoded rowcount 57190 is the
--- number of rows in the lineitem table.
+-- Test that COPY can be aborted by cancel request after the COPY is dispatched.
 SELECT gp_inject_fault('cdb_copy_start_after_dispatch', 'reset', 1);
  gp_inject_fault 
 -----------------
@@ -1453,15 +1451,6 @@ SELECT gp_inject_fault('cdb_copy_start_after_dispatch', 'interrupt', 1);
 
 COPY lineitem TO '/tmp/aborted.data';
 ERROR:  canceling statement due to user request
-CREATE TABLE lineitem_aborted (LIKE lineitem);
-NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
-COPY lineitem_aborted FROM '/tmp/aborted.data';
-SELECT count(*) < 57190 FROM lineitem_aborted;
- ?column? 
-----------
- t
-(1 row)
-
 SELECT gp_inject_fault('cdb_copy_start_after_dispatch', 'reset', 1);
  gp_inject_fault 
 -----------------


### PR DESCRIPTION
The failed test case is to test the command "copy lineitem to '/tmp/abort.csv'"
can be cancelled after COPY is dispatched to QEs. To verify this, it checks that
/tmp/abort.csv has fewer rows than lineitem.

The cancel logical in codes is:

QD dispatched the COPY command to QEs, then if QD get a cancel interrupt, it
sends a cancel request to QEs, however, the QD will keep receiving data from
QEs even QD already get a cancel interrupt. QD relies on QEs to receive the
cancel request and explicitly stop copying data to QD.

Obviously, QEs may already have copied out all data to QDs before they
get cancel requests, so the test case cannot guarantee /tmp/aborted.csv
has fewer rows than lineitem.

To fix this, we just verify the COPY command can be aborted with message
'ERROR:  canceling statement due to user request', the count
verification looks pointless here.

