### PR TITLE
Add Orca support for index only scan

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -527,6 +527,12 @@ CConfigParamMapping::PackConfigParamInBitset
 		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfIndexGet2IndexScan));
 	}
 
+	if (!optimizer_enable_indexonlyscan)
+	{
+		// disable index only scan if the corresponding GUC is turned off
+		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfIndexGet2IndexOnlyScan));
+	}
+
 	if (!optimizer_enable_hashagg)
 	{
 		 traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfGbAgg2HashAgg));

--- a/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
@@ -17,8 +17,20 @@ WHERE
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="103027,102146,101000,101001,103001,103026"/>
+    </dxl:OptimizerConfig>
     <dxl:Stacktrace/>
-    <dxl:TraceFlags Value="103027,102146,101000,101001,103001,103026"/>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
         <dxl:EqualityOp Mdid="0.410.1.0"/>
@@ -1265,10 +1277,10 @@ WHERE
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="41230">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Plan Id="0" SpaceSize="120488">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="43434.041016" Rows="197964.000000" Width="148"/>
+          <dxl:Cost StartupCost="0" TotalCost="1415.900752" Rows="197964.000000" Width="148"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="26" Alias="oid">
@@ -1291,7 +1303,7 @@ WHERE
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="29127.048828" Rows="197964.000000" Width="148"/>
+            <dxl:Cost StartupCost="0" TotalCost="1306.714368" Rows="197964.000000" Width="148"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="26" Alias="oid">
@@ -1322,7 +1334,7 @@ WHERE
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="514.064453" Rows="702.000000" Width="150"/>
+              <dxl:Cost StartupCost="0" TotalCost="1306.698971" Rows="702.000000" Width="150"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="73" Alias="ColRef_0073">
@@ -1349,9 +1361,9 @@ WHERE
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:HashJoin JoinType="Inner">
+            <dxl:HashJoin JoinType="Left">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="410.232422" Rows="702.000000" Width="158"/>
+                <dxl:Cost StartupCost="0" TotalCost="1306.663871" Rows="702.000000" Width="158"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="amname">
@@ -1380,17 +1392,27 @@ WHERE
               <dxl:JoinFilter/>
               <dxl:HashCondList>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                  <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
-                  <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
+                  <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
+                  <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                  <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                  <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                 </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:HashJoin JoinType="Left">
+              <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="344.519531" Rows="702.000000" Width="88"/>
+                  <dxl:Cost StartupCost="0" TotalCost="875.127646" Rows="702.000000" Width="150"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="33" Alias="opcamid">
-                    <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
+                  <dxl:ProjElem ColId="0" Alias="amname">
+                    <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="amstrategies">
+                    <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="26" Alias="oid">
+                    <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="34" Alias="opcname">
                     <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
@@ -1401,29 +1423,30 @@ WHERE
                   <dxl:ProjElem ColId="49" Alias="amopsubtype">
                     <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="72" Alias="count">
-                    <dxl:Ident ColId="72" ColName="count" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                    <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="105.691406" Rows="702.000000" Width="80"/>
+                    <dxl:Cost StartupCost="0" TotalCost="874.854217" Rows="702.000000" Width="150"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="33" Alias="opcamid">
-                      <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
+                    <dxl:ProjElem ColId="0" Alias="amname">
+                      <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="amstrategies">
+                      <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="26" Alias="oid">
+                      <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="34" Alias="opcname">
                       <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
@@ -1443,13 +1466,19 @@ WHERE
                       <dxl:Ident ColId="48" ColName="amopclaid" TypeMdid="0.26.1.0"/>
                     </dxl:Comparison>
                   </dxl:HashCondList>
-                  <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1">
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="21.929688" Rows="141.000000" Width="76"/>
+                      <dxl:Cost StartupCost="0" TotalCost="443.223121" Rows="141.000000" Width="146"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="33" Alias="opcamid">
-                        <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
+                      <dxl:ProjElem ColId="0" Alias="amname">
+                        <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="amstrategies">
+                        <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="26" Alias="oid">
+                        <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="34" Alias="opcname">
                         <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
@@ -1459,15 +1488,56 @@ WHERE
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="10.464844" Rows="141.000000" Width="76"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000891" Rows="2.000000" Width="74"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="33" Alias="opcamid">
-                          <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
+                        <dxl:ProjElem ColId="0" Alias="amname">
+                          <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="amstrategies">
+                          <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="26" Alias="oid">
+                          <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.643.1.0">
+                            <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z2lzdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.643.1.0">
+                            <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z2luAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+                          </dxl:Comparison>
+                        </dxl:And>
+                      </dxl:Filter>
+                      <dxl:TableDescriptor Mdid="0.2601.1.1" TableName="pg_am">
+                        <dxl:Columns>
+                          <dxl:Column ColId="0" Attno="1" ColName="amname" TypeMdid="0.19.1.0"/>
+                          <dxl:Column ColId="1" Attno="2" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+                          <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="26" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                    <dxl:IndexScan IndexScanDirection="Forward">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="12.131206" Rows="70.500000" Width="72"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
                         <dxl:ProjElem ColId="34" Alias="opcname">
                           <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
                         </dxl:ProjElem>
@@ -1476,6 +1546,13 @@ WHERE
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
+                      <dxl:IndexCondList>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                          <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
+                          <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:IndexCondList>
+                      <dxl:IndexDescriptor Mdid="0.2686.1.0" IndexName="pg_opclass_am_name_nsp_index"/>
                       <dxl:TableDescriptor Mdid="0.2616.1.1" TableName="pg_opclass">
                         <dxl:Columns>
                           <dxl:Column ColId="33" Attno="1" ColName="opcamid" TypeMdid="0.26.1.0"/>
@@ -1490,11 +1567,11 @@ WHERE
                           <dxl:Column ColId="47" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:Columns>
                       </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:RandomMotion>
-                  <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                    </dxl:IndexScan>
+                  </dxl:NestedLoopJoin>
+                  <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="17.453125" Rows="1404.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.017375" Rows="702.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="48" Alias="amopclaid">
@@ -1505,39 +1582,47 @@ WHERE
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="5.484375" Rows="702.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="48" Alias="amopclaid">
-                          <dxl:Ident ColId="48" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="49" Alias="amopsubtype">
-                          <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.2602.1.1" TableName="pg_amop">
-                        <dxl:Columns>
-                          <dxl:Column ColId="48" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="49" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="54" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="55" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="56" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="57" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="58" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="59" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:BroadcastMotion>
+                    <dxl:TableDescriptor Mdid="0.2602.1.1" TableName="pg_amop">
+                      <dxl:Columns>
+                        <dxl:Column ColId="48" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="49" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="54" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="55" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="56" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="57" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="58" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="59" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
                 </dxl:HashJoin>
-                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+              </dxl:RedistributeMotion>
+              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.172320" Rows="702.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="60"/>
+                  <dxl:GroupingColumn ColId="61"/>
+                </dxl:GroupingColumns>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="72" Alias="count">
+                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
+                      <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="60" Alias="amopclaid">
+                    <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="61" Alias="amopsubtype">
+                    <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="73.296875" Rows="1404.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.113221" Rows="702.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="60" Alias="amopclaid">
@@ -1546,15 +1631,23 @@ WHERE
                     <dxl:ProjElem ColId="61" Alias="amopsubtype">
                       <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="72" Alias="count">
-                      <dxl:Ident ColId="72" ColName="count" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="74" Alias="ColRef_0074">
+                      <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                    </dxl:HashExpr>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="50.359375" Rows="702.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.101502" Rows="702.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="60" Alias="amopclaid">
@@ -1563,23 +1656,23 @@ WHERE
                       <dxl:ProjElem ColId="61" Alias="amopsubtype">
                         <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="72" Alias="count">
-                        <dxl:Ident ColId="72" ColName="count" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="74" Alias="ColRef_0074">
+                        <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
-                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="50.359375" Rows="702.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.101502" Rows="702.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="60"/>
                         <dxl:GroupingColumn ColId="61"/>
                       </dxl:GroupingColumns>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="72" Alias="count">
-                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                        <dxl:ProjElem ColId="74" Alias="ColRef_0074">
+                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="60" Alias="amopclaid">
                           <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
@@ -1589,9 +1682,9 @@ WHERE
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableScan>
+                      <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="5.484375" Rows="702.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.042403" Rows="702.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="60" Alias="amopclaid">
@@ -1602,84 +1695,39 @@ WHERE
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="0.2602.1.1" TableName="pg_amop">
-                          <dxl:Columns>
-                            <dxl:Column ColId="60" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="61" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="65" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="66" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="67" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="68" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="69" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="70" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="71" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.017375" Rows="702.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="60" Alias="amopclaid">
+                              <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="61" Alias="amopsubtype">
+                              <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.2602.1.1" TableName="pg_amop">
+                            <dxl:Columns>
+                              <dxl:Column ColId="60" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="61" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="65" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="66" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="67" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="68" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="69" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="70" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="71" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:RandomMotion>
                     </dxl:Aggregate>
                   </dxl:Result>
-                </dxl:BroadcastMotion>
-              </dxl:HashJoin>
-              <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.939453" Rows="4.000000" Width="74"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="amname">
-                    <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="amstrategies">
-                    <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="26" Alias="oid">
-                    <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.650391" Rows="2.000000" Width="74"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="amname">
-                      <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="amstrategies">
-                      <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="26" Alias="oid">
-                      <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:And>
-                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.643.1.0">
-                        <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z2lzdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#10;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
-                      </dxl:Comparison>
-                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.643.1.0">
-                        <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z2luAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#10;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
-                      </dxl:Comparison>
-                    </dxl:And>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="0.2601.1.1" TableName="pg_am">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="amname" TypeMdid="0.19.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-                      <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="26" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:BroadcastMotion>
+                </dxl:RedistributeMotion>
+              </dxl:Aggregate>
             </dxl:HashJoin>
           </dxl:Result>
         </dxl:Result>

--- a/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelGPDB.h
+++ b/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelGPDB.h
@@ -116,6 +116,10 @@ namespace gpdbcost
 			static
 			CCost CostIndexScan(CMemoryPool *mp, CExpressionHandle &exprhdl, const CCostModelGPDB *pcmgpdb, const SCostingInfo *pci);
 
+			// cost of index only scan
+			static
+			CCost CostIndexOnlyScan(CMemoryPool *mp, CExpressionHandle &exprhdl, const CCostModelGPDB *pcmgpdb, const SCostingInfo *pci);
+
 			// cost of bitmap table scan
 			static
 			CCost CostBitmapTableScan(CMemoryPool *mp, CExpressionHandle &exprhdl, const CCostModelGPDB *pcmgpdb, const SCostingInfo *pci);

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
@@ -210,10 +210,10 @@ namespace gpopt
 				m_used = EUnknown;
 			}
 
-			EUsedStatus GetUsage() const
+			EUsedStatus GetUsage(BOOL check_system_col=false) const
 			{
 
-				if (GPOS_FTRACE(EopttraceTranslateUnusedColrefs) || FSystemCol())
+				if (GPOS_FTRACE(EopttraceTranslateUnusedColrefs) || (!check_system_col && FSystemCol()))
 				{
 					return EUsed;
 				}

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CIndexDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CIndexDescriptor.h
@@ -118,6 +118,8 @@ namespace gpopt
 				return m_index_type;
 			}
 
+			BOOL SupportsIndexOnlyScan() const;
+
 			// create an index descriptor
 			static CIndexDescriptor *Pindexdesc
 				(

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
@@ -208,6 +208,7 @@ namespace gpopt
 				EopPhysicalTableScan,
 				EopPhysicalExternalScan,
 				EopPhysicalIndexScan,
+				EopPhysicalIndexOnlyScan,
 				EopPhysicalBitmapTableScan,
 				EopPhysicalFilter,
 				EopPhysicalInnerNLJoin,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalIndexOnlyScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalIndexOnlyScan.h
@@ -1,0 +1,204 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//
+//	@filename:
+//		CPhysicalIndexOnlyScan.h
+//
+//	@doc:
+//		Base class for physical index only scan operators
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CPhysicalIndexOnlyScan_H
+#define GPOPT_CPhysicalIndexOnlyScan_H
+
+#include "gpos/base.h"
+#include "gpopt/operators/CPhysicalScan.h"
+#include "gpopt/metadata/CIndexDescriptor.h"
+
+namespace gpopt
+{
+
+	// fwd declarations
+	class CName;
+	class CDistributionSpecHashed;
+
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CPhysicalIndexOnlyScan
+	//
+	//	@doc:
+	//		Base class for physical index only scan operators
+	//
+	//---------------------------------------------------------------------------
+	class CPhysicalIndexOnlyScan : public CPhysicalScan
+	{
+
+		private:
+
+			// index descriptor
+			CIndexDescriptor *m_pindexdesc;
+
+			// origin operator id -- gpos::ulong_max if operator was not generated via a transformation
+			ULONG m_ulOriginOpId;
+
+			// order
+			COrderSpec *m_pos;
+
+			// private copy ctor
+			CPhysicalIndexOnlyScan(const CPhysicalIndexOnlyScan&);
+
+		public:
+
+			// ctors
+			CPhysicalIndexOnlyScan
+				(
+				CMemoryPool *mp,
+				CIndexDescriptor *pindexdesc,
+				CTableDescriptor *ptabdesc,
+				ULONG ulOriginOpId,
+				const CName *pnameAlias,
+				CColRefArray *colref_array,
+				COrderSpec *pos
+				);
+
+			// dtor
+			virtual
+			~CPhysicalIndexOnlyScan();
+
+
+			// ident accessors
+			virtual
+			EOperatorId Eopid() const
+			{
+				return EopPhysicalIndexOnlyScan;
+			}
+
+			// operator name
+			virtual
+			const CHAR *SzId() const
+			{
+				return "CPhysicalIndexOnlyScan";
+			}
+
+			// table alias name
+			const CName &NameAlias() const
+			{
+				return *m_pnameAlias;
+			}
+
+			// origin operator id -- gpos::ulong_max if operator was not generated via a transformation
+			ULONG UlOriginOpId() const
+			{
+				return m_ulOriginOpId;
+			}
+
+			// operator specific hash function
+			virtual
+			ULONG HashValue() const;
+
+			// match function
+			BOOL Matches(COperator *pop) const;
+
+			// index descriptor
+			CIndexDescriptor *Pindexdesc() const
+			{
+				return m_pindexdesc;
+			}
+
+			// sensitivity to order of inputs
+			virtual
+			BOOL FInputOrderSensitive() const
+			{
+				return true;
+			}
+
+			//-------------------------------------------------------------------------------------
+			// Derived Plan Properties
+			//-------------------------------------------------------------------------------------
+
+			// derive sort order
+			virtual
+			COrderSpec *PosDerive
+							(
+							CMemoryPool *,//mp
+							CExpressionHandle &//exprhdl
+							)
+							const
+			{
+				m_pos->AddRef();
+				return m_pos;
+			}
+
+			// derive partition index map
+			virtual
+			CPartIndexMap *PpimDerive
+				(
+				CMemoryPool *mp,
+				CExpressionHandle &, // exprhdl
+				CDrvdPropCtxt * //pdpctxt
+				)
+				const
+			{
+				return GPOS_NEW(mp) CPartIndexMap(mp);
+			}
+
+			virtual
+			CRewindabilitySpec *PrsDerive
+				(
+				CMemoryPool *mp,
+				CExpressionHandle & // exprhdl
+				)
+				const
+			{
+				// rewindability of output is always true
+				return GPOS_NEW(mp) CRewindabilitySpec(CRewindabilitySpec::ErtMarkRestore, CRewindabilitySpec::EmhtNoMotion);
+			}
+
+			//-------------------------------------------------------------------------------------
+			// Enforced Properties
+			//-------------------------------------------------------------------------------------
+
+			// return order property enforcing type for this operator
+			virtual
+			CEnfdProp::EPropEnforcingType EpetOrder(CExpressionHandle &exprhdl, const CEnfdOrder *peo) const;
+
+			// conversion function
+			static
+			CPhysicalIndexOnlyScan *PopConvert
+				(
+				COperator *pop
+				)
+			{
+				GPOS_ASSERT(NULL != pop);
+				GPOS_ASSERT(EopPhysicalIndexOnlyScan == pop->Eopid());
+
+				return dynamic_cast<CPhysicalIndexOnlyScan*>(pop);
+			}
+
+			// statistics derivation during costing
+			virtual
+			IStatistics *PstatsDerive
+				(
+				CMemoryPool *, // mp
+				CExpressionHandle &, // exprhdl
+				CReqdPropPlan *, // prpplan
+				IStatisticsArray * //stats_ctxt
+				)
+				const
+			{
+				GPOS_ASSERT(!"stats derivation during costing for index only scan is invalid");
+
+				return NULL;
+			}
+
+			// debug print
+			virtual
+			IOstream &OsPrint(IOstream &) const;
+
+	}; // class CPhysicalIndexOnlyScan
+
+}
+
+#endif // !GPOPT_CPhysicalIndexOnlyScan_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -183,6 +183,23 @@ namespace gpopt
 				BOOL *pfDML
 				);
 
+			CDXLNode *PdxlnIndexOnlyScan
+				(
+				CExpression *pexprIndexScan,
+				CColRefArray *colref_array,
+				CDistributionSpecArray *pdrgpdsBaseTables,
+				ULONG *pulNonGatherMotions,
+				BOOL *pfDML
+				);
+
+			CDXLNode *PdxlnIndexOnlyScan
+				(
+				CExpression *pexprIndexScan,
+				CColRefArray *colref_array,
+				CDXLPhysicalProperties *dxl_properties,
+				CReqdPropPlan *prpp
+				);
+
 			// translate a bitmap index probe expression to DXL
 			CDXLNode *PdxlnBitmapIndexProbe(CExpression *pexprBitmapIndexProbe);
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
@@ -222,6 +222,7 @@ namespace gpopt
 				ExfLeftOuterJoin2DynamicIndexGetApply,
 				ExfLeftOuterJoinWithInnerSelect2DynamicBitmapIndexGetApply,
 				ExfLeftOuterJoinWithInnerSelect2DynamicIndexGetApply,
+				ExfIndexGet2IndexOnlyScan,
 				ExfInvalid,
 				ExfSentinel = ExfInvalid
 			};

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformIndexGet2IndexOnlyScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformIndexGet2IndexOnlyScan.h
@@ -1,0 +1,84 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//
+//	@filename:
+//		CXformIndexGet2IndexOnlyScan.h
+//
+//	@doc:
+//		Transform Index Get to Index Only Scan
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CXformIndexGet2IndexOnlyScan_H
+#define GPOPT_CXformIndexGet2IndexOnlyScan_H
+
+#include "gpos/base.h"
+#include "gpopt/xforms/CXformImplementation.h"
+
+namespace gpopt
+{
+	using namespace gpos;
+
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CXformIndexGet2IndexOnlyScan
+	//
+	//	@doc:
+	//		Transform Index Get to Index Scan
+	//
+	//---------------------------------------------------------------------------
+	class CXformIndexGet2IndexOnlyScan : public CXformImplementation
+	{
+
+		private:
+
+			// private copy ctor
+			CXformIndexGet2IndexOnlyScan(const CXformIndexGet2IndexOnlyScan &);
+
+		public:
+
+			// ctor
+			explicit
+			CXformIndexGet2IndexOnlyScan(CMemoryPool *);
+
+			// dtor
+			virtual
+			~CXformIndexGet2IndexOnlyScan() {}
+
+			// ident accessors
+			virtual
+			EXformId Exfid() const
+			{
+				return ExfIndexGet2IndexOnlyScan;
+			}
+
+			// xform name
+			virtual
+			const CHAR *SzId() const
+			{
+				return "CXformIndexGet2IndexOnlyScan";
+			}
+
+			// compute xform promise for a given expression handle
+			virtual
+			EXformPromise Exfp
+				(
+				CExpressionHandle &//exprhdl
+				)
+				const;
+
+			// actual transform
+			void Transform
+				(
+				CXformContext *pxfctxt,
+				CXformResult *pxfres,
+				CExpression *pexpr
+				)
+				const;
+
+	}; // class CXformIndexGet2IndexOnlyScan
+
+}
+
+#endif // !GPOPT_CXformIndexGet2IndexOnlyScan_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
@@ -29,6 +29,7 @@
 #include "gpopt/xforms/CXformImplementTVF.h"
 #include "gpopt/xforms/CXformImplementTVFNoArgs.h"
 #include "gpopt/xforms/CXformIndexGet2IndexScan.h"
+#include "gpopt/xforms/CXformIndexGet2IndexOnlyScan.h"
 #include "gpopt/xforms/CXformImplementBitmapTableGet.h"
 #include "gpopt/xforms/CXformImplementDynamicBitmapTableGet.h"
 #include "gpopt/xforms/CXformImplementUnionAll.h"

--- a/src/backend/gporca/libgpopt/src/metadata/CIndexDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CIndexDescriptor.cpp
@@ -154,6 +154,12 @@ CIndexDescriptor::Pindexdesc
 	return pindexdesc;
 }
 
+BOOL
+CIndexDescriptor::SupportsIndexOnlyScan() const
+{
+	return m_index_type == IMDIndex::EmdindBtree;
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CIndexDescriptor::OsPrint

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalIndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalIndexGet.cpp
@@ -259,6 +259,7 @@ const
 	CXformSet *xform_set = GPOS_NEW(mp) CXformSet(mp);
 
 	(void) xform_set->ExchangeSet(CXform::ExfIndexGet2IndexScan);
+	(void) xform_set->ExchangeSet(CXform::ExfIndexGet2IndexOnlyScan);
 
 	return xform_set;
 }

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalIndexOnlyScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalIndexOnlyScan.cpp
@@ -1,0 +1,174 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//
+//	@filename:
+//		CPhysicalIndexOnlyScan.cpp
+//
+//	@doc:
+//		Implementation of index scan operator
+//---------------------------------------------------------------------------
+
+#include "gpos/base.h"
+
+#include "gpopt/base/CUtils.h"
+#include "gpopt/operators/CExpressionHandle.h"
+#include "gpopt/operators/CPhysicalIndexOnlyScan.h"
+
+
+using namespace gpopt;
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalIndexOnlyScan::CPhysicalIndexOnlyScan
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CPhysicalIndexOnlyScan::CPhysicalIndexOnlyScan
+	(
+	CMemoryPool *mp,
+	CIndexDescriptor *pindexdesc,
+	CTableDescriptor *ptabdesc,
+	ULONG ulOriginOpId,
+	const CName *pnameAlias,
+	CColRefArray *pdrgpcrOutput,
+	COrderSpec *pos
+	)
+	:
+	CPhysicalScan(mp, pnameAlias, ptabdesc, pdrgpcrOutput),
+	m_pindexdesc(pindexdesc),
+	m_ulOriginOpId(ulOriginOpId),
+	m_pos(pos)
+{
+	GPOS_ASSERT(NULL != pindexdesc);
+	GPOS_ASSERT(NULL != pos);
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalIndexOnlyScan::~CPhysicalIndexOnlyScan
+//
+//	@doc:
+//		Dtor
+//
+//---------------------------------------------------------------------------
+CPhysicalIndexOnlyScan::~CPhysicalIndexOnlyScan()
+{
+	m_pindexdesc->Release();
+	m_pos->Release();
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalIndexOnlyScan::EpetOrder
+//
+//	@doc:
+//		Return the enforcing type for order property based on this operator
+//
+//---------------------------------------------------------------------------
+CEnfdProp::EPropEnforcingType
+CPhysicalIndexOnlyScan::EpetOrder
+	(
+	CExpressionHandle &, // exprhdl
+	const CEnfdOrder *peo
+	)
+	const
+{
+	GPOS_ASSERT(NULL != peo);
+	GPOS_ASSERT(!peo->PosRequired()->IsEmpty());
+
+	if (peo->FCompatible(m_pos))
+	{
+		// required order is already established by the index
+		return CEnfdProp::EpetUnnecessary;
+	}
+
+	return CEnfdProp::EpetRequired;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalIndexOnlyScan::HashValue
+//
+//	@doc:
+//		Combine pointers for table descriptor, index descriptor and Eop
+//
+//---------------------------------------------------------------------------
+ULONG
+CPhysicalIndexOnlyScan::HashValue() const
+{
+	ULONG ulHash = gpos::CombineHashes
+					(
+					COperator::HashValue(),
+					gpos::CombineHashes
+							(
+							m_pindexdesc->MDId()->HashValue(),
+							gpos::HashPtr<CTableDescriptor>(m_ptabdesc)
+							)
+					);
+	ulHash = gpos::CombineHashes(ulHash, CUtils::UlHashColArray(m_pdrgpcrOutput));
+
+	return ulHash;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalIndexOnlyScan::Matches
+//
+//	@doc:
+//		match operator
+//
+//---------------------------------------------------------------------------
+BOOL
+CPhysicalIndexOnlyScan::Matches
+	(
+	COperator *pop
+	)
+	const
+{
+	return CUtils::FMatchIndex(this, pop);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalIndexOnlyScan::OsPrint
+//
+//	@doc:
+//		debug print
+//
+//---------------------------------------------------------------------------
+IOstream &
+CPhysicalIndexOnlyScan::OsPrint
+	(
+	IOstream &os
+	)
+	const
+{
+	if (m_fPattern)
+	{
+		return COperator::OsPrint(os);
+	}
+
+	os << SzId() << " ";
+	// index name
+	os << "  Index Name: (";
+	m_pindexdesc->Name().OsPrint(os);
+	// table name
+	os <<")";
+	os << ", Table Name: (";
+	m_ptabdesc->Name().OsPrint(os);
+	os <<")";
+	os << ", Columns: [";
+	CUtils::OsPrintDrgPcr(os, m_pdrgpcrOutput);
+	os << "]";
+
+	return os;
+}
+
+// EOF
+

--- a/src/backend/gporca/libgpopt/src/operators/Makefile
+++ b/src/backend/gporca/libgpopt/src/operators/Makefile
@@ -99,6 +99,7 @@ OBJS        = CExpression.o \
               CPhysicalHashAggDeduplicate.o \
               CPhysicalHashJoin.o \
               CPhysicalIndexScan.o \
+              CPhysicalIndexOnlyScan.o \
               CPhysicalInnerHashJoin.o \
               CPhysicalInnerIndexNLJoin.o \
               CPhysicalInnerNLJoin.o \

--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -144,6 +144,7 @@ CXformFactory::Add
 void
 CXformFactory::Instantiate()
 {
+	// Order here needs to correspond to the order defined in CXform::EXformId
 	Add(GPOS_NEW(m_mp) CXformProject2ComputeScalar(m_mp));
 	Add(GPOS_NEW(m_mp) CXformExpandNAryJoin(m_mp));
 	Add(GPOS_NEW(m_mp) CXformExpandNAryJoinMinCard(m_mp));
@@ -296,6 +297,7 @@ CXformFactory::Instantiate()
 	Add(GPOS_NEW(m_mp) CXformLeftOuterJoin2DynamicIndexGetApply(m_mp));
 	Add(GPOS_NEW(m_mp) CXformLeftOuterJoinWithInnerSelect2DynamicBitmapIndexGetApply(m_mp));
 	Add(GPOS_NEW(m_mp) CXformLeftOuterJoinWithInnerSelect2DynamicIndexGetApply(m_mp));
+	Add(GPOS_NEW(m_mp) CXformIndexGet2IndexOnlyScan(m_mp));
 
 	GPOS_ASSERT(NULL != m_rgpxf[CXform::ExfSentinel - 1] &&
 				"Not all xforms have been instantiated");

--- a/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexOnlyScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexOnlyScan.cpp
@@ -1,0 +1,169 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//
+//	@filename:
+//		CXformIndexGet2IndexOnlyScan.cpp
+//
+//	@doc:
+//		Implementation of transform
+//---------------------------------------------------------------------------
+
+#include <cwchar>
+
+#include "gpos/base.h"
+#include "gpopt/xforms/CXformIndexGet2IndexOnlyScan.h"
+#include "gpopt/xforms/CXformUtils.h"
+
+#include "gpopt/operators/CExpressionHandle.h"
+#include "gpopt/operators/CLogicalIndexGet.h"
+#include "gpopt/operators/CPatternLeaf.h"
+#include "gpopt/operators/CPhysicalIndexOnlyScan.h"
+#include "gpopt/metadata/CIndexDescriptor.h"
+#include "gpopt/metadata/CTableDescriptor.h"
+#include "naucrates/md/CMDIndexGPDB.h"
+
+using namespace gpopt;
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformIndexGet2IndexOnlyScan::CXformIndexGet2IndexOnlyScan
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CXformIndexGet2IndexOnlyScan::CXformIndexGet2IndexOnlyScan
+	(
+	CMemoryPool *mp
+	)
+	:
+	// pattern
+	CXformImplementation
+		(
+		GPOS_NEW(mp) CExpression
+				(
+				mp,
+				GPOS_NEW(mp) CLogicalIndexGet(mp),
+				GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CPatternLeaf(mp))	// index lookup predicate
+				)
+		)
+{}
+
+CXform::EXformPromise CXformIndexGet2IndexOnlyScan::Exfp
+(
+ CExpressionHandle &exprhdl
+)
+const
+{
+	CLogicalIndexGet *popGet = CLogicalIndexGet::PopConvert(exprhdl.Pop());
+
+	CTableDescriptor *ptabdesc = popGet->Ptabdesc();
+	CIndexDescriptor *pindexdesc = popGet->Pindexdesc();
+
+	if ((pindexdesc->IndexType() == IMDIndex::EmdindBtree && ptabdesc->IsAORowOrColTable()) ||
+		!pindexdesc->SupportsIndexOnlyScan())
+	{
+		// we don't support btree index scans on AO tables
+		// FIXME: relax btree requirement. GiST and SP-GiST indexes can support some operator classes, but Gin cannot
+		return CXform::ExfpNone;
+	}
+
+	return CXform::ExfpHigh;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformIndexGet2IndexOnlyScan::Transform
+//
+//	@doc:
+//		Actual transformation
+//
+//---------------------------------------------------------------------------
+void
+CXformIndexGet2IndexOnlyScan::Transform
+	(
+	CXformContext *pxfctxt,
+	CXformResult *pxfres,
+	CExpression *pexpr
+	)
+	const
+{
+	GPOS_ASSERT(NULL != pxfctxt);
+	GPOS_ASSERT(FPromising(pxfctxt->Pmp(), this, pexpr));
+	GPOS_ASSERT(FCheckPattern(pexpr));
+
+	CLogicalIndexGet *pop = CLogicalIndexGet::PopConvert(pexpr->Pop());
+	CMemoryPool *mp = pxfctxt->Pmp();
+	CIndexDescriptor *pindexdesc = pop->Pindexdesc();
+	CTableDescriptor *ptabdesc = pop->Ptabdesc();
+
+	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
+	const IMDRelation *pmdrel = md_accessor->RetrieveRel(ptabdesc->MDId());
+	const IMDIndex *pmdindex = md_accessor->RetrieveIndex(pindexdesc->MDId());
+
+	CColRefArray *pdrgpcrOutput = pop->PdrgpcrOutput();
+	GPOS_ASSERT(NULL != pdrgpcrOutput);
+	pdrgpcrOutput->AddRef();
+
+	CColRefSet *matched_cols = CXformUtils::PcrsIndexKeys(mp, pdrgpcrOutput, pmdindex, pmdrel);
+	CColRefSet *output_cols = GPOS_NEW(mp) CColRefSet(mp);
+
+	// An index only scan is allowed iff each used output column reference also
+	// exists as a column in the index.
+	for (ULONG i = 0; i < pdrgpcrOutput->Size(); i++)
+	{
+		CColRef *col = (*pdrgpcrOutput)[i];
+		if (col->GetUsage(true /*check_system_cols*/) == CColRef::EUsed)
+		{
+			output_cols->Include(col);
+		}
+	}
+
+	if (!matched_cols->ContainsAll(output_cols))
+	{
+		matched_cols->Release();
+		output_cols->Release();
+		pdrgpcrOutput->Release();
+		return;
+	}
+
+	matched_cols->Release();
+	output_cols->Release();
+
+	pindexdesc->AddRef();
+	ptabdesc->AddRef();
+
+	COrderSpec *pos = pop->Pos();
+	GPOS_ASSERT(NULL != pos);
+	pos->AddRef();
+
+	// extract components
+	CExpression *pexprIndexCond = (*pexpr)[0];
+
+	// addref all children
+	pexprIndexCond->AddRef();
+
+	CExpression *pexprAlt =
+		GPOS_NEW(mp) CExpression
+			(
+			mp,
+			GPOS_NEW(mp) CPhysicalIndexOnlyScan
+				(
+				mp,
+				pindexdesc,
+				ptabdesc,
+				pexpr->Pop()->UlOpId(),
+				GPOS_NEW(mp) CName (mp, pop->NameAlias()),
+				pdrgpcrOutput,
+				pos
+				),
+			pexprIndexCond
+			);
+	pxfres->Add(pexprAlt);
+}
+
+
+// EOF
+

--- a/src/backend/gporca/libgpopt/src/xforms/Makefile
+++ b/src/backend/gporca/libgpopt/src/xforms/Makefile
@@ -64,6 +64,7 @@ OBJS        = CDecorrelator.o \
               CXformImplementUnionAll.o \
               CXformImplementation.o \
               CXformIndexGet2IndexScan.o \
+              CXformIndexGet2IndexOnlyScan.o \
               CXformInlineCTEConsumer.o \
               CXformInlineCTEConsumerUnderSelect.o \
               CXformInnerApply2InnerJoin.o \

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -329,6 +329,7 @@ bool		optimizer_enable_master_only_queries;
 bool		optimizer_enable_hashjoin;
 bool		optimizer_enable_dynamictablescan;
 bool		optimizer_enable_indexscan;
+bool		optimizer_enable_indexonlyscan;
 bool		optimizer_enable_tablescan;
 bool		optimizer_enable_hashagg;
 bool		optimizer_enable_groupagg;
@@ -2251,6 +2252,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&optimizer_enable_indexscan,
 		true,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_enable_indexonlyscan", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enables the optimizer's use of plans with index only scan."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_indexonlyscan,
+		false,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -211,8 +211,15 @@ namespace gpdxl
 				const CDXLNode *index_scan_dxlnode,
 				CDXLPhysicalIndexScan *dxl_physical_idx_scan_op,
 				CDXLTranslateContext *output_context,
-				BOOL is_index_only_scan,
 				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
+				);
+
+			// translate DXL index scan node into a IndexOnlyScan node
+			Plan *TranslateDXLIndexOnlyScan
+				(
+				 const CDXLNode *index_scan_dxlnode,
+				 CDXLTranslateContext *output_context,
+				 CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate DXL hash join into a HashJoin node
@@ -464,7 +471,6 @@ namespace gpdxl
 			RangeTblEntry *TranslateDXLTblDescrToRangeTblEntry
 				(
 				const CDXLTableDescr *table_descr,
-				const CDXLIndexDescr *index_descr_dxl,
 				Index index,
 				CDXLTranslateContextBaseTable *base_table_context
 				);
@@ -607,7 +613,6 @@ namespace gpdxl
 				(
 				CDXLNode *index_cond_list_dxlnode,
 				const CDXLTableDescr *dxl_tbl_descr,
-				BOOL is_index_only_scan,
 				BOOL is_bitmap_index_probe,
 				const IMDIndex *index,
 				const IMDRelation *md_rel,

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -508,6 +508,7 @@ extern bool optimizer_enable_master_only_queries;
 extern bool optimizer_enable_hashjoin;
 extern bool optimizer_enable_dynamictablescan;
 extern bool optimizer_enable_indexscan;
+extern bool optimizer_enable_indexonlyscan;
 extern bool optimizer_enable_tablescan;
 extern bool optimizer_enable_eageragg;
 extern bool optimizer_expand_fulljoin;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -355,6 +355,7 @@
 		"optimizer_enable_hashjoin_redistribute_broadcast_children",
 		"optimizer_enable_indexjoin",
 		"optimizer_enable_indexscan",
+		"optimizer_enable_indexonlyscan",
 		"optimizer_enable_master_only_queries",
 		"optimizer_enable_materialize",
 		"optimizer_enable_mergejoin",

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -725,3 +725,42 @@ select * from shape_aocs where c && '<(5,5), 3>'::circle;
  <(0,0),5>
 (1 row)
 
+--
+-- Given a table with different column types
+--
+CREATE TABLE table_with_reversed_index(a int, b bool, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+--
+-- And it has an index that is ordered differently than columns on the table.
+--
+CREATE INDEX ON table_with_reversed_index(c, a);
+INSERT INTO table_with_reversed_index VALUES (10, true, 'ab');
+--
+-- Then an index only scan should succeed. (i.e. varattno is set up correctly)
+--
+SET enable_seqscan=off;
+SET enable_bitmapscan=off;
+SET optimizer_enable_tablescan=off;
+SET optimizer_enable_indexscan=off;
+SET optimizer_enable_indexonlyscan=on;
+EXPLAIN SELECT c, a FROM table_with_reversed_index WHERE a > 5;
+                                                                    QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.12..10000000008.16 rows=1 width=7)
+   ->  Index Only Scan using table_with_reversed_index_c_a_idx on table_with_reversed_index  (cost=10000000000.12..10000000008.14 rows=1 width=7)
+         Index Cond: (a > 5)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+SELECT c, a FROM table_with_reversed_index WHERE a > 5;
+ c  | a  
+----+----
+ ab | 10
+(1 row)
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+RESET optimizer_enable_tablescan;
+RESET optimizer_enable_indexscan;
+RESET optimizer_enable_indexonlyscan;

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -693,3 +693,42 @@ select * from shape_aocs where c && '<(5,5), 3>'::circle;
  <(0,0),5>
 (1 row)
 
+--
+-- Given a table with different column types
+--
+CREATE TABLE table_with_reversed_index(a int, b bool, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+--
+-- And it has an index that is ordered differently than columns on the table.
+--
+CREATE INDEX ON table_with_reversed_index(c, a);
+INSERT INTO table_with_reversed_index VALUES (10, true, 'ab');
+--
+-- Then an index only scan should succeed. (i.e. varattno is set up correctly)
+--
+SET enable_seqscan=off;
+SET enable_bitmapscan=off;
+SET optimizer_enable_tablescan=off;
+SET optimizer_enable_indexscan=off;
+SET optimizer_enable_indexonlyscan=on;
+EXPLAIN SELECT c, a FROM table_with_reversed_index WHERE a > 5;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.10 rows=1 width=7)
+   ->  Index Only Scan using table_with_reversed_index_c_a_idx on table_with_reversed_index  (cost=0.00..0.10 rows=1 width=7)
+         Index Cond: (a > 5)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+SELECT c, a FROM table_with_reversed_index WHERE a > 5;
+ c  | a  
+----+----
+ ab | 10
+(1 row)
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+RESET optimizer_enable_tablescan;
+RESET optimizer_enable_indexscan;
+RESET optimizer_enable_indexonlyscan;

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -316,3 +316,30 @@ select * from shape_aocs where c && '<(5,5), 2>'::circle;
 select * from shape_heap where c && '<(5,5), 3>'::circle;
 select * from shape_ao   where c && '<(5,5), 3>'::circle;
 select * from shape_aocs where c && '<(5,5), 3>'::circle;
+
+--
+-- Given a table with different column types
+--
+CREATE TABLE table_with_reversed_index(a int, b bool, c text);
+
+--
+-- And it has an index that is ordered differently than columns on the table.
+--
+CREATE INDEX ON table_with_reversed_index(c, a);
+INSERT INTO table_with_reversed_index VALUES (10, true, 'ab');
+
+--
+-- Then an index only scan should succeed. (i.e. varattno is set up correctly)
+--
+SET enable_seqscan=off;
+SET enable_bitmapscan=off;
+SET optimizer_enable_tablescan=off;
+SET optimizer_enable_indexscan=off;
+SET optimizer_enable_indexonlyscan=on;
+EXPLAIN SELECT c, a FROM table_with_reversed_index WHERE a > 5;
+SELECT c, a FROM table_with_reversed_index WHERE a > 5;
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+RESET optimizer_enable_tablescan;
+RESET optimizer_enable_indexscan;
+RESET optimizer_enable_indexonlyscan;


### PR DESCRIPTION
This commit allows Orca to select plans that leverage IndexOnlyScan
node. A new GUC 'optimizer_enable_indexonlyscan' is used to enable or
disable this feature and is currently disabled by default until the
following issues are addressed:

  1) Implement cost comparison model for index only scans. Currently,
     cost is hard coded for testing purposes.
  2) Support index only scan using GiST and SP-GiST as allowed.
     Currently, code only supports index only scans on b-tree index.

Co-authored-by: Chris Hajas <chajas@vmware.com>

CI run to show plan diffs:
https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-index-only-scan/jobs/icw_gporca_centos7/builds/30
