### PR TITLE
Fix log_errors related issue while creating pxf_fdw extension

### DIFF
--- a/gpcontrib/pxf_fdw/pxf_option.c
+++ b/gpcontrib/pxf_fdw/pxf_option.c
@@ -134,7 +134,7 @@ pxf_fdw_validator(PG_FUNCTION_ARGS)
 	char	   *protocol = NULL;
 	char	   *resource = NULL;
 	char	   *reject_limit_type = FDW_OPTION_REJECT_LIMIT_ROWS;
-	bool		log_errors = -1;
+	bool		log_errors_set = false;
 	List	   *options_list = untransformRelOptions(PG_GETARG_DATUM(0));
 	Oid			catalog = PG_GETARG_OID(1);
 	List	   *copy_options = NIL;
@@ -220,7 +220,10 @@ pxf_fdw_validator(PG_FUNCTION_ARGS)
 								FDW_OPTION_REJECT_LIMIT_PERCENT)));
 		}
 		else if (strcmp(def->defname, FDW_OPTION_LOG_ERRORS) == 0)
-			log_errors = defGetBoolean(def);
+		{
+			(void) defGetBoolean(def); /* call is required for validation */
+			log_errors_set = true;
+		}
 		else if (IsCopyOption(def->defname))
 			copy_options = lappend(copy_options, def);
 	}
@@ -265,7 +268,7 @@ pxf_fdw_validator(PG_FUNCTION_ARGS)
 	}
 	else
 	{
-		if (log_errors != -1)
+		if (log_errors_set)
 			ereport(ERROR,
 					(errcode(ERRCODE_FDW_INVALID_STRING_FORMAT),
 					 errmsg("the %s option cannot be set without reject_limit", FDW_OPTION_LOG_ERRORS)));


### PR DESCRIPTION
On an ARM64 machine, CREATE EXTENSION pxf_fdw fails with :
ERROR:  the log_errors option cannot be set without reject_limit

In pxf_fdw_validator(), the variable log_errors is declared bool, but
it is initialized with -1. Since bool seems to be now a built-in type,
it's definition is implementation dependent, and it's possible that on
ARM, it is defined as unsigned char. Because, through debugger it
could be seen that log_errors's value is 255 when it was assigned -1.
And because (log_errors != -1) condition returns true, we get the
error "log_errors option cannot be set without reject_limit" even when
log_errors option was not specified while creating the extension.
Due to this, all pxf_fdw tests were failing on ARM64.

If log_errors is specified, set log_errors to true rather than to
defGetBoolean(def) value. And rename log_errors to log_errors_set to
reflect that its purpose is not to store the log_errors value, but
rather to denote whether log_errors option was specified.

