### PR TITLE
Coverity: Sizeof not portable

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -4074,7 +4074,7 @@ merge_leaf_stats(VacAttrStatsP stats,
 	MemoryContext old_context;
 
 	HeapTuple *heaptupleStats =
-		(HeapTuple *) palloc(numPartitions * sizeof(HeapTuple *));
+		(HeapTuple *) palloc(numPartitions * sizeof(HeapTuple));
 
 	// NDV calculations
 	float4 colAvgWidth = 0;


### PR DESCRIPTION
sizeof(HeapTuple *) should be sizeof(HeapTuple)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
