### PR TITLE
Don't mock GPORCA functions unnecessarily.

### DIFF
--- a/src/backend/mock.mk
+++ b/src/backend/mock.mk
@@ -29,6 +29,7 @@ EXCL_OBJS=\
 	src/backend/gpopt/relcache/%.o \
 	src/backend/gpopt/translate/%.o \
 	src/backend/gpopt/utils/%.o \
+	src/backend/gporca/%.o \
 
 # More files that are not linked into test programs. There's no particular
 # reason these couldn't be linked into, if necessary, but currently none of


### PR DESCRIPTION
None of the mock tests in the backend call into GPORCA functions, so
no need to generate mock objects for them. Saves some time and space when
running mock tests.
