### PR TITLE
Coverity: Resource leak

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -616,6 +616,8 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 						break;
 					}
 				}
+				if (buffer)
+					PQfreemem(buffer);
 			}
 
 			/* in SREH mode, check if this seg rejected (how many) rows */

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -4891,6 +4891,7 @@ getTypeStorageOptions(Archive *fout, int *numTypes)
 	{
 		numTypes = 0;
 		tstorageoptions = (TypeStorageOptions *) pg_malloc(0);
+		destroyPQExpBuffer(query);
 		return tstorageoptions;
 	}
 


### PR DESCRIPTION
Should not call gzdopen(dup(fileno(stdout)) directly, since return
value of dup() could be negative.
Also fix some resource leak.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
