### PR TITLE
Disable strxfrm for mk_sort at compile time

### DIFF
--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -712,6 +712,11 @@ create_mksort_context(MKContext *mkctxt,
 			if (sinfo->scanKey.sk_func.fn_addr == btint4cmp)
 				sinfo->lvtype = MKLV_TYPE_INT32;
 
+/*
+* Users who are certain that their glibc is not affected by strcoll() and strxfrm()
+* inconsistency can speed up mk sort defining TRUST_STRXFRM_MK_SORT at compile time.
+*/
+#ifdef TRUST_STRXFRM_MK_SORT
 			/* GPDB_91_MERGE_FIXME: these MKLV_TYPE_CHAR and MKLV_TYPE_TEXT
 			 * fastpaths only work with the default collation of the database.
 			 */
@@ -723,6 +728,7 @@ create_mksort_context(MKContext *mkctxt,
 				else if (sinfo->scanKey.sk_func.fn_addr == bttextcmp)
 					sinfo->lvtype = MKLV_TYPE_TEXT;
 			}
+#endif
 		}
 		else
 		{

--- a/src/test/regress/expected/sort.out
+++ b/src/test/regress/expected/sort.out
@@ -620,3 +620,24 @@ select * from colltest order by t COLLATE "C" NULLS FIRST;
  d
 (9 rows)
 
+--
+-- Test strxfrm()/strcoll() sort order inconsistency in a
+-- merge join with russian characters and default collation
+--
+set optimizer = off;
+set gp_enable_mk_sort = on;
+set enable_hashjoin = off;
+with t as (
+    select * from (values ('б б'), ('бб ')) as t1(b)
+    full join (values ('б б'), ('бб ')) as t2(b)
+    using (b)
+)
+select count(*) from t;
+ count 
+-------
+     2
+(1 row)
+
+reset optimizer;
+reset gp_enable_mk_sort;
+reset enable_hashjoin;

--- a/src/test/regress/sql/sort.sql
+++ b/src/test/regress/sql/sort.sql
@@ -119,3 +119,23 @@ insert into colltest VALUES ('a'), ('A'), ('b'), ('B'), ('c'), ('C'), ('d'), ('D
 
 select * from colltest order by t COLLATE "C";
 select * from colltest order by t COLLATE "C" NULLS FIRST;
+
+
+--
+-- Test strxfrm()/strcoll() sort order inconsistency in a
+-- merge join with russian characters and default collation
+--
+set optimizer = off;
+set gp_enable_mk_sort = on;
+set enable_hashjoin = off;
+
+with t as (
+    select * from (values ('б б'), ('бб ')) as t1(b)
+    full join (values ('б б'), ('бб ')) as t2(b)
+    using (b)
+)
+select count(*) from t;
+
+reset optimizer;
+reset gp_enable_mk_sort;
+reset enable_hashjoin;


### PR DESCRIPTION
This PR is another approach to solve https://github.com/greenplum-db/gpdb/issues/6586 (previous solution was suggested in https://github.com/greenplum-db/gpdb/pull/6927 by @hlinnaka).

Glibc implementations are known to return inconsistent results for `strcoll()` and `strxfrm()` on many platforms that can cause unpredictable bugs. Because of that PostgreSQL disabled `strxfrm()` by default since 9.5 at compile time by `TRUST_STRXFRM` definition. Greenplum has its own mk sort implementation that can also use `strxfrm()`. Hence mk sort can also be affected by `strcoll()` and `strxfrm()` inconsistency (breaks merge joins). That is why `strxfrm()` should be disabled by default with `TRUST_STRXFRM_MK_SORT` definition for mk sort as well. We don't use PostgreSQL's `TRUST_STRXFRM` definition as many users used Greenplum with `strxfrm()` enabled for mk sort and disabled in PostgreSQL core. Keeping `TRUST_STRXFRM_MK_SORT` as a separate definition allows these users not to reindex after version upgrade.

Another possible solution was to keep some allow list of encodings in a GUC that are surely not affected by `strxfrm()`/`strcoll()` inconsistency and where `strxfrm()` doesn't produce additional entropy (MacOS as a good example). Possibly this allow list should allow `strxfrm()` not only for mk sort but for PostgreSQL `varlena.c` as well (removing of `TRUST_STRXFRM` requires reindex). But I believe it's too dangerous to allow users do such things themselves - it should be a maintainer's responsibility. Maintainer can build a special version with `strxfrm()` support at configure time with `-DTRUST_STRXFRM_MK_SORT` option. I also believe that this define should be set disabling `strxfrm()` by default rather that enabling it (because `strxfrm()` is a dangerous hack and open source users should not care about proc and cons of it building Greenplum).