### PR TITLE
Correctly report instrumentation of zero-output node

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1430,7 +1430,7 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 	 * Executor memory used by this individual node, if it allocates from a
 	 * memory context of its own instead of sharing the per-query context.
 	 */
-	if (es->analyze && ns->execmemused.vcnt > 0)
+	if (es->analyze && ns->execmemused.vcnt > 0 && ns->execmemused.vmax > 0)
 	{
 		if (es->format == EXPLAIN_FORMAT_TEXT)
 		{

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1453,7 +1453,8 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 	/*
 	 * Actual work_mem used and wanted
 	 */
-	if (es->analyze && es->verbose && ns->workmemused.vcnt > 0)
+	if (es->analyze && es->verbose && ns->workmemused.vcnt > 0 &&
+		ns->workmemused.vmax > 0)
 	{
 		if (es->format == EXPLAIN_FORMAT_TEXT)
 		{
@@ -1474,7 +1475,7 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 
 			appendStringInfo(es->str, "\n");
 
-			if (ns->workmemwanted.vcnt > 0)
+			if (ns->workmemwanted.vcnt > 0 && ns->workmemwanted.vmax > 0)
 			{
 				appendStringInfoSpaces(es->str, es->indent * 2);
 				cdbexplain_formatMemory(maxbuf, sizeof(maxbuf), ns->workmemwanted.vmax);
@@ -1512,7 +1513,7 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 			if (nodeSupportWorkfileCaching(planstate))
 				ExplainPropertyInteger("Workfile Spilling", NULL, ns->totalWorkfileCreated.vcnt, es);
 
-			if (ns->workmemwanted.vcnt > 0)
+			if (ns->workmemwanted.vcnt > 0 && ns->workmemwanted.vmax > 0)
 			{
 				ExplainPropertyInteger("Max Memory Wanted", "kB", kb(ns->workmemwanted.vmax), es);
 

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -2505,7 +2505,7 @@ ExecHashTableExplainEnd(PlanState *planstate, struct StringInfoData *buf)
 
     /* Report hash chain statistics. */
     total_buckets = stats->nonemptybatches * hashtable->nbuckets;
-    if (total_buckets > 0)
+    if (total_buckets > 0 && stats->chainlength.vmax > 0)
     {
         appendStringInfo(buf,
                          "Hash chain length"

--- a/src/include/cdb/cdbexplain.h
+++ b/src/include/cdb/cdbexplain.h
@@ -43,13 +43,13 @@ cdbexplain_agg_init0(CdbExplain_Agg *agg)
 static inline bool
 cdbexplain_agg_upd(CdbExplain_Agg *agg, double v, int id)
 {
-    if (v > 0)
+    if (v >= 0)
     {
         agg->vsum += v;
         agg->vcnt++;
 
         if (v > agg->vmax ||
-            agg->vcnt == 0)
+            agg->vcnt == 1)
         {
             agg->vmax = v;
             agg->imax = id;

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -651,7 +651,7 @@ set enable_hashjoin=off;
 -- end_ignore
 explain (costs off, timing off, summary off, analyze) select * from t, pt where tid = ptid and pt1 = 'hello0';
                                                  QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
    ->  Nested Loop (actual rows=1 loops=1)
          Join Filter: (t.tid = pt_1_prt_2.ptid)
@@ -662,15 +662,15 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
                ->  Append (actual rows=1 loops=1)
                      ->  Index Scan using pt_1_prt_2_pt1_idx on pt_1_prt_2 (actual rows=1 loops=1)
                            Index Cond: (pt1 = 'hello0'::text)
-                     ->  Index Scan using pt_1_prt_3_pt1_idx on pt_1_prt_3 (never executed)
+                     ->  Index Scan using pt_1_prt_3_pt1_idx on pt_1_prt_3 (actual rows=0 loops=1)
                            Index Cond: (pt1 = 'hello0'::text)
-                     ->  Index Scan using pt_1_prt_4_pt1_idx on pt_1_prt_4 (never executed)
+                     ->  Index Scan using pt_1_prt_4_pt1_idx on pt_1_prt_4 (actual rows=0 loops=1)
                            Index Cond: (pt1 = 'hello0'::text)
-                     ->  Index Scan using pt_1_prt_5_pt1_idx on pt_1_prt_5 (never executed)
+                     ->  Index Scan using pt_1_prt_5_pt1_idx on pt_1_prt_5 (actual rows=0 loops=1)
                            Index Cond: (pt1 = 'hello0'::text)
-                     ->  Index Scan using pt_1_prt_6_pt1_idx on pt_1_prt_6 (never executed)
+                     ->  Index Scan using pt_1_prt_6_pt1_idx on pt_1_prt_6 (actual rows=0 loops=1)
                            Index Cond: (pt1 = 'hello0'::text)
-                     ->  Index Scan using pt_1_prt_junk_data_pt1_idx on pt_1_prt_junk_data (never executed)
+                     ->  Index Scan using pt_1_prt_junk_data_pt1_idx on pt_1_prt_junk_data (actual rows=0 loops=1)
                            Index Cond: (pt1 = 'hello0'::text)
  Optimizer: Postgres query optimizer
 (21 rows)
@@ -1019,10 +1019,12 @@ explain (costs off, timing off, summary off, analyze) select * from t1 inner joi
    ->  Hash Join (actual rows=1 loops=1)
          Hash Cond: ((pt1.dist = t1.dist) AND (pt1.ptid = t1.tid))
          Join Filter: ((t1.tid <= pt2.ptid) AND (pt1.ptid <= t1.tid))
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 131072 buckets.
          Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 131072 buckets.
          ->  Hash Join (actual rows=3 loops=1)
                Hash Cond: ((pt1.dist = pt2.dist) AND (pt1.ptid = pt2.ptid))
                Join Filter: (pt1.ptid <= pt2.ptid)
+               Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 14 of 262144 buckets.
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 14 of 262144 buckets.
                ->  Append (actual rows=3 loops=1)
                      Partition Selectors: $0, $1
@@ -1084,18 +1086,23 @@ explain (costs off, timing off, summary off, analyze) select * from pt, pt1 wher
                                        ->  Seq Scan on pt_1_prt_2 (actual rows=1 loops=1)
                                              Filter: (pt1 = 'hello0'::text)
                                              Rows Removed by Filter: 4
-                                       ->  Seq Scan on pt_1_prt_3 (never executed)
+                                       ->  Seq Scan on pt_1_prt_3 (actual rows=0 loops=1)
                                              Filter: (pt1 = 'hello0'::text)
-                                       ->  Seq Scan on pt_1_prt_4 (never executed)
+                                             Rows Removed by Filter: 3
+                                       ->  Seq Scan on pt_1_prt_4 (actual rows=0 loops=1)
                                              Filter: (pt1 = 'hello0'::text)
-                                       ->  Seq Scan on pt_1_prt_5 (never executed)
+                                             Rows Removed by Filter: 2
+                                       ->  Seq Scan on pt_1_prt_5 (actual rows=0 loops=1)
                                              Filter: (pt1 = 'hello0'::text)
-                                       ->  Seq Scan on pt_1_prt_6 (never executed)
+                                             Rows Removed by Filter: 5
+                                       ->  Seq Scan on pt_1_prt_6 (actual rows=0 loops=1)
                                              Filter: (pt1 = 'hello0'::text)
-                                       ->  Seq Scan on pt_1_prt_junk_data (never executed)
+                                             Rows Removed by Filter: 4
+                                       ->  Seq Scan on pt_1_prt_junk_data (actual rows=0 loops=1)
                                              Filter: (pt1 = 'hello0'::text)
+                                             Rows Removed by Filter: 3
  Optimizer: Postgres query optimizer
-(34 rows)
+(41 rows)
 
 select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' order by pt1.dist;
  dist |  pt1   |  pt2  |    pt3    | ptid | dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -1136,18 +1143,23 @@ explain (costs off, timing off, summary off, analyze) select count(*) from pt, p
                                              ->  Seq Scan on pt_1_prt_2 (actual rows=1 loops=1)
                                                    Filter: (pt1 = 'hello0'::text)
                                                    Rows Removed by Filter: 4
-                                             ->  Seq Scan on pt_1_prt_3 (never executed)
+                                             ->  Seq Scan on pt_1_prt_3 (actual rows=0 loops=1)
                                                    Filter: (pt1 = 'hello0'::text)
-                                             ->  Seq Scan on pt_1_prt_4 (never executed)
+                                                   Rows Removed by Filter: 3
+                                             ->  Seq Scan on pt_1_prt_4 (actual rows=0 loops=1)
                                                    Filter: (pt1 = 'hello0'::text)
-                                             ->  Seq Scan on pt_1_prt_5 (never executed)
+                                                   Rows Removed by Filter: 2
+                                             ->  Seq Scan on pt_1_prt_5 (actual rows=0 loops=1)
                                                    Filter: (pt1 = 'hello0'::text)
-                                             ->  Seq Scan on pt_1_prt_6 (never executed)
+                                                   Rows Removed by Filter: 5
+                                             ->  Seq Scan on pt_1_prt_6 (actual rows=0 loops=1)
                                                    Filter: (pt1 = 'hello0'::text)
-                                             ->  Seq Scan on pt_1_prt_junk_data (never executed)
+                                                   Rows Removed by Filter: 4
+                                             ->  Seq Scan on pt_1_prt_junk_data (actual rows=0 loops=1)
                                                    Filter: (pt1 = 'hello0'::text)
+                                                   Rows Removed by Filter: 3
  Optimizer: Postgres query optimizer
-(32 rows)
+(38 rows)
 
 select count(*) from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0';
  count 
@@ -1230,9 +1242,9 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Nested Loop (never executed)
+   ->  Nested Loop (actual rows=0 loops=1)
          Join Filter: (t.a = pt_1_prt_1.b)
-         ->  Append (never executed)
+         ->  Append (actual rows=0 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt_1_prt_1 (never executed)
                ->  Seq Scan on pt_1_prt_2 (never executed)
@@ -1304,16 +1316,16 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
                ->  Append (actual rows=200 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_1_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_1_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_2_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_2_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_2_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_2_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_3_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_3_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_4_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_4_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_4_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_4_2_prt_wa (actual rows=0 loops=1)
                ->  Hash (actual rows=3 loops=1)
                      Buckets: 131072  Batches: 1  Memory Usage: 1025kB
                      ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=3 loops=1)
@@ -1472,7 +1484,7 @@ select * from dim1 inner join fact1 on (dim1.pid=fact1.pid and dim1.code=fact1.c
 set gp_dynamic_partition_pruning=off;
 explain (costs off, timing off, summary off, analyze) select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) order by fact1.u;
                                          QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=100 loops=1)
    Merge Key: fact1_1_prt_1_2_prt_ca.u
    ->  Sort (actual rows=100 loops=1)
@@ -1485,22 +1497,22 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
                ->  Append (actual rows=200 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_1_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_1_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_2_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_2_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_2_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_2_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_3_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_3_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_4_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_4_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_4_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_4_2_prt_wa (actual rows=0 loops=1)
                ->  Hash (actual rows=3 loops=1)
                      Buckets: 131072  Batches: 1  Memory Usage: 1025kB
                      ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=3 loops=1)
                            ->  Seq Scan on dim1 (actual rows=3 loops=1)
  Optimizer: Postgres query optimizer
-(25 rows)
+(27 rows)
 
 select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) order by fact1.u;
  dist | pid | code |   t1   | dist | pid | code |   u   
@@ -1624,10 +1636,10 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
                      Partition Selectors: $0
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_1_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_1_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_2_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_2_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_2_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_2_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_ca (never executed)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_oh (never executed)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_wa (never executed)
@@ -1640,7 +1652,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
                            ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=3 loops=1)
                                  ->  Seq Scan on dim1 (actual rows=3 loops=1)
  Optimizer: Postgres query optimizer
-(27 rows)
+(29 rows)
 
 select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) order by fact1.u;
  dist | pid | code |   t1   | dist | pid | code |   u   
@@ -1762,21 +1774,21 @@ select * from dim1 inner join fact1 on (dim1.dist = fact1.dist and dim1.code=fac
          ->  Append (actual rows=200 loops=1)
                ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
-               ->  Seq Scan on fact1_1_prt_1_2_prt_wa (never executed)
+               ->  Seq Scan on fact1_1_prt_1_2_prt_wa (actual rows=0 loops=1)
                ->  Seq Scan on fact1_1_prt_2_2_prt_ca (actual rows=25 loops=1)
                ->  Seq Scan on fact1_1_prt_2_2_prt_oh (actual rows=25 loops=1)
-               ->  Seq Scan on fact1_1_prt_2_2_prt_wa (never executed)
+               ->  Seq Scan on fact1_1_prt_2_2_prt_wa (actual rows=0 loops=1)
                ->  Seq Scan on fact1_1_prt_3_2_prt_ca (actual rows=25 loops=1)
                ->  Seq Scan on fact1_1_prt_3_2_prt_oh (actual rows=25 loops=1)
-               ->  Seq Scan on fact1_1_prt_3_2_prt_wa (never executed)
+               ->  Seq Scan on fact1_1_prt_3_2_prt_wa (actual rows=0 loops=1)
                ->  Seq Scan on fact1_1_prt_4_2_prt_ca (actual rows=25 loops=1)
                ->  Seq Scan on fact1_1_prt_4_2_prt_oh (actual rows=25 loops=1)
-               ->  Seq Scan on fact1_1_prt_4_2_prt_wa (never executed)
+               ->  Seq Scan on fact1_1_prt_4_2_prt_wa (actual rows=0 loops=1)
          ->  Hash (actual rows=3 loops=1)
                Buckets: 262144  Batches: 1  Memory Usage: 2049kB
                ->  Seq Scan on dim1 (actual rows=3 loops=1)
  Optimizer: Postgres query optimizer
-(20 rows)
+(21 rows)
 
 select * from dim1 inner join fact1 on (dim1.dist = fact1.dist and dim1.code=fact1.code);
  dist | pid | code |   t1   | dist | pid | code |  u  
@@ -2397,7 +2409,7 @@ select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) and fact1.code = 'OH
 set gp_dynamic_partition_pruning=off;
 explain (costs off, timing off, summary off, analyze) select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
                                                QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
    Merge Key: fact1_1_prt_1_2_prt_ca.code
    ->  GroupAggregate (actual rows=2 loops=1)
@@ -2414,22 +2426,22 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
                            ->  Append (actual rows=200 loops=1)
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
-                                 ->  Seq Scan on fact1_1_prt_1_2_prt_wa (never executed)
+                                 ->  Seq Scan on fact1_1_prt_1_2_prt_wa (actual rows=0 loops=1)
                                  ->  Seq Scan on fact1_1_prt_2_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_2_2_prt_oh (actual rows=25 loops=1)
-                                 ->  Seq Scan on fact1_1_prt_2_2_prt_wa (never executed)
+                                 ->  Seq Scan on fact1_1_prt_2_2_prt_wa (actual rows=0 loops=1)
                                  ->  Seq Scan on fact1_1_prt_3_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_3_2_prt_oh (actual rows=25 loops=1)
-                                 ->  Seq Scan on fact1_1_prt_3_2_prt_wa (never executed)
+                                 ->  Seq Scan on fact1_1_prt_3_2_prt_wa (actual rows=0 loops=1)
                                  ->  Seq Scan on fact1_1_prt_4_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_4_2_prt_oh (actual rows=25 loops=1)
-                                 ->  Seq Scan on fact1_1_prt_4_2_prt_wa (never executed)
+                                 ->  Seq Scan on fact1_1_prt_4_2_prt_wa (actual rows=0 loops=1)
                            ->  Hash (actual rows=3 loops=1)
                                  Buckets: 262144  Batches: 1  Memory Usage: 2049kB
                                  ->  Broadcast Motion 3:3  (slice3; segments: 3) (actual rows=3 loops=1)
                                        ->  Seq Scan on dim1 (actual rows=3 loops=1)
  Optimizer: Postgres query optimizer
-(29 rows)
+(31 rows)
 
 select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
  code | count 
@@ -2459,10 +2471,10 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
                                  Partition Selectors: $0
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
-                                 ->  Seq Scan on fact1_1_prt_1_2_prt_wa (never executed)
+                                 ->  Seq Scan on fact1_1_prt_1_2_prt_wa (actual rows=0 loops=1)
                                  ->  Seq Scan on fact1_1_prt_2_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_2_2_prt_oh (actual rows=25 loops=1)
-                                 ->  Seq Scan on fact1_1_prt_2_2_prt_wa (never executed)
+                                 ->  Seq Scan on fact1_1_prt_2_2_prt_wa (actual rows=0 loops=1)
                                  ->  Seq Scan on fact1_1_prt_3_2_prt_ca (never executed)
                                  ->  Seq Scan on fact1_1_prt_3_2_prt_oh (never executed)
                                  ->  Seq Scan on fact1_1_prt_3_2_prt_wa (never executed)
@@ -2475,7 +2487,7 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
                                        ->  Broadcast Motion 3:3  (slice3; segments: 3) (actual rows=3 loops=1)
                                              ->  Seq Scan on dim1 (actual rows=3 loops=1)
  Optimizer: Postgres query optimizer
-(31 rows)
+(33 rows)
 
 select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
  code | count 

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -907,12 +907,12 @@ explain (costs off, timing off, summary off, analyze) select * from t1 inner joi
                      Index Cond: (ptid = t1.tid)
                      Filter: ((ptid = t1.tid) AND (t1.dist = dist))
                      Number of partitions to scan: 6 
-                     Partitions scanned:  Avg 6.0 x 2 workers.  Max 6 parts (seg0).
+                     Partitions scanned:  Avg 4.0 x 3 workers.  Max 6 parts (seg0).
          ->  Dynamic Index Scan on ptid_idx on pt pt_1 (actual rows=1 loops=1)
                Index Cond: ((ptid <= pt.ptid) AND (ptid = pt.ptid))
                Filter: ((ptid <= pt.ptid) AND (ptid = pt.ptid) AND (dist = pt.dist))
                Number of partitions to scan: 6 
-               Partitions scanned:  Avg 6.0 x 2 workers.  Max 6 parts (seg0).
+               Partitions scanned:  Avg 4.0 x 3 workers.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (17 rows)
 
@@ -945,7 +945,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt, pt1 wher
                                        Number of partitions to scan: 6 
                                        Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(21 rows)
 
 select * from pt, pt1 where pt.ptid = pt1.ptid and pt.pt1 = 'hello0' order by pt1.dist;
  dist |  pt1   |  pt2  |    pt3    | ptid | dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -1064,18 +1064,19 @@ analyze t;
 analyze pt;
 explain (costs off, timing off, summary off, analyze) select * from t, pt where a = b;
                                    QUERY PLAN                                   
---------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Hash Join (never executed)
+   ->  Hash Join (actual rows=0 loops=1)
          Hash Cond: (pt.b = t.a)
-         ->  Dynamic Seq Scan on pt (never executed)
+         Extra Text: (seg0)   Hash chain length 2.0 avg, 2 max, using 2 of 524288 buckets.
+         ->  Dynamic Seq Scan on pt (actual rows=0 loops=1)
                Number of partitions to scan: 5 
          ->  Hash (actual rows=4 loops=1)
                Buckets: 524288  Batches: 1  Memory Usage: 4097kB
                ->  Partition Selector (selector id: $0) (actual rows=4 loops=1)
                      ->  Seq Scan on t (actual rows=4 loops=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(11 rows)
 
 select * from t, pt where a = b;
  a | b 
@@ -1136,22 +1137,22 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
                ->  Append (actual rows=200 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_1_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_1_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_2_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_2_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_2_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_2_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_3_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_3_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_4_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_4_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_4_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_4_2_prt_wa (actual rows=0 loops=1)
                ->  Hash (actual rows=3 loops=1)
                      Buckets: 131072  Batches: 1  Memory Usage: 1025kB
                      ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=3 loops=1)
                            ->  Seq Scan on dim1 (actual rows=3 loops=1)
  Optimizer: Postgres query optimizer
-(25 rows)
+(27 rows)
 
 select * from dim1 inner join fact1 on (dim1.pid=fact1.pid and dim1.code=fact1.code) order by fact1.u;
  dist | pid | code |   t1   | dist | pid | code |  u  
@@ -1304,7 +1305,7 @@ select * from dim1 inner join fact1 on (dim1.pid=fact1.pid and dim1.code=fact1.c
 set gp_dynamic_partition_pruning=off;
 explain (costs off, timing off, summary off, analyze) select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) order by fact1.u;
                                          QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=100 loops=1)
    Merge Key: fact1_1_prt_1_2_prt_ca.u
    ->  Sort (actual rows=100 loops=1)
@@ -1317,22 +1318,22 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
                ->  Append (actual rows=200 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_1_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_1_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_2_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_2_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_2_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_2_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_3_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_3_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_4_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_4_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_4_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_4_2_prt_wa (actual rows=0 loops=1)
                ->  Hash (actual rows=3 loops=1)
                      Buckets: 131072  Batches: 1  Memory Usage: 1025kB
                      ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=3 loops=1)
                            ->  Seq Scan on dim1 (actual rows=3 loops=1)
  Optimizer: Postgres query optimizer
-(25 rows)
+(27 rows)
 
 select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) order by fact1.u;
  dist | pid | code |   t1   | dist | pid | code |   u   
@@ -1456,10 +1457,10 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
                      Partition Selectors: $0
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_1_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_1_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_2_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_2_2_prt_oh (actual rows=25 loops=1)
-                     ->  Seq Scan on fact1_1_prt_2_2_prt_wa (never executed)
+                     ->  Seq Scan on fact1_1_prt_2_2_prt_wa (actual rows=0 loops=1)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_ca (never executed)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_oh (never executed)
                      ->  Seq Scan on fact1_1_prt_3_2_prt_wa (never executed)
@@ -1472,7 +1473,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
                            ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=3 loops=1)
                                  ->  Seq Scan on dim1 (actual rows=3 loops=1)
  Optimizer: Postgres query optimizer
-(27 rows)
+(29 rows)
 
 select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) order by fact1.u;
  dist | pid | code |   t1   | dist | pid | code |   u   
@@ -1594,21 +1595,21 @@ select * from dim1 inner join fact1 on (dim1.dist = fact1.dist and dim1.code=fac
          ->  Append (actual rows=200 loops=1)
                ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
-               ->  Seq Scan on fact1_1_prt_1_2_prt_wa (never executed)
+               ->  Seq Scan on fact1_1_prt_1_2_prt_wa (actual rows=0 loops=1)
                ->  Seq Scan on fact1_1_prt_2_2_prt_ca (actual rows=25 loops=1)
                ->  Seq Scan on fact1_1_prt_2_2_prt_oh (actual rows=25 loops=1)
-               ->  Seq Scan on fact1_1_prt_2_2_prt_wa (never executed)
+               ->  Seq Scan on fact1_1_prt_2_2_prt_wa (actual rows=0 loops=1)
                ->  Seq Scan on fact1_1_prt_3_2_prt_ca (actual rows=25 loops=1)
                ->  Seq Scan on fact1_1_prt_3_2_prt_oh (actual rows=25 loops=1)
-               ->  Seq Scan on fact1_1_prt_3_2_prt_wa (never executed)
+               ->  Seq Scan on fact1_1_prt_3_2_prt_wa (actual rows=0 loops=1)
                ->  Seq Scan on fact1_1_prt_4_2_prt_ca (actual rows=25 loops=1)
                ->  Seq Scan on fact1_1_prt_4_2_prt_oh (actual rows=25 loops=1)
-               ->  Seq Scan on fact1_1_prt_4_2_prt_wa (never executed)
+               ->  Seq Scan on fact1_1_prt_4_2_prt_wa (actual rows=0 loops=1)
          ->  Hash (actual rows=3 loops=1)
                Buckets: 262144  Batches: 1  Memory Usage: 2049kB
                ->  Seq Scan on dim1 (actual rows=3 loops=1)
  Optimizer: Postgres query optimizer
-(20 rows)
+(21 rows)
 
 select * from dim1 inner join fact1 on (dim1.dist = fact1.dist and dim1.code=fact1.code);
  dist | pid | code |   t1   | dist | pid | code |  u  
@@ -2229,7 +2230,7 @@ select * from dim1 inner join fact1 on (dim1.pid=fact1.pid) and fact1.code = 'OH
 set gp_dynamic_partition_pruning=off;
 explain (costs off, timing off, summary off, analyze) select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
                                                QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
    Merge Key: fact1_1_prt_1_2_prt_ca.code
    ->  GroupAggregate (actual rows=2 loops=1)
@@ -2246,22 +2247,22 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
                            ->  Append (actual rows=200 loops=1)
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
-                                 ->  Seq Scan on fact1_1_prt_1_2_prt_wa (never executed)
+                                 ->  Seq Scan on fact1_1_prt_1_2_prt_wa (actual rows=0 loops=1)
                                  ->  Seq Scan on fact1_1_prt_2_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_2_2_prt_oh (actual rows=25 loops=1)
-                                 ->  Seq Scan on fact1_1_prt_2_2_prt_wa (never executed)
+                                 ->  Seq Scan on fact1_1_prt_2_2_prt_wa (actual rows=0 loops=1)
                                  ->  Seq Scan on fact1_1_prt_3_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_3_2_prt_oh (actual rows=25 loops=1)
-                                 ->  Seq Scan on fact1_1_prt_3_2_prt_wa (never executed)
+                                 ->  Seq Scan on fact1_1_prt_3_2_prt_wa (actual rows=0 loops=1)
                                  ->  Seq Scan on fact1_1_prt_4_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_4_2_prt_oh (actual rows=25 loops=1)
-                                 ->  Seq Scan on fact1_1_prt_4_2_prt_wa (never executed)
+                                 ->  Seq Scan on fact1_1_prt_4_2_prt_wa (actual rows=0 loops=1)
                            ->  Hash (actual rows=3 loops=1)
                                  Buckets: 262144  Batches: 1  Memory Usage: 2049kB
                                  ->  Broadcast Motion 3:3  (slice3; segments: 3) (actual rows=3 loops=1)
                                        ->  Seq Scan on dim1 (actual rows=3 loops=1)
  Optimizer: Postgres query optimizer
-(29 rows)
+(31 rows)
 
 select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
  code | count 
@@ -2291,10 +2292,10 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
                                  Partition Selectors: $0
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
-                                 ->  Seq Scan on fact1_1_prt_1_2_prt_wa (never executed)
+                                 ->  Seq Scan on fact1_1_prt_1_2_prt_wa (actual rows=0 loops=1)
                                  ->  Seq Scan on fact1_1_prt_2_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_2_2_prt_oh (actual rows=25 loops=1)
-                                 ->  Seq Scan on fact1_1_prt_2_2_prt_wa (never executed)
+                                 ->  Seq Scan on fact1_1_prt_2_2_prt_wa (actual rows=0 loops=1)
                                  ->  Seq Scan on fact1_1_prt_3_2_prt_ca (never executed)
                                  ->  Seq Scan on fact1_1_prt_3_2_prt_oh (never executed)
                                  ->  Seq Scan on fact1_1_prt_3_2_prt_wa (never executed)
@@ -2307,7 +2308,7 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
                                        ->  Broadcast Motion 3:3  (slice3; segments: 3) (actual rows=3 loops=1)
                                              ->  Seq Scan on dim1 (actual rows=3 loops=1)
  Optimizer: Postgres query optimizer
-(31 rows)
+(33 rows)
 
 select fact1.code, count(*) from dim1 inner join fact1 on (dim1.pid=fact1.pid) group by 1 order by 1;
  code | count 
@@ -2695,7 +2696,7 @@ analyze pt;
 explain (analyze, costs off, timing off, summary off)
 select * from pt, t where t.dist = pt.dist and t.tid < pt.ptid;
                                    QUERY PLAN                                   
---------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=11 loops=1)
    ->  Hash Join (actual rows=11 loops=1)
          Hash Cond: (pt.dist = t.dist)
@@ -2704,13 +2705,13 @@ select * from pt, t where t.dist = pt.dist and t.tid < pt.ptid;
          Extra Text: (seg1)   Hash chain length 2.0 avg, 2 max, using 1 of 524288 buckets.
          ->  Dynamic Seq Scan on pt (actual rows=7 loops=1)
                Number of partitions to scan: 6 
-               Partitions scanned:  4  (seg1).
+               Partitions scanned:  Avg 1.3 x 3 workers.  Max 4 parts (seg1).
          ->  Hash (actual rows=2 loops=1)
                Buckets: 524288  Batches: 1  Memory Usage: 4097kB
                ->  Partition Selector (selector id: $0) (actual rows=2 loops=1)
                      ->  Seq Scan on t (actual rows=2 loops=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(14 rows)
 
 --
 -- Test join pruning with a MergeAppend

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -1,9 +1,3 @@
--- GPDB_MERGE_12_FIXME: replace the match ignores with SUMMARY OFF
--- start_matchignore
--- m/Execution time: \d+\.\d+ ms/
--- m/Planning time: \d+\.\d+ ms/
--- m/Memory used:  \d+\w?B/
--- end_matchignore
 CREATE TEMP TABLE empty_table(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -11,17 +5,12 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 -- from every segment. This was misleading because "never executed" should
 -- indicate that the node was never executed by its parent.
 -- explain_processing_off
-EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table;
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT a FROM empty_table;
                                    QUERY PLAN                                    
----------------------------------------------------------------------------------
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Seq Scan on empty_table (actual rows=0 loops=1)
- Planning time: 21.532 ms
-   (slice0)    Executor memory: 36K bytes.
-   (slice1)    Executor memory: 35K bytes avg x 3 workers, 35K bytes max (seg0).
- Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA)
- Execution time: 1.045 ms
-(8 rows)
+(3 rows)
 
 -- explain_processing_on

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -2,6 +2,7 @@
 -- start_matchignore
 -- m/Execution time: \d+\.\d+ ms/
 -- m/Planning time: \d+\.\d+ ms/
+-- m/Memory used:  \d+\w?B/
 -- end_matchignore
 CREATE TEMP TABLE empty_table(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -14,9 +14,7 @@ EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   Executor Memory: 0kB  Segments: 1  Max: 0kB (segment -1)
    ->  Seq Scan on empty_table (actual rows=0 loops=1)
-         Executor Memory: 0kB  Segments: 3  Max: 0kB (segment 0)
  Planning time: 21.532 ms
    (slice0)    Executor memory: 36K bytes.
    (slice1)    Executor memory: 35K bytes avg x 3 workers, 35K bytes max (seg0).

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -1,0 +1,28 @@
+-- GPDB_MERGE_12_FIXME: replace the match ignores with SUMMARY OFF
+-- start_matchignore
+-- m/Execution time: \d+\.\d+ ms/
+-- m/Planning time: \d+\.\d+ ms/
+-- end_matchignore
+CREATE TEMP TABLE empty_table(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- We used to incorrectly report "never executed" for a node that returns 0 rows
+-- from every segment. This was misleading because "never executed" should
+-- indicate that the node was never executed by its parent.
+-- explain_processing_off
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   Executor Memory: 0kB  Segments: 1  Max: 0kB (segment -1)
+   ->  Seq Scan on empty_table (actual rows=0 loops=1)
+         Executor Memory: 0kB  Segments: 3  Max: 0kB (segment 0)
+ Planning time: 21.532 ms
+   (slice0)    Executor memory: 36K bytes.
+   (slice1)    Executor memory: 35K bytes avg x 3 workers, 35K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 1.045 ms
+(8 rows)
+
+-- explain_processing_on

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -9,8 +9,8 @@
 -- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
 -- m/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/
 -- s/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/Memory: ###kB  Max Memory: ###kB  Peak Memory: ###kB  Avg Memory: ###kB \(3 segments\)/
--- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/
--- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(0 spilling\)/
+-- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(\d+ spilling\)/
+-- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(\d+ spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(# spilling\)/
 -- m/Execution Time: \d+\.\d+ ms/
 -- s/Execution Time: \d+\.\d+ ms/Execution Time: ##.### ms/
 -- m/Planning Time: \d+\.\d+ ms/
@@ -27,6 +27,8 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Hash chain length \d+\.\d+ avg, \d+ max, using \d+ of \d+ buckets./
+-- s/Hash chain length \d+\.\d+ avg, \d+ max, using \d+ of \d+ buckets./Hash chain length ###, using ### of ### buckets./
 -- end_matchsubs
 --
 -- DEFAULT syntax
@@ -63,23 +65,24 @@ EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT 
 -- explain_processing_off
 EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                                                                 QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=3577.00..11272.25 rows=77900 width=84) (actual time=45.646..45.646 rows=0 loops=1)
-   ->  Hash Left Join  (cost=3577.00..9714.25 rows=25967 width=84) (never executed)
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=812.00..3838.66 rows=77900 width=84) (actual time=13.111..13.111 rows=0 loops=1)
+   ->  Hash Left Join  (cost=812.00..2799.99 rows=25967 width=84) (actual time=12.667..12.667 rows=0 loops=1)
          Hash Cond: (boxes.location_id = box_locations.id)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2361.00..7427.12 rows=25967 width=48) (never executed)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=406.00..2066.16 rows=25967 width=48) (actual time=11.577..11.577 rows=0 loops=1)
                Hash Key: boxes.location_id
-               ->  Hash Left Join  (cost=2361.00..5869.12 rows=25967 width=48) (never executed)
+               ->  Hash Left Join  (cost=406.00..1546.83 rows=25967 width=48) (actual time=11.160..11.160 rows=0 loops=1)
                      Hash Cond: (boxes.apple_id = apples.id)
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12) (never executed)
+                     Extra Text: (seg0)   Hash chain length 1.1 avg, 4 max, using 29560 of 131072 buckets.
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..813.00 rows=25967 width=12) (actual time=0.003..0.003 rows=0 loops=1)
                            Hash Key: boxes.apple_id
-                           ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12) (never executed)
-                     ->  Hash  (cost=1111.00..1111.00 rows=33334 width=36) (actual time=39.093..39.093 rows=33462 loops=1)
-                           Buckets: 131072  Batches: 1  Memory Usage: 2332kB
-                           ->  Seq Scan on apples  (cost=0.00..1111.00 rows=33334 width=36) (actual time=0.075..10.163 rows=33462 loops=1)
-         ->  Hash  (cost=596.00..596.00 rows=16534 width=36) (never executed)
+                           ->  Seq Scan on boxes  (cost=0.00..293.67 rows=25967 width=12) (actual time=0.007..0.007 rows=0 loops=1)
+                     ->  Hash  (cost=199.33..199.33 rows=16533 width=36) (actual time=9.505..9.505 rows=33462 loops=1)
+                           Buckets: 131072  Batches: 1  Memory Usage: 2201kB
+                           ->  Seq Scan on apples  (cost=0.00..199.33 rows=16533 width=36) (actual time=0.023..3.126 rows=33462 loops=1)
+         ->  Hash  (cost=199.33..199.33 rows=16533 width=36) (actual time=0.011..0.011 rows=0 loops=1)
                Buckets: 131072  Batches: 1  Memory Usage: 1024kB
-               ->  Seq Scan on box_locations  (cost=0.00..596.00 rows=16534 width=36) (never executed)
+               ->  Seq Scan on box_locations  (cost=0.00..199.33 rows=16533 width=36) (actual time=0.010..0.010 rows=0 loops=1)
  Planning Time: 2.219 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 1104K bytes avg x 3 workers, 1104K bytes max (seg0).  Work_mem: 1024K bytes max.
@@ -419,6 +422,8 @@ QUERY PLAN
                 Actual Loops: 0
                 Inner Unique: true
                 Hash Cond: "(boxes.apple_id = apples.id)"
+                Extra Text: 
+                  - Extra Text: "(seg0)   Hash chain length 1.1 avg, 4 max, using 29560 of 131072 buckets."
                 Plans: 
                   - Node Type: "Redistribute Motion"
                     Senders: 3
@@ -563,13 +568,13 @@ QUERY PLAN
 Gather Motion 3:1  (slice1; segments: 3)  (cost=2197.59..3301.17 rows=77900 width=12) (actual time=0.380..0.380 rows=0 loops=1)
   Output: id, apple_id, location_id
   Merge Key: apple_id
-  ->  Sort  (cost=2197.59..2262.51 rows=25967 width=12) (never executed)
+  ->  Sort  (cost=2197.59..2262.51 rows=25967 width=12) (actual time=0.071..0.071 rows=0 loops=1)
         Output: id, apple_id, location_id
         Sort Key: boxes.apple_id
         Sort Method:  quicksort  Memory: 75kB  Max Memory: 25kB  Avg Memory: 25kB (3 segments)
         Executor Memory: 177kB  Segments: 3  Max: 59kB (segment 0)
-        work_mem: 177kB  Segments: 3  Max: 59kB (segment 0)  Workfile: (0 spilling)
-        ->  Seq Scan on public.boxes  (cost=0.00..293.67 rows=25967 width=12) (never executed)
+        work_mem: 177kB  Segments: 3  Max: 59kB (segment 0)  Workfile: (3 spilling)
+        ->  Seq Scan on public.boxes  (cost=0.00..293.67 rows=25967 width=12) (actual time=0.010..0.010 rows=0 loops=1)
               Output: id, apple_id, location_id
 Optimizer: Postgres query optimizer
 Settings: cpu_index_tuple_cost = '0.1', optimizer = 'off', random_page_cost = '1'

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -9,8 +9,8 @@
 -- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
 -- m/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/
 -- s/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/Memory: ###kB  Max Memory: ###kB  Peak Memory: ###kB  Avg Memory: ###kB \(3 segments\)/
--- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/
--- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(0 spilling\)/
+-- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(\d+ spilling\)/
+-- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(\d+ spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(# spilling\)/
 -- m/Execution Time: \d+\.\d+ ms/
 -- s/Execution Time: \d+\.\d+ ms/Execution Time: ##.### ms/
 -- m/Planning Time: \d+\.\d+ ms/
@@ -27,6 +27,8 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Hash chain length \d+\.\d+ avg, \d+ max, using \d+ of \d+ buckets./
+-- s/Hash chain length \d+\.\d+ avg, \d+ max, using \d+ of \d+ buckets./Hash chain length ###, using ### of ### buckets./
 -- end_matchsubs
 --
 -- DEFAULT syntax
@@ -63,17 +65,17 @@ EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT 
 -- explain_processing_off
 EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
                                                             QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..449.00 rows=3 width=36) (actual time=2.753..2.753 rows=0 loops=1)
-   ->  Nested Loop Left Join  (cost=0.00..449.00 rows=1 width=36) (never executed)
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..449.00 rows=3 width=36) (actual time=1.894..1.894 rows=0 loops=1)
+   ->  Nested Loop Left Join  (cost=0.00..449.00 rows=1 width=36) (actual time=1.391..1.391 rows=0 loops=1)
          Join Filter: true
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..437.00 rows=1 width=24) (never executed)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..437.00 rows=1 width=24) (actual time=1.362..1.362 rows=0 loops=1)
                Hash Key: boxes.apple_id
-               ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=24) (never executed)
+               ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=24) (actual time=0.384..0.384 rows=0 loops=1)
                      Join Filter: true
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12) (never executed)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12) (actual time=0.380..0.380 rows=0 loops=1)
                            Hash Key: boxes.location_id
-                           ->  Seq Scan on boxes  (cost=0.00..431.00 rows=1 width=12) (never executed)
+                           ->  Seq Scan on boxes  (cost=0.00..431.00 rows=1 width=12) (actual time=0.006..0.006 rows=0 loops=1)
                      ->  Index Scan using box_locations_pkey on box_locations  (cost=0.00..6.00 rows=1 width=12) (never executed)
                            Index Cond: (id = boxes.location_id)
          ->  Index Scan using apples_pkey on apples  (cost=0.00..12.00 rows=1 width=12) (never executed)
@@ -511,13 +513,13 @@ QUERY PLAN
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12) (actual time=0.388..0.388 rows=0 loops=1)
   Output: id, apple_id, location_id
   Merge Key: apple_id
-  ->  Sort  (cost=0.00..431.00 rows=1 width=12) (never executed)
+  ->  Sort  (cost=0.00..431.00 rows=1 width=12) (actual time=0.065..0.065 rows=0 loops=1)
         Output: id, apple_id, location_id
         Sort Key: boxes.apple_id
         Sort Method:  quicksort  Memory: 75kB  Max Memory: 25kB  Avg Memory: 25kB (3 segments)
         Executor Memory: 177kB  Segments: 3  Max: 59kB (segment 0)
-        work_mem: 177kB  Segments: 3  Max: 59kB (segment 0)  Workfile: (0 spilling)
-        ->  Seq Scan on public.boxes  (cost=0.00..431.00 rows=1 width=12) (never executed)
+        work_mem: 177kB  Segments: 3  Max: 59kB (segment 0)  Workfile: (3 spilling)
+        ->  Seq Scan on public.boxes  (cost=0.00..431.00 rows=1 width=12) (actual time=0.011..0.011 rows=0 loops=1)
               Output: id, apple_id, location_id
 Optimizer: Pivotal Optimizer (GPORCA)
 Settings: cpu_index_tuple_cost = '0.1', random_page_cost = '1'

--- a/src/test/regress/expected/partition_prune.out
+++ b/src/test/regress/expected/partition_prune.out
@@ -1900,13 +1900,13 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 2, 3);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 6
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b2 (never executed)
+         ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b3 (never executed)
+         ->  Seq Scan on ab_a2_b3 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
  Optimizer: Postgres query optimizer
 (10 rows)
@@ -1915,19 +1915,19 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (1, 2, 3);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 3
-         ->  Seq Scan on ab_a1_b1 (never executed)
+         ->  Seq Scan on ab_a1_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a1_b2 (never executed)
+         ->  Seq Scan on ab_a1_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a1_b3 (never executed)
+         ->  Seq Scan on ab_a1_b3 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b2 (never executed)
+         ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b3 (never executed)
+         ->  Seq Scan on ab_a2_b3 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
  Optimizer: Postgres query optimizer
 (16 rows)
@@ -1940,11 +1940,11 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 2);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 4
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a2_b2 (never executed)
+         ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
  Optimizer: Postgres query optimizer
 (8 rows)
@@ -1953,15 +1953,15 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 4);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 2
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a2_b2 (never executed)
+         ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a3_b1 (never executed)
+         ->  Seq Scan on ab_a3_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a3_b2 (never executed)
+         ->  Seq Scan on ab_a3_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -1976,11 +1976,11 @@ explain (analyze, costs off, summary off, timing off) execute ab_q2 (2, 2);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 6
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
-         ->  Seq Scan on ab_a2_b2 (never executed)
+         ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
          ->  Seq Scan on ab_a2_b3 (never executed)
                Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
@@ -1996,11 +1996,11 @@ explain (analyze, costs off, summary off, timing off) execute ab_q3 (2, 2);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 6
-         ->  Seq Scan on ab_a1_b2 (never executed)
+         ->  Seq Scan on ab_a1_b2 (actual rows=0 loops=1)
                Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
-         ->  Seq Scan on ab_a2_b2 (never executed)
+         ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
          ->  Seq Scan on ab_a3_b2 (never executed)
                Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
@@ -2059,17 +2059,20 @@ explain (analyze, costs off, summary off, timing off) select * from list_part wh
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
-         ->  Seq Scan on list_part1 (never executed)
+   ->  Append (actual rows=0 loops=1)
+         ->  Seq Scan on list_part1 (actual rows=0 loops=1)
                Filter: (a = (1 + a))
-         ->  Seq Scan on list_part2 (never executed)
+         ->  Seq Scan on list_part2 (actual rows=0 loops=1)
                Filter: (a = (1 + a))
-         ->  Seq Scan on list_part3 (never executed)
+               Rows Removed by Filter: 1
+         ->  Seq Scan on list_part3 (actual rows=0 loops=1)
                Filter: (a = (1 + a))
-         ->  Seq Scan on list_part4 (never executed)
+               Rows Removed by Filter: 1
+         ->  Seq Scan on list_part4 (actual rows=0 loops=1)
                Filter: (a = (1 + a))
+               Rows Removed by Filter: 1
  Optimizer: Postgres query optimizer
-(11 rows)
+(14 rows)
 
 rollback;
 drop table list_part;
@@ -2107,13 +2110,13 @@ select explain_parallel_append('execute ab_q4 (2, 2)');
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (never executed)
+               ->  Append (actual rows=0 loops=1)
                      Subplans Removed: 6
-                     ->  Seq Scan on ab_a2_b1 (never executed)
+                     ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Seq Scan on ab_a2_b2 (never executed)
+                     ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Seq Scan on ab_a2_b3 (never executed)
+                     ->  Seq Scan on ab_a2_b3 (actual rows=0 loops=1)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2127,13 +2130,13 @@ select explain_parallel_append('execute ab_q5 (1, 1, 1)');
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (never executed)
+               ->  Append (actual rows=0 loops=1)
                      Subplans Removed: 6
-                     ->  Seq Scan on ab_a1_b1 (never executed)
+                     ->  Seq Scan on ab_a1_b1 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a1_b2 (never executed)
+                     ->  Seq Scan on ab_a1_b2 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a1_b3 (never executed)
+                     ->  Seq Scan on ab_a1_b3 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2144,19 +2147,19 @@ select explain_parallel_append('execute ab_q5 (2, 3, 3)');
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (never executed)
+               ->  Append (actual rows=0 loops=1)
                      Subplans Removed: 3
-                     ->  Seq Scan on ab_a2_b1 (never executed)
+                     ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a2_b2 (never executed)
+                     ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a2_b3 (never executed)
+                     ->  Seq Scan on ab_a2_b3 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b1 (never executed)
+                     ->  Seq Scan on ab_a3_b1 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b2 (never executed)
+                     ->  Seq Scan on ab_a3_b2 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b3 (never executed)
+                     ->  Seq Scan on ab_a3_b3 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (18 rows)
@@ -2169,7 +2172,7 @@ select explain_parallel_append('execute ab_q5 (33, 44, 55)');
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (never executed)
+               ->  Append (actual rows=0 loops=1)
                      Subplans Removed: 8
                      ->  Seq Scan on ab_a1_b1 (never executed)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
@@ -2187,12 +2190,12 @@ select explain_parallel_append('select count(*) from ab where (a = (select 1) or
      ->  Result (actual rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (never executed)
-                     ->  Seq Scan on ab_a1_b2 (never executed)
+               ->  Append (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a1_b2 (actual rows=0 loops=1)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
                      ->  Seq Scan on ab_a2_b2 (never executed)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-                     ->  Seq Scan on ab_a3_b2 (never executed)
+                     ->  Seq Scan on ab_a3_b2 (actual rows=0 loops=1)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
  Optimizer: Postgres query optimizer
 (15 rows)
@@ -2216,38 +2219,40 @@ create index ab_a3_b3_a_idx on ab_a3_b3 (a);
 set enable_hashjoin = 0;
 set enable_mergejoin = 0;
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(0, 0, 1)');
-                                    explain_parallel_append                                     
-------------------------------------------------------------------------------------------------
+                                        explain_parallel_append                                        
+-------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (never executed)
+               ->  Merge Join (actual rows=0 loops=1)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (never executed)
+                     ->  Sort (actual rows=0 loops=1)
                            Sort Key: ab_a1_b1.a
-                           Sort Method:  quicksort  Memory: 50kB
-                           ->  Append (never executed)
+                           Sort Method:  quicksort  Memory: 25kB
+                           Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
+                           ->  Append (actual rows=0 loops=1)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
-                           Sort Method:  quicksort  Memory: 60kB
+                           Sort Method:  quicksort  Memory: 30kB
+                           Executor Memory: 29kB  Segments: 1  Max: 29kB (segment 1)
                            ->  Partition Selector (selector id: $0) (actual rows=102 loops=1)
                                  ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
                                        Filter: (a = ANY ('{0,0,1}'::integer[]))
  Optimizer: Postgres query optimizer
-(29 rows)
+(31 rows)
 
 -- Ensure the same partitions are pruned when we make the nested loop
 -- parameter an Expr rather than a plain Param.
@@ -2257,7 +2262,7 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Nested Loop (never executed)
+               ->  Nested Loop (actual rows=0 loops=1)
                      ->  Redistribute Motion 1:3  (slice2; segments: 1) (actual rows=102 loops=1)
                            Hash Key: (a.a + 0)
                            ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
@@ -2286,29 +2291,30 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
 
 insert into lprt_a values(3),(3);
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 3)');
-                                    explain_parallel_append                                     
-------------------------------------------------------------------------------------------------
+                                        explain_parallel_append                                        
+-------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 2:1  (slice1; segments: 2) (actual rows=2 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (never executed)
+               ->  Merge Join (actual rows=0 loops=1)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (never executed)
+                     ->  Sort (actual rows=0 loops=1)
                            Sort Key: ab_a1_b1.a
-                           Sort Method:  quicksort  Memory: 100kB
-                           ->  Append (never executed)
+                           Sort Method:  quicksort  Memory: 50kB
+                           Executor Memory: 51kB  Segments: 2  Max: 26kB (segment 1)
+                           ->  Append (actual rows=0 loops=1)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a3_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
@@ -2324,46 +2330,49 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
-                           Sort Method:  quicksort  Memory: 110kB
+                           Sort Method:  quicksort  Memory: 55kB
+                           Executor Memory: 88kB  Segments: 2  Max: 59kB (segment 0)
                            ->  Partition Selector (selector id: $0) (actual rows=102 loops=1)
                                  ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
                                        Filter: (a = ANY ('{1,0,3}'::integer[]))
  Optimizer: Postgres query optimizer
-(41 rows)
+(43 rows)
 
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
-                                    explain_parallel_append                                     
-------------------------------------------------------------------------------------------------
+                                        explain_parallel_append                                        
+-------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (never executed)
+               ->  Merge Join (actual rows=0 loops=1)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (never executed)
+                     ->  Sort (actual rows=0 loops=1)
                            Sort Key: ab_a1_b1.a
-                           Sort Method:  quicksort  Memory: 50kB
-                           ->  Append (never executed)
+                           Sort Method:  quicksort  Memory: 25kB
+                           Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
+                           ->  Append (actual rows=0 loops=1)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
-                           Sort Method:  quicksort  Memory: 60kB
+                           Sort Method:  quicksort  Memory: 30kB
+                           Executor Memory: 29kB  Segments: 1  Max: 29kB (segment 1)
                            ->  Partition Selector (selector id: $0) (actual rows=102 loops=1)
                                  ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
                                        Filter: (a = ANY ('{1,0,0}'::integer[]))
  Optimizer: Postgres query optimizer
-(29 rows)
+(31 rows)
 
 delete from lprt_a where a = 1;
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
@@ -2372,12 +2381,13 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (never executed)
+               ->  Merge Join (actual rows=0 loops=1)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (never executed)
+                     ->  Sort (actual rows=0 loops=1)
                            Sort Key: ab_a1_b1.a
-                           Sort Method:  quicksort  Memory: 50kB
-                           ->  Append (never executed)
+                           Sort Method:  quicksort  Memory: 25kB
+                           Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
+                           ->  Append (actual rows=0 loops=1)
                                  Partition Selectors: $0
                                  ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
@@ -2393,12 +2403,13 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
-                           Sort Method:  quicksort  Memory: 60kB
+                           Sort Method:  quicksort  Memory: 30kB
+                           Executor Memory: 29kB  Segments: 1  Max: 29kB (segment 1)
                            ->  Partition Selector (selector id: $0) (actual rows=100 loops=1)
                                  ->  Seq Scan on lprt_a a (actual rows=100 loops=1)
                                        Filter: (a = ANY ('{1,0,0}'::integer[]))
  Optimizer: Postgres query optimizer
-(29 rows)
+(31 rows)
 
 reset enable_hashjoin;
 reset enable_mergejoin;
@@ -2422,7 +2433,7 @@ select * from ab where a = (select max(a) from lprt_a) and b = (select max(a)-1 
            ->  Gather Motion 3:1  (slice5; segments: 3) (actual rows=3 loops=1)
                  ->  Partial Aggregate (actual rows=1 loops=1)
                        ->  Seq Scan on lprt_a lprt_a_1 (actual rows=100 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
@@ -2458,10 +2469,10 @@ select * from ab where a = (select max(a) from lprt_a) and b = (select max(a)-1 
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a3_b1_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a3_b2 (never executed)
+         ->  Bitmap Heap Scan on ab_a3_b2 (actual rows=0 loops=1)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
-               ->  Bitmap Index Scan on ab_a3_b2_a_idx (never executed)
+               ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=0 loops=1)
                      Index Cond: (a = $0)
          ->  Bitmap Heap Scan on ab_a3_b3 (never executed)
                Recheck Cond: (a = $0)
@@ -2479,12 +2490,12 @@ select * from (select * from ab where a = 1 union all select * from ab) ab where
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Append (never executed)
-         ->  Append (never executed)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
+   ->  Append (actual rows=0 loops=1)
+         ->  Append (actual rows=0 loops=1)
+               ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (actual rows=0 loops=1)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                            Index Cond: (a = 1)
                ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (never executed)
                      Recheck Cond: (a = 1)
@@ -2496,19 +2507,19 @@ select * from (select * from ab where a = 1 union all select * from ab) ab where
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                            Index Cond: (a = 1)
-         ->  Seq Scan on ab_a1_b1 (never executed)
+         ->  Seq Scan on ab_a1_b1 (actual rows=0 loops=1)
                Filter: (b = $0)
          ->  Seq Scan on ab_a1_b2 (never executed)
                Filter: (b = $0)
          ->  Seq Scan on ab_a1_b3 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: (b = $0)
          ->  Seq Scan on ab_a2_b2 (never executed)
                Filter: (b = $0)
          ->  Seq Scan on ab_a2_b3 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b1 (never executed)
+         ->  Seq Scan on ab_a3_b1 (actual rows=0 loops=1)
                Filter: (b = $0)
          ->  Seq Scan on ab_a3_b2 (never executed)
                Filter: (b = $0)
@@ -2518,6 +2529,15 @@ select * from (select * from ab where a = 1 union all select * from ab) ab where
 (39 rows)
 
 -- A case containing a UNION ALL with a non-partitioned child.
+-- GPDB:
+-- The one-time filter for values(10,5) can be executed on either one of the two segments,
+-- depending on random choice by the planner. Accept either plan.
+-- start_matchsubs
+-- m/ Result \(never executed\)/
+-- s/ Result \(never executed\)/ Result XXX/
+-- m/ Result \(actual rows=0 loops=1\)/
+-- s/ Result \(actual rows=0 loops=1\)/ Result XXX/
+-- end_matchsubs
 explain (analyze, costs off, summary off, timing off)
 select * from (select * from ab where a = 1 union all (values(10,5)) union all select * from ab) ab where b = (select 1);
                                      QUERY PLAN                                      
@@ -2525,12 +2545,12 @@ select * from (select * from ab where a = 1 union all (values(10,5)) union all s
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Append (never executed)
-         ->  Append (never executed)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
+   ->  Append (actual rows=0 loops=1)
+         ->  Append (actual rows=0 loops=1)
+               ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (actual rows=0 loops=1)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                            Index Cond: (a = 1)
                ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (never executed)
                      Recheck Cond: (a = 1)
@@ -2542,23 +2562,23 @@ select * from (select * from ab where a = 1 union all (values(10,5)) union all s
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                            Index Cond: (a = 1)
-         ->  Result (never executed)
-               One-Time Filter: (gp_execution_segment() = 1)
-               ->  Result (never executed)
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: (gp_execution_segment() = 0)
+               ->  Result (actual rows=0 loops=1)
                      One-Time Filter: (5 = $0)
-         ->  Seq Scan on ab_a1_b1 (never executed)
+         ->  Seq Scan on ab_a1_b1 (actual rows=0 loops=1)
                Filter: (b = $0)
          ->  Seq Scan on ab_a1_b2 (never executed)
                Filter: (b = $0)
          ->  Seq Scan on ab_a1_b3 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: (b = $0)
          ->  Seq Scan on ab_a2_b2 (never executed)
                Filter: (b = $0)
          ->  Seq Scan on ab_a2_b3 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b1 (never executed)
+         ->  Seq Scan on ab_a3_b1 (actual rows=0 loops=1)
                Filter: (b = $0)
          ->  Seq Scan on ab_a3_b2 (never executed)
                Filter: (b = $0)
@@ -2587,7 +2607,7 @@ explain (analyze, costs off, summary off, timing off) execute ab_q6(1);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 12
          ->  Seq Scan on ab_a1_b1 (never executed)
                Filter: ((a = $1) AND (b = $0))
@@ -2595,7 +2615,7 @@ explain (analyze, costs off, summary off, timing off) execute ab_q6(1);
                Filter: ((a = $1) AND (b = $0))
          ->  Seq Scan on ab_a1_b3 (never executed)
                Filter: ((a = $1) AND (b = $0))
-         ->  Seq Scan on xy_1 (never executed)
+         ->  Seq Scan on xy_1 (actual rows=0 loops=1)
                Filter: ((x = $1) AND (y = $0))
          ->  Seq Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
                Filter: ((a = $1) AND (b = $0))
@@ -2627,14 +2647,14 @@ explain (analyze, costs off, summary off, timing off)
 update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
- Update on ab_a1 (never executed)
+ Update on ab_a1 (actual rows=0 loops=1)
    Update on ab_a1_b1
    Update on ab_a1_b2
    Update on ab_a1_b3
-   ->  Nested Loop (never executed)
-         ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
+   ->  Nested Loop (actual rows=0 loops=1)
+         ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
                Recheck Cond: (a = 1)
-               ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+               ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                      Index Cond: (a = 1)
          ->  Materialize (never executed)
                ->  Append (never executed)
@@ -2657,20 +2677,20 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
                      Index Cond: (a = 1)
          ->  Materialize (actual rows=1 loops=1)
                ->  Append (actual rows=1 loops=1)
-                     ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (actual rows=0 loops=1)
                            Recheck Cond: (a = 1)
-                           ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+                           ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                                  Index Cond: (a = 1)
                      ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (actual rows=1 loops=1)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b3 ab_a1_b3_1 (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b3 ab_a1_b3_1 (actual rows=0 loops=1)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
                                  Index Cond: (a = 1)
-   ->  Nested Loop (never executed)
-         ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
+   ->  Nested Loop (actual rows=0 loops=1)
+         ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
                Recheck Cond: (a = 1)
                ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
                      Index Cond: (a = 1)
@@ -2704,12 +2724,12 @@ explain (analyze, costs off, summary off, timing off)
 update ab_a1 set b = 3 from ab_a2 where ab_a2.b = (select 1);
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Update on ab_a1 (never executed)
+ Update on ab_a1 (actual rows=0 loops=1)
    Update on ab_a1_b1
    Update on ab_a1_b2
    Update on ab_a1_b3
    InitPlan 1 (returns $0)  (slice1)
-     ->  Result (actual rows=1 loops=1)
+     ->  Result (never executed)
    ->  Nested Loop (actual rows=1 loops=1)
          ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=1 loops=1)
                ->  Append (actual rows=1 loops=1)
@@ -3040,7 +3060,7 @@ select * from tbl1 join tprt on tbl1.col1 = tprt.col1;
                                QUERY PLAN                                
 -------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Nested Loop (never executed)
+   ->  Nested Loop (actual rows=0 loops=1)
          ->  Seq Scan on tbl1 (actual rows=1 loops=1)
          ->  Append (never executed)
                ->  Bitmap Heap Scan on tprt_1 (never executed)
@@ -3097,7 +3117,7 @@ explain (analyze, costs off, summary off, timing off) execute part_abc_q1 (1, 2,
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Seq Scan on part_abc_p1 (never executed)
+   ->  Seq Scan on part_abc_p1 (actual rows=0 loops=1)
          Filter: ((a = $1) AND (b = $2) AND (c = $3))
  Optimizer: Postgres query optimizer
 (4 rows)
@@ -3124,9 +3144,9 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (1,1);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on listp_1_1 (never executed)
+         ->  Seq Scan on listp_1_1 (actual rows=0 loops=1)
                Filter: (b = ANY (ARRAY[$1, $2]))
  Optimizer: Postgres query optimizer
 (6 rows)
@@ -3135,9 +3155,9 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (2,2);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on listp_2_1 (never executed)
+         ->  Seq Scan on listp_2_1 (actual rows=0 loops=1)
                Filter: (b = ANY (ARRAY[$1, $2]))
  Optimizer: Postgres query optimizer
 (6 rows)
@@ -3148,7 +3168,7 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (0,0);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
          ->  Seq Scan on listp_1_1 (never executed)
                Filter: (b = ANY (ARRAY[$1, $2]))
@@ -3163,9 +3183,9 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (1,2,2,0);
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on listp_1_1 (never executed)
+         ->  Seq Scan on listp_1_1 (actual rows=0 loops=1)
                Filter: ((b = ANY (ARRAY[$1, $2])) AND ($3 <> b) AND ($4 <> b))
  Optimizer: Postgres query optimizer
 (6 rows)
@@ -3176,7 +3196,7 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (1,2,2,1);
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
          ->  Seq Scan on listp_1_1 (never executed)
                Filter: ((b = ANY (ARRAY[$1, $2])) AND ($3 <> b) AND ($4 <> b))
@@ -3191,7 +3211,7 @@ select * from listp where a = (select null::int);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          ->  Seq Scan on listp_1_1 (never executed)
                Filter: (a = $0)
          ->  Seq Scan on listp_2_1 (never executed)
@@ -3218,11 +3238,11 @@ select * from stable_qual_pruning where a < localtimestamp;
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
-         ->  Seq Scan on stable_qual_pruning1 (never executed)
-               Filter: (a < 'Tue Mar 16 00:06:06.937984 2021'::timestamp without time zone)
-         ->  Seq Scan on stable_qual_pruning2 (never executed)
-               Filter: (a < 'Tue Mar 16 00:06:06.937984 2021'::timestamp without time zone)
+   ->  Append (actual rows=0 loops=1)
+         ->  Seq Scan on stable_qual_pruning1 (actual rows=0 loops=1)
+               Filter: (a < 'Wed Sep 14 20:13:42.946328 2022'::timestamp without time zone)
+         ->  Seq Scan on stable_qual_pruning2 (actual rows=0 loops=1)
+               Filter: (a < 'Wed Sep 14 20:13:42.946328 2022'::timestamp without time zone)
  Optimizer: Postgres query optimizer
 (7 rows)
 
@@ -3232,9 +3252,9 @@ select * from stable_qual_pruning where a < '2000-02-01'::timestamptz;
                                       QUERY PLAN                                      
 --------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 2
-         ->  Seq Scan on stable_qual_pruning1 (never executed)
+         ->  Seq Scan on stable_qual_pruning1 (actual rows=0 loops=1)
                Filter: (a < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
  Optimizer: Postgres query optimizer
 (6 rows)
@@ -3255,7 +3275,7 @@ select * from stable_qual_pruning
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Seq Scan on stable_qual_pruning2 (never executed)
+   ->  Seq Scan on stable_qual_pruning2 (actual rows=0 loops=1)
          Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Fri Jan 01 00:00:00 2010"}'::timestamp without time zone[]))
  Optimizer: Postgres query optimizer
 (4 rows)
@@ -3266,8 +3286,8 @@ select * from stable_qual_pruning
                                                          QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Seq Scan on stable_qual_pruning2 (never executed)
-         Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Tue Mar 16 00:06:06.94494 2021"}'::timestamp without time zone[]))
+   ->  Seq Scan on stable_qual_pruning2 (actual rows=0 loops=1)
+         Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Wed Sep 14 20:13:42.954236 2022"}'::timestamp without time zone[]))
  Optimizer: Postgres query optimizer
 (4 rows)
 
@@ -3277,7 +3297,7 @@ select * from stable_qual_pruning
                                                            QUERY PLAN                                                            
 ---------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 2
          ->  Seq Scan on stable_qual_pruning1 (never executed)
                Filter: (a = ANY ('{"Mon Feb 01 00:00:00 2010 PST","Wed Jan 01 00:00:00 2020 PST"}'::timestamp with time zone[]))
@@ -3290,9 +3310,9 @@ select * from stable_qual_pruning
                                                            QUERY PLAN                                                            
 ---------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 2
-         ->  Seq Scan on stable_qual_pruning2 (never executed)
+         ->  Seq Scan on stable_qual_pruning2 (actual rows=0 loops=1)
                Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000 PST","Fri Jan 01 00:00:00 2010 PST"}'::timestamp with time zone[]))
  Optimizer: Postgres query optimizer
 (6 rows)
@@ -3384,10 +3404,10 @@ select * from boolp where a = (select value from boolvalues where value);
            ->  Seq Scan on boolvalues (actual rows=1 loops=1)
                  Filter: value
                  Rows Removed by Filter: 1
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          ->  Seq Scan on boolp_f (never executed)
                Filter: (a = $0)
-         ->  Seq Scan on boolp_t (never executed)
+         ->  Seq Scan on boolp_t (actual rows=0 loops=1)
                Filter: (a = $0)
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -3402,8 +3422,8 @@ select * from boolp where a = (select value from boolvalues where not value);
            ->  Seq Scan on boolvalues (actual rows=1 loops=1)
                  Filter: (NOT value)
                  Rows Removed by Filter: 1
-   ->  Append (never executed)
-         ->  Seq Scan on boolp_f (never executed)
+   ->  Append (actual rows=0 loops=1)
+         ->  Seq Scan on boolp_f (actual rows=0 loops=1)
                Filter: (a = $0)
          ->  Seq Scan on boolp_t (never executed)
                Filter: (a = $0)
@@ -3474,7 +3494,7 @@ explain (analyze, costs off, summary off, timing off) execute mt_q1(35);
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    Merge Key: ma_test_p1.b
-   ->  Merge Append (never executed)
+   ->  Merge Append (actual rows=0 loops=1)
          Sort Key: ma_test_p1.b
          Subplans Removed: 2
          ->  Index Scan using ma_test_p1_b_idx on ma_test_p1 (never executed)
@@ -3985,7 +4005,7 @@ select * from listp where a = (select 2) and b <> 10;
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Seq Scan on listp1 (never executed)
+   ->  Seq Scan on listp1 (actual rows=0 loops=1)
          Filter: ((b <> 10) AND (a = $0))
  Optimizer: Postgres query optimizer
 (6 rows)

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -1820,13 +1820,13 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 2, 3);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 6
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b2 (never executed)
+         ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b3 (never executed)
+         ->  Seq Scan on ab_a2_b3 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
  Optimizer: Postgres query optimizer
 (10 rows)
@@ -1835,19 +1835,19 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (1, 2, 3);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 3
-         ->  Seq Scan on ab_a1_b1 (never executed)
+         ->  Seq Scan on ab_a1_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a1_b2 (never executed)
+         ->  Seq Scan on ab_a1_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a1_b3 (never executed)
+         ->  Seq Scan on ab_a1_b3 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b2 (never executed)
+         ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b3 (never executed)
+         ->  Seq Scan on ab_a2_b3 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
  Optimizer: Postgres query optimizer
 (16 rows)
@@ -1860,11 +1860,11 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 2);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 4
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a2_b2 (never executed)
+         ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
  Optimizer: Postgres query optimizer
 (8 rows)
@@ -1873,15 +1873,15 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 4);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 2
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a2_b2 (never executed)
+         ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a3_b1 (never executed)
+         ->  Seq Scan on ab_a3_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a3_b2 (never executed)
+         ->  Seq Scan on ab_a3_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -1896,11 +1896,11 @@ explain (analyze, costs off, summary off, timing off) execute ab_q2 (2, 2);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 6
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
-         ->  Seq Scan on ab_a2_b2 (never executed)
+         ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
          ->  Seq Scan on ab_a2_b3 (never executed)
                Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
@@ -1916,11 +1916,11 @@ explain (analyze, costs off, summary off, timing off) execute ab_q3 (2, 2);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 6
-         ->  Seq Scan on ab_a1_b2 (never executed)
+         ->  Seq Scan on ab_a1_b2 (actual rows=0 loops=1)
                Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
-         ->  Seq Scan on ab_a2_b2 (never executed)
+         ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
          ->  Seq Scan on ab_a3_b2 (never executed)
                Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
@@ -1976,7 +1976,7 @@ explain (analyze, costs off, summary off, timing off) select * from list_part wh
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Dynamic Seq Scan on list_part (never executed)
+   ->  Dynamic Seq Scan on list_part (actual rows=0 loops=1)
          Number of partitions to scan: 4 
          Filter: (a = (1 + a))
          Partitions scanned:  Avg 4.0 x 3 workers.  Max 4 parts (seg0).
@@ -2019,13 +2019,13 @@ select explain_parallel_append('execute ab_q4 (2, 2)');
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (never executed)
+               ->  Append (actual rows=0 loops=1)
                      Subplans Removed: 6
-                     ->  Seq Scan on ab_a2_b1 (never executed)
+                     ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Seq Scan on ab_a2_b2 (never executed)
+                     ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Seq Scan on ab_a2_b3 (never executed)
+                     ->  Seq Scan on ab_a2_b3 (actual rows=0 loops=1)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2039,13 +2039,13 @@ select explain_parallel_append('execute ab_q5 (1, 1, 1)');
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (never executed)
+               ->  Append (actual rows=0 loops=1)
                      Subplans Removed: 6
-                     ->  Seq Scan on ab_a1_b1 (never executed)
+                     ->  Seq Scan on ab_a1_b1 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a1_b2 (never executed)
+                     ->  Seq Scan on ab_a1_b2 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a1_b3 (never executed)
+                     ->  Seq Scan on ab_a1_b3 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2056,19 +2056,19 @@ select explain_parallel_append('execute ab_q5 (2, 3, 3)');
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (never executed)
+               ->  Append (actual rows=0 loops=1)
                      Subplans Removed: 3
-                     ->  Seq Scan on ab_a2_b1 (never executed)
+                     ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a2_b2 (never executed)
+                     ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a2_b3 (never executed)
+                     ->  Seq Scan on ab_a2_b3 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b1 (never executed)
+                     ->  Seq Scan on ab_a3_b1 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b2 (never executed)
+                     ->  Seq Scan on ab_a3_b2 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b3 (never executed)
+                     ->  Seq Scan on ab_a3_b3 (actual rows=0 loops=1)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (18 rows)
@@ -2081,7 +2081,7 @@ select explain_parallel_append('execute ab_q5 (33, 44, 55)');
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (never executed)
+               ->  Append (actual rows=0 loops=1)
                      Subplans Removed: 8
                      ->  Seq Scan on ab_a1_b1 (never executed)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
@@ -2099,12 +2099,12 @@ select explain_parallel_append('select count(*) from ab where (a = (select 1) or
      ->  Result (actual rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (never executed)
-                     ->  Seq Scan on ab_a1_b2 (never executed)
+               ->  Append (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a1_b2 (actual rows=0 loops=1)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
                      ->  Seq Scan on ab_a2_b2 (never executed)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-                     ->  Seq Scan on ab_a3_b2 (never executed)
+                     ->  Seq Scan on ab_a3_b2 (actual rows=0 loops=1)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
  Optimizer: Postgres query optimizer
 (15 rows)
@@ -2130,38 +2130,40 @@ create index ab_a3_b3_a_idx on ab_a3_b3 (a);
 set enable_hashjoin = 0;
 set enable_mergejoin = 0;
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(0, 0, 1)');
-                                    explain_parallel_append                                     
-------------------------------------------------------------------------------------------------
+                                        explain_parallel_append                                        
+-------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (never executed)
+               ->  Merge Join (actual rows=0 loops=1)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (never executed)
+                     ->  Sort (actual rows=0 loops=1)
                            Sort Key: ab_a1_b1.a
-                           Sort Method:  quicksort  Memory: 50kB
-                           ->  Append (never executed)
+                           Sort Method:  quicksort  Memory: 25kB
+                           Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
+                           ->  Append (actual rows=0 loops=1)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
-                           Sort Method:  quicksort  Memory: 60kB
+                           Sort Method:  quicksort  Memory: 30kB
+                           Executor Memory: 29kB  Segments: 1  Max: 29kB (segment 1)
                            ->  Partition Selector (selector id: $0) (actual rows=102 loops=1)
                                  ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
                                        Filter: (a = ANY ('{0,0,1}'::integer[]))
  Optimizer: Postgres query optimizer
-(29 rows)
+(31 rows)
 
 -- Ensure the same partitions are pruned when we make the nested loop
 -- parameter an Expr rather than a plain Param.
@@ -2171,7 +2173,7 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Nested Loop (never executed)
+               ->  Nested Loop (actual rows=0 loops=1)
                      ->  Redistribute Motion 1:3  (slice2; segments: 1) (actual rows=102 loops=1)
                            Hash Key: (a.a + 0)
                            ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
@@ -2200,29 +2202,30 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
 
 insert into lprt_a values(3),(3);
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 3)');
-                                    explain_parallel_append                                     
-------------------------------------------------------------------------------------------------
+                                        explain_parallel_append                                        
+-------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 2:1  (slice1; segments: 2) (actual rows=2 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (never executed)
+               ->  Merge Join (actual rows=0 loops=1)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (never executed)
+                     ->  Sort (actual rows=0 loops=1)
                            Sort Key: ab_a1_b1.a
-                           Sort Method:  quicksort  Memory: 100kB
-                           ->  Append (never executed)
+                           Sort Method:  quicksort  Memory: 50kB
+                           Executor Memory: 51kB  Segments: 2  Max: 26kB (segment 1)
+                           ->  Append (actual rows=0 loops=1)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                                  ->  Bitmap Heap Scan on ab_a3_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
@@ -2238,46 +2241,49 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
-                           Sort Method:  quicksort  Memory: 110kB
+                           Sort Method:  quicksort  Memory: 55kB
+                           Executor Memory: 88kB  Segments: 2  Max: 59kB (segment 0)
                            ->  Partition Selector (selector id: $0) (actual rows=102 loops=1)
                                  ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
                                        Filter: (a = ANY ('{1,0,3}'::integer[]))
  Optimizer: Postgres query optimizer
-(41 rows)
+(43 rows)
 
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
-                                    explain_parallel_append                                     
-------------------------------------------------------------------------------------------------
+                                        explain_parallel_append                                        
+-------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (never executed)
+               ->  Merge Join (actual rows=0 loops=1)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (never executed)
+                     ->  Sort (actual rows=0 loops=1)
                            Sort Key: ab_a1_b1.a
-                           Sort Method:  quicksort  Memory: 50kB
-                           ->  Append (never executed)
+                           Sort Method:  quicksort  Memory: 25kB
+                           Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
+                           ->  Append (actual rows=0 loops=1)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=0 loops=1)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
-                           Sort Method:  quicksort  Memory: 60kB
+                           Sort Method:  quicksort  Memory: 30kB
+                           Executor Memory: 29kB  Segments: 1  Max: 29kB (segment 1)
                            ->  Partition Selector (selector id: $0) (actual rows=102 loops=1)
                                  ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
                                        Filter: (a = ANY ('{1,0,0}'::integer[]))
  Optimizer: Postgres query optimizer
-(29 rows)
+(31 rows)
 
 delete from lprt_a where a = 1;
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
@@ -2286,12 +2292,13 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (never executed)
+               ->  Merge Join (actual rows=0 loops=1)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (never executed)
+                     ->  Sort (actual rows=0 loops=1)
                            Sort Key: ab_a1_b1.a
-                           Sort Method:  quicksort  Memory: 50kB
-                           ->  Append (never executed)
+                           Sort Method:  quicksort  Memory: 25kB
+                           Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
+                           ->  Append (actual rows=0 loops=1)
                                  Partition Selectors: $0
                                  ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
@@ -2307,12 +2314,13 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: a.a
-                           Sort Method:  quicksort  Memory: 60kB
+                           Sort Method:  quicksort  Memory: 30kB
+                           Executor Memory: 29kB  Segments: 1  Max: 29kB (segment 1)
                            ->  Partition Selector (selector id: $0) (actual rows=100 loops=1)
                                  ->  Seq Scan on lprt_a a (actual rows=100 loops=1)
                                        Filter: (a = ANY ('{1,0,0}'::integer[]))
  Optimizer: Postgres query optimizer
-(29 rows)
+(31 rows)
 
 reset enable_hashjoin;
 reset enable_mergejoin;
@@ -2336,7 +2344,7 @@ select * from ab where a = (select max(a) from lprt_a) and b = (select max(a)-1 
            ->  Gather Motion 3:1  (slice5; segments: 3) (actual rows=3 loops=1)
                  ->  Partial Aggregate (actual rows=1 loops=1)
                        ->  Seq Scan on lprt_a lprt_a_1 (actual rows=100 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
@@ -2372,10 +2380,10 @@ select * from ab where a = (select max(a) from lprt_a) and b = (select max(a)-1 
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a3_b1_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a3_b2 (never executed)
+         ->  Bitmap Heap Scan on ab_a3_b2 (actual rows=0 loops=1)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
-               ->  Bitmap Index Scan on ab_a3_b2_a_idx (never executed)
+               ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=0 loops=1)
                      Index Cond: (a = $0)
          ->  Bitmap Heap Scan on ab_a3_b3 (never executed)
                Recheck Cond: (a = $0)
@@ -2389,16 +2397,16 @@ select * from ab where a = (select max(a) from lprt_a) and b = (select max(a)-1 
 explain (analyze, costs off, summary off, timing off)
 select * from (select * from ab where a = 1 union all select * from ab) ab where b = (select 1);
                                   QUERY PLAN                                  
-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Append (never executed)
-         ->  Append (never executed)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
+   ->  Append (actual rows=0 loops=1)
+         ->  Append (actual rows=0 loops=1)
+               ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (actual rows=0 loops=1)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                            Index Cond: (a = 1)
                ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (never executed)
                      Recheck Cond: (a = 1)
@@ -2410,19 +2418,19 @@ select * from (select * from ab where a = 1 union all select * from ab) ab where
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                            Index Cond: (a = 1)
-         ->  Seq Scan on ab_a1_b1 (never executed)
+         ->  Seq Scan on ab_a1_b1 (actual rows=0 loops=1)
                Filter: (b = $0)
          ->  Seq Scan on ab_a1_b2 (never executed)
                Filter: (b = $0)
          ->  Seq Scan on ab_a1_b3 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: (b = $0)
          ->  Seq Scan on ab_a2_b2 (never executed)
                Filter: (b = $0)
          ->  Seq Scan on ab_a2_b3 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b1 (never executed)
+         ->  Seq Scan on ab_a3_b1 (actual rows=0 loops=1)
                Filter: (b = $0)
          ->  Seq Scan on ab_a3_b2 (never executed)
                Filter: (b = $0)
@@ -2432,19 +2440,28 @@ select * from (select * from ab where a = 1 union all select * from ab) ab where
 (39 rows)
 
 -- A case containing a UNION ALL with a non-partitioned child.
+-- GPDB:
+-- The one-time filter for values(10,5) can be executed on either one of the two segments,
+-- depending on random choice by the planner. Accept either plan.
+-- start_matchsubs
+-- m/ Result \(never executed\)/
+-- s/ Result \(never executed\)/ Result XXX/
+-- m/ Result \(actual rows=0 loops=1\)/
+-- s/ Result \(actual rows=0 loops=1\)/ Result XXX/
+-- end_matchsubs
 explain (analyze, costs off, summary off, timing off)
 select * from (select * from ab where a = 1 union all (values(10,5)) union all select * from ab) ab where b = (select 1);
                                   QUERY PLAN                                  
-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Append (never executed)
-         ->  Append (never executed)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
+   ->  Append (actual rows=0 loops=1)
+         ->  Append (actual rows=0 loops=1)
+               ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (actual rows=0 loops=1)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                            Index Cond: (a = 1)
                ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (never executed)
                      Recheck Cond: (a = 1)
@@ -2456,23 +2473,23 @@ select * from (select * from ab where a = 1 union all (values(10,5)) union all s
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                            Index Cond: (a = 1)
-         ->  Result (never executed)
-               One-Time Filter: (gp_execution_segment() = 0)
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: (gp_execution_segment() = 2)
                ->  Result (never executed)
                      One-Time Filter: (5 = $0)
-         ->  Seq Scan on ab_a1_b1 (never executed)
+         ->  Seq Scan on ab_a1_b1 (actual rows=0 loops=1)
                Filter: (b = $0)
          ->  Seq Scan on ab_a1_b2 (never executed)
                Filter: (b = $0)
          ->  Seq Scan on ab_a1_b3 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b1 (never executed)
+         ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
                Filter: (b = $0)
          ->  Seq Scan on ab_a2_b2 (never executed)
                Filter: (b = $0)
          ->  Seq Scan on ab_a2_b3 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b1 (never executed)
+         ->  Seq Scan on ab_a3_b1 (actual rows=0 loops=1)
                Filter: (b = $0)
          ->  Seq Scan on ab_a3_b2 (never executed)
                Filter: (b = $0)
@@ -2503,7 +2520,7 @@ explain (analyze, costs off, summary off, timing off) execute ab_q6(1);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 12
          ->  Seq Scan on ab_a1_b1 (never executed)
                Filter: ((a = $1) AND (b = $0))
@@ -2511,7 +2528,7 @@ explain (analyze, costs off, summary off, timing off) execute ab_q6(1);
                Filter: ((a = $1) AND (b = $0))
          ->  Seq Scan on ab_a1_b3 (never executed)
                Filter: ((a = $1) AND (b = $0))
-         ->  Seq Scan on xy_1 (never executed)
+         ->  Seq Scan on xy_1 (actual rows=0 loops=1)
                Filter: ((x = $1) AND (y = $0))
          ->  Seq Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
                Filter: ((a = $1) AND (b = $0))
@@ -2543,14 +2560,14 @@ explain (analyze, costs off, summary off, timing off)
 update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
- Update on ab_a1 (never executed)
+ Update on ab_a1 (actual rows=0 loops=1)
    Update on ab_a1_b1
    Update on ab_a1_b2
    Update on ab_a1_b3
-   ->  Nested Loop (never executed)
-         ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
+   ->  Nested Loop (actual rows=0 loops=1)
+         ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
                Recheck Cond: (a = 1)
-               ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+               ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                      Index Cond: (a = 1)
          ->  Materialize (never executed)
                ->  Append (never executed)
@@ -2573,20 +2590,20 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
                      Index Cond: (a = 1)
          ->  Materialize (actual rows=1 loops=1)
                ->  Append (actual rows=1 loops=1)
-                     ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (actual rows=0 loops=1)
                            Recheck Cond: (a = 1)
-                           ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
+                           ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                                  Index Cond: (a = 1)
                      ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (actual rows=1 loops=1)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b3 ab_a1_b3_1 (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b3 ab_a1_b3_1 (actual rows=0 loops=1)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
                                  Index Cond: (a = 1)
-   ->  Nested Loop (never executed)
-         ->  Bitmap Heap Scan on ab_a1_b3 (never executed)
+   ->  Nested Loop (actual rows=0 loops=1)
+         ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
                Recheck Cond: (a = 1)
                ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
                      Index Cond: (a = 1)
@@ -2620,12 +2637,12 @@ explain (analyze, costs off, summary off, timing off)
 update ab_a1 set b = 3 from ab_a2 where ab_a2.b = (select 1);
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Update on ab_a1 (never executed)
+ Update on ab_a1 (actual rows=0 loops=1)
    Update on ab_a1_b1
    Update on ab_a1_b2
    Update on ab_a1_b3
    InitPlan 1 (returns $0)  (slice1)
-     ->  Result (actual rows=1 loops=1)
+     ->  Result (never executed)
    ->  Nested Loop (actual rows=1 loops=1)
          ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=1 loops=1)
                ->  Append (actual rows=1 loops=1)
@@ -2868,10 +2885,11 @@ insert into tbl1 values (10000);
 explain (analyze, costs off, summary off, timing off)
 select * from tbl1 join tprt on tbl1.col1 = tprt.col1;
                                      QUERY PLAN                                     
-------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Hash Join (never executed)
+   ->  Hash Join (actual rows=0 loops=1)
          Hash Cond: (tbl1.col1 = tprt.col1)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 3 of 524288 buckets.
          ->  Seq Scan on tbl1 (actual rows=1 loops=1)
          ->  Hash (actual rows=3 loops=1)
                Buckets: 524288  Batches: 1  Memory Usage: 4097kB
@@ -2879,7 +2897,7 @@ select * from tbl1 join tprt on tbl1.col1 = tprt.col1;
                      Number of partitions to scan: 6 
                      Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(11 rows)
 
 select tbl1.col1, tprt.col1 from tbl1
 inner join tprt on tbl1.col1 = tprt.col1
@@ -2916,7 +2934,7 @@ explain (analyze, costs off, summary off, timing off) execute part_abc_q1 (1, 2,
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Seq Scan on part_abc_p1 (never executed)
+   ->  Seq Scan on part_abc_p1 (actual rows=0 loops=1)
          Filter: ((a = $1) AND (b = $2) AND (c = $3))
  Optimizer: Postgres query optimizer
 (4 rows)
@@ -2949,9 +2967,9 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (1,1);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on listp_1_1 (never executed)
+         ->  Seq Scan on listp_1_1 (actual rows=0 loops=1)
                Filter: (b = ANY (ARRAY[$1, $2]))
  Optimizer: Postgres query optimizer
 (6 rows)
@@ -2960,9 +2978,9 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (2,2);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on listp_2_1 (never executed)
+         ->  Seq Scan on listp_2_1 (actual rows=0 loops=1)
                Filter: (b = ANY (ARRAY[$1, $2]))
  Optimizer: Postgres query optimizer
 (6 rows)
@@ -2973,7 +2991,7 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (0,0);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
          ->  Seq Scan on listp_1_1 (never executed)
                Filter: (b = ANY (ARRAY[$1, $2]))
@@ -2988,9 +3006,9 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (1,2,2,0);
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on listp_1_1 (never executed)
+         ->  Seq Scan on listp_1_1 (actual rows=0 loops=1)
                Filter: ((b = ANY (ARRAY[$1, $2])) AND ($3 <> b) AND ($4 <> b))
  Optimizer: Postgres query optimizer
 (6 rows)
@@ -3001,7 +3019,7 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (1,2,2,1);
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
          ->  Seq Scan on listp_1_1 (never executed)
                Filter: ((b = ANY (ARRAY[$1, $2])) AND ($3 <> b) AND ($4 <> b))
@@ -3016,7 +3034,7 @@ select * from listp where a = (select null::int);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Append (never executed)
+   ->  Append (actual rows=0 loops=1)
          ->  Seq Scan on listp_1_1 (never executed)
                Filter: (a = $0)
          ->  Seq Scan on listp_2_1 (never executed)
@@ -3044,11 +3062,11 @@ NOTICE:  table has parent, setting distribution columns to match parent table
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning where a < localtimestamp;
                                      QUERY PLAN                                      
--------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Dynamic Seq Scan on stable_qual_pruning (never executed)
+   ->  Dynamic Seq Scan on stable_qual_pruning (actual rows=0 loops=1)
          Number of partitions to scan: 2 
-         Filter: (a < 'Thu May 19 15:14:26.02528 2022'::timestamp without time zone)
+         Filter: (a < 'Wed Sep 14 17:02:12.338299 2022'::timestamp without time zone)
          Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
@@ -3059,7 +3077,7 @@ select * from stable_qual_pruning where a < '2000-02-01'::timestamptz;
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Dynamic Seq Scan on stable_qual_pruning (never executed)
+   ->  Dynamic Seq Scan on stable_qual_pruning (actual rows=0 loops=1)
          Number of partitions to scan: 1 
          Filter: (a < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
          Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
@@ -3083,7 +3101,7 @@ select * from stable_qual_pruning
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Dynamic Seq Scan on stable_qual_pruning (never executed)
+   ->  Dynamic Seq Scan on stable_qual_pruning (actual rows=0 loops=1)
          Number of partitions to scan: 1 
          Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Fri Jan 01 00:00:00 2010"}'::timestamp without time zone[]))
          Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
@@ -3096,9 +3114,9 @@ select * from stable_qual_pruning
                                                          QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Dynamic Seq Scan on stable_qual_pruning (never executed)
+   ->  Dynamic Seq Scan on stable_qual_pruning (actual rows=0 loops=1)
          Number of partitions to scan: 1 
-         Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Thu May 19 15:14:26.037645 2022"}'::timestamp without time zone[]))
+         Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Wed Sep 14 17:02:12.374447 2022"}'::timestamp without time zone[]))
          Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
@@ -3119,7 +3137,7 @@ select * from stable_qual_pruning
                                                         QUERY PLAN                                                         
 ---------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Dynamic Seq Scan on stable_qual_pruning (never executed)
+   ->  Dynamic Seq Scan on stable_qual_pruning (actual rows=0 loops=1)
          Number of partitions to scan: 1 
          Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000 PST","Fri Jan 01 00:00:00 2010 PST"}'::timestamp with time zone[]))
          Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
@@ -3219,7 +3237,7 @@ select * from boolp where a = (select value from boolvalues where value);
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Hash Join (never executed)
+   ->  Hash Join (actual rows=0 loops=1)
          Hash Cond: (boolvalues.value = boolp.a)
          ->  Redistribute Motion 1:3  (slice2) (never executed)
                ->  Assert (actual rows=1 loops=1)
@@ -3229,10 +3247,10 @@ select * from boolp where a = (select value from boolvalues where value);
                                  ->  Seq Scan on boolvalues (actual rows=1 loops=1)
                                        Filter: value
                                        Rows Removed by Filter: 1
-         ->  Hash (never executed)
+         ->  Hash (actual rows=0 loops=1)
                Buckets: 262144  Batches: 1  Memory Usage: 2048kB
-               ->  Broadcast Motion 3:3  (slice4; segments: 3) (never executed)
-                     ->  Dynamic Seq Scan on boolp (never executed)
+               ->  Broadcast Motion 3:3  (slice4; segments: 3) (actual rows=0 loops=1)
+                     ->  Dynamic Seq Scan on boolp (actual rows=0 loops=1)
                            Number of partitions to scan: 2 
                            Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3243,7 +3261,7 @@ select * from boolp where a = (select value from boolvalues where not value);
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Hash Join (never executed)
+   ->  Hash Join (actual rows=0 loops=1)
          Hash Cond: (boolvalues.value = boolp.a)
          ->  Redistribute Motion 1:3  (slice2) (never executed)
                ->  Assert (actual rows=1 loops=1)
@@ -3253,10 +3271,10 @@ select * from boolp where a = (select value from boolvalues where not value);
                                  ->  Seq Scan on boolvalues (actual rows=1 loops=1)
                                        Filter: (NOT value)
                                        Rows Removed by Filter: 1
-         ->  Hash (never executed)
+         ->  Hash (actual rows=0 loops=1)
                Buckets: 262144  Batches: 1  Memory Usage: 2048kB
-               ->  Broadcast Motion 3:3  (slice4; segments: 3) (never executed)
-                     ->  Dynamic Seq Scan on boolp (never executed)
+               ->  Broadcast Motion 3:3  (slice4; segments: 3) (actual rows=0 loops=1)
+                     ->  Dynamic Seq Scan on boolp (actual rows=0 loops=1)
                            Number of partitions to scan: 2 
                            Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3331,7 +3349,7 @@ explain (analyze, costs off, summary off, timing off) execute mt_q1(35);
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    Merge Key: ma_test_p1.b
-   ->  Merge Append (never executed)
+   ->  Merge Append (actual rows=0 loops=1)
          Sort Key: ma_test_p1.b
          Subplans Removed: 2
          ->  Index Scan using ma_test_p1_b_idx on ma_test_p1 (never executed)
@@ -3905,7 +3923,7 @@ select * from listp where a = (select 2) and b <> 10;
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-   ->  Seq Scan on listp1 (never executed)
+   ->  Seq Scan on listp1 (actual rows=0 loops=1)
          Filter: ((b <> 10) AND (a = $0))
  Optimizer: Postgres query optimizer
 (6 rows)

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -55,7 +55,7 @@ test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp li
 test: gpcopy
 
 test: orca_static_pruning orca_groupingsets_fallbacks
-test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format olap_plans gp_copy_dtx
+test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format olap_plans gp_copy_dtx  explain_analyze
 # below test(s) inject faults so each of them need to be in a separate group
 test: guc_gp
 test: toast

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -1,0 +1,13 @@
+-- GPDB_MERGE_12_FIXME: replace the match ignores with SUMMARY OFF
+-- start_matchignore
+-- m/Execution time: \d+\.\d+ ms/
+-- m/Planning time: \d+\.\d+ ms/
+-- end_matchignore
+
+CREATE TEMP TABLE empty_table(a int);
+-- We used to incorrectly report "never executed" for a node that returns 0 rows
+-- from every segment. This was misleading because "never executed" should
+-- indicate that the node was never executed by its parent.
+-- explain_processing_off
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table;
+-- explain_processing_on

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -1,14 +1,8 @@
--- GPDB_MERGE_12_FIXME: replace the match ignores with SUMMARY OFF
--- start_matchignore
--- m/Execution time: \d+\.\d+ ms/
--- m/Planning time: \d+\.\d+ ms/
--- m/Memory used:  \d+\w?B/
--- end_matchignore
 
 CREATE TEMP TABLE empty_table(a int);
 -- We used to incorrectly report "never executed" for a node that returns 0 rows
 -- from every segment. This was misleading because "never executed" should
 -- indicate that the node was never executed by its parent.
 -- explain_processing_off
-EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table;
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT a FROM empty_table;
 -- explain_processing_on

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -2,6 +2,7 @@
 -- start_matchignore
 -- m/Execution time: \d+\.\d+ ms/
 -- m/Planning time: \d+\.\d+ ms/
+-- m/Memory used:  \d+\w?B/
 -- end_matchignore
 
 CREATE TEMP TABLE empty_table(a int);

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -9,8 +9,8 @@
 -- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
 -- m/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/
 -- s/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/Memory: ###kB  Max Memory: ###kB  Peak Memory: ###kB  Avg Memory: ###kB \(3 segments\)/
--- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/
--- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(0 spilling\)/
+-- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(\d+ spilling\)/
+-- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(\d+ spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(# spilling\)/
 -- m/Execution Time: \d+\.\d+ ms/
 -- s/Execution Time: \d+\.\d+ ms/Execution Time: ##.### ms/
 -- m/Planning Time: \d+\.\d+ ms/
@@ -27,6 +27,8 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Hash chain length \d+\.\d+ avg, \d+ max, using \d+ of \d+ buckets./
+-- s/Hash chain length \d+\.\d+ avg, \d+ max, using \d+ of \d+ buckets./Hash chain length ###, using ### of ### buckets./
 -- end_matchsubs
 --
 -- DEFAULT syntax

--- a/src/test/regress/sql/partition_prune.sql
+++ b/src/test/regress/sql/partition_prune.sql
@@ -540,6 +540,15 @@ explain (analyze, costs off, summary off, timing off)
 select * from (select * from ab where a = 1 union all select * from ab) ab where b = (select 1);
 
 -- A case containing a UNION ALL with a non-partitioned child.
+-- GPDB:
+-- The one-time filter for values(10,5) can be executed on either one of the two segments,
+-- depending on random choice by the planner. Accept either plan.
+-- start_matchsubs
+-- m/ Result \(never executed\)/
+-- s/ Result \(never executed\)/ Result XXX/
+-- m/ Result \(actual rows=0 loops=1\)/
+-- s/ Result \(actual rows=0 loops=1\)/ Result XXX/
+-- end_matchsubs
 explain (analyze, costs off, summary off, timing off)
 select * from (select * from ab where a = 1 union all (values(10,5)) union all select * from ab) ab where b = (select 1);
 


### PR DESCRIPTION
We used to incorrectly report "never executed" for a node that returns 0
rows from every segment. This was misleading because "never executed"
should indicate that the node was never executed by its parent.

A more subtle artifact of the bug is that the average count of rows was
higher than what it should be, because we only averaged among the
segments that return non-zero rows.

Co-authored-by: Jesse Zhang <sbjesse@gmail.com>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
