### PR TITLE
docs - add GUC gp_add_column_inherits_table_setting 6.x only

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -146,6 +146,8 @@
             <li>
               <xref href="#from_collapse_limit"/>
             </li>
+            <li><xref href="#gp_add_column_inherits_table_setting"/>
+            </li>
             <li>
               <xref href="#gp_adjust_selectivity_for_outerjoins"/>
             </li>
@@ -2029,6 +2031,57 @@
             <row>
               <entry colname="col1">1-<i>n</i></entry>
               <entry colname="col2">20</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gp_add_column_inherits_table_setting">
+    <title>gp_add_column_inherits_table_setting</title>
+    <body>
+      <p>When adding a column to an append-optimized, column-oriented table with the <codeph><xref
+            href="../sql_commands/ALTER_TABLE.xml">ALTER TABLE</xref></codeph> command, this
+        parameter controls whether the table's data compression parameters for a column
+          (<codeph>compresstype</codeph>, <codeph>compresslevel</codeph>, and
+          <codeph>blocksize</codeph>) can be inherited from the table values. The default is
+          <codeph>off</codeph>, the table's data compression settings are not considered when adding
+        a column to the table. If the value is <codeph>on</codeph>, the table's settings are
+        considered. </p>
+      <p>When you create an append-optimized column-oriented table, you can set the table's data
+        compression parameters <codeph>compresstype</codeph>, <codeph>compresslevel</codeph>, and
+          <codeph>blocksize</codeph> for the table in the <codeph>WITH</codeph> clause. When you add
+        a column, Greenplum Database sets each data compression parameter based on the following
+        setting, in order of preference.<ol id="ol_hqk_l4w_kmb">
+          <li>The data compression setting specified in the <codeph>ALTER TABLE</codeph> command
+              <codeph>ENCODING</codeph> clause.</li>
+          <li>If this server configuration parameter is set to <codeph>on</codeph>, the table's data
+            compression setting specified in the <codeph>WITH</codeph> clause when the table was
+            created. Otherwise, the table's data compression setting is ignored.</li>
+          <li>The data compression setting specified in the server configuration parameter
+                <codeph><xref href="#gp_default_storage_options"
+              >gp_default_storage_options</xref></codeph>.</li>
+          <li> The default data compression setting.</li>
+        </ol></p>
+      <p>For information about the data storage compression parameters, see <codeph><xref
+            href="../sql_commands/CREATE_TABLE.xml">CREATE TABLE</xref></codeph>.</p>
+      <table id="table_nyn_wjd_lmb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">off</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -2052,8 +2052,8 @@
       <p>When you create an append-optimized column-oriented table, you can set the table's data
         compression parameters <codeph>compresstype</codeph>, <codeph>compresslevel</codeph>, and
           <codeph>blocksize</codeph> for the table in the <codeph>WITH</codeph> clause. When you add
-        a column, Greenplum Database sets each data compression parameter based on the following
-        setting, in order of preference.<ol id="ol_hqk_l4w_kmb">
+        a column, Greenplum Database sets each data compression parameter based on one of the
+        following settings, in order of preference.<ol id="ol_hqk_l4w_kmb">
           <li>The data compression setting specified in the <codeph>ALTER TABLE</codeph> command
               <codeph>ENCODING</codeph> clause.</li>
           <li>If this server configuration parameter is set to <codeph>on</codeph>, the table's data

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1291,20 +1291,18 @@
           Greenplum Database.</p>
         <simpletable frame="none" id="simpletable_awg_1tl_zp">
           <strow>
-            <stentry>
-              <p>
+            <stentry><p>
                 <xref href="guc-list.xml#max_appendonly_tables" type="section"
                   >max_appendonly_tables</xref>
-              </p>
+              </p><xref href="guc-list.xml#gp_add_column_inherits_table_setting"
+                >gp_add_column_inherits_table_setting</xref>
               <p>
                 <xref href="guc-list.xml#gp_appendonly_compaction" type="section"
                   >gp_appendonly_compaction</xref>
-              </p>
-              <p>
-                <xref href="guc-list.xml#gp_appendonly_compaction_threshold"/></p>
-              <p><xref href="guc-list.xml#validate_previous_free_tid"/>
-              </p>
-            </stentry>
+              </p><p>
+                <xref href="guc-list.xml#gp_appendonly_compaction_threshold"/></p><p><xref
+                  href="guc-list.xml#validate_previous_free_tid"/>
+              </p></stentry>
           </strow>
         </simpletable>
       </body>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -73,6 +73,7 @@
             <topicref href="guc-list.xml#explain_pretty_print"/>
             <topicref href="guc-list.xml#extra_float_digits"/>
             <topicref href="guc-list.xml#from_collapse_limit"/>
+            <topicref href="guc-list.xml#gp_add_column_inherits_table_setting"/>
             <topicref href="guc-list.xml#gp_adjust_selectivity_for_outerjoins"/>
             <topicref href="guc-list.xml#gp_appendonly_compaction"/>
             <topicref href="guc-list.xml#gp_appendonly_compaction_threshold"/>
@@ -132,7 +133,6 @@
             <topicref href="guc-list.xml#gp_max_packet_size"/>
             <topicref href="guc-list.xml#gp_max_plan_size"/>
             <topicref href="guc-list.xml#gp_max_slices"/>
-            <topicref href="guc-list.xml#memory_spill_ratio"/>
             <topicref href="guc-list.xml#gp_motion_cost_per_row"/>
             <topicref href="guc-list.xml#gp_recursive_cte"/>
             <topicref href="guc-list.xml#gp_reject_percent_threshold"/>
@@ -215,6 +215,7 @@
             <topicref href="guc-list.xml#max_resource_queues"/>
             <topicref href="guc-list.xml#max_stack_depth"/>
             <topicref href="guc-list.xml#max_statement_mem"/>
+            <topicref href="guc-list.xml#memory_spill_ratio"/>
             <topicref href="guc-list.xml#optimizer"/>
             <topicref href="guc-list.xml#optimizer_array_expansion_threshold"/>
             <topicref href="guc-list.xml#optimizer_analyze_root_partition"/>

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -139,7 +139,32 @@ where <varname>action</varname> is one of:
                                                   href="CREATE_TABLE.xml">CREATE
                                                 TABLE</xref></codeph>. The <codeph>ENCODING</codeph>
                                         clause is valid only for append-optimized, column-oriented
-                                        tables.</li>
+                                                tables.<p>When you add a column to an
+                                                append-optimized, column-oriented table, Greenplum
+                                                Database sets each data compression parameter for
+                                                the column (<codeph>compresstype</codeph>,
+                                                  <codeph>compresslevel</codeph>, and
+                                                  <codeph>blocksize</codeph>) based on the following
+                                                setting, in order of preference.<ol
+                                                  id="ol_hqk_l4w_kmb">
+                                                  <li>The compression parameter setting specified in
+                                                  the <codeph>ALTER TABLE</codeph> command
+                                                  <codeph>ENCODING</codeph> clause.</li>
+                                                  <li>The compression parameter setting specified in
+                                                  the server configuration parameter <codeph><xref
+                                                  href="../config_params/guc-list.xml#gp_default_storage_options"
+                                                  >gp_default_storage_option</xref></codeph>.</li>
+                                                  <li>The default compression parameter value.</li>
+                                                </ol></p><p>By default, the table's data compression
+                                                parameters specified in the <codeph>WITH</codeph>
+                                                clause when the table was created are ignored. The
+                                                server configuration parameter <codeph><xref
+                                                  href="../config_params/guc-list.xml#gp_add_column_inherits_table_setting"
+                                                  >gp_add_column_inherits_table_setting</xref></codeph>.
+                                                controls whether the table's compression parameters
+                                                can be used when a column is added. With the default
+                                                value, <codeph>off</codeph>, the table's data
+                                                compression parameters are ignored. </p></li>
                                 <li><b>DROP COLUMN [IF EXISTS]</b> — Drops a column from a table.
                                         Note that if you drop table columns that are being used as
                                         the Greenplum Database distribution key, the distribution

--- a/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ALTER_TABLE.xml
@@ -150,21 +150,23 @@ where <varname>action</varname> is one of:
                                                   <li>The compression parameter setting specified in
                                                   the <codeph>ALTER TABLE</codeph> command
                                                   <codeph>ENCODING</codeph> clause.</li>
+                                                  <li>If the server configuration parameter
+                                                  <codeph><xref
+                                                  href="../config_params/guc-list.xml#gp_add_column_inherits_table_setting"
+                                                  >gp_add_column_inherits_table_setting</xref></codeph>
+                                                  is <codeph>on</codeph>, use the table's data
+                                                  compression parameters specified in the
+                                                  <codeph>WITH</codeph> clause when the table was
+                                                  created. The default server configuration
+                                                  parameter default is <codeph>off</codeph>, the
+                                                  <codeph>WITH</codeph> clause parameters are
+                                                  ignored.</li>
                                                   <li>The compression parameter setting specified in
                                                   the server configuration parameter <codeph><xref
                                                   href="../config_params/guc-list.xml#gp_default_storage_options"
                                                   >gp_default_storage_option</xref></codeph>.</li>
                                                   <li>The default compression parameter value.</li>
-                                                </ol></p><p>By default, the table's data compression
-                                                parameters specified in the <codeph>WITH</codeph>
-                                                clause when the table was created are ignored. The
-                                                server configuration parameter <codeph><xref
-                                                  href="../config_params/guc-list.xml#gp_add_column_inherits_table_setting"
-                                                  >gp_add_column_inherits_table_setting</xref></codeph>.
-                                                controls whether the table's compression parameters
-                                                can be used when a column is added. With the default
-                                                value, <codeph>off</codeph>, the table's data
-                                                compression parameters are ignored. </p></li>
+                                                </ol></p></li>
                                 <li><b>DROP COLUMN [IF EXISTS]</b> — Drops a column from a table.
                                         Note that if you drop table columns that are being used as
                                         the Greenplum Database distribution key, the distribution


### PR DESCRIPTION
-Add GUC
-Also, updated ADD COLUMN clause of  ALTER TABLE command with GUC information

This is for 6X_STABLE only.

DEV PR https://github.com/greenplum-db/gpdb/pull/10432


Link to HTML docs in a temporary GPDB doc review site.

GUC reference
https://docs-msk-gpdb6-dev.cfapps.io/6-9/ref_guide/config_params/guc-list.html#gp_add_column_inherits_table_setting

ALTER TABLE... ADD COLUMN
https://docs-msk-gpdb6-dev.cfapps.io/6-9/ref_guide/sql_commands/ALTER_TABLE.html#topic1__section3


