### PR TITLE
ic-proxy: include postmaster pid in the domain socket path

### DIFF
--- a/src/backend/cdb/motion/ic_proxy.h
+++ b/src/backend/cdb/motion/ic_proxy.h
@@ -46,12 +46,13 @@
  * Every proxy on the same host must use a different path, this is important to
  * let proxies from different segments or even different clusters to coexist.
  *
- * This is ensured by including the postmaster port in the path.
+ * This is ensured by including the postmaster port & pid in the path.
  */
 static inline void
 ic_proxy_build_server_sock_path(char *buf, size_t bufsize)
 {
-	snprintf(buf, bufsize, "/tmp/.s.proxy.%d", PostPortNumber);
+	snprintf(buf, bufsize, "/tmp/.s.PGSQL.ic_proxy.%d.%d",
+			 PostPortNumber, PostmasterPid);
 }
 
 #endif   /* IC_PROXY_H */


### PR DESCRIPTION
We used to store them under /tmp/, we include the postmaster port number
in the file name in the hope that two clusters will not conflict with
each other on this file.

However the conflict still happen in the test src/bin/pg_basebackup.
And it can also happen if a second cluster is missed configured by
accident.  So to make things safe we also include the postmaster pid in
the domain socket path, there is no chance for two postmasters to share
the same pids.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
