### PR TITLE
docs - note how oss users get gpbackup

### DIFF
--- a/gpdb-doc/markdown/common/gpdb-features.html.md.erb
+++ b/gpdb-doc/markdown/common/gpdb-features.html.md.erb
@@ -52,6 +52,10 @@ the Greenplum hosts.
 
 - The deprecated <codeph>gpcheck</codeph> management utility and its replacement <codeph>gpsupport</codeph> are only supported with Pivotal Greenplum Database. 
 
-- To use the Greenplum Platform Extension Framework (PXF) with open source Greenplum Database, you must separately build and install the PXF server software. Refer to the build and packaging instructions in the [PXF Packaging README](https://github.com/greenplum-db/pxf/blob/master/package/README.md) file located in the PXF github repository.
-
 - Suggestions to contact Pivotal Technical Support in this documentation are intended only for Pivotal Greenplum Database customers. 
+
+Source code for the following open source Greenplum components are located in repositories outside of the Greenplum Database repo:
+
+- To use Backup and Restore with open source Greenplum Database, you must separately build and install the backup/restore software. Refer to the build instructions in the [README](https://github.com/greenplum-db/gpbackup/blob/master/README.md) file located in the Greenplum Backup and Restore github repository.
+
+- To use the Greenplum Platform Extension Framework (PXF) with open source Greenplum Database, you must separately build and install the PXF server software. Refer to the build and packaging instructions in the [PXF Packaging README](https://github.com/greenplum-db/pxf/blob/master/package/README.md) file located in the PXF github repository.

--- a/gpdb-doc/markdown/common/gpdb-features.html.md.erb
+++ b/gpdb-doc/markdown/common/gpdb-features.html.md.erb
@@ -58,4 +58,4 @@ Source code for the following open source Greenplum components are located in re
 
 - To use Backup and Restore with open source Greenplum Database, you must separately build and install the backup/restore software. Refer to the build instructions in the [README](https://github.com/greenplum-db/gpbackup/blob/master/README.md) file located in the Greenplum Backup and Restore github repository.
 
-- To use the Greenplum Platform Extension Framework (PXF) with open source Greenplum Database, you must separately build and install the PXF server software. Refer to the build and packaging instructions in the [PXF Packaging README](https://github.com/greenplum-db/pxf/blob/master/package/README.md) file located in the PXF github repository.
+- To use the Greenplum Platform Extension Framework (PXF) with open source Greenplum Database, you must separately build and install the PXF software. Refer to the build and packaging instructions in the [PXF Packaging README](https://github.com/greenplum-db/pxf/blob/master/package/README.md) file located in the PXF github repository.


### PR DESCRIPTION
add a blurb on the open source greenplum docs landing page that open source users need to build and install gpbackup, and xref to the README file in the gpbackup repo.

i added this gpbackup info to new section for greenplum components (i added a new section because most of the info on the page is related to pivotal / opensource differences), and moved the pxf info there as well.

