### PR TITLE
Resolve high `CacheMemoryContext` usage for `ANALYZE` on large partition table.

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -4092,17 +4092,40 @@ merge_leaf_stats(VacAttrStatsP stats,
 	int totalhll_count = 0;
 	foreach (lc, oid_list)
 	{
-		Oid relid = lfirst_oid(lc);
-		colAvgWidth =
-			colAvgWidth +
-			get_attavgwidth(relid, stats->attr->attnum) * relTuples[i];
-		nullCount = nullCount +
-					get_attnullfrac(relid, stats->attr->attnum) * relTuples[i];
+		Oid		leaf_relid = lfirst_oid(lc);
+		int32	stawidth = 0;
+		float4	stanullfrac = 0.0;
 
+		/*
+		 * Here, using the root table's attnum to retrieve the attname. And then use
+		 * the attname to retrieve the real attnum in current leaf table.
+		 * This is required because modification on root partition columns will cause
+		 * inconsistent attnum between root table and new added leaf tables.
+		 */
 		const char *attname = get_relid_attribute_name(stats->attr->attrelid, stats->attr->attnum);
-		AttrNumber child_attno = get_attnum(relid, attname);
 
-		heaptupleStats[i] = get_att_stats(relid, child_attno);
+		/*
+		 * fetch_leaf_attnum and fetch_leaf_att_stats retrieve leaf partition
+		 * table's pg_attribute tuple and pg_statistic tuple through index scan
+		 * instead of system catalog cache. Since if using system catalog cache,
+		 * the total tuple entries insert into the cache will up to:
+		 * (number_of_leaf_tables * number_of_column_in_this_table) pg_attribute tuples
+		 * +
+		 * (number_of_leaf_tables * number_of_column_in_this_table) pg_statistic tuples
+		 * which could use extremely large memroy in CacheMemoryContext.
+		 * This happens when all of the leaf tables are analyzed. And the current function
+		 * will execute for all columns.
+		 *
+		 * fetch_leaf_att_stats copy the original tuple, so remember to free it.
+		 *
+		 * As a side-effect, ANALYZE same root table serveral times in same session is much
+		 * more slower than before since we don't rely on system catalog cache.
+		 *
+		 * But we still using the tuple descriptor in system catalog cache to retrieve
+		 * attribute in fetched tuples. See get_attstatsslot.
+		 */
+		AttrNumber child_attno = fetch_leaf_attnum(leaf_relid, attname);
+		heaptupleStats[i] = fetch_leaf_att_stats(leaf_relid, child_attno);
 
 		// if there is no colstats, we can skip this partition's stats
 		if (!HeapTupleIsValid(heaptupleStats[i]))
@@ -4110,6 +4133,11 @@ merge_leaf_stats(VacAttrStatsP stats,
 			i++;
 			continue;
 		}
+
+		stawidth = ((Form_pg_statistic) GETSTRUCT(heaptupleStats[i]))->stawidth;
+		stanullfrac = ((Form_pg_statistic) GETSTRUCT(heaptupleStats[i]))->stanullfrac;
+		colAvgWidth = colAvgWidth + (stawidth > 0 ? stawidth : 0) * relTuples[i];
+		nullCount = nullCount + (stanullfrac > 0.0 ? stanullfrac : 0.0) * relTuples[i];
 
 		AttStatsSlot hllSlot;
 

--- a/src/include/commands/analyzeutils.h
+++ b/src/include/commands/analyzeutils.h
@@ -56,6 +56,8 @@ extern int aggregate_leaf_partition_histograms(Oid relationOid,
 											   int rem_mcv,
 											   void **result);
 extern bool needs_sample(VacAttrStats **vacattrstats, int attr_cnt);
+extern AttrNumber fetch_leaf_attnum(Oid leafRelid, const char* attname);
+extern HeapTuple fetch_leaf_att_stats(Oid leafRelid, AttrNumber leafAttNum);
 extern bool leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel);
 
 #endif  /* ANALYZEUTILS_H */


### PR DESCRIPTION
In some cases, merge stats logic for root partition table may consume
very high memory usage in CacheMemoryContext.
This may lead to `Canceling query because of high VMEM usage` when
concurrently ANALYZE partition tables.

For example, there are several root partition tables and they both have
thousands of leaf tables. And these tables are all wide tables that may
contain hundreds of columns.
So when analyze()/auto_stats() leaf tables concurrently,
`leaf_parts_analyzed` will consume lots of memory(catalog catch for
pg_statistic and pg_attribute) under
CacheMemoryContext for each backend, which may hit the protect VMEM
limit.
In `leaf_parts_analyzed`, a single backend's leaf table analysis for a
root partition table, it may add cache entries up to
number_of_leaf_tables * number_of_columns tuples from pg_statistic and
number_of_leaf_tables * number_of_columns tuples from pg_arrtibute.
Set guc `optimizer_analyze_root_partition` or
`optimizer_analyze_enable_merge_of_leaf_stats` to false could skip merge
stats for root table and `leaf_parts_analyzed` will not execute.

To resolve this issue:
1. When checking whether merge stats are available for a root table in
`leaf_parts_analyzed`, check whether all leaf tables are ANALYZEd first,
if they're still un-ANALYZE leaf table exists, return quickly to avoid touch
columns' pg_attribute and pg_statistic per leaf table(this will save lots of time).
And also don't rely on system catalog cache and use the
index to fetch the stats tuple to avoid one-time cache usage(in common cases).

2. When merging a stats in `merge_leaf_stats`, don't rely on system
catalog cache and use the index to fetch the stats tuple.

There are side-effects for not rely on system catalog cache(which are all **rare** situations).
1. If insert/update/copy several leaf tables which under **same
root partition** table in **same session** and all leaf tables are **analyzed**
will be much slower since auto_stats will call `leaf_parts_analyzed` once the leaf
table gets updated, and we don't rely on system catalog cache now.
(`set optimizer_analyze_enable_merge_of_leaf_stats=false` could avoid
this, gpcopy and gprestore should always set this guc to false and when
all leaf tables are copied, run analyze on the root partition table)

2. ANALYZE same root table several times in same session is much
slower than before since we don't rely on system catalog cache.

Seems this solution improves the performance for ANALYZE, and
it also makes ANALYZE won't hit the memory issue anymore.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
