### PR TITLE
Coverity: Argument cannot be negative

### DIFF
--- a/src/backend/cdb/cdbappendonlystorageread.c
+++ b/src/backend/cdb/cdbappendonlystorageread.c
@@ -283,7 +283,7 @@ AppendOnlyStorageRead_FinishOpenFile(AppendOnlyStorageRead *storageRead,
 				 errmsg("append-only storage read error on segment file '%s' for relation '%s'",
 						filePathName, storageRead->relationName),
 				 errdetail("FileSeek offset = 0.  Error code = %d (%s).",
-						(int) seekResult, strerror((int) seekResult))));
+						errno, strerror(errno))));
 	}
 
 	storageRead->file = file;

--- a/src/backend/utils/hyperloglog/gp_hyperloglog.c
+++ b/src/backend/utils/hyperloglog/gp_hyperloglog.c
@@ -592,6 +592,13 @@ gp_hll_compress_dense(GpHLLCounter hloglog)
     	}
     	return hloglog;
     }
+
+	if (len < 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("LZ compression failed"),
+				 errdetail("LZ compression return value: %d", len)));
+
     memcpy(hloglog->data,dest,len);
 
     /* resize the counter to only encompass the compressed data and the struct
@@ -649,6 +656,13 @@ gp_hll_compress_dense_unpacked(GpHLLCounter hloglog)
 		}
 		return hloglog;
 	}
+
+	if (len < 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("LZ compression failed"),
+				 errdetail("LZ compression return value: %d", len)));
+
 	memcpy(hloglog->data, dest, len);
 
 	/* resize the counter to only encompass the compressed data and the struct


### PR DESCRIPTION
Should check the len parameter of memcpy is not negative in
gp_hyperloglog.c
Should use errno instead of seekResult in cdbappendonlystorageread.c

No test case needed.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
