### PR TITLE
Coverity: Variable unused

### DIFF
--- a/src/backend/access/external/external.c
+++ b/src/backend/access/external/external.c
@@ -773,7 +773,6 @@ create_external_scan_uri_list(ExtTableEntry *ext, bool *ismasteronly)
 
 				uri = ParseExternalTableUri(uri_str);
 
-				found_candidate = false;
 				found_match = false;
 
 				/*
@@ -803,9 +802,6 @@ create_external_scan_uri_list(ExtTableEntry *ext, bool *ismasteronly)
 							if (skip_map[segind])
 								continue;	/* skip it */
 						}
-
-						/* a valid primary segdb exist on this host */
-						found_candidate = true;
 
 						if (segdb_file_map[segind] == NULL)
 						{

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -88,7 +88,6 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 	char	   *locationUris = NULL;
 	char	   *locationExec = NULL;
 	char	   *commandString = NULL;
-	char	   *customProtName = NULL;
 	char		rejectlimittype = '\0';
 	char		formattype;
 	int			rejectlimit = -1;
@@ -329,9 +328,6 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 									GetAssignedOidsForDispatch(),
 									NULL);
 	}
-
-	if (customProtName)
-		pfree(customProtName);
 }
 
 /*

--- a/src/include/utils/tuplesort.h
+++ b/src/include/utils/tuplesort.h
@@ -288,7 +288,6 @@ switcheroo_tuplesort_begin_cluster(TupleDesc tupDesc,
 			tuplesort_begin_cluster_pg(tupDesc, indexRel,
 									   workMem, randomAccess);
 	}
-	state->is_mk_tuplesortstate = gp_enable_mk_sort;
 	state->is_mk_tuplesortstate = false;
 	return state;
 }


### PR DESCRIPTION
Remove unused varaible.
For tuplesort.h, we doesn't support mksort based cluster,
so we should just set is_mk_tuplesortstate to false

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
