### PR TITLE
When dropping a partition, keep the lock until end of transaction.

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -1372,19 +1372,6 @@ AcquireDeletionLock(const ObjectAddress *object, int flags)
 			LockRelationOid(object->objectId, ShareUpdateExclusiveLock);
 		else
 			LockRelationOid(object->objectId, AccessExclusiveLock);
-		/*
-		 * GPDB: If this was a partition, or some other object for which
-		 * we are careful to always lock the parent object, we don't need
-		 * to keep the lock on the sub-object. This helps to keep the lock
-		 * table size in check, if you e.g. drop a table with thousands
-		 * of partitions. It would be unpleasent if you could not drop
-		 * such a table because the lock table runs out of space.
-		 *
-		 * To provide at least some protection though, we still actuire
-		 * the lock momentarily.
-		 */
-		if (!rel_needs_long_lock(object->objectId))
-			UnlockRelationOid(object->objectId, AccessExclusiveLock);
 	}
 	else
 	{
@@ -1401,16 +1388,7 @@ static void
 ReleaseDeletionLock(const ObjectAddress *object)
 {
 	if (object->classId == RelationRelationId)
-	{
-		/*
-		 * GPDB: Since we might already have released the lock (see
-		 * AcquireDeletionLock), we mustn't try to release it again.
-		 */
-		if (!rel_needs_long_lock(object->objectId))
-			return;
-
 		UnlockRelationOid(object->objectId, AccessExclusiveLock);
-	}
 	else
 		/* assume we should lock the whole object not a sub-object */
 		UnlockDatabaseObject(object->classId, object->objectId, 0,

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -2345,7 +2345,6 @@ void
 heap_drop_with_catalog(Oid relid)
 {
 	Relation	rel;
-	bool		is_part_child = false;
 	bool		is_appendonly_rel;
 	char		relkind;
 
@@ -2404,15 +2403,11 @@ heap_drop_with_catalog(Oid relid)
 	}
 
 	/*
-	 * Close relcache entry, but *keep* AccessExclusiveLock (unless this is
-	 * a child partition) on the relation until transaction commit.  This
-	 * ensures no one else will try to do something with the doomed relation.
+	 * Close relcache entry, but *keep* AccessExclusiveLock on the relation
+	 * until transaction commit.  This ensures no one else will try to do
+	 * something with the doomed relation.
 	 */
-	is_part_child = !rel_needs_long_lock(RelationGetRelid(rel));
-	if (is_part_child)
-		relation_close(rel, AccessExclusiveLock);
-	else
-		relation_close(rel, NoLock);
+	relation_close(rel, NoLock);
 
 	/*
 	 * Forget any ON COMMIT action for the rel

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -1255,19 +1255,8 @@ index_create(Relation heapRelation,
 	/*
 	 * Close the index; but we keep the lock that we acquired above until end
 	 * of transaction.  Closing the heap is caller's responsibility.
-	 *
-	 * GPDB: if we're dealing with a child of a partitioned table, also release
-	 * the lock. We should be holding a lock on the master, which is sufficient.
 	 */
-	if (rel_needs_long_lock(RelationGetRelid(heapRelation)))
-	{
-		index_close(indexRelation, NoLock);
-	}
-	else
-	{
-		index_close(indexRelation, AccessExclusiveLock);
-	}
-
+	index_close(indexRelation, NoLock);
 	return indexRelationId;
 }
 
@@ -1528,7 +1517,6 @@ index_drop(Oid indexId, bool concurrent)
 	Relation	indexRelation;
 	HeapTuple	tuple;
 	bool		hasexprs;
-	bool		need_long_lock;
 	LockRelId	heaprelid,
 				indexrelid;
 	LOCKTAG		heaplocktag;
@@ -1738,11 +1726,7 @@ index_drop(Oid indexId, bool concurrent)
 	 * try to rebuild it while we're deleting catalog entries. We keep the
 	 * lock though.
 	 */
-	need_long_lock = rel_needs_long_lock(RelationGetRelid(userIndexRelation));
-	if (need_long_lock)
-		index_close(userIndexRelation, NoLock);
-	else
-		index_close(userIndexRelation, AccessExclusiveLock);
+	index_close(userIndexRelation, NoLock);
 
 	RelationForgetRelation(indexId);
 
@@ -1801,8 +1785,7 @@ index_drop(Oid indexId, bool concurrent)
 	/*
 	 * Close owning rel, but keep lock
 	 */
-	heap_close(userHeapRelation, need_long_lock ? NoLock : AccessExclusiveLock);
-
+	heap_close(userHeapRelation, NoLock);
 
 	/*
 	 * Release the session locks before we go.

--- a/src/backend/catalog/pg_constraint.c
+++ b/src/backend/catalog/pg_constraint.c
@@ -556,7 +556,6 @@ RemoveConstraintById(Oid conId)
 	if (OidIsValid(con->conrelid))
 	{
 		Relation	rel;
-		bool		is_part_child = false;
 
 		/*
 		 * If the constraint is for a relation, open and exclusive-lock the
@@ -597,14 +596,8 @@ RemoveConstraintById(Oid conId)
 			heap_close(pgrel, RowExclusiveLock);
 		}
 
-		is_part_child = !rel_needs_long_lock(RelationGetRelid(rel));
-
-		if (is_part_child)
-			/* sufficiently locked, in the case of a partitioned table */
-			heap_close(rel, AccessExclusiveLock);
-		else
-			/* Keep lock on constraint's rel until end of xact */
-			heap_close(rel, NoLock);
+		/* Keep lock on constraint's rel until end of xact */
+		heap_close(rel, NoLock);
 	}
 	else if (OidIsValid(con->contypid))
 	{

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -715,7 +715,7 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, char relpersistence,
 	OldHeap = heap_open(OIDOldHeap, lockmode);
 	OldHeapDesc = RelationGetDescr(OldHeap);
 
-	is_part_child = !rel_needs_long_lock(OIDOldHeap);
+	is_part_child = rel_is_part_child(OIDOldHeap);
 
 	/*
 	 * Check pg_inherits to determine if the OldHeap relation is a non-leaf

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -443,7 +443,6 @@ DefineIndex(Oid relationId,
 	LOCKTAG		heaplocktag;
 	LOCKMODE	lockmode;
 	Snapshot	snapshot;
-	bool		need_longlock = true;
 	bool		shouldDispatch;
 	int			i;
 
@@ -944,14 +943,6 @@ DefineIndex(Oid relationId,
 		 */
 	}
 
-	if (rel_needs_long_lock(RelationGetRelid(rel)))
-		need_longlock = true;
-	/* if this is a concurrent build, we must lock you long time */
-	else if (stmt->concurrent)
-		need_longlock = true;
-	else
-		need_longlock = false;
-
 	/*
 	 * A valid stmt->oldNode implies that we already have a built form of the
 	 * index.  The caller should also decline any index build.
@@ -1028,10 +1019,7 @@ DefineIndex(Oid relationId,
 			for (i = 0; i < numberOfAttributes; i++)
 				opfamOids[i] = get_opclass_family(classObjectId[i]);
 
-			if (need_longlock)
-				heap_close(rel, NoLock);
-			else
-				heap_close(rel, lockmode);
+			heap_close(rel, NoLock);
 
 			/*
 			 * For each partition, scan all existing indexes; if one matches
@@ -1218,10 +1206,7 @@ DefineIndex(Oid relationId,
 		 */
 		else
 		{
-			if (need_longlock)
-				heap_close(rel, NoLock);
-			else
-				heap_close(rel, lockmode);
+			heap_close(rel, NoLock);
 		}
 		/*
 		 * Indexes on partitioned tables are not themselves built, so we're
@@ -1233,10 +1218,7 @@ DefineIndex(Oid relationId,
 	if (!stmt->concurrent)
 	{
 		/* Close the heap and we're done, in the non-concurrent case */
-		if (need_longlock)
-			heap_close(rel, NoLock);
-		else
-			heap_close(rel, lockmode);
+		heap_close(rel, NoLock);
 		return address;
 	}
 
@@ -1254,10 +1236,7 @@ DefineIndex(Oid relationId,
 	/* save lockrelid and locktag for below, then close rel */
 	heaprelid = rel->rd_lockInfo.lockRelId;
 	SET_LOCKTAG_RELATION(heaplocktag, heaprelid.dbId, heaprelid.relId);
-	if (need_longlock)
-		heap_close(rel, NoLock);
-	else
-		heap_close(rel, lockmode);
+	heap_close(rel, NoLock);
 
 	/*
 	 * For a concurrent build, it's important to make the catalog entries

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -1711,7 +1711,7 @@ expand_inherited_rtentry(PlannerInfo *root, RangeTblEntry *rte, Index rti)
 
 		/* Close child relations, but keep locks */
 		if (childOID != parentOID)
-			heap_close(newrelation, rel_needs_long_lock(childOID) ? NoLock: lockmode);
+			heap_close(newrelation, NoLock);
 	}
 
 	heap_close(oldrelation, NoLock);

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -108,7 +108,6 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 	Relation	relation;
 	bool		hasindex;
 	List	   *indexinfos = NIL;
-	bool		needs_longlock;
 
 	/*
 	 * We need not lock the relation since it was already locked, either by
@@ -116,7 +115,6 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 	 * rangetable.
 	 */
 	relation = heap_open(relationObjectId, NoLock);
-	needs_longlock = rel_needs_long_lock(relationObjectId);
 
 	/* Temporary and unlogged relations are inaccessible during recovery. */
 	if (!RelationNeedsWAL(relation) && RecoveryInProgress())
@@ -409,7 +407,7 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 				info->tree_height = -1;
 			}
 
-			index_close(indexRelation, needs_longlock ? NoLock : lmode);
+			index_close(indexRelation, NoLock);
 
 			indexinfos = lcons(info, indexinfos);
 		}

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -3315,17 +3315,9 @@ transformIndexStmt(Oid relid, IndexStmt *stmt, const char *queryString)
 	free_parsestate(pstate);
 
 	/*
-	 * Close relation. Unless this is a CREATE INDEX
-	 * for a partitioned table, and we're processing a partition. In that
-	 * case, we want to release the lock on the partition early, so that
-	 * you don't run out of space in the lock manager if there are a lot
-	 * of partitions. Holding the lock on the parent table should be
-	 * enough.
+	 * Close relation, but keep the lock.
 	 */
-	if (!rel_needs_long_lock(RelationGetRelid(rel)))
-		heap_close(rel, lockmode);
-	else
-		heap_close(rel, NoLock);
+	heap_close(rel, NoLock);
 
 	/* Mark statement as successfully transformed */
 	stmt->transformed = true;

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -118,7 +118,7 @@ extern void AtEOSubXact_on_commit_actions(bool isCommit,
 							  SubTransactionId parentSubid);
 
 extern bool rel_is_parent(Oid relid);
-extern bool rel_needs_long_lock(Oid relid);
+extern bool rel_is_part_child(Oid relid);
 extern Oid  rel_partition_get_master(Oid relid);
 
 extern Oid get_settable_tablespace_oid(char *tablespacename);

--- a/src/test/isolation2/expected/gdd/dml_locks_only_targeted_table_in_query_optimizer.out
+++ b/src/test/isolation2/expected/gdd/dml_locks_only_targeted_table_in_query_optimizer.out
@@ -21,8 +21,7 @@ DELETE 10
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del_1_prt_1'::regclass::oid AND gp_segment_id = -1;
  ?column? 
 ----------
- 1        
-(1 row)
+(0 rows)
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del'::regclass::oid AND gp_segment_id = -1;
  ?column? 
 ----------
@@ -40,8 +39,7 @@ UPDATE 1
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del_1_prt_1'::regclass::oid AND gp_segment_id = -1;
  ?column? 
 ----------
- 1        
-(1 row)
+(0 rows)
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del'::regclass::oid AND gp_segment_id = -1;
  ?column? 
 ----------

--- a/src/test/isolation2/sql/gdd/dml_locks_only_targeted_table_in_query.sql
+++ b/src/test/isolation2/sql/gdd/dml_locks_only_targeted_table_in_query.sql
@@ -8,18 +8,16 @@ INSERT INTO part_tbl_upd_del SELECT i, 1, i FROM generate_series(1,10)i;
 
 1: BEGIN;
 1: DELETE FROM part_tbl_upd_del;
--- since the delete operation is on root part and gdd is on, there will be no lock on leaf partition on QD
+-- on QD, there's a lock on the root and the target partition
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del_1_prt_1'::regclass::oid AND gp_segment_id = -1;
--- lock on qd will be there for root partition
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del'::regclass::oid AND gp_segment_id = -1;
 1: ROLLBACK;
 
 
 1: BEGIN;
 1: UPDATE part_tbl_upd_del SET c = 1 WHERE c = 1;
--- since the update operation is on root part and gdd is on, there will be no lock on leaf partition on QD
+-- on QD, there's a lock on the root and the target partition
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del_1_prt_1'::regclass::oid AND gp_segment_id = -1;
--- lock on qd will be there for root partition
 1: SELECT 1 FROM pg_locks WHERE relation='part_tbl_upd_del'::regclass::oid AND gp_segment_id = -1;
 1: ROLLBACK;
 

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -1,5 +1,12 @@
--- Test locking behaviour. When creating, dropping, querying or adding indexes
--- partitioned tables, we want to lock only the master, not the children.
+-- Test locking behaviour when operating on partitions.
+--
+-- In previous versions of GPDB, we used to only lock the parent table in
+-- many DDL operations. That was always a bit bogus, but we did it to avoid
+-- running out of lock space when working on large partition hierarchies. We
+-- don't play fast and loose like that anymore, but keep the tests. If a user
+-- runs out of lock space, you can work around that by simply bumping up
+-- max_locks_per_transactions.
+--
 -- Show locks in master and in segments. Because the number of segments
 -- in the cluster depends on configuration, we print only summary information
 -- of the locks in segments. If a relation is locked only on one segment,
@@ -115,7 +122,34 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
-(3 rows)
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(30 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -123,7 +157,34 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
-(3 rows)
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(30 rows)
 
 commit;
 -- AO table (ao segments, block directory won't exist after create)
@@ -199,7 +260,25 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
-(6 rows)
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(24 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -210,7 +289,25 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
-(6 rows)
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(24 rows)
 
 commit;
 -- Indexing
@@ -239,36 +336,54 @@ NOTICE:  building index for child partition "partlockt_1_prt_7"
 NOTICE:  building index for child partition "partlockt_1_prt_8"
 NOTICE:  building index for child partition "partlockt_1_prt_9"
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-     coalesce      |        mode         | locktype |  node  
--------------------+---------------------+----------+--------
- partlockt         | ShareLock           | relation | master
- partlockt_1_prt_1 | ShareLock           | relation | master
- partlockt_1_prt_2 | ShareLock           | relation | master
- partlockt_1_prt_3 | ShareLock           | relation | master
- partlockt_1_prt_4 | ShareLock           | relation | master
- partlockt_1_prt_5 | ShareLock           | relation | master
- partlockt_1_prt_6 | ShareLock           | relation | master
- partlockt_1_prt_7 | ShareLock           | relation | master
- partlockt_1_prt_8 | ShareLock           | relation | master
- partlockt_1_prt_9 | ShareLock           | relation | master
- partlockt_idx     | AccessExclusiveLock | relation | master
-(11 rows)
+        coalesce         |        mode         | locktype |  node  
+-------------------------+---------------------+----------+--------
+ partlockt               | ShareLock           | relation | master
+ partlockt_1_prt_1       | ShareLock           | relation | master
+ partlockt_1_prt_1_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_2       | ShareLock           | relation | master
+ partlockt_1_prt_2_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_3       | ShareLock           | relation | master
+ partlockt_1_prt_3_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_4       | ShareLock           | relation | master
+ partlockt_1_prt_4_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_5       | ShareLock           | relation | master
+ partlockt_1_prt_5_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_6       | ShareLock           | relation | master
+ partlockt_1_prt_6_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_7       | ShareLock           | relation | master
+ partlockt_1_prt_7_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_8       | ShareLock           | relation | master
+ partlockt_1_prt_8_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_9       | ShareLock           | relation | master
+ partlockt_1_prt_9_i_idx | AccessExclusiveLock | relation | master
+ partlockt_idx           | AccessExclusiveLock | relation | master
+(20 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-     coalesce      |        mode         | locktype |    node    
--------------------+---------------------+----------+------------
- partlockt_idx     | AccessExclusiveLock | relation | n segments
- partlockt_1_prt_5 | ShareLock           | relation | n segments
- partlockt_1_prt_2 | ShareLock           | relation | n segments
- partlockt_1_prt_4 | ShareLock           | relation | n segments
- partlockt_1_prt_9 | ShareLock           | relation | n segments
- partlockt_1_prt_8 | ShareLock           | relation | n segments
- partlockt_1_prt_6 | ShareLock           | relation | n segments
- partlockt_1_prt_3 | ShareLock           | relation | n segments
- partlockt_1_prt_1 | ShareLock           | relation | n segments
- partlockt         | ShareLock           | relation | n segments
- partlockt_1_prt_7 | ShareLock           | relation | n segments
-(11 rows)
+        coalesce         |        mode         | locktype |    node    
+-------------------------+---------------------+----------+------------
+ partlockt               | ShareLock           | relation | n segments
+ partlockt_1_prt_1       | ShareLock           | relation | n segments
+ partlockt_1_prt_1_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_2       | ShareLock           | relation | n segments
+ partlockt_1_prt_2_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_3       | ShareLock           | relation | n segments
+ partlockt_1_prt_3_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_4       | ShareLock           | relation | n segments
+ partlockt_1_prt_4_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_5       | ShareLock           | relation | n segments
+ partlockt_1_prt_5_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_6       | ShareLock           | relation | n segments
+ partlockt_1_prt_6_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_7       | ShareLock           | relation | n segments
+ partlockt_1_prt_7_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_8       | ShareLock           | relation | n segments
+ partlockt_1_prt_8_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_9       | ShareLock           | relation | n segments
+ partlockt_1_prt_9_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_idx           | AccessExclusiveLock | relation | n segments
+(20 rows)
 
 commit;
 -- Force use of the index in the select and delete below. We're not interested
@@ -290,7 +405,23 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  partlockt               | AccessShareLock | relation | master
  partlockt_1_prt_1       | AccessShareLock | relation | master
  partlockt_1_prt_1_i_idx | AccessShareLock | relation | master
-(3 rows)
+ partlockt_1_prt_2       | AccessShareLock | relation | master
+ partlockt_1_prt_2_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_3       | AccessShareLock | relation | master
+ partlockt_1_prt_3_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_4       | AccessShareLock | relation | master
+ partlockt_1_prt_4_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_5       | AccessShareLock | relation | master
+ partlockt_1_prt_5_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_6       | AccessShareLock | relation | master
+ partlockt_1_prt_6_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_7       | AccessShareLock | relation | master
+ partlockt_1_prt_7_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_8       | AccessShareLock | relation | master
+ partlockt_1_prt_8_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_9       | AccessShareLock | relation | master
+ partlockt_1_prt_9_i_idx | AccessShareLock | relation | master
+(19 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
         coalesce         |      mode       | locktype |   node    
@@ -331,11 +462,29 @@ begin;
 delete from partlockt where i = 4;
 -- Known_opt_diff: MPP-20936
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-     coalesce      |     mode      | locktype |  node  
--------------------+---------------+----------+--------
- partlockt         | ExclusiveLock | relation | master
- partlockt_1_prt_4 | ExclusiveLock | relation | master
-(2 rows)
+        coalesce         |       mode       | locktype |  node  
+-------------------------+------------------+----------+--------
+ partlockt               | ExclusiveLock    | relation | master
+ partlockt_1_prt_1       | RowExclusiveLock | relation | master
+ partlockt_1_prt_1_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_2       | RowExclusiveLock | relation | master
+ partlockt_1_prt_2_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_3       | RowExclusiveLock | relation | master
+ partlockt_1_prt_3_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_4       | ExclusiveLock    | relation | master
+ partlockt_1_prt_4       | RowExclusiveLock | relation | master
+ partlockt_1_prt_4_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_5       | RowExclusiveLock | relation | master
+ partlockt_1_prt_5_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_6       | RowExclusiveLock | relation | master
+ partlockt_1_prt_6_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_7       | RowExclusiveLock | relation | master
+ partlockt_1_prt_7_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_8       | RowExclusiveLock | relation | master
+ partlockt_1_prt_8_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_9       | RowExclusiveLock | relation | master
+ partlockt_1_prt_9_i_idx | RowExclusiveLock | relation | master
+(20 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |   node    
@@ -354,7 +503,43 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
-(4 rows)
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(40 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -363,6 +548,42 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
-(4 rows)
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(40 rows)
 
 commit;

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -1,5 +1,12 @@
--- Test locking behaviour. When creating, dropping, querying or adding indexes
--- partitioned tables, we want to lock only the master, not the children.
+-- Test locking behaviour when operating on partitions.
+--
+-- In previous versions of GPDB, we used to only lock the parent table in
+-- many DDL operations. That was always a bit bogus, but we did it to avoid
+-- running out of lock space when working on large partition hierarchies. We
+-- don't play fast and loose like that anymore, but keep the tests. If a user
+-- runs out of lock space, you can work around that by simply bumping up
+-- max_locks_per_transactions.
+--
 -- Show locks in master and in segments. Because the number of segments
 -- in the cluster depends on configuration, we print only summary information
 -- of the locks in segments. If a relation is locked only on one segment,
@@ -115,7 +122,34 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
-(3 rows)
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(30 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -123,7 +157,34 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
-(3 rows)
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(30 rows)
 
 commit;
 -- AO table (ao segments, block directory won't exist after create)
@@ -199,7 +260,25 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
-(6 rows)
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(24 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -210,7 +289,25 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
-(6 rows)
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(24 rows)
 
 commit;
 -- Indexing
@@ -239,36 +336,54 @@ NOTICE:  building index for child partition "partlockt_1_prt_7"
 NOTICE:  building index for child partition "partlockt_1_prt_8"
 NOTICE:  building index for child partition "partlockt_1_prt_9"
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-     coalesce      |        mode         | locktype |  node  
--------------------+---------------------+----------+--------
- partlockt         | ShareLock           | relation | master
- partlockt_1_prt_1 | ShareLock           | relation | master
- partlockt_1_prt_2 | ShareLock           | relation | master
- partlockt_1_prt_3 | ShareLock           | relation | master
- partlockt_1_prt_4 | ShareLock           | relation | master
- partlockt_1_prt_5 | ShareLock           | relation | master
- partlockt_1_prt_6 | ShareLock           | relation | master
- partlockt_1_prt_7 | ShareLock           | relation | master
- partlockt_1_prt_8 | ShareLock           | relation | master
- partlockt_1_prt_9 | ShareLock           | relation | master
- partlockt_idx     | AccessExclusiveLock | relation | master
-(11 rows)
+        coalesce         |        mode         | locktype |  node  
+-------------------------+---------------------+----------+--------
+ partlockt               | ShareLock           | relation | master
+ partlockt_1_prt_1       | ShareLock           | relation | master
+ partlockt_1_prt_1_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_2       | ShareLock           | relation | master
+ partlockt_1_prt_2_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_3       | ShareLock           | relation | master
+ partlockt_1_prt_3_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_4       | ShareLock           | relation | master
+ partlockt_1_prt_4_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_5       | ShareLock           | relation | master
+ partlockt_1_prt_5_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_6       | ShareLock           | relation | master
+ partlockt_1_prt_6_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_7       | ShareLock           | relation | master
+ partlockt_1_prt_7_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_8       | ShareLock           | relation | master
+ partlockt_1_prt_8_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_9       | ShareLock           | relation | master
+ partlockt_1_prt_9_i_idx | AccessExclusiveLock | relation | master
+ partlockt_idx           | AccessExclusiveLock | relation | master
+(20 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-     coalesce      |        mode         | locktype |    node    
--------------------+---------------------+----------+------------
- partlockt_1_prt_6 | ShareLock           | relation | n segments
- partlockt_1_prt_5 | ShareLock           | relation | n segments
- partlockt         | ShareLock           | relation | n segments
- partlockt_1_prt_9 | ShareLock           | relation | n segments
- partlockt_1_prt_1 | ShareLock           | relation | n segments
- partlockt_1_prt_3 | ShareLock           | relation | n segments
- partlockt_1_prt_8 | ShareLock           | relation | n segments
- partlockt_1_prt_4 | ShareLock           | relation | n segments
- partlockt_1_prt_7 | ShareLock           | relation | n segments
- partlockt_1_prt_2 | ShareLock           | relation | n segments
- partlockt_idx     | AccessExclusiveLock | relation | n segments
-(11 rows)
+        coalesce         |        mode         | locktype |    node    
+-------------------------+---------------------+----------+------------
+ partlockt               | ShareLock           | relation | n segments
+ partlockt_1_prt_1       | ShareLock           | relation | n segments
+ partlockt_1_prt_1_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_2       | ShareLock           | relation | n segments
+ partlockt_1_prt_2_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_3       | ShareLock           | relation | n segments
+ partlockt_1_prt_3_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_4       | ShareLock           | relation | n segments
+ partlockt_1_prt_4_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_5       | ShareLock           | relation | n segments
+ partlockt_1_prt_5_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_6       | ShareLock           | relation | n segments
+ partlockt_1_prt_6_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_7       | ShareLock           | relation | n segments
+ partlockt_1_prt_7_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_8       | ShareLock           | relation | n segments
+ partlockt_1_prt_8_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_9       | ShareLock           | relation | n segments
+ partlockt_1_prt_9_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_idx           | AccessExclusiveLock | relation | n segments
+(20 rows)
 
 commit;
 -- Force use of the index in the select and delete below. We're not interested
@@ -362,7 +477,43 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
-(4 rows)
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(40 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -371,6 +522,42 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
-(4 rows)
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(40 rows)
 
 commit;

--- a/src/test/regress/sql/partition_locking.sql
+++ b/src/test/regress/sql/partition_locking.sql
@@ -1,5 +1,12 @@
--- Test locking behaviour. When creating, dropping, querying or adding indexes
--- partitioned tables, we want to lock only the master, not the children.
+-- Test locking behaviour when operating on partitions.
+--
+-- In previous versions of GPDB, we used to only lock the parent table in
+-- many DDL operations. That was always a bit bogus, but we did it to avoid
+-- running out of lock space when working on large partition hierarchies. We
+-- don't play fast and loose like that anymore, but keep the tests. If a user
+-- runs out of lock space, you can work around that by simply bumping up
+-- max_locks_per_transactions.
+--
 
 -- Show locks in master and in segments. Because the number of segments
 -- in the cluster depends on configuration, we print only summary information


### PR DESCRIPTION
That's how the locking works for all other tables, including inherited
tables, and for partitions in PostgreSQL v10 partitioning. But in GPDB,
we were intentionally releasing the lock too early, to save memory when
working on huge partition hierarchies I believe. But that's a lousy
tradeoff, we shouldn't skimp on safety just to save some memory. If
you run out of lock memory as a result, you need to bump up
max_locks_per_tranactions. Memory is cheap, and if you're working with
tens of thousands of partitions, you can afford reserving some memory for
the lock manager.

Fixes https://github.com/greenplum-db/gpdb/issues/5919
