### PR TITLE
docs - add information on upgrading to PostGIS 2.5.4

### DIFF
--- a/gpdb-doc/dita/analytics/analytics.ditamap
+++ b/gpdb-doc/dita/analytics/analytics.ditamap
@@ -5,28 +5,31 @@
         navtitle="Pivotal Greenplum® 7.0 Beta Documentation" format="html" otherprops="op-help"/>
     <topicref href="overview.xml" linking="none"/>
     <topicref href="madlib.xml" navtitle="Machine Learning and Deep Learning" linking="none">
-      <topicref href="madlib.xml#topic3" navtitle="Installing MADlib" linking="none"/>
-      <topicref href="madlib.xml#topic_eqm_klx_hw" navtitle="Upgrading MADlib" linking="none"/>
-      <topicref href="madlib.xml#topic6" navtitle="Uninstalling MADlib" linking="none"/>
-      <topicref href="madlib.xml#topic9" navtitle="Examples" linking="none"/>
-      <topicref href="madlib.xml#topic10" navtitle="References" linking="none"/>
-      </topicref>
-    <topicref href="graph.xml" navtitle="Graph Analytics" linking="none"/>    
-    <topicref href="postGIS.xml" navtitle="Geospatial Analytics" otherprops="pivotal" linking="none"/>
-    <topicref href="text.xml" navtitle="Text Analytics and Search" otherprops="pivotal" linking="none"/>
+        <topicref href="madlib.xml#topic3" navtitle="Installing MADlib" linking="none"/>
+        <topicref href="madlib.xml#topic_eqm_klx_hw" navtitle="Upgrading MADlib" linking="none"/>
+        <topicref href="madlib.xml#topic6" navtitle="Uninstalling MADlib" linking="none"/>
+        <topicref href="madlib.xml#topic9" navtitle="Examples" linking="none"/>
+        <topicref href="madlib.xml#topic10" navtitle="References" linking="none"/>
+    </topicref>
+    <topicref href="graph.xml" navtitle="Graph Analytics" linking="none"/>
+    <topicref href="postGIS.xml" navtitle="Geospatial Analytics" otherprops="pivotal" linking="none">
+        <topicref href="postgis-upgrade.xml" otherprops="pivotal" linking="none"/>
+    </topicref>
+    <topicref href="text.xml" navtitle="Text Analytics and Search" otherprops="pivotal"
+        linking="none"/>
     <topicref href="intro.xml" navtitle="Procedural Languages" linking="none">
-    <topicref href="pl_container.xml" navtitle="PL/Container" linking="none">
-          <topicref href="pl_container.xml#about_pl_container"  linking="none"/>
-          <topicref href="pl_container.xml#topic3"  linking="none"/>
-          <topicref href="pl_container.xml#upgrade_plcontainer"  linking="none"/>
-          <topicref href="pl_container.xml#uninstall_plcontainer"  linking="none"/>
-          <topicref href="pl_container_using.xml"  linking="none"/>
-          </topicref>
-      <topicref href="pl_java.xml" linking="none"/>
-      <topicref href="pl_perl.xml" linking="none"/>
-      <topicref href="pl_sql.xml" linking="none"/>
-      <topicref href="pl_python.xml" linking="none"/>
-      <topicref href="pl_r.xml" linking="none"/>
+        <topicref href="pl_container.xml" navtitle="PL/Container" linking="none">
+            <topicref href="pl_container.xml#about_pl_container" linking="none"/>
+            <topicref href="pl_container.xml#topic3" linking="none"/>
+            <topicref href="pl_container.xml#upgrade_plcontainer" linking="none"/>
+            <topicref href="pl_container.xml#uninstall_plcontainer" linking="none"/>
+            <topicref href="pl_container_using.xml" linking="none"/>
+        </topicref>
+        <topicref href="pl_java.xml" linking="none"/>
+        <topicref href="pl_perl.xml" linking="none"/>
+        <topicref href="pl_sql.xml" linking="none"/>
+        <topicref href="pl_python.xml" linking="none"/>
+        <topicref href="pl_r.xml" linking="none"/>
     </topicref>
     <topicref href="greenplum_r_client.xml" linking="none"/>
 </map>

--- a/gpdb-doc/dita/analytics/postGIS.xml
+++ b/gpdb-doc/dita/analytics/postGIS.xml
@@ -21,6 +21,8 @@
         <xref href="#postgis_support" format="dita"/>
       </li>
     </ul>
+    <p>For information about upgrading PostGIS on Greenplum Database 6 systems, see <xref
+        href="postgis-upgrade.xml"/></p>
   </body>
   <topic id="topic2" xml:lang="en">
     <title id="ij166739">About PostGIS</title>
@@ -146,6 +148,8 @@
           <li><xref href="#topic_fx2_fpx_llb" format="dita"/></li>
           <li><xref href="#topic_bgz_vcl_r1b" format="dita"/></li>
         </ul></p>
+      <p>For information about upgrading PostGIS on Greenplum Database 6 systems, see <xref
+          href="postgis-upgrade.xml"/></p>
     </body>
     <topic id="topic_ln5_xcl_r1b">
       <title>Enabling PostGIS Support</title>
@@ -262,6 +266,10 @@ CREATE EXTENSION address_standardizer_data_us ;</codeblock></li>
             <codeph>POSTGIS_ENABLE_OUTDB_RASTERS</codeph>,
             <codeph>POSTGIS_GDAL_ENABLED_DRIVERS</codeph>. The environment variables are removed
           when you uninstall the PostGIS extension package.</p>
+        <note type="important">Before removing PostGIS support from a database, ensure that no users
+          are accessing the database. Removing PostGIS support from a database drops PostGIS
+          database objects from the database. Users accessing PostGIS objects might interfere with
+          the dropping of the objects. </note>
         <section id="drop_postgis_cmd">
           <title>Using the DROP EXTENSION Command</title>
           <p>Depending on the extensions you enabled for PostGIS, drop support for the extensions in

--- a/gpdb-doc/dita/analytics/postgis-upgrade.xml
+++ b/gpdb-doc/dita/analytics/postgis-upgrade.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_khf_ltc_vbb">
+  <title>Upgrading from PostGIS 2.1.5 or 2.5.4</title>
+  <body>
+    <p>For Greenplum Database 6, you can upgrade from PostGIS 2.1.5 to 2.5.4, or from a PostGIS
+      2.5.4 package to a newer PostGIS 2.5.4 package.</p>
+    <ul id="ul_eyk_db3_kmb">
+      <li><xref href="#topic_k4x_dp3_kmb" format="dita"/></li>
+      <li><xref href="#topic_zgw_v5x_3mb" format="dita"/></li>
+      <li><xref href="#topic_yzz_l3h_kmb" format="dita"/></li>
+    </ul>
+    <note type="important">Before removing PostGIS support from a database, ensure that no users are
+      accessing the database. Removing PostGIS support from a database drops PostGIS database
+      objects from the database. Users accessing PostGIS objects might interfere with the dropping
+      of PostGIS objects. See <xref href="#topic_hm5_3zk_jmb" format="dita"/>.</note>
+  </body>
+  <topic id="topic_k4x_dp3_kmb">
+    <title>Upgrade a PostGIS 2.5.4 Package</title>
+    <body>
+      <p>You can perform these upgrades of a Greenplum PostGIS 2.5.4 package.<ul id="ul_vks_pp3_kmb">
+          <li><xref href="#topic_r22_s5x_3mb" format="dita"/><p>Upgrades the PostGIS
+                <codeph>pivotal.2</codeph> package to the <codeph>pivotal.3</codeph> minor release
+              package. </p></li>
+          <li><xref href="#topic_ogy_ph3_kmb" format="dita"/><p>Upgrades the PostGIS package to the
+                <codeph>pivotal.2</codeph> minor release package. The minor release supports using
+              the <codeph>CREATE EXTENSION</codeph> command and the <codeph>DROP EXTENSION</codeph>
+              command to enable and remove PostGIS support in a database.</p></li>
+          <li><xref href="#topic_unb_45x_3mb" format="dita"/><p>Upgrades the PostGIS package to the
+                <codeph>build.2</codeph> maintenance release. The release is an ABI (Application
+              Binary Interface) compatible PostGIS package that contains the same PostGIS version
+              (2.5.4).</p></li>
+        </ul></p>
+    </body>
+    <topic id="topic_r22_s5x_3mb">
+      <title>Upgrading PostGIS 2.5.4 package from pivotal.2 to pivotal.3</title>
+      <body>
+        <p>Upgrading the installed PostGIS 2.5.4 package from <codeph>pivotal.2</codeph> to
+            <codeph>pivotal.3</codeph> updates the PostGIS 2.5.4 to a new minor release
+            <codeph>pivotal.3</codeph> that uses the same PostGIS version (2.5.4).</p>
+        <ol id="ul_sjw_sp4_kmb">
+          <li>Confirm you have a PostGIS 2.5.4 package
+              <codeph>postgis-2.5.4+<b>pivotal.2</b></codeph> installed in a Greenplum Database
+            system. See <xref href="#topic_yzz_l3h_kmb" format="dita"/>.</li>
+          <li>Upgrade the PostGIS package in the Greenplum Database system using the
+              <codeph>gppkg</codeph> option <codeph>-u</codeph>. The command updates the package to
+            the <codeph>postgis-2.5.4+pivotal.3.build.1</codeph>
+            package.<codeblock dir="ltr">gppkg -u postgis-2.5.4+pivotal.3.build.1-gp6-rhel7-x86_64.gppkg</codeblock></li>
+          <li>Run the <codeph>gppkg -q --all</codeph> command to verify the updated package version
+            is installed in the Greenplum Database system. </li>
+        </ol>
+      </body>
+    </topic>
+    <topic id="topic_ogy_ph3_kmb">
+      <title>Upgrading the postgis-2.5.4 Package from pivotal.1 to pivotal.2</title>
+      <body>
+        <p>Upgrading an installed PostGIS 2.5.4 package from <codeph>pivotal.1</codeph> to
+            <codeph>pivotal.2</codeph> updates the Greenplum PostGIS 2.5.4 package to a minor
+          release that uses the same PostGIS version (2.5.4). The PostGIS 2.5.4
+            <codeph>pivotal.2</codeph> package supports using the <codeph>CREATE EXTENSION</codeph>
+          command and the <codeph>DROP EXTENSION</codeph> command to enable and remove PostGIS
+          support in a database. See <xref href="#topic_hm5_3zk_jmb" format="dita"/>.</p>
+        <p>Updating to <codeph>pivotal.2</codeph> also requires converting PostGIS so that you can
+          use the <codeph>CREATE EXTENSION</codeph> command and the <codeph>DROP EXTENSION</codeph>
+          command to enable and remove PostGIS support in a database.</p>
+        <ol id="ol_d3f_th3_kmb">
+          <li>Confirm you have a PostGIS 2.5.4 package
+              <codeph>postgis-2.5.4+<b>pivotal.1</b></codeph> installed in a Greenplum Database
+            system. See <xref href="#topic_yzz_l3h_kmb" format="dita"/>.</li>
+          <li>Upgrade the PostGIS package in the Greenplum Database system using the
+              <codeph>gppkg</codeph> option <codeph>-u</codeph>. This command updates the package to
+            the <codeph>postgis-2.5.4+pivotal.2.build.2</codeph>
+              package.<codeblock dir="ltr">$ gppkg -u postgis-2.5.4+pivotal.2.build.2-gp6-rhel7-x86_64.gppkg</codeblock><p>Run
+              the <codeph>gppkg -q --all</codeph> command to verify the updated package version is
+              installed in the Greenplum Database system. </p></li>
+          <li>Run the following commands in all databases that have PostGIS 2.5.4 enabled. The
+            commands update PostGIS to use the <codeph>DROP EXTENSION</codeph> command to remove
+            PostGIS support from the database. <p>Do not run these commands in a database that does
+              not have PostGIS enabled.</p>
+            <note type="important">Before running these commands, ensure that no users are accessing
+              the database. The <codeph>CREATE EXTENSION</codeph> command updates a system catalog
+              table. Other users concurrently accessing catalog tables might cause catalog
+              corruption
+            issues.</note><codeblock># SET allow_system_table_mods TO on;
+# CREATE EXTENSION postgis SCHEMA public FROM unpackaged;
+# SET allow_system_table_mods TO off;</codeblock></li>
+          <li>You can verify that PostGIS 2.5.4 is installed and enabled as an extension in the
+            database with this
+            query.<codeblock>SELECT * FROM pg_available_extensions WHERE name = 'postgis' ;</codeblock></li>
+          <li>Run the <codeph>gppkg -q --all</codeph> command to verify the updated package version
+            is installed in the Greenplum Database system. </li>
+        </ol>
+        <p>To enable PostGIS in a database after you have upgraded to a PostGIS 2.5.4
+            <codeph>pivotal.2</codeph> package, use the <codeph>CREATE EXTENSION postgis</codeph>
+          command. To remove PostGIS support, use the <codeph>DROP EXTENSION postgis
+            CASCADE</codeph> command.</p>
+      </body>
+    </topic>
+    <topic id="topic_unb_45x_3mb">
+      <title>Upgrade the postgis-2.5.4+pivotal.2 package from build.1 to build.2</title>
+      <body>
+        <p>You can upgrade the installed PostGIS package
+              <codeph>postgis-2.5.4+pivotal.2.<b>build.1</b></codeph> to
+              <codeph>postgis-2.5.4+pivotal.2.<b>build.2</b></codeph>. The upgrade updates the
+          PostGIS package (<codeph>build.1</codeph>) with an ABI (Application Binary Interface)
+          compatible PostGIS package (<codeph>build.2</codeph>) that contains the same PostGIS
+          version.</p>
+        <ol id="ol_snc_1fx_3mb">
+          <li>Confirm you have PostGIS 2.5.4 package
+              <codeph>postgis-2.5.4+<b>pivotal.2.build.1</b></codeph> installed in a Greenplum
+            Database system. See <xref href="#topic_yzz_l3h_kmb" format="dita"/>.</li>
+          <li dir="ltr">Upgrade PostGIS 2.5.4 to the <codeph>build.2</codeph> package in the
+            Greenplum Database system using the <codeph>gppkg</codeph> option <codeph>-u</codeph>.
+            This command upgrades PostGIS on a RedHat 7 or CentOS 7
+            system.<codeblock>$ gppkg -u postgis-2.5.4+pivotal.2.build.2-gp6-rhel7-x86_64.gppkg</codeblock></li>
+          <li>Run the <codeph>gppkg -q --all</codeph> command to verify the updated package version
+            is installed in the Greenplum Database system. </li>
+        </ol>
+      </body>
+    </topic>
+  </topic>
+  <topic id="topic_zgw_v5x_3mb">
+    <title>Upgrade from PostGIS 2.1.5 to PostGIS 2.5.4</title>
+    <body>
+      <p dir="ltr">Upgrading the Greenplum PostGIS 2.1.5 package to a <codeph>postgis-2.5.4</codeph>
+        package, requires removing PostGIS 2.1.5 support from databases with PostGIS enabled.
+        Removing PostGIS support drops the PostGIS 2.1.5 objects from the database. Before removing
+        PostGIS 2.1.5 support, ensure that no users are accessing the database. Removing PostGIS
+        support from a database drops PostGIS database objects from the database. Users accessing
+        PostGIS objects might interfere with dropping PostGIS objects.</p>
+      <p>You can perform these upgrades of a PostGIS 2.1.5 package to a Greenplum PostGIS 2.5.4
+          package.<ul id="ul_shm_4n4_kmb">
+          <li><xref href="#topic_pml_bq4_kmb" format="dita"/><p>The <codeph>pivotal.3</codeph>
+              package supports using the <codeph>CREATE EXTENSION</codeph> command and the
+                <codeph>DROP EXTENSION</codeph> command to enable and remove PostGIS support in a
+              database. The package also improves support for upgrading PostGIS 2.5.4
+            packages.</p></li>
+          <li><xref href="#topic_nnk_dvn_kmb" format="dita"/><p>The <codeph>pivotal.2</codeph>
+              package supports using the <codeph>CREATE EXTENSION</codeph> command and the
+                <codeph>DROP EXTENSION</codeph> command to enable and remove PostGIS support in a
+              database.</p></li>
+          <li><xref href="#topic_xql_1vn_kmb" format="dita"/><p>The <codeph>pivotal.1</codeph>
+              package requires using a script to enable and remove PostGIS support in a
+              database.</p></li>
+        </ul></p>
+      <p>After upgrading the PostGIS package, you can <xref href="#topic_unj_v5n_kmb" format="dita"
+          >remove the PostGIS 2.1.5 package</xref>.</p>
+    </body>
+    <topic id="topic_pml_bq4_kmb">
+      <title>Upgrading from PostGIS 2.1.5 to a PostGIS 2.5.4 pivotal.3 Package</title>
+      <body>
+        <p>A PostGIS 2.5.4 <codeph>pivotal.3</codeph> package contains PostGIS 2.5.4. Also, the
+          PostGIS 2.5.4 <codeph>pivotal.3</codeph> package supports using the <codeph>CREATE
+            EXTENSION</codeph> command and the <codeph>DROP EXTENSION</codeph> command to enable and
+          remove PostGIS support in a database. <codeph>DROP EXTENSION</codeph> support is included
+          starting with PostGIS 2.5.4 <codeph>pivotal.2</codeph>.</p>
+        <note dir="ltr" type="important">Upgrading from a Greenplum PostGIS 2.1.5 package to a
+          PostGIS 2.5.4 <codeph>pivotal.3</codeph> package requires running the PostGIS 2.5.4
+            <codeph>postgis_manager.sh</codeph> script. The script drops PostGIS 2.1.5 objects from
+          the database and updates a catalog table. Before running the script, ensure that no users
+          are accessing the database. Users accessing database objects might interfere with the
+          upgrade.</note>
+        <ol id="ol_w35_cq4_kmb">
+          <li>Confirm you have a PostGIS 2.1.5 package <codeph>postgis-2.1.5+pivotal.1</codeph>
+            installed in a Greenplum Database system. See <xref href="#topic_yzz_l3h_kmb"
+              format="dita"/>.</li>
+          <li dir="ltr">Install the PostGIS 2.5.4 package into Greenplum Database system with the
+              <codeph>gppkg</codeph>
+              utility.<codeblock dir="ltr">gppkg -i postgis-2.5.4+pivotal.3.build.1-gp6-rhel7-x86_64.gppkg</codeblock><p>Run
+              the <codeph>gppkg -q --all</codeph> command to verify the updated package version is
+              installed in the Greenplum Database system. </p></li>
+          <li dir="ltr">For all databases with PostGIS enabled, run the PostGIS 2.5.4
+              <codeph>postgis_manager.sh</codeph> script in the directory
+              <codeph>$GPHOME/share/postgresql/contrib/postgis-2.5</codeph> to upgrade PostGIS in
+            that database. This command upgrades PostGIS that is enabled in the database
+              <codeph>mytest</codeph> in the Greenplum Database
+            system.<codeblock>$GPHOME/share/postgresql/contrib/postgis-2.5/postgis_manager.sh mytest upgrade</codeblock></li>
+          <li>After running the script, you can verify that PostGIS 2.5.4 is installed and enabled
+            as an extension in a database with this
+            query.<codeblock>SELECT * FROM pg_available_extensions WHERE name = 'postgis' ;</codeblock></li>
+          <li dir="ltr">You can validate that the PostGIS 2.5 is enabled in the database with the
+              <codeph>postgis_version()</codeph> function.</li>
+        </ol>
+        <p>To enable PostGIS in a database after you have upgraded to a PostGIS 2.5.4
+            <codeph>pivotal.3</codeph> package, use the <codeph>CREATE EXTENSION postgis</codeph>
+          command. To remove PostGIS support, use the <codeph>DROP EXTENSION postgis
+            CASCADE</codeph> command.</p>
+      </body>
+    </topic>
+    <topic id="topic_nnk_dvn_kmb">
+      <title>Upgrading from PostGIS 2.1.5 to a PostGIS 2.5.4 pivotal.2 Package</title>
+      <body>
+        <p>Upgrading an installed PostGIS 2.1.5 package to a PostGIS 2.5.4
+            <codeph>pivotal.2</codeph> package updates the Greenplum PostGIS 2.1.5 package to a
+          minor release that uses the PostGIS 2.5.4. Also, the PostGIS 2.5.4
+            <codeph>pivotal.2</codeph> package supports using the <codeph>CREATE EXTENSION</codeph>
+          command and the <codeph>DROP EXTENSION</codeph> command to enable and remove PostGIS
+          support in a database. See <xref href="#topic_hm5_3zk_jmb" format="dita"/>.</p>
+        <ol id="ol_hnc_1fx_3mb">
+          <li>Confirm you have a PostGIS 2.1.5 package such as
+              <codeph>postgis-2.1.5+pivotal.2</codeph> installed in a Greenplum Database system and
+            PostGIS 2.1.5 is enabled for a database. See <xref href="#topic_yzz_l3h_kmb"
+              format="dita"/>.</li>
+          <li dir="ltr">Install the PostGIS 2.5.4 package into a Greenplum Database system with the
+              <codeph>gppkg</codeph> utility. This <codeph>gppkg</codeph> command installs
+              <codeph>postgis-2.5.4+pivotal.2.build.2</codeph>.<codeblock dir="ltr">gppkg -i postgis-2.5.4+pivotal.2.build.2-gp6-rhel7-x86_64.gppkg</codeblock><p>Run
+              the <codeph>gppkg -q --all</codeph> command to verify the updated package version is
+              installed in the Greenplum Database system. </p></li>
+          <li dir="ltr">For all databases with PostGIS 2.1.5 enabled, remove PostGIS support from
+            the database with the version 2.1.5 <codeph>postgis_manager.sh</codeph> script. This
+            command removes support from the database <codeph>mytest</codeph> in the Greenplum
+            Database system.
+            <codeblock>$GPHOME/share/postgresql/contrib/postgis-2.1/postgis_manager.sh mytest uninstall</codeblock></li>
+          <li dir="ltr">Enable PostGIS 2.5.4 support for a database with the <codeph>CREATE
+              EXTENSION</codeph> command.<codeblock># CREATE EXTENSION postgis;</codeblock></li>
+          <li dir="ltr">You can validate that the PostGIS 2.5 is enabled in the database with the
+              <codeph>postgis_version()</codeph> function.</li>
+        </ol>
+      </body>
+    </topic>
+    <topic id="topic_xql_1vn_kmb">
+      <title>Upgrading from PostGIS 2.1.5 to a PostGIS 2.5.4 pivotal.1 Package</title>
+      <body>
+        <p>Upgrading an installed PostGIS 2.1.5 package to a PostGIS 2.5.4
+            <codeph>pivotal.1</codeph> version package updates the Greenplum PostGIS 2.1.5 package
+          to a package that uses the PostGIS 2.5.4. </p>
+        <ol id="ol_fnc_1fx_3mb">
+          <li>Confirm you have a PostGIS 2.1.5 package such <codeph>postgis-2.1.5+pivotal.2</codeph>
+            installed in a Greenplum Database system and PostGIS 2.1.5 is enabled for a database.
+            See <xref href="#topic_yzz_l3h_kmb" format="dita"/>.</li>
+          <li dir="ltr">Install PostGIS 2.5.4 into a Greenplum Database
+              system.<codeblock dir="ltr">gppkg -i postgis-2.5.4+pivotal.1.build.3-gp6-rhel7-x86_64.gppkg</codeblock><p>Run
+              the <codeph>gppkg -q --all</codeph> command to verify the updated package version is
+              installed in the Greenplum Database system. </p></li>
+          <li dir="ltr">For all databases with PostGIS 2.1.5 enabled, remove PostGIS 2.1.5 support
+            from database with the version 2.1.5 <codeph>postgis_manager.sh</codeph> script. This
+            command removes support from the database <codeph>mytest</codeph> in the Greenplum
+            Database
+            system.<codeblock>$GPHOME/share/postgresql/contrib/postgis-2.1/postgis_manager.sh mytest uninstall</codeblock></li>
+          <li dir="ltr">Enable PostGIS 2.5.4 support for a database with the 2.5.4
+              <codeph>postgis_manager.sh</codeph> script. This command enables support from the
+            database <codeph>mytest</codeph> in the Greenplum Database
+            system.<codeblock>$GPHOME/share/postgresql/contrib/postgis-2.5/postgis_manager.sh mytest install</codeblock></li>
+          <li dir="ltr">You can validate that PostGIS 2.5 is enabled in the database with the
+              <codeph>postgis_version()</codeph> function.</li>
+        </ol>
+      </body>
+    </topic>
+    <topic id="topic_unj_v5n_kmb">
+      <title>Removing the PostGIS 2.1.5 package</title>
+      <body>
+        <p>After upgrading the databases in the Greenplum Database system, you can remove the
+          PostGIS 2.1.5 package from the system. This command removes the
+            <codeph>postgis-2.1.5+pivotal.2</codeph> package from a Greenplum Database
+          system.<codeblock dir="ltr">gppkg -r postgis-2.1.5+pivotal.2</codeblock></p>
+        <p>Run the <codeph>gppkg -q --all</codeph> command to list the installed Greenplum
+          packages.</p>
+      </body>
+    </topic>
+  </topic>
+  <topic id="topic_yzz_l3h_kmb">
+    <title>Checking the PostGIS Version</title>
+    <body>
+      <p>When upgrading PostGIS you must check the version of the Greenplum PostGIS package
+        installed on the Greenplum Database system and the version of PostGIS enabled in the
+        database. <ul id="ul_s1t_x54_kmb">
+          <li>Check the installed PostGIS package version with the <codeph>gppkg</codeph> utility.
+            This command lists all installed Greenplum
+            packages.<codeblock>$ gppkg -q --all</codeblock></li>
+          <li>Check the enabled PostGIS version in a database with the
+              <codeph>postgis_version()</codeph> function. This <codeph>psql</codeph> command
+            displays the version PostGIS that is enabled for the database <codeph>testdb</codeph>.
+              <codeblock>$ psql -d testdb -c 'select postgis_version();'</codeblock><p>If PostGIS is
+              not enabled for the database, Greenplum returns a <codeph>function does not
+                exist</codeph> error.</p></li>
+        </ul></p>
+    </body>
+  </topic>
+  <topic id="topic_hm5_3zk_jmb">
+    <title>Notes</title>
+    <body>
+      <p>Upgrading from a PostGIS 2.1.5 package to a PostGIS 2.5.4 package requires removing support
+        for PostGIS 2.1.5 from a database with the <codeph>postgis_manager.sh</codeph> script. The
+        script drops the PostGIS objects from the database that were created with PostGIS 2.1.5. </p>
+      <p>Starting with the <codeph>postgis-2.5.4+pivotal.2</codeph> package, you enable support
+        PostGIS for a database with the <codeph>CREATE EXTENSION</codeph> command. For previous
+        PostGIS 2.5.4 packages and all PostGIS 2.1.5 packages, you use an SQL script.</p>
+      <p>Removing PostGIS support from a database drops PostGIS objects from the database. Dropping
+        the PostGIS objects cascades to objects that reference the PostGIS objects. For example,
+        this <codeph>CREATE TABLE</codeph> command creates a table with column <codeph>b</codeph> is
+        defined with PostGIS <codeph>geometry</codeph> data
+        type.<codeblock># CREATE TABLE test(a int, b geometry) DISTRIBUTED RANDOMLY;</codeblock></p>
+      <p>This is the table definition in a database with PostGIS
+        enabled.<codeblock># \d test
+ Table "public.test"
+ Column |   Type   | Modifiers
+--------+----------+-----------
+ a      | integer  |
+ b      | geometry |
+Distributed randomly</codeblock></p>
+      <p>This is the table definition in a database after PostGIS support has been
+        removed.<codeblock># \d test
+  Table "public.test"
+ Column |  Type   | Modifiers
+--------+---------+-----------
+ a      | integer |
+Distributed randomly</codeblock></p>
+    </body>
+  </topic>
+</topic>


### PR DESCRIPTION
Upgrade instructions from 2.1.5 to different versions of 2.5.4

Note: The docs contain instructions to upgrade to postgis-2.5.4+pivotal.3 which is not yet available.

This will be ported to 6X_STABLE only,

Link to HTML doc on a temporary GPDB doc review site.
https://docs-msk-gpdb7-dev.cfapps.io/7-0/analytics/postgis-upgrade.html