### PR TITLE
6X backport: Add Orca support for index only scan

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -529,6 +529,12 @@ CConfigParamMapping::PackConfigParamInBitset
 		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfIndexGet2IndexScan));
 	}
 
+	if (!optimizer_enable_indexonlyscan)
+	{
+		// disable index only scan if the corresponding GUC is turned off
+		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfIndexGet2IndexOnlyScan));
+	}
+
 	if (!optimizer_enable_hashagg)
 	{
 		 traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfGbAgg2HashAgg));

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -126,6 +126,7 @@ CTranslatorDXLToPlStmt::InitTranslators()
 			{EdxlopPhysicalTableScan,				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLTblScan},
 			{EdxlopPhysicalExternalScan,			&gpopt::CTranslatorDXLToPlStmt::TranslateDXLTblScan},
 			{EdxlopPhysicalIndexScan,				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLIndexScan},
+			{EdxlopPhysicalIndexOnlyScan,           &gpopt::CTranslatorDXLToPlStmt::TranslateDXLIndexOnlyScan},
 			{EdxlopPhysicalHashJoin, 				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLHashJoin},
 			{EdxlopPhysicalNLJoin, 					&gpopt::CTranslatorDXLToPlStmt::TranslateDXLNLJoin},
 			{EdxlopPhysicalMergeJoin,				&gpopt::CTranslatorDXLToPlStmt::TranslateDXLMergeJoin},
@@ -445,7 +446,7 @@ CTranslatorDXLToPlStmt::TranslateDXLTblScan
 
 	const CDXLTableDescr *dxl_table_descr = phy_tbl_scan_dxlop->GetDXLTableDescr();
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(dxl_table_descr->MDId());
-	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(dxl_table_descr, NULL /*index_descr_dxl*/, index, &base_table_context);
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(dxl_table_descr, index, &base_table_context);
 	GPOS_ASSERT(NULL != rte);
 	rte->requiredPerms |= ACL_SELECT;
 	m_dxl_to_plstmt_context->AddRTE(rte);
@@ -599,7 +600,7 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 	// translate table descriptor into a range table entry
 	CDXLPhysicalIndexScan *physical_idx_scan_dxlop = CDXLPhysicalIndexScan::Cast(index_scan_dxlnode->GetOperator());
 
-	return TranslateDXLIndexScan(index_scan_dxlnode, physical_idx_scan_dxlop, output_context, false /*is_index_only_scan*/, ctxt_translation_prev_siblings);
+	return TranslateDXLIndexScan(index_scan_dxlnode, physical_idx_scan_dxlop, output_context, ctxt_translation_prev_siblings);
 }
 
 //---------------------------------------------------------------------------
@@ -616,7 +617,6 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 	const CDXLNode *index_scan_dxlnode,
 	CDXLPhysicalIndexScan *physical_idx_scan_dxlop,
 	CDXLTranslateContext *output_context,
-	BOOL is_index_only_scan,
 	CDXLTranslationContextArray *ctxt_translation_prev_siblings
 	)
 {
@@ -625,21 +625,14 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 
 	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	const CDXLIndexDescr *index_descr_dxl = NULL;
-	if (is_index_only_scan)
-	{
-		index_descr_dxl = physical_idx_scan_dxlop->GetDXLIndexDescr();
-	}
-
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(physical_idx_scan_dxlop->GetDXLTableDescr()->MDId());
 
-	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(physical_idx_scan_dxlop->GetDXLTableDescr(), index_descr_dxl, index, &base_table_context);
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(physical_idx_scan_dxlop->GetDXLTableDescr(), index, &base_table_context);
 	GPOS_ASSERT(NULL != rte);
 	rte->requiredPerms |= ACL_SELECT;
 	m_dxl_to_plstmt_context->AddRTE(rte);
 
 	IndexScan *index_scan = NULL;
-	GPOS_ASSERT(!is_index_only_scan);
 	index_scan = MakeNode(IndexScan);
 	index_scan->scan.scanrelid = index;
 
@@ -696,7 +689,6 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 		(
 		index_cond_list_dxlnode,
 		physical_idx_scan_dxlop->GetDXLTableDescr(),
-		is_index_only_scan,
 		false, // is_bitmap_index_probe
 		md_index,
 		md_rel,
@@ -715,6 +707,159 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexScan
 	 * As of 8.4, the indexstrategy and indexsubtype fields are no longer
 	 * available or needed in IndexScan. Ignore them.
 	 */
+	SetParamIds(plan);
+
+	return (Plan *) index_scan;
+}
+
+static List *
+TranslateDXLIndexTList
+	(
+	const IMDRelation *md_rel,
+	const IMDIndex *md_index,
+	Index new_varno,
+	const CDXLTableDescr *table_descr,
+	CDXLTranslateContextBaseTable *index_context
+	)
+{
+	List *target_list = NIL;
+
+	index_context->SetRelIndex(INDEX_VAR);
+
+	for (ULONG ul = 0; ul < md_index->Keys(); ul++)
+	{
+		ULONG key = md_index->KeyAt(ul);
+
+		const IMDColumn *col = md_rel->GetMdCol(key);
+
+		TargetEntry *target_entry = MakeNode(TargetEntry);
+		target_entry->resno = (AttrNumber) ul + 1;
+
+		Expr *indexvar = (Expr *) gpdb::MakeVar(new_varno,
+									col->AttrNum(),
+									CMDIdGPDB::CastMdid(col->MdidType())->Oid(),
+									col->TypeModifier() /*vartypmod*/,
+									0/*varlevelsup*/);
+		target_entry->expr = indexvar;
+
+		// Fix up proj list. Since index only scan does not read full tuples,
+		// the var->varattno must be updated as it should no longer point to
+		// column in the table, but rather a column in the index. We achieve
+		// this by mapping col id to a new varattno based on index columns.
+		for (ULONG j = 0; j < table_descr->Arity(); j++)
+		{
+			const CDXLColDescr *dxl_col_descr = table_descr->GetColumnDescrAt(j);
+			if (dxl_col_descr->AttrNum() == ((Var *)indexvar)->varattno)
+			{
+				(void) index_context->InsertMapping(dxl_col_descr->Id(), ul + 1);
+				break;
+			}
+		}
+
+		target_list = gpdb::LAppend(target_list, target_entry);
+	}
+
+	return target_list;
+}
+
+Plan *
+CTranslatorDXLToPlStmt::TranslateDXLIndexOnlyScan
+	(
+	const CDXLNode *index_scan_dxlnode,
+	CDXLTranslateContext *output_context,
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
+	)
+{
+	// translate table descriptor into a range table entry
+	CDXLPhysicalIndexOnlyScan *physical_idx_scan_dxlop = CDXLPhysicalIndexOnlyScan::Cast(index_scan_dxlnode->GetOperator());
+	const CDXLTableDescr *table_desc = physical_idx_scan_dxlop->GetDXLTableDescr();
+
+	// translation context for column mappings in the base relation
+	CDXLTranslateContextBaseTable base_table_context(m_mp);
+
+	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
+
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(physical_idx_scan_dxlop->GetDXLTableDescr()->MDId());
+
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(physical_idx_scan_dxlop->GetDXLTableDescr(), index, &base_table_context);
+	GPOS_ASSERT(NULL != rte);
+	rte->requiredPerms |= ACL_SELECT;
+	m_dxl_to_plstmt_context->AddRTE(rte);
+
+	IndexOnlyScan *index_scan = MakeNode(IndexOnlyScan);
+	index_scan->scan.scanrelid = index;
+
+	CMDIdGPDB *mdid_index = CMDIdGPDB::CastMdid(physical_idx_scan_dxlop->GetDXLIndexDescr()->MDId());
+	const IMDIndex *md_index = m_md_accessor->RetrieveIndex(mdid_index);
+	Oid index_oid = mdid_index->Oid();
+
+	GPOS_ASSERT(InvalidOid != index_oid);
+	index_scan->indexid = index_oid;
+
+	Plan *plan = &(index_scan->scan.plan);
+	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+
+	// translate operator costs
+	TranslatePlanCosts
+		(
+		 CDXLPhysicalProperties::PdxlpropConvert(index_scan_dxlnode->GetProperties())->GetDXLOperatorCost(),
+		 &(plan->startup_cost),
+		 &(plan->total_cost),
+		 &(plan->plan_rows),
+		 &(plan->plan_width)
+		);
+
+	// an index scan node must have 3 children: projection list, filter and index condition list
+	GPOS_ASSERT(3 == index_scan_dxlnode->Arity());
+
+	// translate proj list and filter
+	CDXLNode *project_list_dxlnode = (*index_scan_dxlnode)[EdxlisIndexProjList];
+	CDXLNode *filter_dxlnode = (*index_scan_dxlnode)[EdxlisIndexFilter];
+	CDXLNode *index_cond_list_dxlnode = (*index_scan_dxlnode)[EdxlisIndexCondition];
+
+	CDXLTranslateContextBaseTable index_context(m_mp);
+
+	// translate index targetlist
+	index_scan->indextlist = TranslateDXLIndexTList(md_rel, md_index, index, table_desc, &index_context);
+
+	// translate target list
+	plan->targetlist = TranslateDXLProjList(project_list_dxlnode, &index_context, NULL /*child_contexts*/, output_context);
+
+	// translate index filter
+	plan->qual = TranslateDXLIndexFilter
+		(
+		 filter_dxlnode,
+		 output_context,
+		 &index_context,
+		 ctxt_translation_prev_siblings
+		);
+
+	index_scan->indexorderdir = CTranslatorUtils::GetScanDirection(physical_idx_scan_dxlop->GetIndexScanDir());
+
+	// translate index condition list
+	List *index_cond = NIL;
+	List *index_orig_cond = NIL;
+	List *index_strategy_list = NIL;
+	List *index_subtype_list = NIL;
+
+	TranslateIndexConditions
+		(
+		 index_cond_list_dxlnode,
+		 physical_idx_scan_dxlop->GetDXLTableDescr(),
+		 false, // is_bitmap_index_probe
+		 md_index,
+		 md_rel,
+		 output_context,
+		 &base_table_context,
+		 ctxt_translation_prev_siblings,
+		 &index_cond,
+		 &index_orig_cond,
+		 &index_strategy_list,
+		 &index_subtype_list
+		);
+
+	index_scan->indexqual = index_cond;
+	index_scan->indexqualorig = index_orig_cond;
 	SetParamIds(plan);
 
 	return (Plan *) index_scan;
@@ -767,7 +912,6 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions
 	(
 	CDXLNode *index_cond_list_dxlnode,
 	const CDXLTableDescr *dxl_tbl_descr,
-	BOOL is_index_only_scan,
 	BOOL is_bitmap_index_probe,
 	const IMDIndex *index,
 	const IMDRelation *md_rel,
@@ -803,13 +947,9 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion, GPOS_WSZ_LIT("ScalarArrayOpExpr condition on index scan"));
 		}
 
-		// for indexonlyscan, we already have the attno referring to the index
-		if (!is_index_only_scan)
-		{
-			// Otherwise, we need to perform mapping of Varattnos relative to column positions in index keys
-			SContextIndexVarAttno index_varattno_ctxt(md_rel, index);
-			SetIndexVarAttnoWalker((Node *) index_cond_expr, &index_varattno_ctxt);
-		}
+		// We need to perform mapping of Varattnos relative to column positions in index keys
+		SContextIndexVarAttno index_varattno_ctxt(md_rel, index);
+		SetIndexVarAttnoWalker((Node *) index_cond_expr, &index_varattno_ctxt);
 		
 		// find index key's attno
 		List *args_list = NULL;
@@ -3701,7 +3841,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDynTblScan
 	// add the new range table entry as the last element of the range table
 	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
-	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(dyn_tbl_scan_dxlop->GetDXLTableDescr(), NULL /*index_descr_dxl*/, index, &base_table_context);
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(dyn_tbl_scan_dxlop->GetDXLTableDescr(), index, &base_table_context);
 	GPOS_ASSERT(NULL != rte);
 	rte->requiredPerms |= ACL_SELECT;
 
@@ -3774,7 +3914,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan
 	Index index = gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
 
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(dyn_index_scan_dxlop->GetDXLTableDescr()->MDId());
-	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(dyn_index_scan_dxlop->GetDXLTableDescr(), NULL /*index_descr_dxl*/, index, &base_table_context);
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(dyn_index_scan_dxlop->GetDXLTableDescr(), index, &base_table_context);
 	GPOS_ASSERT(NULL != rte);
 	rte->requiredPerms |= ACL_SELECT;
 	m_dxl_to_plstmt_context->AddRTE(rte);
@@ -3839,7 +3979,6 @@ CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan
 		(
 		index_cond_list_dxlnode,
 		dyn_index_scan_dxlop->GetDXLTableDescr(),
-		false, // is_index_only_scan
 		false, // is_bitmap_index_probe
 		md_index,
 		md_rel,
@@ -3935,7 +4074,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDml
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(phy_dml_dxlop->GetDXLTableDescr()->MDId());
 
 	CDXLTableDescr *table_descr = phy_dml_dxlop->GetDXLTableDescr();
-	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(table_descr, NULL /*index_descr_dxl*/, index, &base_table_context);
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(table_descr, index, &base_table_context);
 	GPOS_ASSERT(NULL != rte);
 	rte->requiredPerms |= acl_mode;
 	m_dxl_to_plstmt_context->AddRTE(rte);
@@ -4388,7 +4527,6 @@ RangeTblEntry *
 CTranslatorDXLToPlStmt::TranslateDXLTblDescrToRangeTblEntry
 	(
 	const CDXLTableDescr *table_descr,
-	const CDXLIndexDescr *index_descr_dxl, // should be NULL unless we have an index-only scan
 	Index index,
 	CDXLTranslateContextBaseTable *base_table_context
 	)
@@ -4400,13 +4538,6 @@ CTranslatorDXLToPlStmt::TranslateDXLTblDescrToRangeTblEntry
 
 	RangeTblEntry *rte = MakeNode(RangeTblEntry);
 	rte->rtekind = RTE_RELATION;
-
-	// get the index if given
-	const IMDIndex *md_index = NULL;
-	if (NULL != index_descr_dxl)
-	{
-		md_index = m_md_accessor->RetrieveIndex(index_descr_dxl->MDId());
-	}
 
 	// get oid for table
 	Oid oid = CMDIdGPDB::CastMdid(table_descr->MDId())->Oid();
@@ -4456,12 +4587,6 @@ CTranslatorDXLToPlStmt::TranslateDXLTblDescrToRangeTblEntry
 
 			alias->colnames = gpdb::LAppend(alias->colnames, val_colname);
 			last_attno = attno;
-		}
-
-		// get the attno from the index, in case of indexonlyscan
-		if (NULL != md_index)
-		{
-			attno = 1 + md_index->GetKeyPos((ULONG) attno - 1);
 		}
 
 		// save mapping col id -> index in translate context
@@ -5459,7 +5584,7 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan
 
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
 
-	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(table_descr, NULL /*index_descr_dxl*/, index, &base_table_context);
+	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(table_descr, index, &base_table_context);
 	GPOS_ASSERT(NULL != rte);
 	rte->requiredPerms |= ACL_SELECT;
 
@@ -5729,7 +5854,6 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapIndexProbe
 		(
 		index_cond_list_dxlnode,
 		table_descr,
-		false /*is_index_only_scan*/,
 		true  /*is_bitmap_index_probe*/,
 		index,
 		md_rel,

--- a/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
@@ -17,8 +17,20 @@ WHERE
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="103027,102146,101000,101001,103001,103026"/>
+    </dxl:OptimizerConfig>
     <dxl:Stacktrace/>
-    <dxl:TraceFlags Value="103027,102146,101000,101001,103001,103026"/>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
         <dxl:EqualityOp Mdid="0.410.1.0"/>
@@ -1265,10 +1277,10 @@ WHERE
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="41230">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Plan Id="0" SpaceSize="120488">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="43434.041016" Rows="197964.000000" Width="148"/>
+          <dxl:Cost StartupCost="0" TotalCost="1415.900752" Rows="197964.000000" Width="148"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="26" Alias="oid">
@@ -1291,7 +1303,7 @@ WHERE
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="29127.048828" Rows="197964.000000" Width="148"/>
+            <dxl:Cost StartupCost="0" TotalCost="1306.714368" Rows="197964.000000" Width="148"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="26" Alias="oid">
@@ -1322,7 +1334,7 @@ WHERE
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="514.064453" Rows="702.000000" Width="150"/>
+              <dxl:Cost StartupCost="0" TotalCost="1306.698971" Rows="702.000000" Width="150"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="73" Alias="ColRef_0073">
@@ -1349,9 +1361,9 @@ WHERE
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:HashJoin JoinType="Inner">
+            <dxl:HashJoin JoinType="Left">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="410.232422" Rows="702.000000" Width="158"/>
+                <dxl:Cost StartupCost="0" TotalCost="1306.663871" Rows="702.000000" Width="158"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="amname">
@@ -1380,17 +1392,27 @@ WHERE
               <dxl:JoinFilter/>
               <dxl:HashCondList>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                  <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
-                  <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
+                  <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
+                  <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                  <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                  <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                 </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:HashJoin JoinType="Left">
+              <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="344.519531" Rows="702.000000" Width="88"/>
+                  <dxl:Cost StartupCost="0" TotalCost="875.127646" Rows="702.000000" Width="150"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="33" Alias="opcamid">
-                    <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
+                  <dxl:ProjElem ColId="0" Alias="amname">
+                    <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="amstrategies">
+                    <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="26" Alias="oid">
+                    <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="34" Alias="opcname">
                     <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
@@ -1401,29 +1423,30 @@ WHERE
                   <dxl:ProjElem ColId="49" Alias="amopsubtype">
                     <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="72" Alias="count">
-                    <dxl:Ident ColId="72" ColName="count" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                    <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="105.691406" Rows="702.000000" Width="80"/>
+                    <dxl:Cost StartupCost="0" TotalCost="874.854217" Rows="702.000000" Width="150"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="33" Alias="opcamid">
-                      <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
+                    <dxl:ProjElem ColId="0" Alias="amname">
+                      <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="amstrategies">
+                      <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="26" Alias="oid">
+                      <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="34" Alias="opcname">
                       <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
@@ -1443,13 +1466,19 @@ WHERE
                       <dxl:Ident ColId="48" ColName="amopclaid" TypeMdid="0.26.1.0"/>
                     </dxl:Comparison>
                   </dxl:HashCondList>
-                  <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1">
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="21.929688" Rows="141.000000" Width="76"/>
+                      <dxl:Cost StartupCost="0" TotalCost="443.223121" Rows="141.000000" Width="146"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="33" Alias="opcamid">
-                        <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
+                      <dxl:ProjElem ColId="0" Alias="amname">
+                        <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="amstrategies">
+                        <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="26" Alias="oid">
+                        <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="34" Alias="opcname">
                         <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
@@ -1459,15 +1488,56 @@ WHERE
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="10.464844" Rows="141.000000" Width="76"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000891" Rows="2.000000" Width="74"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="33" Alias="opcamid">
-                          <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
+                        <dxl:ProjElem ColId="0" Alias="amname">
+                          <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="amstrategies">
+                          <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="26" Alias="oid">
+                          <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.643.1.0">
+                            <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z2lzdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.643.1.0">
+                            <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z2luAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+                          </dxl:Comparison>
+                        </dxl:And>
+                      </dxl:Filter>
+                      <dxl:TableDescriptor Mdid="0.2601.1.1" TableName="pg_am">
+                        <dxl:Columns>
+                          <dxl:Column ColId="0" Attno="1" ColName="amname" TypeMdid="0.19.1.0"/>
+                          <dxl:Column ColId="1" Attno="2" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+                          <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="26" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                    <dxl:IndexScan IndexScanDirection="Forward">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="12.131206" Rows="70.500000" Width="72"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
                         <dxl:ProjElem ColId="34" Alias="opcname">
                           <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
                         </dxl:ProjElem>
@@ -1476,6 +1546,13 @@ WHERE
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
+                      <dxl:IndexCondList>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                          <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
+                          <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:IndexCondList>
+                      <dxl:IndexDescriptor Mdid="0.2686.1.0" IndexName="pg_opclass_am_name_nsp_index"/>
                       <dxl:TableDescriptor Mdid="0.2616.1.1" TableName="pg_opclass">
                         <dxl:Columns>
                           <dxl:Column ColId="33" Attno="1" ColName="opcamid" TypeMdid="0.26.1.0"/>
@@ -1490,11 +1567,11 @@ WHERE
                           <dxl:Column ColId="47" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:Columns>
                       </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:RandomMotion>
-                  <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                    </dxl:IndexScan>
+                  </dxl:NestedLoopJoin>
+                  <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="17.453125" Rows="1404.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.017375" Rows="702.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="48" Alias="amopclaid">
@@ -1505,39 +1582,47 @@ WHERE
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="5.484375" Rows="702.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="48" Alias="amopclaid">
-                          <dxl:Ident ColId="48" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="49" Alias="amopsubtype">
-                          <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.2602.1.1" TableName="pg_amop">
-                        <dxl:Columns>
-                          <dxl:Column ColId="48" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="49" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="54" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="55" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="56" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="57" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="58" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="59" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:BroadcastMotion>
+                    <dxl:TableDescriptor Mdid="0.2602.1.1" TableName="pg_amop">
+                      <dxl:Columns>
+                        <dxl:Column ColId="48" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="49" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="54" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="55" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="56" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="57" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="58" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="59" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
                 </dxl:HashJoin>
-                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+              </dxl:RedistributeMotion>
+              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.172320" Rows="702.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="60"/>
+                  <dxl:GroupingColumn ColId="61"/>
+                </dxl:GroupingColumns>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="72" Alias="count">
+                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
+                      <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="60" Alias="amopclaid">
+                    <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="61" Alias="amopsubtype">
+                    <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="73.296875" Rows="1404.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.113221" Rows="702.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="60" Alias="amopclaid">
@@ -1546,15 +1631,23 @@ WHERE
                     <dxl:ProjElem ColId="61" Alias="amopsubtype">
                       <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="72" Alias="count">
-                      <dxl:Ident ColId="72" ColName="count" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="74" Alias="ColRef_0074">
+                      <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                    </dxl:HashExpr>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="50.359375" Rows="702.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.101502" Rows="702.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="60" Alias="amopclaid">
@@ -1563,23 +1656,23 @@ WHERE
                       <dxl:ProjElem ColId="61" Alias="amopsubtype">
                         <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="72" Alias="count">
-                        <dxl:Ident ColId="72" ColName="count" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="74" Alias="ColRef_0074">
+                        <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
-                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="50.359375" Rows="702.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.101502" Rows="702.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="60"/>
                         <dxl:GroupingColumn ColId="61"/>
                       </dxl:GroupingColumns>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="72" Alias="count">
-                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                        <dxl:ProjElem ColId="74" Alias="ColRef_0074">
+                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="60" Alias="amopclaid">
                           <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
@@ -1589,9 +1682,9 @@ WHERE
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableScan>
+                      <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="5.484375" Rows="702.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.042403" Rows="702.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="60" Alias="amopclaid">
@@ -1602,84 +1695,39 @@ WHERE
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="0.2602.1.1" TableName="pg_amop">
-                          <dxl:Columns>
-                            <dxl:Column ColId="60" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="61" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="65" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="66" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="67" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="68" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="69" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="70" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="71" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.017375" Rows="702.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="60" Alias="amopclaid">
+                              <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="61" Alias="amopsubtype">
+                              <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.2602.1.1" TableName="pg_amop">
+                            <dxl:Columns>
+                              <dxl:Column ColId="60" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="61" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="65" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="66" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="67" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="68" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="69" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="70" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="71" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:RandomMotion>
                     </dxl:Aggregate>
                   </dxl:Result>
-                </dxl:BroadcastMotion>
-              </dxl:HashJoin>
-              <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.939453" Rows="4.000000" Width="74"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="amname">
-                    <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="amstrategies">
-                    <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="26" Alias="oid">
-                    <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.650391" Rows="2.000000" Width="74"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="amname">
-                      <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="amstrategies">
-                      <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="26" Alias="oid">
-                      <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:And>
-                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.643.1.0">
-                        <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z2lzdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#10;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
-                      </dxl:Comparison>
-                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.643.1.0">
-                        <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z2luAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#10;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
-                      </dxl:Comparison>
-                    </dxl:And>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="0.2601.1.1" TableName="pg_am">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="amname" TypeMdid="0.19.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-                      <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="26" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:BroadcastMotion>
+                </dxl:RedistributeMotion>
+              </dxl:Aggregate>
             </dxl:HashJoin>
           </dxl:Result>
         </dxl:Result>

--- a/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelGPDB.h
+++ b/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelGPDB.h
@@ -116,6 +116,10 @@ namespace gpdbcost
 			static
 			CCost CostIndexScan(CMemoryPool *mp, CExpressionHandle &exprhdl, const CCostModelGPDB *pcmgpdb, const SCostingInfo *pci);
 
+			// cost of index only scan
+			static
+			CCost CostIndexOnlyScan(CMemoryPool *mp, CExpressionHandle &exprhdl, const CCostModelGPDB *pcmgpdb, const SCostingInfo *pci);
+
 			// cost of bitmap table scan
 			static
 			CCost CostBitmapTableScan(CMemoryPool *mp, CExpressionHandle &exprhdl, const CCostModelGPDB *pcmgpdb, const SCostingInfo *pci);

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
@@ -210,10 +210,10 @@ namespace gpopt
 				m_used = EUnknown;
 			}
 
-			EUsedStatus GetUsage() const
+			EUsedStatus GetUsage(BOOL check_system_col=false) const
 			{
 
-				if (GPOS_FTRACE(EopttraceTranslateUnusedColrefs) || FSystemCol())
+				if (GPOS_FTRACE(EopttraceTranslateUnusedColrefs) || (!check_system_col && FSystemCol()))
 				{
 					return EUsed;
 				}

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CIndexDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CIndexDescriptor.h
@@ -118,6 +118,8 @@ namespace gpopt
 				return m_index_type;
 			}
 
+			BOOL SupportsIndexOnlyScan() const;
+
 			// create an index descriptor
 			static CIndexDescriptor *Pindexdesc
 				(

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
@@ -208,6 +208,7 @@ namespace gpopt
 				EopPhysicalTableScan,
 				EopPhysicalExternalScan,
 				EopPhysicalIndexScan,
+				EopPhysicalIndexOnlyScan,
 				EopPhysicalBitmapTableScan,
 				EopPhysicalFilter,
 				EopPhysicalInnerNLJoin,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalIndexOnlyScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalIndexOnlyScan.h
@@ -1,0 +1,204 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//
+//	@filename:
+//		CPhysicalIndexOnlyScan.h
+//
+//	@doc:
+//		Base class for physical index only scan operators
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CPhysicalIndexOnlyScan_H
+#define GPOPT_CPhysicalIndexOnlyScan_H
+
+#include "gpos/base.h"
+#include "gpopt/operators/CPhysicalScan.h"
+#include "gpopt/metadata/CIndexDescriptor.h"
+
+namespace gpopt
+{
+
+	// fwd declarations
+	class CName;
+	class CDistributionSpecHashed;
+
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CPhysicalIndexOnlyScan
+	//
+	//	@doc:
+	//		Base class for physical index only scan operators
+	//
+	//---------------------------------------------------------------------------
+	class CPhysicalIndexOnlyScan : public CPhysicalScan
+	{
+
+		private:
+
+			// index descriptor
+			CIndexDescriptor *m_pindexdesc;
+
+			// origin operator id -- gpos::ulong_max if operator was not generated via a transformation
+			ULONG m_ulOriginOpId;
+
+			// order
+			COrderSpec *m_pos;
+
+			// private copy ctor
+			CPhysicalIndexOnlyScan(const CPhysicalIndexOnlyScan&);
+
+		public:
+
+			// ctors
+			CPhysicalIndexOnlyScan
+				(
+				CMemoryPool *mp,
+				CIndexDescriptor *pindexdesc,
+				CTableDescriptor *ptabdesc,
+				ULONG ulOriginOpId,
+				const CName *pnameAlias,
+				CColRefArray *colref_array,
+				COrderSpec *pos
+				);
+
+			// dtor
+			virtual
+			~CPhysicalIndexOnlyScan();
+
+
+			// ident accessors
+			virtual
+			EOperatorId Eopid() const
+			{
+				return EopPhysicalIndexOnlyScan;
+			}
+
+			// operator name
+			virtual
+			const CHAR *SzId() const
+			{
+				return "CPhysicalIndexOnlyScan";
+			}
+
+			// table alias name
+			const CName &NameAlias() const
+			{
+				return *m_pnameAlias;
+			}
+
+			// origin operator id -- gpos::ulong_max if operator was not generated via a transformation
+			ULONG UlOriginOpId() const
+			{
+				return m_ulOriginOpId;
+			}
+
+			// operator specific hash function
+			virtual
+			ULONG HashValue() const;
+
+			// match function
+			BOOL Matches(COperator *pop) const;
+
+			// index descriptor
+			CIndexDescriptor *Pindexdesc() const
+			{
+				return m_pindexdesc;
+			}
+
+			// sensitivity to order of inputs
+			virtual
+			BOOL FInputOrderSensitive() const
+			{
+				return true;
+			}
+
+			//-------------------------------------------------------------------------------------
+			// Derived Plan Properties
+			//-------------------------------------------------------------------------------------
+
+			// derive sort order
+			virtual
+			COrderSpec *PosDerive
+							(
+							CMemoryPool *,//mp
+							CExpressionHandle &//exprhdl
+							)
+							const
+			{
+				m_pos->AddRef();
+				return m_pos;
+			}
+
+			// derive partition index map
+			virtual
+			CPartIndexMap *PpimDerive
+				(
+				CMemoryPool *mp,
+				CExpressionHandle &, // exprhdl
+				CDrvdPropCtxt * //pdpctxt
+				)
+				const
+			{
+				return GPOS_NEW(mp) CPartIndexMap(mp);
+			}
+
+			virtual
+			CRewindabilitySpec *PrsDerive
+				(
+				CMemoryPool *mp,
+				CExpressionHandle & // exprhdl
+				)
+				const
+			{
+				// rewindability of output is always true
+				return GPOS_NEW(mp) CRewindabilitySpec(CRewindabilitySpec::ErtMarkRestore, CRewindabilitySpec::EmhtNoMotion);
+			}
+
+			//-------------------------------------------------------------------------------------
+			// Enforced Properties
+			//-------------------------------------------------------------------------------------
+
+			// return order property enforcing type for this operator
+			virtual
+			CEnfdProp::EPropEnforcingType EpetOrder(CExpressionHandle &exprhdl, const CEnfdOrder *peo) const;
+
+			// conversion function
+			static
+			CPhysicalIndexOnlyScan *PopConvert
+				(
+				COperator *pop
+				)
+			{
+				GPOS_ASSERT(NULL != pop);
+				GPOS_ASSERT(EopPhysicalIndexOnlyScan == pop->Eopid());
+
+				return dynamic_cast<CPhysicalIndexOnlyScan*>(pop);
+			}
+
+			// statistics derivation during costing
+			virtual
+			IStatistics *PstatsDerive
+				(
+				CMemoryPool *, // mp
+				CExpressionHandle &, // exprhdl
+				CReqdPropPlan *, // prpplan
+				IStatisticsArray * //stats_ctxt
+				)
+				const
+			{
+				GPOS_ASSERT(!"stats derivation during costing for index only scan is invalid");
+
+				return NULL;
+			}
+
+			// debug print
+			virtual
+			IOstream &OsPrint(IOstream &) const;
+
+	}; // class CPhysicalIndexOnlyScan
+
+}
+
+#endif // !GPOPT_CPhysicalIndexOnlyScan_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -183,6 +183,23 @@ namespace gpopt
 				BOOL *pfDML
 				);
 
+			CDXLNode *PdxlnIndexOnlyScan
+				(
+				CExpression *pexprIndexScan,
+				CColRefArray *colref_array,
+				CDistributionSpecArray *pdrgpdsBaseTables,
+				ULONG *pulNonGatherMotions,
+				BOOL *pfDML
+				);
+
+			CDXLNode *PdxlnIndexOnlyScan
+				(
+				CExpression *pexprIndexScan,
+				CColRefArray *colref_array,
+				CDXLPhysicalProperties *dxl_properties,
+				CReqdPropPlan *prpp
+				);
+
 			// translate a bitmap index probe expression to DXL
 			CDXLNode *PdxlnBitmapIndexProbe(CExpression *pexprBitmapIndexProbe);
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
@@ -222,6 +222,7 @@ namespace gpopt
 				ExfLeftOuterJoin2DynamicIndexGetApply,
 				ExfLeftOuterJoinWithInnerSelect2DynamicBitmapIndexGetApply,
 				ExfLeftOuterJoinWithInnerSelect2DynamicIndexGetApply,
+				ExfIndexGet2IndexOnlyScan,
 				ExfInvalid,
 				ExfSentinel = ExfInvalid
 			};

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformIndexGet2IndexOnlyScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformIndexGet2IndexOnlyScan.h
@@ -1,0 +1,84 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//
+//	@filename:
+//		CXformIndexGet2IndexOnlyScan.h
+//
+//	@doc:
+//		Transform Index Get to Index Only Scan
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CXformIndexGet2IndexOnlyScan_H
+#define GPOPT_CXformIndexGet2IndexOnlyScan_H
+
+#include "gpos/base.h"
+#include "gpopt/xforms/CXformImplementation.h"
+
+namespace gpopt
+{
+	using namespace gpos;
+
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CXformIndexGet2IndexOnlyScan
+	//
+	//	@doc:
+	//		Transform Index Get to Index Scan
+	//
+	//---------------------------------------------------------------------------
+	class CXformIndexGet2IndexOnlyScan : public CXformImplementation
+	{
+
+		private:
+
+			// private copy ctor
+			CXformIndexGet2IndexOnlyScan(const CXformIndexGet2IndexOnlyScan &);
+
+		public:
+
+			// ctor
+			explicit
+			CXformIndexGet2IndexOnlyScan(CMemoryPool *);
+
+			// dtor
+			virtual
+			~CXformIndexGet2IndexOnlyScan() {}
+
+			// ident accessors
+			virtual
+			EXformId Exfid() const
+			{
+				return ExfIndexGet2IndexOnlyScan;
+			}
+
+			// xform name
+			virtual
+			const CHAR *SzId() const
+			{
+				return "CXformIndexGet2IndexOnlyScan";
+			}
+
+			// compute xform promise for a given expression handle
+			virtual
+			EXformPromise Exfp
+				(
+				CExpressionHandle &//exprhdl
+				)
+				const;
+
+			// actual transform
+			void Transform
+				(
+				CXformContext *pxfctxt,
+				CXformResult *pxfres,
+				CExpression *pexpr
+				)
+				const;
+
+	}; // class CXformIndexGet2IndexOnlyScan
+
+}
+
+#endif // !GPOPT_CXformIndexGet2IndexOnlyScan_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
@@ -29,6 +29,7 @@
 #include "gpopt/xforms/CXformImplementTVF.h"
 #include "gpopt/xforms/CXformImplementTVFNoArgs.h"
 #include "gpopt/xforms/CXformIndexGet2IndexScan.h"
+#include "gpopt/xforms/CXformIndexGet2IndexOnlyScan.h"
 #include "gpopt/xforms/CXformImplementBitmapTableGet.h"
 #include "gpopt/xforms/CXformImplementDynamicBitmapTableGet.h"
 #include "gpopt/xforms/CXformImplementUnionAll.h"

--- a/src/backend/gporca/libgpopt/src/metadata/CIndexDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CIndexDescriptor.cpp
@@ -154,6 +154,12 @@ CIndexDescriptor::Pindexdesc
 	return pindexdesc;
 }
 
+BOOL
+CIndexDescriptor::SupportsIndexOnlyScan() const
+{
+	return m_index_type == IMDIndex::EmdindBtree;
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CIndexDescriptor::OsPrint

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalIndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalIndexGet.cpp
@@ -259,6 +259,7 @@ const
 	CXformSet *xform_set = GPOS_NEW(mp) CXformSet(mp);
 
 	(void) xform_set->ExchangeSet(CXform::ExfIndexGet2IndexScan);
+	(void) xform_set->ExchangeSet(CXform::ExfIndexGet2IndexOnlyScan);
 
 	return xform_set;
 }

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalIndexOnlyScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalIndexOnlyScan.cpp
@@ -1,0 +1,174 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//
+//	@filename:
+//		CPhysicalIndexOnlyScan.cpp
+//
+//	@doc:
+//		Implementation of index scan operator
+//---------------------------------------------------------------------------
+
+#include "gpos/base.h"
+
+#include "gpopt/base/CUtils.h"
+#include "gpopt/operators/CExpressionHandle.h"
+#include "gpopt/operators/CPhysicalIndexOnlyScan.h"
+
+
+using namespace gpopt;
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalIndexOnlyScan::CPhysicalIndexOnlyScan
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CPhysicalIndexOnlyScan::CPhysicalIndexOnlyScan
+	(
+	CMemoryPool *mp,
+	CIndexDescriptor *pindexdesc,
+	CTableDescriptor *ptabdesc,
+	ULONG ulOriginOpId,
+	const CName *pnameAlias,
+	CColRefArray *pdrgpcrOutput,
+	COrderSpec *pos
+	)
+	:
+	CPhysicalScan(mp, pnameAlias, ptabdesc, pdrgpcrOutput),
+	m_pindexdesc(pindexdesc),
+	m_ulOriginOpId(ulOriginOpId),
+	m_pos(pos)
+{
+	GPOS_ASSERT(NULL != pindexdesc);
+	GPOS_ASSERT(NULL != pos);
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalIndexOnlyScan::~CPhysicalIndexOnlyScan
+//
+//	@doc:
+//		Dtor
+//
+//---------------------------------------------------------------------------
+CPhysicalIndexOnlyScan::~CPhysicalIndexOnlyScan()
+{
+	m_pindexdesc->Release();
+	m_pos->Release();
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalIndexOnlyScan::EpetOrder
+//
+//	@doc:
+//		Return the enforcing type for order property based on this operator
+//
+//---------------------------------------------------------------------------
+CEnfdProp::EPropEnforcingType
+CPhysicalIndexOnlyScan::EpetOrder
+	(
+	CExpressionHandle &, // exprhdl
+	const CEnfdOrder *peo
+	)
+	const
+{
+	GPOS_ASSERT(NULL != peo);
+	GPOS_ASSERT(!peo->PosRequired()->IsEmpty());
+
+	if (peo->FCompatible(m_pos))
+	{
+		// required order is already established by the index
+		return CEnfdProp::EpetUnnecessary;
+	}
+
+	return CEnfdProp::EpetRequired;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalIndexOnlyScan::HashValue
+//
+//	@doc:
+//		Combine pointers for table descriptor, index descriptor and Eop
+//
+//---------------------------------------------------------------------------
+ULONG
+CPhysicalIndexOnlyScan::HashValue() const
+{
+	ULONG ulHash = gpos::CombineHashes
+					(
+					COperator::HashValue(),
+					gpos::CombineHashes
+							(
+							m_pindexdesc->MDId()->HashValue(),
+							gpos::HashPtr<CTableDescriptor>(m_ptabdesc)
+							)
+					);
+	ulHash = gpos::CombineHashes(ulHash, CUtils::UlHashColArray(m_pdrgpcrOutput));
+
+	return ulHash;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalIndexOnlyScan::Matches
+//
+//	@doc:
+//		match operator
+//
+//---------------------------------------------------------------------------
+BOOL
+CPhysicalIndexOnlyScan::Matches
+	(
+	COperator *pop
+	)
+	const
+{
+	return CUtils::FMatchIndex(this, pop);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalIndexOnlyScan::OsPrint
+//
+//	@doc:
+//		debug print
+//
+//---------------------------------------------------------------------------
+IOstream &
+CPhysicalIndexOnlyScan::OsPrint
+	(
+	IOstream &os
+	)
+	const
+{
+	if (m_fPattern)
+	{
+		return COperator::OsPrint(os);
+	}
+
+	os << SzId() << " ";
+	// index name
+	os << "  Index Name: (";
+	m_pindexdesc->Name().OsPrint(os);
+	// table name
+	os <<")";
+	os << ", Table Name: (";
+	m_ptabdesc->Name().OsPrint(os);
+	os <<")";
+	os << ", Columns: [";
+	CUtils::OsPrintDrgPcr(os, m_pdrgpcrOutput);
+	os << "]";
+
+	return os;
+}
+
+// EOF
+

--- a/src/backend/gporca/libgpopt/src/operators/Makefile
+++ b/src/backend/gporca/libgpopt/src/operators/Makefile
@@ -99,6 +99,7 @@ OBJS        = CExpression.o \
               CPhysicalHashAggDeduplicate.o \
               CPhysicalHashJoin.o \
               CPhysicalIndexScan.o \
+              CPhysicalIndexOnlyScan.o \
               CPhysicalInnerHashJoin.o \
               CPhysicalInnerIndexNLJoin.o \
               CPhysicalInnerNLJoin.o \

--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -144,6 +144,7 @@ CXformFactory::Add
 void
 CXformFactory::Instantiate()
 {
+	// Order here needs to correspond to the order defined in CXform::EXformId
 	Add(GPOS_NEW(m_mp) CXformProject2ComputeScalar(m_mp));
 	Add(GPOS_NEW(m_mp) CXformExpandNAryJoin(m_mp));
 	Add(GPOS_NEW(m_mp) CXformExpandNAryJoinMinCard(m_mp));
@@ -296,6 +297,7 @@ CXformFactory::Instantiate()
 	Add(GPOS_NEW(m_mp) CXformLeftOuterJoin2DynamicIndexGetApply(m_mp));
 	Add(GPOS_NEW(m_mp) CXformLeftOuterJoinWithInnerSelect2DynamicBitmapIndexGetApply(m_mp));
 	Add(GPOS_NEW(m_mp) CXformLeftOuterJoinWithInnerSelect2DynamicIndexGetApply(m_mp));
+	Add(GPOS_NEW(m_mp) CXformIndexGet2IndexOnlyScan(m_mp));
 
 	GPOS_ASSERT(NULL != m_rgpxf[CXform::ExfSentinel - 1] &&
 				"Not all xforms have been instantiated");

--- a/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexOnlyScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexOnlyScan.cpp
@@ -1,0 +1,169 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//
+//	@filename:
+//		CXformIndexGet2IndexOnlyScan.cpp
+//
+//	@doc:
+//		Implementation of transform
+//---------------------------------------------------------------------------
+
+#include <cwchar>
+
+#include "gpos/base.h"
+#include "gpopt/xforms/CXformIndexGet2IndexOnlyScan.h"
+#include "gpopt/xforms/CXformUtils.h"
+
+#include "gpopt/operators/CExpressionHandle.h"
+#include "gpopt/operators/CLogicalIndexGet.h"
+#include "gpopt/operators/CPatternLeaf.h"
+#include "gpopt/operators/CPhysicalIndexOnlyScan.h"
+#include "gpopt/metadata/CIndexDescriptor.h"
+#include "gpopt/metadata/CTableDescriptor.h"
+#include "naucrates/md/CMDIndexGPDB.h"
+
+using namespace gpopt;
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformIndexGet2IndexOnlyScan::CXformIndexGet2IndexOnlyScan
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CXformIndexGet2IndexOnlyScan::CXformIndexGet2IndexOnlyScan
+	(
+	CMemoryPool *mp
+	)
+	:
+	// pattern
+	CXformImplementation
+		(
+		GPOS_NEW(mp) CExpression
+				(
+				mp,
+				GPOS_NEW(mp) CLogicalIndexGet(mp),
+				GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CPatternLeaf(mp))	// index lookup predicate
+				)
+		)
+{}
+
+CXform::EXformPromise CXformIndexGet2IndexOnlyScan::Exfp
+(
+ CExpressionHandle &exprhdl
+)
+const
+{
+	CLogicalIndexGet *popGet = CLogicalIndexGet::PopConvert(exprhdl.Pop());
+
+	CTableDescriptor *ptabdesc = popGet->Ptabdesc();
+	CIndexDescriptor *pindexdesc = popGet->Pindexdesc();
+
+	if ((pindexdesc->IndexType() == IMDIndex::EmdindBtree && ptabdesc->IsAORowOrColTable()) ||
+		!pindexdesc->SupportsIndexOnlyScan())
+	{
+		// we don't support btree index scans on AO tables
+		// FIXME: relax btree requirement. GiST and SP-GiST indexes can support some operator classes, but Gin cannot
+		return CXform::ExfpNone;
+	}
+
+	return CXform::ExfpHigh;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformIndexGet2IndexOnlyScan::Transform
+//
+//	@doc:
+//		Actual transformation
+//
+//---------------------------------------------------------------------------
+void
+CXformIndexGet2IndexOnlyScan::Transform
+	(
+	CXformContext *pxfctxt,
+	CXformResult *pxfres,
+	CExpression *pexpr
+	)
+	const
+{
+	GPOS_ASSERT(NULL != pxfctxt);
+	GPOS_ASSERT(FPromising(pxfctxt->Pmp(), this, pexpr));
+	GPOS_ASSERT(FCheckPattern(pexpr));
+
+	CLogicalIndexGet *pop = CLogicalIndexGet::PopConvert(pexpr->Pop());
+	CMemoryPool *mp = pxfctxt->Pmp();
+	CIndexDescriptor *pindexdesc = pop->Pindexdesc();
+	CTableDescriptor *ptabdesc = pop->Ptabdesc();
+
+	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
+	const IMDRelation *pmdrel = md_accessor->RetrieveRel(ptabdesc->MDId());
+	const IMDIndex *pmdindex = md_accessor->RetrieveIndex(pindexdesc->MDId());
+
+	CColRefArray *pdrgpcrOutput = pop->PdrgpcrOutput();
+	GPOS_ASSERT(NULL != pdrgpcrOutput);
+	pdrgpcrOutput->AddRef();
+
+	CColRefSet *matched_cols = CXformUtils::PcrsIndexKeys(mp, pdrgpcrOutput, pmdindex, pmdrel);
+	CColRefSet *output_cols = GPOS_NEW(mp) CColRefSet(mp);
+
+	// An index only scan is allowed iff each used output column reference also
+	// exists as a column in the index.
+	for (ULONG i = 0; i < pdrgpcrOutput->Size(); i++)
+	{
+		CColRef *col = (*pdrgpcrOutput)[i];
+		if (col->GetUsage(true /*check_system_cols*/) == CColRef::EUsed)
+		{
+			output_cols->Include(col);
+		}
+	}
+
+	if (!matched_cols->ContainsAll(output_cols))
+	{
+		matched_cols->Release();
+		output_cols->Release();
+		pdrgpcrOutput->Release();
+		return;
+	}
+
+	matched_cols->Release();
+	output_cols->Release();
+
+	pindexdesc->AddRef();
+	ptabdesc->AddRef();
+
+	COrderSpec *pos = pop->Pos();
+	GPOS_ASSERT(NULL != pos);
+	pos->AddRef();
+
+	// extract components
+	CExpression *pexprIndexCond = (*pexpr)[0];
+
+	// addref all children
+	pexprIndexCond->AddRef();
+
+	CExpression *pexprAlt =
+		GPOS_NEW(mp) CExpression
+			(
+			mp,
+			GPOS_NEW(mp) CPhysicalIndexOnlyScan
+				(
+				mp,
+				pindexdesc,
+				ptabdesc,
+				pexpr->Pop()->UlOpId(),
+				GPOS_NEW(mp) CName (mp, pop->NameAlias()),
+				pdrgpcrOutput,
+				pos
+				),
+			pexprIndexCond
+			);
+	pxfres->Add(pexprAlt);
+}
+
+
+// EOF
+

--- a/src/backend/gporca/libgpopt/src/xforms/Makefile
+++ b/src/backend/gporca/libgpopt/src/xforms/Makefile
@@ -64,6 +64,7 @@ OBJS        = CDecorrelator.o \
               CXformImplementUnionAll.o \
               CXformImplementation.o \
               CXformIndexGet2IndexScan.o \
+              CXformIndexGet2IndexOnlyScan.o \
               CXformInlineCTEConsumer.o \
               CXformInlineCTEConsumerUnderSelect.o \
               CXformInnerApply2InnerJoin.o \

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -350,6 +350,7 @@ bool		optimizer_enable_master_only_queries;
 bool		optimizer_enable_hashjoin;
 bool		optimizer_enable_dynamictablescan;
 bool		optimizer_enable_indexscan;
+bool		optimizer_enable_indexonlyscan;
 bool		optimizer_enable_tablescan;
 bool		optimizer_enable_hashagg;
 bool		optimizer_enable_groupagg;
@@ -2403,6 +2404,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&optimizer_enable_indexscan,
 		true,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_enable_indexonlyscan", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enables the optimizer's use of plans with index only scan."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_indexonlyscan,
+		false,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -220,8 +220,15 @@ namespace gpdxl
 				const CDXLNode *index_scan_dxlnode,
 				CDXLPhysicalIndexScan *dxl_physical_idx_scan_op,
 				CDXLTranslateContext *output_context,
-				BOOL is_index_only_scan,
 				CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
+				);
+
+			// translate DXL index scan node into a IndexOnlyScan node
+			Plan *TranslateDXLIndexOnlyScan
+				(
+				 const CDXLNode *index_scan_dxlnode,
+				 CDXLTranslateContext *output_context,
+				 CDXLTranslationContextArray *ctxt_translation_prev_siblings // translation contexts of previous siblings
 				);
 
 			// translate DXL hash join into a HashJoin node
@@ -491,7 +498,6 @@ namespace gpdxl
 			RangeTblEntry *TranslateDXLTblDescrToRangeTblEntry
 				(
 				const CDXLTableDescr *table_descr,
-				const CDXLIndexDescr *index_descr_dxl,
 				Index index,
 				CDXLTranslateContextBaseTable *base_table_context
 				);
@@ -634,7 +640,6 @@ namespace gpdxl
 				(
 				CDXLNode *index_cond_list_dxlnode,
 				const CDXLTableDescr *dxl_tbl_descr,
-				BOOL is_index_only_scan,
 				BOOL is_bitmap_index_probe,
 				const IMDIndex *index,
 				const IMDRelation *md_rel,

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -479,6 +479,7 @@ extern bool optimizer_enable_master_only_queries;
 extern bool optimizer_enable_hashjoin;
 extern bool optimizer_enable_dynamictablescan;
 extern bool optimizer_enable_indexscan;
+extern bool optimizer_enable_indexonlyscan;
 extern bool optimizer_enable_tablescan;
 extern bool optimizer_enable_eageragg;
 extern bool optimizer_expand_fulljoin;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -359,6 +359,7 @@
 		"optimizer_enable_hashjoin_redistribute_broadcast_children",
 		"optimizer_enable_indexjoin",
 		"optimizer_enable_indexscan",
+		"optimizer_enable_indexonlyscan",
 		"optimizer_enable_master_only_queries",
 		"optimizer_enable_materialize",
 		"optimizer_enable_mergejoin",

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -724,3 +724,42 @@ select * from shape_aocs where c && '<(5,5), 3>'::circle;
  <(0,0),5>
 (1 row)
 
+--
+-- Given a table with different column types
+--
+CREATE TABLE table_with_reversed_index(a int, b bool, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+--
+-- And it has an index that is ordered differently than columns on the table.
+--
+CREATE INDEX ON table_with_reversed_index(c, a);
+INSERT INTO table_with_reversed_index VALUES (10, true, 'ab');
+--
+-- Then an index only scan should succeed. (i.e. varattno is set up correctly)
+--
+SET enable_seqscan=off;
+SET enable_bitmapscan=off;
+SET optimizer_enable_tablescan=off;
+SET optimizer_enable_indexscan=off;
+SET optimizer_enable_indexonlyscan=on;
+EXPLAIN SELECT c, a FROM table_with_reversed_index WHERE a > 5;
+                                                                    QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.12..10000000008.16 rows=1 width=7)
+   ->  Index Only Scan using table_with_reversed_index_c_a_idx on table_with_reversed_index  (cost=10000000000.12..10000000008.14 rows=1 width=7)
+         Index Cond: (a > 5)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+SELECT c, a FROM table_with_reversed_index WHERE a > 5;
+ c  | a  
+----+----
+ ab | 10
+(1 row)
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+RESET optimizer_enable_tablescan;
+RESET optimizer_enable_indexscan;
+RESET optimizer_enable_indexonlyscan;

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -692,3 +692,42 @@ select * from shape_aocs where c && '<(5,5), 3>'::circle;
  <(0,0),5>
 (1 row)
 
+--
+-- Given a table with different column types
+--
+CREATE TABLE table_with_reversed_index(a int, b bool, c text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+--
+-- And it has an index that is ordered differently than columns on the table.
+--
+CREATE INDEX ON table_with_reversed_index(c, a);
+INSERT INTO table_with_reversed_index VALUES (10, true, 'ab');
+--
+-- Then an index only scan should succeed. (i.e. varattno is set up correctly)
+--
+SET enable_seqscan=off;
+SET enable_bitmapscan=off;
+SET optimizer_enable_tablescan=off;
+SET optimizer_enable_indexscan=off;
+SET optimizer_enable_indexonlyscan=on;
+EXPLAIN SELECT c, a FROM table_with_reversed_index WHERE a > 5;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.10 rows=1 width=7)
+   ->  Index Only Scan using table_with_reversed_index_c_a_idx on table_with_reversed_index  (cost=0.00..0.10 rows=1 width=7)
+         Index Cond: (a > 5)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+SELECT c, a FROM table_with_reversed_index WHERE a > 5;
+ c  | a  
+----+----
+ ab | 10
+(1 row)
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+RESET optimizer_enable_tablescan;
+RESET optimizer_enable_indexscan;
+RESET optimizer_enable_indexonlyscan;

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -315,3 +315,30 @@ select * from shape_aocs where c && '<(5,5), 2>'::circle;
 select * from shape_heap where c && '<(5,5), 3>'::circle;
 select * from shape_ao   where c && '<(5,5), 3>'::circle;
 select * from shape_aocs where c && '<(5,5), 3>'::circle;
+
+--
+-- Given a table with different column types
+--
+CREATE TABLE table_with_reversed_index(a int, b bool, c text);
+
+--
+-- And it has an index that is ordered differently than columns on the table.
+--
+CREATE INDEX ON table_with_reversed_index(c, a);
+INSERT INTO table_with_reversed_index VALUES (10, true, 'ab');
+
+--
+-- Then an index only scan should succeed. (i.e. varattno is set up correctly)
+--
+SET enable_seqscan=off;
+SET enable_bitmapscan=off;
+SET optimizer_enable_tablescan=off;
+SET optimizer_enable_indexscan=off;
+SET optimizer_enable_indexonlyscan=on;
+EXPLAIN SELECT c, a FROM table_with_reversed_index WHERE a > 5;
+SELECT c, a FROM table_with_reversed_index WHERE a > 5;
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+RESET optimizer_enable_tablescan;
+RESET optimizer_enable_indexscan;
+RESET optimizer_enable_indexonlyscan;


### PR DESCRIPTION
Add Orca support for index only scan
    
This commit allows Orca to select plans that leverage IndexOnlyScan
node. A new GUC 'optimizer_enable_indexonlyscan' is used to enable or
disable this feature. Index only scan is disabled by default, until the
following issues are addressed:
    
  1) Implement cost comparison model for index only scans. Currently,
     cost is hard coded for testing purposes.
  2) Support index only scan using GiST and SP-GiST as allowed.
     Currently, code only supports index only scans on b-tree index.
    
Co-authored-by: Chris Hajas <chajas@vmware.com>
(cherry picked from commit 3b72df1810411f4716137446f00b550378084835)