### PR TITLE
gpinitsystem: accept legacy format gpinitsystem_config files

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1695,6 +1695,9 @@ READ_INPUT_CONFIG () {
 
     . $INPUT_CONFIG
     SET_VAR $QD_PRIMARY_ARRAY
+
+    # always use the new 6-field format to allow uniform handling of the QD
+    QD_PRIMARY_ARRAY="$GP_HOSTNAME"~"$GP_HOSTADDRESS"~"$GP_PORT"~"$GP_DIR"~"$GP_DBID"~"$GP_CONTENT"
     MASTER_HOSTNAME=$GP_HOSTADDRESS
     MASTER_DIRECTORY=`$DIRNAME $GP_DIR`
     MASTER_PORT=$GP_PORT
@@ -1703,6 +1706,9 @@ READ_INPUT_CONFIG () {
     MACHINE_LIST=()
     DATA_DIRECTORY=()
     CONTENT_COUNT=0
+
+    # always use the new 6-field format to allow uniform handling of primaries
+    SET_PRIMARY_ARRAY_TO_NEW_FORMAT
     for QE in ${PRIMARY_ARRAY[@]}
     do
         SET_VAR $QE
@@ -1718,6 +1724,9 @@ READ_INPUT_CONFIG () {
     if [ x"" != x"${MIRROR_ARRAY}" ] ; then
         MIRRORING=1
         MIRROR_DATA_DIRECTORY=()
+
+        # always use the new 6-field format to allow uniform handling of mirrors
+        SET_MIRROR_ARRAY_TO_NEW_FORMAT
         for QE in ${MIRROR_ARRAY[@]}
         do
             SET_VAR $QE

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -1383,6 +1383,26 @@ SET_VAR () {
 	fi
 }
 
+SET_PRIMARY_ARRAY_TO_NEW_FORMAT() {
+  local tmp_array=()
+  for QE in "${PRIMARY_ARRAY[@]}"
+  do
+    SET_VAR "$QE"
+    tmp_array=("${tmp_array[@]}" "$GP_HOSTNAME"~"$GP_HOSTADDRESS"~"$GP_PORT"~"$GP_DIR"~"$GP_DBID"~"$GP_CONTENT")
+  done
+  PRIMARY_ARRAY=("${tmp_array[@]}")
+}
+
+SET_MIRROR_ARRAY_TO_NEW_FORMAT(){
+  local tmp_array=()
+  for QE in "${MIRROR_ARRAY[@]}"
+  do
+    SET_VAR "$QE"
+    tmp_array=("${tmp_array[@]}" "$GP_HOSTNAME"~"$GP_HOSTADDRESS"~"$GP_PORT"~"$GP_DIR"~"$GP_DBID"~"$GP_CONTENT")
+  done
+  MIRROR_ARRAY=("${tmp_array[@]}")
+}
+
 #******************************************************************************
 # Main Section
 #******************************************************************************

--- a/gpMgmt/bin/test/gpinitsystem_test.bash
+++ b/gpMgmt/bin/test/gpinitsystem_test.bash
@@ -190,6 +190,26 @@ set_var_should_error_out_if_given_bad_field_values() {
   fi
 }
 
+formats_primary_array_for_both_legacy_and_new_formats() {
+  PRIMARY_ARRAY=("sdw1:50433:/data/primary/gpseg0:1:0" "sdw2:50434:/data/primary/gpseg1:2:1" "sdw1~myhost~50435~/data/primary/gpseg2~3~2")
+  SET_PRIMARY_ARRAY_TO_NEW_FORMAT
+  NEW_PRIMARY_ARRAY=("sdw1~sdw1~50433~/data/primary/gpseg0~1~0" "sdw2~sdw2~50434~/data/primary/gpseg1~2~1" "sdw1~myhost~50435~/data/primary/gpseg2~3~2")
+  if [[ "${PRIMARY_ARRAY[@]}" != "${NEW_PRIMARY_ARRAY[@]}" ]]; then
+    echo "got ${PRIMARY_ARRAY[@]}, want ${NEW_PRIMARY_ARRAY[@]}"
+    exit 1
+  fi
+}
+
+formats_mirror_array_for_both_legacy_and_new_formats() {
+  MIRROR_ARRAY=("sdw1:50433:/data/mirror/gpseg0:1:0" "sdw2:50434:/data/mirror/gpseg1:2:1" "sdw2~myhost~50435~/data/mirror/gpseg2~3~2")
+  SET_MIRROR_ARRAY_TO_NEW_FORMAT
+  NEW_MIRROR_ARRAY=("sdw1~sdw1~50433~/data/mirror/gpseg0~1~0" "sdw2~sdw2~50434~/data/mirror/gpseg1~2~1" "sdw2~myhost~50435~/data/mirror/gpseg2~3~2")
+  if [[ "${MIRROR_ARRAY[@]}" != "${NEW_MIRROR_ARRAY[@]}" ]]; then
+    echo "got ${MIRROR_ARRAY[@]}, want ${NEW_MIRROR_ARRAY[@]}"
+    exit 1
+  fi
+}
+
 main() {
   it_should_quote_the_username_during_alter_user_in_SET_GP_USER_PW
   it_should_quote_the_password_during_alter_user_in_SET_GP_USER_PW
@@ -198,6 +218,8 @@ main() {
   it_should_work_without_a_hostname_and_previous_6x_versions
   set_var_should_error_out_if_given_the_wrong_number_of_fields
   set_var_should_error_out_if_given_bad_field_values
+  formats_mirror_array_for_both_legacy_and_new_formats
+  formats_primary_array_for_both_legacy_and_new_formats
 }
 
 main

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -17,6 +17,14 @@ Feature: gpinitsystem tests
         And gpconfig should print "Master  value: off" to stdout
         And gpconfig should print "Segment value: off" to stdout
 
+    Scenario: gpinitsystem creates a cluster with a legacy input initialization file
+        Given a working directory of the test as '/tmp/gpinitsystem'
+        And the database is not running
+        And a legacy initialization file format "/tmp/gpinitsystem/initializationFile" is created
+        When the user runs command "gpinitsystem -aI /tmp/gpinitsystem/initializationFile --ignore-warnings"
+        Then gpinitsystem should return a return code of 0
+        Given the cluster with master data directory "/tmp/gpinitsystem/gpseg-1" is stopped
+
     Scenario: gpinitsystem creates a cluster when the user confirms the dialog when --ignore-warnings is passed in
         Given create demo cluster config
          When the user runs command "echo y | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile --ignore-warnings"

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -197,8 +197,11 @@ def stop_database_if_started(context):
         stop_database(context)
 
 
-def stop_database(context):
-    run_gpcommand(context, 'gpstop -M fast -a')
+def stop_database(context, master_data_dir=""):
+    cmd = 'gpstop -M fast -a'
+    if master_data_dir:
+        cmd += ' -d ' + master_data_dir
+    run_gpcommand(context, cmd)
     if context.exception:
         raise context.exception
 


### PR DESCRIPTION
This fixes a big using `gpinitsystem -I gpinitsystem_config` in 6X.  

In 6X, we allow either a 5-field or 6-field format for the PRIMARY_ARRAY and the MIRROR_ARRAY.  The 6-field format adds an explicit host address(`host:address:1025:/data/primary/gpseg0:2:0:1089` vs `host:1025:/data/primary/gpseg0:2:0:1089`).    

The bug is that an internal routine assumes that we have the 6-field format always.  The net result is that we end up sorting the MIRROR_ARRAY numerically.  This can cause the sort to work on the hostnames or the ports.  This can cause all sorts of issues, the current manifestation being a mismatch between the contentIDs of the primary with its corresponding mirror.

Co-authored-by: David Krieger <dkrieger@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
