### PR TITLE
Add test cases for correlated subqueries with outer joins

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.108.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.109.", GPORCA_VERSION_STRING, 6);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.108.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.109.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12487,7 +12487,7 @@ int
 main ()
 {
 
-return strncmp("3.108.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.109.", GPORCA_VERSION_STRING, 6);
 
   ;
   return 0;
@@ -12497,7 +12497,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.108.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.109.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.108.0@gpdb/stable
+orca/v3.109.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.108.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.109.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11683,18 +11683,19 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 insert into tcorr1 values (1,99);
 insert into tcorr2 values (1,1);
 set optimizer_trace_fallback to on;
-select *
-from tcorr1 out
-where out.b in (select coalesce(tcorr2.a, 99)
-                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
- a | b 
----+---
-(0 rows)
-
 -- expect 1 row
 -- FIXME: Incorrect result with planner
 select *
 from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+ a | b 
+---+---
+(0 rows)
+
+-- expect 1 row
+select *
+from tcorr1 out
 where out.b in (select max(tcorr2.b + out.b - 1)
                 from tcorr2
                 where tcorr2.a=out.a);
@@ -11712,7 +11713,7 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                              where tcorr2.b = out.b
                                              group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
 ERROR:  correlated subquery with skip-level correlations is not supported
--- expect 1 row
+-- FIXME: currently no plan produced for this query
 select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
@@ -11720,8 +11721,9 @@ where out.b in (select coalesce(tcorr2.a, 99)
 ERROR:  Query requires a feature that has been disabled by a configuration setting.
 DETAIL:  Could not devise a query plan for the given query.
 HINT:  Current settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
--- currently no plan produced for this query
 set optimizer_join_order to exhaustive2;
+-- expect 1 row
+-- FIXME: Falls back and produces incorrect result
 select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
@@ -11731,7 +11733,6 @@ where out.b in (select coalesce(tcorr2.a, 99)
 (0 rows)
 
 -- expect 1 row
--- FIXME: Falls back and produces incorrect result
 select *
 from tcorr1 out
 where out.b in (select max(tcorr2.b + out.b - 1)
@@ -11751,7 +11752,7 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                              where tcorr2.b = out.b
                                              group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
 ERROR:  correlated subquery with skip-level correlations is not supported
--- expect 1 row
+-- FIXME: currently no plan produced for this query
 select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
@@ -11759,5 +11760,4 @@ where out.b in (select coalesce(tcorr2.a, 99)
 ERROR:  Query requires a feature that has been disabled by a configuration setting.
 DETAIL:  Could not devise a query plan for the given query.
 HINT:  Current settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
--- currently no plan produced for this query
 reset optimizer_join_order;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11671,3 +11671,93 @@ SELECT * from tp;
  99 |  99
 (1 row)
 
+drop table if exists tcorr1, tcorr2;
+NOTICE:  table "tcorr1" does not exist, skipping
+NOTICE:  table "tcorr2" does not exist, skipping
+create table tcorr1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tcorr2(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into tcorr1 values (1,99);
+insert into tcorr2 values (1,1);
+set optimizer_trace_fallback to on;
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+ a | b 
+---+---
+(0 rows)
+
+-- expect 1 row
+-- FIXME: Incorrect result with planner
+select *
+from tcorr1 out
+where out.b in (select max(tcorr2.b + out.b - 1)
+                from tcorr2
+                where tcorr2.a=out.a);
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+-- expect 1 row
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2_d.c, 99)
+                from tcorr1 left outer join (select a, count(*) as c
+                                             from tcorr2
+                                             where tcorr2.b = out.b
+                                             group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
+ERROR:  correlated subquery with skip-level correlations is not supported
+-- expect 1 row
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 full outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+ERROR:  Query requires a feature that has been disabled by a configuration setting.
+DETAIL:  Could not devise a query plan for the given query.
+HINT:  Current settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+-- currently no plan produced for this query
+set optimizer_join_order to exhaustive2;
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+ a | b 
+---+---
+(0 rows)
+
+-- expect 1 row
+-- FIXME: Falls back and produces incorrect result
+select *
+from tcorr1 out
+where out.b in (select max(tcorr2.b + out.b - 1)
+                from tcorr2
+                where tcorr2.a=out.a);
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+-- expect 1 row
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2_d.c, 99)
+                from tcorr1 left outer join (select a, count(*) as c
+                                             from tcorr2
+                                             where tcorr2.b = out.b
+                                             group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
+ERROR:  correlated subquery with skip-level correlations is not supported
+-- expect 1 row
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 full outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+ERROR:  Query requires a feature that has been disabled by a configuration setting.
+DETAIL:  Could not devise a query plan for the given query.
+HINT:  Current settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+-- currently no plan produced for this query
+reset optimizer_join_order;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11683,6 +11683,31 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 insert into tcorr1 values (1,99);
 insert into tcorr2 values (1,1);
 set optimizer_trace_fallback to on;
+explain
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=2.19..3.31 rows=4 width=8)
+   ->  Nested Loop EXISTS Join  (cost=2.19..3.31 rows=2 width=8)
+         Join Filter: "out".b = COALESCE(tcorr2.a, 99) AND tcorr1.a = (tcorr2.a + "out".a)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
+               Hash Key: "out".b
+               ->  Seq Scan on tcorr1 "out"  (cost=0.00..1.01 rows=1 width=8)
+         ->  Materialize  (cost=2.19..2.23 rows=2 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=1.05..2.19 rows=2 width=8)
+                     Hash Key: COALESCE(tcorr2.a, 99)
+                     ->  Nested Loop Left Join  (cost=1.05..2.12 rows=2 width=8)
+                           ->  Seq Scan on tcorr1  (cost=0.00..1.01 rows=1 width=4)
+                           ->  Materialize  (cost=1.05..1.08 rows=1 width=4)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.05 rows=1 width=4)
+                                       ->  Seq Scan on tcorr2  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: legacy query optimizer
+(16 rows)
+
 -- expect 1 row
 -- FIXME: Incorrect result with planner
 select *
@@ -11692,6 +11717,28 @@ where out.b in (select coalesce(tcorr2.a, 99)
  a | b 
 ---+---
 (0 rows)
+
+explain
+select *
+from tcorr1 out
+where out.b in (select max(tcorr2.b + out.b - 1)
+                from tcorr2
+                where tcorr2.a=out.a);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..2.08 rows=1 width=8)
+   ->  Seq Scan on tcorr1 "out"  (cost=0.00..2.08 rows=1 width=8)
+         Filter: (subplan)
+         SubPlan 1
+           ->  Aggregate  (cost=1.06..1.07 rows=1 width=4)
+                 ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                       Filter: tcorr2.a = $1
+                       ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                   ->  Seq Scan on tcorr2  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: legacy query optimizer
+(12 rows)
 
 -- expect 1 row
 select *
@@ -11704,6 +11751,15 @@ where out.b in (select max(tcorr2.b + out.b - 1)
  1 | 99
 (1 row)
 
+explain
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2_d.c, 99)
+                from tcorr1 left outer join (select a, count(*) as c
+                                             from tcorr2
+                                             where tcorr2.b = out.b
+                                             group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
+ERROR:  correlated subquery with skip-level correlations is not supported
 -- expect 1 row
 select *
 from tcorr1 out
@@ -11722,6 +11778,31 @@ ERROR:  Query requires a feature that has been disabled by a configuration setti
 DETAIL:  Could not devise a query plan for the given query.
 HINT:  Current settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
 set optimizer_join_order to exhaustive2;
+explain
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=2.19..3.31 rows=4 width=8)
+   ->  Nested Loop EXISTS Join  (cost=2.19..3.31 rows=2 width=8)
+         Join Filter: "out".b = COALESCE(tcorr2.a, 99) AND tcorr1.a = (tcorr2.a + "out".a)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
+               Hash Key: "out".b
+               ->  Seq Scan on tcorr1 "out"  (cost=0.00..1.01 rows=1 width=8)
+         ->  Materialize  (cost=2.19..2.23 rows=2 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=1.05..2.19 rows=2 width=8)
+                     Hash Key: COALESCE(tcorr2.a, 99)
+                     ->  Nested Loop Left Join  (cost=1.05..2.12 rows=2 width=8)
+                           ->  Seq Scan on tcorr1  (cost=0.00..1.01 rows=1 width=4)
+                           ->  Materialize  (cost=1.05..1.08 rows=1 width=4)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.05 rows=1 width=4)
+                                       ->  Seq Scan on tcorr2  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_join_order=exhaustive2; optimizer_metadata_caching=on
+ Optimizer status: legacy query optimizer
+(16 rows)
+
 -- expect 1 row
 -- FIXME: Falls back and produces incorrect result
 select *
@@ -11731,6 +11812,28 @@ where out.b in (select coalesce(tcorr2.a, 99)
  a | b 
 ---+---
 (0 rows)
+
+explain
+select *
+from tcorr1 out
+where out.b in (select max(tcorr2.b + out.b - 1)
+                from tcorr2
+                where tcorr2.a=out.a);
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..2.08 rows=1 width=8)
+   ->  Seq Scan on tcorr1 "out"  (cost=0.00..2.08 rows=1 width=8)
+         Filter: (subplan)
+         SubPlan 1
+           ->  Aggregate  (cost=1.06..1.07 rows=1 width=4)
+                 ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                       Filter: tcorr2.a = $1
+                       ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                   ->  Seq Scan on tcorr2  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  optimizer=off; optimizer_cte_inlining_bound=1000; optimizer_join_order=exhaustive2; optimizer_metadata_caching=on
+ Optimizer status: legacy query optimizer
+(12 rows)
 
 -- expect 1 row
 select *
@@ -11743,6 +11846,15 @@ where out.b in (select max(tcorr2.b + out.b - 1)
  1 | 99
 (1 row)
 
+explain
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2_d.c, 99)
+                from tcorr1 left outer join (select a, count(*) as c
+                                             from tcorr2
+                                             where tcorr2.b = out.b
+                                             group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
+ERROR:  correlated subquery with skip-level correlations is not supported
 -- expect 1 row
 select *
 from tcorr1 out

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11808,8 +11808,8 @@ select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
                 from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..1356692026.74 rows=1 width=8)
    Filter: (subplan)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
@@ -11845,8 +11845,8 @@ from tcorr1 out
 where out.b in (select max(tcorr2.b + out.b - 1)
                 from tcorr2
                 where tcorr2.a=out.a);
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..1324032.62 rows=1 width=8)
    Filter: (subplan)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
@@ -11881,8 +11881,8 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                              from tcorr2
                                              where tcorr2.b = out.b
                                              group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..1356692176.26 rows=1 width=8)
    Filter: (subplan)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11676,6 +11676,31 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 insert into tcorr1 values (1,99);
 insert into tcorr2 values (1,1);
 set optimizer_trace_fallback to on;
+explain
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1356692026.74 rows=1 width=8)
+   Filter: (subplan)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Table Scan on tcorr1  (cost=0.00..431.00 rows=1 width=8)
+   SubPlan 1
+     ->  Result  (cost=0.00..1324032.56 rows=1 width=4)
+           ->  Nested Loop Left Join  (cost=0.00..1324032.56 rows=1 width=4)
+                 Join Filter: orca.tcorr1.a = (tcorr2.a + $1)
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Table Scan on tcorr1  (cost=0.00..431.00 rows=1 width=4)
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Table Scan on tcorr2  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: PQO version 3.107.0
+(16 rows)
+
 -- expect 1 row
 -- FIXME: Incorrect result with planner
 select *
@@ -11687,6 +11712,29 @@ where out.b in (select coalesce(tcorr2.a, 99)
  1 | 99
 (1 row)
 
+explain
+select *
+from tcorr1 out
+where out.b in (select max(tcorr2.b + out.b - 1)
+                from tcorr2
+                where tcorr2.a=out.a);
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324032.62 rows=1 width=8)
+   Filter: (subplan)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Table Scan on tcorr1  (cost=0.00..431.00 rows=1 width=8)
+   SubPlan 1
+     ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                 Filter: tcorr2.a = $1
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                             ->  Table Scan on tcorr2  (cost=0.00..431.00 rows=1 width=8)
+ Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: PQO version 3.107.0
+(13 rows)
+
 -- expect 1 row
 select *
 from tcorr1 out
@@ -11697,6 +11745,40 @@ where out.b in (select max(tcorr2.b + out.b - 1)
 ---+----
  1 | 99
 (1 row)
+
+explain
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2_d.c, 99)
+                from tcorr1 left outer join (select a, count(*) as c
+                                             from tcorr2
+                                             where tcorr2.b = out.b
+                                             group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1356692176.26 rows=1 width=8)
+   Filter: (subplan)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Table Scan on tcorr1  (cost=0.00..431.00 rows=1 width=8)
+   SubPlan 1
+     ->  Result  (cost=0.00..1324032.70 rows=1 width=8)
+           ->  Nested Loop Left Join  (cost=0.00..1324032.70 rows=1 width=8)
+                 Join Filter: orca.tcorr1.a = tcorr2.a
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Table Scan on tcorr1  (cost=0.00..431.00 rows=1 width=4)
+                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                       Group By: tcorr2.a
+                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                             Sort Key: tcorr2.a
+                             ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                   Filter: tcorr2.b = $1
+                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                               ->  Table Scan on tcorr2  (cost=0.00..431.00 rows=1 width=8)
+ Settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+ Optimizer status: PQO version 3.107.0
+(22 rows)
 
 -- expect 1 row
 select *
@@ -11721,6 +11803,31 @@ ERROR:  Query requires a feature that has been disabled by a configuration setti
 DETAIL:  Could not devise a query plan for the given query.
 HINT:  Current settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
 set optimizer_join_order to exhaustive2;
+explain
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1356692026.74 rows=1 width=8)
+   Filter: (subplan)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Table Scan on tcorr1  (cost=0.00..431.00 rows=1 width=8)
+   SubPlan 1
+     ->  Result  (cost=0.00..1324032.56 rows=1 width=4)
+           ->  Nested Loop Left Join  (cost=0.00..1324032.56 rows=1 width=4)
+                 Join Filter: orca.tcorr1.a = (tcorr2.a + $1)
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Table Scan on tcorr1  (cost=0.00..431.00 rows=1 width=4)
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Table Scan on tcorr2  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer_cte_inlining_bound=1000; optimizer_join_order=exhaustive2; optimizer_metadata_caching=on
+ Optimizer status: PQO version 3.107.0
+(16 rows)
+
 -- expect 1 row
 -- FIXME: Falls back and produces incorrect result
 select *
@@ -11732,6 +11839,29 @@ where out.b in (select coalesce(tcorr2.a, 99)
  1 | 99
 (1 row)
 
+explain
+select *
+from tcorr1 out
+where out.b in (select max(tcorr2.b + out.b - 1)
+                from tcorr2
+                where tcorr2.a=out.a);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324032.62 rows=1 width=8)
+   Filter: (subplan)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Table Scan on tcorr1  (cost=0.00..431.00 rows=1 width=8)
+   SubPlan 1
+     ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                 Filter: tcorr2.a = $1
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                       ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                             ->  Table Scan on tcorr2  (cost=0.00..431.00 rows=1 width=8)
+ Settings:  optimizer_cte_inlining_bound=1000; optimizer_join_order=exhaustive2; optimizer_metadata_caching=on
+ Optimizer status: PQO version 3.107.0
+(13 rows)
+
 -- expect 1 row
 select *
 from tcorr1 out
@@ -11742,6 +11872,40 @@ where out.b in (select max(tcorr2.b + out.b - 1)
 ---+----
  1 | 99
 (1 row)
+
+explain
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2_d.c, 99)
+                from tcorr1 left outer join (select a, count(*) as c
+                                             from tcorr2
+                                             where tcorr2.b = out.b
+                                             group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1356692176.26 rows=1 width=8)
+   Filter: (subplan)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Table Scan on tcorr1  (cost=0.00..431.00 rows=1 width=8)
+   SubPlan 1
+     ->  Result  (cost=0.00..1324032.70 rows=1 width=8)
+           ->  Nested Loop Left Join  (cost=0.00..1324032.70 rows=1 width=8)
+                 Join Filter: orca.tcorr1.a = tcorr2.a
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Table Scan on tcorr1  (cost=0.00..431.00 rows=1 width=4)
+                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                       Group By: tcorr2.a
+                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                             Sort Key: tcorr2.a
+                             ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                   Filter: tcorr2.b = $1
+                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                               ->  Table Scan on tcorr2  (cost=0.00..431.00 rows=1 width=8)
+ Settings:  optimizer_cte_inlining_bound=1000; optimizer_join_order=exhaustive2; optimizer_metadata_caching=on
+ Optimizer status: PQO version 3.107.0
+(22 rows)
 
 -- expect 1 row
 select *

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11676,19 +11676,20 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 insert into tcorr1 values (1,99);
 insert into tcorr2 values (1,1);
 set optimizer_trace_fallback to on;
-select *
-from tcorr1 out
-where out.b in (select coalesce(tcorr2.a, 99)
-                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
- a | b  
----+----
- 1 | 99
-(1 row)
-
 -- expect 1 row
 -- FIXME: Incorrect result with planner
 select *
 from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+-- expect 1 row
+select *
+from tcorr1 out
 where out.b in (select max(tcorr2.b + out.b - 1)
                 from tcorr2
                 where tcorr2.a=out.a);
@@ -11710,7 +11711,7 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
  1 | 99
 (1 row)
 
--- expect 1 row
+-- FIXME: currently no plan produced for this query
 select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
@@ -11719,8 +11720,9 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 ERROR:  Query requires a feature that has been disabled by a configuration setting.
 DETAIL:  Could not devise a query plan for the given query.
 HINT:  Current settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
--- currently no plan produced for this query
 set optimizer_join_order to exhaustive2;
+-- expect 1 row
+-- FIXME: Falls back and produces incorrect result
 select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
@@ -11731,7 +11733,6 @@ where out.b in (select coalesce(tcorr2.a, 99)
 (1 row)
 
 -- expect 1 row
--- FIXME: Falls back and produces incorrect result
 select *
 from tcorr1 out
 where out.b in (select max(tcorr2.b + out.b - 1)
@@ -11755,7 +11756,7 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
  1 | 99
 (1 row)
 
--- expect 1 row
+-- FIXME: currently no plan produced for this query
 select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
@@ -11764,5 +11765,4 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 ERROR:  Query requires a feature that has been disabled by a configuration setting.
 DETAIL:  Could not devise a query plan for the given query.
 HINT:  Current settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
--- currently no plan produced for this query
 reset optimizer_join_order;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11664,3 +11664,105 @@ SELECT * from tp;
  99 |  99
 (1 row)
 
+drop table if exists tcorr1, tcorr2;
+NOTICE:  table "tcorr1" does not exist, skipping
+NOTICE:  table "tcorr2" does not exist, skipping
+create table tcorr1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tcorr2(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into tcorr1 values (1,99);
+insert into tcorr2 values (1,1);
+set optimizer_trace_fallback to on;
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+-- expect 1 row
+-- FIXME: Incorrect result with planner
+select *
+from tcorr1 out
+where out.b in (select max(tcorr2.b + out.b - 1)
+                from tcorr2
+                where tcorr2.a=out.a);
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+-- expect 1 row
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2_d.c, 99)
+                from tcorr1 left outer join (select a, count(*) as c
+                                             from tcorr2
+                                             where tcorr2.b = out.b
+                                             group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+-- expect 1 row
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 full outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+ERROR:  Query requires a feature that has been disabled by a configuration setting.
+DETAIL:  Could not devise a query plan for the given query.
+HINT:  Current settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+-- currently no plan produced for this query
+set optimizer_join_order to exhaustive2;
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+-- expect 1 row
+-- FIXME: Falls back and produces incorrect result
+select *
+from tcorr1 out
+where out.b in (select max(tcorr2.b + out.b - 1)
+                from tcorr2
+                where tcorr2.a=out.a);
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+-- expect 1 row
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2_d.c, 99)
+                from tcorr1 left outer join (select a, count(*) as c
+                                             from tcorr2
+                                             where tcorr2.b = out.b
+                                             group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+-- expect 1 row
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 full outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+ERROR:  Query requires a feature that has been disabled by a configuration setting.
+DETAIL:  Could not devise a query plan for the given query.
+HINT:  Current settings:  optimizer_cte_inlining_bound=1000; optimizer_metadata_caching=on
+-- currently no plan produced for this query
+reset optimizer_join_order;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1949,20 +1949,21 @@ insert into tcorr2 values (1,1);
 
 set optimizer_trace_fallback to on;
 
+-- expect 1 row
+-- FIXME: Incorrect result with planner
 select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
                 from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
--- expect 1 row
--- FIXME: Incorrect result with planner
 
+-- expect 1 row
 select *
 from tcorr1 out
 where out.b in (select max(tcorr2.b + out.b - 1)
                 from tcorr2
                 where tcorr2.a=out.a);
--- expect 1 row
 
+-- expect 1 row
 select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2_d.c, 99)
@@ -1970,30 +1971,30 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                              from tcorr2
                                              where tcorr2.b = out.b
                                              group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
--- expect 1 row
 
+-- FIXME: currently no plan produced for this query
 select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
                 from tcorr1 full outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
--- currently no plan produced for this query
 
 set optimizer_join_order to exhaustive2;
 
+-- expect 1 row
+-- FIXME: Falls back and produces incorrect result
 select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
                 from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
--- expect 1 row
--- FIXME: Falls back and produces incorrect result
 
+-- expect 1 row
 select *
 from tcorr1 out
 where out.b in (select max(tcorr2.b + out.b - 1)
                 from tcorr2
                 where tcorr2.a=out.a);
--- expect 1 row
 
+-- expect 1 row
 select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2_d.c, 99)
@@ -2001,13 +2002,12 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                              from tcorr2
                                              where tcorr2.b = out.b
                                              group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
--- expect 1 row
 
+-- FIXME: currently no plan produced for this query
 select *
 from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
                 from tcorr1 full outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
--- currently no plan produced for this query
 
 reset optimizer_join_order;
 

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1939,6 +1939,78 @@ WHERE L1.lid = META.LOAD_ID;
 reset optimizer_join_order;
 SELECT * from tp;
 
+drop table if exists tcorr1, tcorr2;
+
+create table tcorr1(a int, b int);
+create table tcorr2(a int, b int);
+
+insert into tcorr1 values (1,99);
+insert into tcorr2 values (1,1);
+
+set optimizer_trace_fallback to on;
+
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+-- expect 1 row
+-- FIXME: Incorrect result with planner
+
+select *
+from tcorr1 out
+where out.b in (select max(tcorr2.b + out.b - 1)
+                from tcorr2
+                where tcorr2.a=out.a);
+-- expect 1 row
+
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2_d.c, 99)
+                from tcorr1 left outer join (select a, count(*) as c
+                                             from tcorr2
+                                             where tcorr2.b = out.b
+                                             group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
+-- expect 1 row
+
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 full outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+-- currently no plan produced for this query
+
+set optimizer_join_order to exhaustive2;
+
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+-- expect 1 row
+-- FIXME: Falls back and produces incorrect result
+
+select *
+from tcorr1 out
+where out.b in (select max(tcorr2.b + out.b - 1)
+                from tcorr2
+                where tcorr2.a=out.a);
+-- expect 1 row
+
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2_d.c, 99)
+                from tcorr1 left outer join (select a, count(*) as c
+                                             from tcorr2
+                                             where tcorr2.b = out.b
+                                             group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
+-- expect 1 row
+
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 full outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+-- currently no plan produced for this query
+
+reset optimizer_join_order;
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1949,6 +1949,12 @@ insert into tcorr2 values (1,1);
 
 set optimizer_trace_fallback to on;
 
+explain
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
+
 -- expect 1 row
 -- FIXME: Incorrect result with planner
 select *
@@ -1956,6 +1962,12 @@ from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
                 from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
 
+explain
+select *
+from tcorr1 out
+where out.b in (select max(tcorr2.b + out.b - 1)
+                from tcorr2
+                where tcorr2.a=out.a);
 -- expect 1 row
 select *
 from tcorr1 out
@@ -1963,6 +1975,14 @@ where out.b in (select max(tcorr2.b + out.b - 1)
                 from tcorr2
                 where tcorr2.a=out.a);
 
+explain
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2_d.c, 99)
+                from tcorr1 left outer join (select a, count(*) as c
+                                             from tcorr2
+                                             where tcorr2.b = out.b
+                                             group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
 -- expect 1 row
 select *
 from tcorr1 out
@@ -1980,6 +2000,11 @@ where out.b in (select coalesce(tcorr2.a, 99)
 
 set optimizer_join_order to exhaustive2;
 
+explain
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2.a, 99)
+                from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
 -- expect 1 row
 -- FIXME: Falls back and produces incorrect result
 select *
@@ -1987,6 +2012,12 @@ from tcorr1 out
 where out.b in (select coalesce(tcorr2.a, 99)
                 from tcorr1 left outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
 
+explain
+select *
+from tcorr1 out
+where out.b in (select max(tcorr2.b + out.b - 1)
+                from tcorr2
+                where tcorr2.a=out.a);
 -- expect 1 row
 select *
 from tcorr1 out
@@ -1994,6 +2025,14 @@ where out.b in (select max(tcorr2.b + out.b - 1)
                 from tcorr2
                 where tcorr2.a=out.a);
 
+explain
+select *
+from tcorr1 out
+where out.b in (select coalesce(tcorr2_d.c, 99)
+                from tcorr1 left outer join (select a, count(*) as c
+                                             from tcorr2
+                                             where tcorr2.b = out.b
+                                             group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
 -- expect 1 row
 select *
 from tcorr1 out


### PR DESCRIPTION
We found several problems with outer references in outer joins and
related areas, especially when using optimizer_join_order = exhaustive2.

Adding some tests. Please note that due to some remaining problems in
both ORCA and planner, the tests contain some FIXMEs.

The corresponding ORCA PR is https://github.com/greenplum-db/gporca/pull/599.
Issue https://github.com/greenplum-db/gpdb/issues/10452 was filed for the wrong results with planner.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
