### PR TITLE
[6X Backport] Add debug code in shared snap shot and latch code.

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2475,14 +2475,18 @@ StartTransaction(void)
 			XactReadOnly = isMppTxOptions_ReadOnly(
 				QEDtxContextInfo.distributedTxnOptions);
 
-			ereportif(Debug_print_full_dtm, LOG,
-					  (errmsg("qExec reader: distributedXid %d currcid %d "
-							  "gxid = %u DtxContext '%s' sharedsnapshots: %s",
-							  QEDtxContextInfo.distributedXid,
-							  QEDtxContextInfo.curcid,
-							  getDistributedTransactionId(),
-							  DtxContextToString(DistributedTransactionContext),
-							  SharedSnapshotDump())));
+			if (unlikely(Debug_print_full_dtm))
+			{
+				LWLockAcquire(SharedSnapshotLock, LW_SHARED); /* For SharedSnapshotDump() */
+				ereport(LOG, (errmsg("qExec reader: distributedXid %d currcid %d "
+									   "gxid = %u DtxContext '%s' sharedsnapshots: %s",
+									   QEDtxContextInfo.distributedXid,
+									   QEDtxContextInfo.curcid,
+									   getDistributedTransactionId(),
+									   DtxContextToString(DistributedTransactionContext),
+									   SharedSnapshotDump())));
+				LWLockRelease(SharedSnapshotLock);
+			}
 		}
 		break;
 	

--- a/src/backend/port/unix_latch.c
+++ b/src/backend/port/unix_latch.c
@@ -155,7 +155,8 @@ OwnLatch(volatile Latch *latch)
 
 	/* sanity check */
 	if (latch->owner_pid != 0)
-		elog(ERROR, "latch already owned");
+		elog(ERROR, "latch already owned by pid %d (is_set: %d)",
+			 latch->owner_pid, (int) latch->is_set);
 
 	latch->owner_pid = MyProcPid;
 }

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2227,6 +2227,8 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 
 				if (total_sleep_time_us >= segmate_timeout_us)
 				{
+					LWLockRelease(SharedLocalSnapshotSlot->slotLock);
+					LWLockAcquire(SharedSnapshotLock, LW_SHARED); /* For SharedSnapshotDump() */
 					ereport(ERROR,
 							(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 							 errmsg("GetSnapshotData timed out waiting for Writer to set the shared snapshot."),

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -320,12 +320,12 @@ SharedSnapshotDump(void)
 	volatile SharedSnapshotStruct *arrayP = sharedSnapshotArray;
 	int			index;
 
+	Assert(LWLockHeldByMe(SharedSnapshotLock));
+
 	initStringInfo(&str);
 
 	appendStringInfo(&str, "Local SharedSnapshot Slot Dump: currSlots: %d maxSlots: %d ",
 					 arrayP->numSlots, arrayP->maxSlots);
-
-	LWLockAcquire(SharedSnapshotLock, LW_EXCLUSIVE);
 
 	for (index=0; index < arrayP->maxSlots; index++)
 	{
@@ -340,8 +340,6 @@ SharedSnapshotDump(void)
 		}
 
 	}
-
-	LWLockRelease(SharedSnapshotLock);
 
 	return str.data;
 }
@@ -360,8 +358,7 @@ SharedSnapshotAdd(int32 slotId)
 {
 	SharedSnapshotSlot *slot;
 	volatile SharedSnapshotStruct *arrayP = sharedSnapshotArray;
-	int nextSlot = -1;
-	int i;
+	int nextSlot, i;
 	int retryCount = gp_snapshotadd_timeout * 10; /* .1 s per wait */
 
 retry:
@@ -387,10 +384,10 @@ retry:
 	{
 		elog(DEBUG1, "SharedSnapshotAdd: found existing entry for our session-id. id %d retry %d pid %u", slotId, retryCount,
 				slot->writer_proc ? slot->writer_proc->pid : 0);
-		LWLockRelease(SharedSnapshotLock);
 
 		if (retryCount > 0)
 		{
+			LWLockRelease(SharedSnapshotLock);
 			retryCount--;
 
 			pg_usleep(100000); /* 100ms, wait gp_snapshotadd_timeout seconds max. */
@@ -398,7 +395,8 @@ retry:
 		}
 		else
 		{
-			elog(ERROR, "writer segworker group shared snapshot collision on id %d", slotId);
+			elog(ERROR, "writer segworker group shared snapshot collision on id %d. Slot array dump: %s",
+				 slotId, SharedSnapshotDump());
 		}
 	}
 
@@ -424,6 +422,7 @@ retry:
 	/*
 	 * find the next available slot
 	 */
+	nextSlot = -1;
 	for (i=arrayP->nextSlot+1; i < arrayP->maxSlots; i++)
 	{
 		SharedSnapshotSlot *tmpSlot = &arrayP->slots[i];
@@ -435,13 +434,8 @@ retry:
 		}
 	}
 
-	/* mark that there isn't a nextSlot if the above loop didn't find one */
-	if (nextSlot == arrayP->nextSlot)
-		arrayP->nextSlot = -1;
-	else
-		arrayP->nextSlot = nextSlot;
-
-	arrayP->numSlots += 1;
+	arrayP->nextSlot = nextSlot;
+	arrayP->numSlots++;
 
 	/* initialize some things */
 	slot->slotid = slotId;
@@ -494,10 +488,7 @@ SharedSnapshotLookup(int32 slotId)
 			testSlot = &arrayP->slots[index];
 
 			if (testSlot->slotindex > arrayP->maxSlots)
-			{
-				LWLockRelease(SharedSnapshotLock);
 				elog(ERROR, "Shared Local Snapshots Array appears corrupted: %s", SharedSnapshotDump());
-			}
 
 			if (testSlot->slotid == slotId)
 			{
@@ -572,21 +563,7 @@ SharedSnapshotRemove(volatile SharedSnapshotSlot *slot, char *creatorDescription
 void
 addSharedSnapshot(char *creatorDescription, int id)
 {
-	SharedSnapshotSlot *slot;
-
-	slot = SharedSnapshotAdd(id);
-
-	if (slot==NULL)
-	{
-		ereport(ERROR,
-				(errmsg("%s could not set the Shared Local Snapshot!",
-						creatorDescription),
-				 errdetail("Tried to set the shared local snapshot slot with id: %d "
-						   "and failed. Shared Local Snapshots dump: %s", id,
-						   SharedSnapshotDump())));
-	}
-
-	SharedLocalSnapshotSlot = slot;
+	SharedLocalSnapshotSlot = SharedSnapshotAdd(id);
 
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),"%s added Shared Local Snapshot slot for gp_session_id = %d (address %p)",
 		 creatorDescription, id, SharedLocalSnapshotSlot);
@@ -601,6 +578,7 @@ lookupSharedSnapshot(char *lookerDescription, char *creatorDescription, int id)
 
 	if (slot == NULL)
 	{
+		LWLockAcquire(SharedSnapshotLock, LW_SHARED);
 		ereport(ERROR,
 				(errmsg("%s could not find Shared Local Snapshot!",
 						lookerDescription),


### PR DESCRIPTION
Will push the code once pr pipeline passes.

```
commit 139ac5af87a1ea6e85019c987218a0b74a119321 (HEAD -> 6x_debug, origin/6x_debug)
Author: Paul Guo <guopa@vmware.com>
Date:   Wed Jul 8 13:04:46 2020 +0800

    Add debugging code in shared snapshot code and tweak the shared snapshot code a bit.

    Notably we want the shared snapshot dumping information when encountering the
    "snapshot collision" error, which was seen on real scenario and it is hard to
    debug.

    (cherry picked from commit ee2d4641bc14d23ab91d051064f4dfbca3aa088b)

commit 16404701368f839fe22c6540f9c78cda51565841
Author: Paul Guo <guopa@vmware.com>
Date:   Thu Jul 16 13:34:55 2020 +0800

    Add debugging code for the "latch already owned" error.

    We've seen such a case on a stable release but it is hard to debug via the
    message only, so let's provide more details in the error message.
```