### PR TITLE
Revert "ic-proxy: get libuv on pr pipeline"

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -47,13 +47,6 @@ resources:
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: gp-internal-artifacts/centos7/libquicklz-devel-(1\.5\.0-.*)-1.el7.x86_64.rpm
 
-- name: libuv-centos7
-  type: gcs
-  source:
-    bucket: ((gcs-bucket))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: gp-internal-artifacts/centos7/libuv-(1\.38\.0.*).tar.gz
-
 
 jobs:
 - name: compile_and_test_gpdb
@@ -70,8 +63,6 @@ jobs:
       resource: libquicklz-centos7
     - get: libquicklz-devel-installer
       resource: libquicklz-devel-centos7
-    - get: libuv-installer
-      resource: libuv-centos7
 
   - put: gpdb_pr
     params:


### PR DESCRIPTION
This reverts commit ef887cfe457dbefcdb477b9ec838ee999ec04c59.

----

According to https://github.com/greenplum-db/gpdb/pull/10522 we no longer need to get the libuv installer.  The master pipelines are already handled by it, this one handles the master PR pipeline.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
