### PR TITLE
[6X BugFix] Fix "Too many distributed transactions for snapshot"

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1527,7 +1527,7 @@ GetDistributedSnapshotMaxCount(DtxContext distributedTransactionContext)
 		return 0;
 
 	case DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE:
-		return max_prepared_xacts;
+		return GetMaxSnapshotXidCount();
 
 	case DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER:
 	case DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER:


### PR DESCRIPTION
Now that we do not have to use full gang for distributed transaction, that
makes in-progress distributed transaction on master might be greater than
max_prepared_xacts if max_prepared_xacts is configured with a small value.
max_prepared_xacts is used to as the inProgressXidArray length for distributed
snapshot. This might lead to distributed snapshot creation failure due to "Too
many distributed transactions for snapshot" if the system is in heavy 2pc load.
Fixing this by using GetMaxSnapshotXidCount() for the length of array
inProgressXidArray, following the setting on master.

This fixes github issue https://github.com/greenplum-db/gpdb/issues/10057

No test for this since test isolation2:prepare_limit already covered this.  (I
encoutered this issue when backporting a PR that introduces the test
isolation2:prepare_limit, so need to push this at first then the backporting
PR).
