### PR TITLE
6X: Revert "ic-proxy: get libuv on pr pipeline"

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -61,13 +61,6 @@ resources:
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: gp-internal-artifacts/centos7/python-(2\.7\.12\+.*).tar.gz
 
-- name: libuv-centos7
-  type: gcs
-  source:
-    bucket: ((gcs-bucket))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: gp-internal-artifacts/centos7/libuv-(1\.38\.0.*).tar.gz
-
 
 jobs:
 - name: compile_and_test_gpdb
@@ -88,8 +81,6 @@ jobs:
       resource: libsigar-centos7
     - get: python-tarball
       resource: python-centos7
-    - get: libuv-installer
-      resource: libuv-centos7
 
   - put: gpdb_pr
     params:


### PR DESCRIPTION
This reverts commit 7f44bfa83ce03955f4f4ba987f044a18ea5cf798.

----

According to #10522 we no longer need to get the libuv installer. The master pipelines are already handled by it, this one handles the 6X PR pipeline.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
