### PR TITLE
Coverity: release memory when the memory pointer is no longer held.

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1007,12 +1007,13 @@ static int
 is_file_exists(const char* filename)
 {
 	FILE* file;
-    if ((file = fopen(filename, "r")) > 0)
-    {
-        fclose(file);
-        return 1;
-    }
-    return 0;
+	file = fopen(filename, "r");
+	if (file)
+	{
+		fclose(file);
+		return 1;
+	}
+	return 0;
 }
 
 URL_FILE *

--- a/src/backend/bootstrap/bootstrap.c
+++ b/src/backend/bootstrap/bootstrap.c
@@ -335,6 +335,12 @@ AuxiliaryProcessMain(int argc, char *argv[])
 		if (!SelectConfigFiles(userDoption, progname))
 			proc_exit(1);
 	}
+	if (userDoption)
+	{
+		/* userDoption isn't used any more */
+		free(userDoption);
+		userDoption = NULL;
+	}
 
 	/* Validate we have been given a reasonable-looking DataDir */
 	Assert(DataDir);

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -1410,8 +1410,9 @@ CreateFunction(CreateFunctionStmt *stmt, const char *queryString)
 						&prosrc_str, &probin_str);
 	
 	/* double check that we really have a function body */
+	/* prosrc_str doesn't point to a palloc()'d string in interpret_AS_clause() */
 	if (prosrc_str == NULL)
-		prosrc_str = strdup("");
+		prosrc_str = "";
 
 	/* Handle the describe callback, if any */
 	if (describeQualName != NIL)

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -136,7 +136,8 @@ checkIODataDirectory(void)
 		}
 	} while (0);
 
-	if (fd > 0)
+	pfree(data);
+	if (fd >= 0)
 	{
 		close(fd);
 
@@ -163,7 +164,6 @@ checkIODataDirectory(void)
 		ereport(ERROR,
 				(errmsg("disk IO check during FTS probe failed")));
 
-	pfree(data);
 	return failure;
 }
 


### PR DESCRIPTION
This PR is mostly relevant to release memory when the memory pointer is no longer held.

- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
