### PR TITLE
[5X Backport] Add debug code in shared snap shot and latch code. 

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2440,14 +2440,18 @@ StartTransaction(void)
 			 */
 			Assert (SharedLocalSnapshotSlot != NULL);
 			s->distribXid = QEDtxContextInfo.distributedXid;
+			if (Debug_print_full_dtm)
+			{
+				LWLockAcquire(SharedSnapshotLock, LW_SHARED); /* For SharedSnapshotDump() */
 
-			ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-					(errmsg("qExec reader: distributedXid %d currcid %d gxid = %u DtxContext '%s' sharedsnapshots: %s",
-							QEDtxContextInfo.distributedXid,
-							QEDtxContextInfo.curcid,
-							getDistributedTransactionId(),
-							DtxContextToString(DistributedTransactionContext),
-							SharedSnapshotDump())));
+				ereport(LOG, (errmsg("qExec reader: distributedXid %d currcid %d gxid = %u DtxContext '%s' sharedsnapshots: %s",
+						 QEDtxContextInfo.distributedXid,
+						 QEDtxContextInfo.curcid,
+						 getDistributedTransactionId(),
+						 DtxContextToString(DistributedTransactionContext),
+						 SharedSnapshotDump())));
+				LWLockRelease(SharedSnapshotLock);
+			}
 		}
 		break;
 	

--- a/src/backend/port/unix_latch.c
+++ b/src/backend/port/unix_latch.c
@@ -154,7 +154,8 @@ OwnLatch(volatile Latch *latch)
 
 	/* sanity check */
 	if (latch->owner_pid != 0)
-		elog(ERROR, "latch already owned");
+		elog(ERROR, "latch already owned by pid %d (is_set: %d)",
+			 latch->owner_pid, (int) latch->is_set);
 
 	latch->owner_pid = MyProcPid;
 }

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1235,6 +1235,8 @@ GetSnapshotData(Snapshot snapshot)
 
 				if (total_sleep_time_us >= segmate_timeout_us)
 				{
+					LWLockRelease(SharedLocalSnapshotSlot->slotLock);
+					LWLockAcquire(SharedSnapshotLock, LW_SHARED); /* For SharedSnapshotDump() */
 					ereport(ERROR,
 							(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 							 errmsg("GetSnapshotData timed out waiting for Writer to set the shared snapshot."),

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -317,12 +317,12 @@ SharedSnapshotDump(void)
 	volatile SharedSnapshotStruct *arrayP = sharedSnapshotArray;
 	int			index;
 
+	Assert(LWLockHeldByMe(SharedSnapshotLock));
+
 	initStringInfo(&str);
 
 	appendStringInfo(&str, "Local SharedSnapshot Slot Dump: currSlots: %d maxSlots: %d ",
 					 arrayP->numSlots, arrayP->maxSlots);
-
-	LWLockAcquire(SharedSnapshotLock, LW_EXCLUSIVE);
 
 	for (index=0; index < arrayP->maxSlots; index++)
 	{
@@ -336,8 +336,6 @@ SharedSnapshotDump(void)
 		}
 
 	}
-
-	LWLockRelease(SharedSnapshotLock);
 
 	return str.data;
 }
@@ -356,8 +354,7 @@ SharedSnapshotAdd(int4 slotId)
 {
 	SharedSnapshotSlot *slot;
 	volatile SharedSnapshotStruct *arrayP = sharedSnapshotArray;
-	int nextSlot = -1;
-	int i;
+	int nextSlot, i;
 	int retryCount = gp_snapshotadd_timeout * 10; /* .1 s per wait */
 
 retry:
@@ -382,10 +379,10 @@ retry:
 	if (slot != NULL)
 	{
 		elog(DEBUG1, "SharedSnapshotAdd: found existing entry for our session-id. id %d retry %d pid %u", slotId, retryCount, (int)slot->pid);
-		LWLockRelease(SharedSnapshotLock);
 
 		if (retryCount > 0)
 		{
+			LWLockRelease(SharedSnapshotLock);
 			retryCount--;
 
 			pg_usleep(100000); /* 100ms, wait gp_snapshotadd_timeout seconds max. */
@@ -393,7 +390,8 @@ retry:
 		}
 		else
 		{
-			insist_log(false, "writer segworker group shared snapshot collision on id %d", slotId);
+			elog(ERROR, "writer segworker group shared snapshot collision on id %d. Slot array dump: %s",
+				 slotId, SharedSnapshotDump());
 		}
 		/* not reached */
 	}
@@ -420,6 +418,7 @@ retry:
 	/*
 	 * find the next available slot
 	 */
+	nextSlot = -1;
 	for (i=arrayP->nextSlot+1; i < arrayP->maxSlots; i++)
 	{
 		SharedSnapshotSlot *tmpSlot = &arrayP->slots[i];
@@ -431,13 +430,8 @@ retry:
 		}
 	}
 
-	/* mark that there isn't a nextSlot if the above loop didn't find one */
-	if (nextSlot == arrayP->nextSlot)
-		arrayP->nextSlot = -1;
-	else
-		arrayP->nextSlot = nextSlot;
-
-	arrayP->numSlots += 1;
+	arrayP->nextSlot = nextSlot;
+	arrayP->numSlots++;
 
 	/* initialize some things */
 	slot->slotid = slotId;
@@ -492,10 +486,7 @@ SharedSnapshotLookup(int4 slotId)
 			testSlot = &arrayP->slots[index];
 
 			if (testSlot->slotindex > arrayP->maxSlots)
-			{
-				LWLockRelease(SharedSnapshotLock);
 				elog(ERROR, "Shared Local Snapshots Array appears corrupted: %s", SharedSnapshotDump());
-			}
 
 			if (testSlot->slotid == slotId)
 			{
@@ -573,21 +564,7 @@ SharedSnapshotRemove(volatile SharedSnapshotSlot *slot, char *creatorDescription
 void
 addSharedSnapshot(char *creatorDescription, int id)
 {
-	SharedSnapshotSlot *slot;
-
-	slot = SharedSnapshotAdd(id);
-
-	if (slot==NULL)
-	{
-		ereport(ERROR,
-				(errmsg("%s could not set the Shared Local Snapshot!",
-						creatorDescription),
-				 errdetail("Tried to set the shared local snapshot slot with id: %d "
-						   "and failed. Shared Local Snapshots dump: %s", id,
-						   SharedSnapshotDump())));
-	}
-
-	SharedLocalSnapshotSlot = slot;
+	SharedLocalSnapshotSlot = SharedSnapshotAdd(id);
 
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),"%s added Shared Local Snapshot slot for gp_session_id = %d (address %p)",
 		 creatorDescription, id, SharedLocalSnapshotSlot);
@@ -602,6 +579,7 @@ lookupSharedSnapshot(char *lookerDescription, char *creatorDescription, int id)
 
 	if (slot == NULL)
 	{
+		LWLockAcquire(SharedSnapshotLock, LW_SHARED);
 		ereport(ERROR,
 				(errmsg("%s could not find Shared Local Snapshot!",
 						lookerDescription),


### PR DESCRIPTION
Will push the code once the pr pipeline passes.
```
commit 752239e4ae79f351a15bb1f50728a031e2121fdd (HEAD -> 5x_debug, origin/5x_debug)
Author: Paul Guo <guopa@vmware.com>
Date:   Wed Jul 8 13:04:46 2020 +0800

    Add debugging code in shared snapshot code and tweak the shared snapshot code a bit.

    Notably we want the shared snapshot dumping information when encountering the
    "snapshot collision" error, which was seen on real scenario and it is hard to
    debug.

    (cherry picked from commit ee2d4641bc14d23ab91d051064f4dfbca3aa088b)

commit 40c1feee65d4b6c66f0a286f092cbd553b756bb2
Author: Paul Guo <guopa@vmware.com>
Date:   Thu Jul 16 13:34:55 2020 +0800

    Add debugging code for the "latch already owned" error.

    We've seen such a case on a stable release but it is hard to debug via the
    message only, so let's provide more details in the error message.
```