### PR TITLE
Coverity: Check return value of strcmp

### DIFF
--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -3541,8 +3541,8 @@ _printTocEntry(ArchiveHandle *AH, TocEntry *te, bool isData)
 
 	/* Set up OID mode too */
 	if (strcmp(te->desc, "TABLE") == 0 ||
-		strcmp(te->desc, "EXTERNAL TABLE") ||
-		strcmp(te->desc, "FOREIGN TABLE"))
+		strcmp(te->desc, "EXTERNAL TABLE") == 0 ||
+		strcmp(te->desc, "FOREIGN TABLE") == 0)
 		_setWithOids(AH, te);
 
 	/* Emit header comment for item */


### PR DESCRIPTION
return value of strcmp is not checked in some branches.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
