### PR TITLE
(6X only) Fix cdbpath_dedup_fixup does not consider merge append path.

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -202,6 +202,9 @@ pathnode_walk_kids(Path            *path,
 		case T_Append:
 			v = pathnode_walk_list(((AppendPath *)path)->subpaths, walker, context);
 			break;
+		case T_MergeAppend:
+			v = pathnode_walk_list(((MergeAppendPath *)path)->subpaths, walker, context);
+			break;
 		case T_Material:
 			v = pathnode_walk_node(((MaterialPath *)path)->subpath, walker, context);
 			break;

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3422,6 +3422,73 @@ EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0' 
  Optimizer: Postgres query optimizer
 (10 rows)
 
+-- The following case is to test Greenplum specific plan
+-- unique row id plan works correctly  with merge append path.
+-- See Github issue: https://github.com/greenplum-db/gpdb/issues/9427
+set optimizer = off;
+create table t_9427(a int, b int, c int)
+partition by range (a)
+(
+        PARTITION p1 START (1) END (10) exclusive,
+        PARTITION p2 START (21) END (30) exclusive,
+        DEFAULT PARTITION default_part
+)
+;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "t_9427_1_prt_default_part" for table "t_9427"
+NOTICE:  CREATE TABLE will create partition "t_9427_1_prt_p1" for table "t_9427"
+NOTICE:  CREATE TABLE will create partition "t_9427_1_prt_p2" for table "t_9427"
+create index idx_c_9427 on t_9427(c);
+create index idx_a_9427 on t_9427(a);
+insert into t_9427 select i%30, i%30, i from generate_series(1, 100000)i;
+set enable_hashjoin = off;
+set enable_mergejoin = on;
+set enable_nestloop = off;
+set enable_seqscan = off;
+set enable_bitmapscan = off;
+analyze t_9427;
+explain (costs off) select * from t_9427 where a in (select a from t_9427 where c < 100 ) and a < 200;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Merge Join
+         Merge Cond: (t_9427_1_prt_default_part.a = t_9427_1_prt_default_part_1.a)
+         ->  Merge Append
+               Sort Key: t_9427_1_prt_default_part.a
+               ->  Result
+                     One-Time Filter: PartSelected
+                     ->  Index Scan using t_9427_1_prt_default_part_a_idx on t_9427_1_prt_default_part
+                           Index Cond: (a < 200)
+               ->  Result
+                     One-Time Filter: PartSelected
+                     ->  Index Scan using t_9427_1_prt_p1_a_idx on t_9427_1_prt_p1
+                           Index Cond: (a < 200)
+               ->  Result
+                     One-Time Filter: PartSelected
+                     ->  Index Scan using t_9427_1_prt_p2_a_idx on t_9427_1_prt_p2
+                           Index Cond: (a < 200)
+         ->  Sort
+               Sort Key: t_9427_1_prt_default_part_1.a
+               ->  Partition Selector for t_9427 (dynamic scan id: 1)
+                     Filter: t_9427_1_prt_default_part_1.a
+                     ->  HashAggregate
+                           Group Key: t_9427_1_prt_default_part_1.a
+                           ->  Append
+                                 ->  Index Scan using t_9427_1_prt_default_part_c_idx on t_9427_1_prt_default_part t_9427_1_prt_default_part_1
+                                       Index Cond: (c < 100)
+                                       Filter: (a < 200)
+                                 ->  Index Scan using t_9427_1_prt_p1_c_idx on t_9427_1_prt_p1 t_9427_1_prt_p1_1
+                                       Index Cond: (c < 100)
+                                       Filter: (a < 200)
+                                 ->  Index Scan using t_9427_1_prt_p2_c_idx on t_9427_1_prt_p2 t_9427_1_prt_p2_1
+                                       Index Cond: (c < 100)
+                                       Filter: (a < 200)
+ Optimizer: Postgres query optimizer
+(34 rows)
+
+drop table t_9427;
+reset optimizer;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3419,6 +3419,73 @@ EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0' 
  Optimizer: Postgres query optimizer
 (10 rows)
 
+-- The following case is to test Greenplum specific plan
+-- unique row id plan works correctly  with merge append path.
+-- See Github issue: https://github.com/greenplum-db/gpdb/issues/9427
+set optimizer = off;
+create table t_9427(a int, b int, c int)
+partition by range (a)
+(
+        PARTITION p1 START (1) END (10) exclusive,
+        PARTITION p2 START (21) END (30) exclusive,
+        DEFAULT PARTITION default_part
+)
+;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "t_9427_1_prt_default_part" for table "t_9427"
+NOTICE:  CREATE TABLE will create partition "t_9427_1_prt_p1" for table "t_9427"
+NOTICE:  CREATE TABLE will create partition "t_9427_1_prt_p2" for table "t_9427"
+create index idx_c_9427 on t_9427(c);
+create index idx_a_9427 on t_9427(a);
+insert into t_9427 select i%30, i%30, i from generate_series(1, 100000)i;
+set enable_hashjoin = off;
+set enable_mergejoin = on;
+set enable_nestloop = off;
+set enable_seqscan = off;
+set enable_bitmapscan = off;
+analyze t_9427;
+explain (costs off) select * from t_9427 where a in (select a from t_9427 where c < 100 ) and a < 200;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Merge Join
+         Merge Cond: (t_9427_1_prt_default_part.a = t_9427_1_prt_default_part_1.a)
+         ->  Merge Append
+               Sort Key: t_9427_1_prt_default_part.a
+               ->  Result
+                     One-Time Filter: PartSelected
+                     ->  Index Scan using t_9427_1_prt_default_part_a_idx on t_9427_1_prt_default_part
+                           Index Cond: (a < 200)
+               ->  Result
+                     One-Time Filter: PartSelected
+                     ->  Index Scan using t_9427_1_prt_p1_a_idx on t_9427_1_prt_p1
+                           Index Cond: (a < 200)
+               ->  Result
+                     One-Time Filter: PartSelected
+                     ->  Index Scan using t_9427_1_prt_p2_a_idx on t_9427_1_prt_p2
+                           Index Cond: (a < 200)
+         ->  Sort
+               Sort Key: t_9427_1_prt_default_part_1.a
+               ->  Partition Selector for t_9427 (dynamic scan id: 1)
+                     Filter: t_9427_1_prt_default_part_1.a
+                     ->  HashAggregate
+                           Group Key: t_9427_1_prt_default_part_1.a
+                           ->  Append
+                                 ->  Index Scan using t_9427_1_prt_default_part_c_idx on t_9427_1_prt_default_part t_9427_1_prt_default_part_1
+                                       Index Cond: (c < 100)
+                                       Filter: (a < 200)
+                                 ->  Index Scan using t_9427_1_prt_p1_c_idx on t_9427_1_prt_p1 t_9427_1_prt_p1_1
+                                       Index Cond: (c < 100)
+                                       Filter: (a < 200)
+                                 ->  Index Scan using t_9427_1_prt_p2_c_idx on t_9427_1_prt_p2 t_9427_1_prt_p2_1
+                                       Index Cond: (c < 100)
+                                       Filter: (a < 200)
+ Optimizer: Postgres query optimizer
+(34 rows)
+
+drop table t_9427;
+reset optimizer;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1207,7 +1207,7 @@ select p from
           (box(point(0.8,0.8), point(1.0,1.0)))) as v(bb)
 cross join lateral
   (select p from gist_tbl_github9733 where p <@ bb order by p <-> bb[0] limit 2) ss;
-ERROR:  could not devise a query plan for the given query (pathnode.c:417)
+ERROR:  could not devise a query plan for the given query (pathnode.c:420)
 reset enable_seqscan;
 explain (costs off)
 select p from

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1223,7 +1223,7 @@ select p from
           (box(point(0.8,0.8), point(1.0,1.0)))) as v(bb)
 cross join lateral
   (select p from gist_tbl_github9733 where p <@ bb order by p <-> bb[0] limit 2) ss;
-ERROR:  could not devise a query plan for the given query (pathnode.c:417)
+ERROR:  could not devise a query plan for the given query (pathnode.c:420)
 reset enable_seqscan;
 explain (costs off)
 select p from


### PR DESCRIPTION
Greenplum use unique row id path as a candidate to implement semijoin.
It is introduced long before. But GPDB6 has upgraded the kernel
version to Postgres 9.4 and introduced many new path types and
new plan nodes, thus cdbpath_dedup_fixup failed to consider them.
Some typical issues are: https://github.com/greenplum-db/gpdb/issues/9427

On Master branch, Heikki's commit 9628a33 refactored this part of code
so that it is OK on master. And for 4X and 5X, we do not have many new
kinds of plannode and pathnode, it is also OK.

It is very hard to backport commit 9628a33 to 6X, there is no concept of
a Path's target list in 9.4. And to totally remove this kind of path
is too overkilling. So the policy is to fix them one bye one if reported.

------------------------------------

Fix github issue  https://github.com/greenplum-db/gpdb/issues/9427
