### PR TITLE
WIP: Three stage grouping set aggs

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -344,7 +344,6 @@ add_twostage_group_agg_path(PlannerInfo *root,
 							RelOptInfo *output_rel)
 {
 	Query	   *parse = root->parse;
-	CdbPathLocus singleQE_locus;
 	Path	   *initial_agg_path = NULL;
 	DQAType     dqa_type;
 	CdbPathLocus group_locus;
@@ -528,35 +527,30 @@ add_twostage_group_agg_path(PlannerInfo *root,
 		Assert(false);
 	}
 
-	/*
-	 * GroupAgg -> GATHER MOTION -> GroupAgg.
-	 *
-	 * This has the advantage that it retains the input order. The
-	 * downside is that it gathers everything to a single node. If that's
-	 * where the final result is needed anyway, that's quite possibly better
-	 * than scattering the partial aggregate results and having another
-	 * motion to gather the final results, though,
-	 *
-	 * Alternatively, we could redistribute based on the GROUP BY key. That
-	 * would have the advantage that the Finalize Agg stage could run in
-	 * parallel. However, it would destroy the sort order, so it's probaly
-	 * not a good idea.
-	 */
-	CdbPathLocus_MakeSingleQE(&singleQE_locus, getgpsegmentCount());
-	path = cdbpath_create_motion_path(root,
-									  initial_agg_path,
-									  motion_pathkeys,
-									  false,
-									  singleQE_locus);
-
 	if (parse->groupingSets)
 	{
-
 		List		*pathkeys;
+		CdbPathLocus singleQE_locus;
+		CdbPathLocus group_locus;
 
 		pathkeys = make_pathkeys_for_sortclauses(root,
 												 grouping_sets_groupClause,
 												 grouping_sets_tlist);
+
+		/*
+		 * Alternative #1:
+		 *   Partial GroupAgg -> GATHER MOTION -> Finalize GroupAgg.
+		 *
+		 * The Partial Agg stage computes the partial aggregates for each
+		 * grouping set. The partial results are then Gathered, and
+		 * the final aggregates are computed.
+		 */
+		CdbPathLocus_MakeSingleQE(&singleQE_locus, getgpsegmentCount());
+		path = cdbpath_create_motion_path(root,
+										  initial_agg_path,
+										  motion_pathkeys,
+										  false,
+										  singleQE_locus);
 
 		path = (Path *) create_sort_path(root,
 										 output_rel,
@@ -576,9 +570,75 @@ add_twostage_group_agg_path(PlannerInfo *root,
 										ctx->agg_final_costs,
 										ctx->dNumGroups,
 										NULL);
+		elog(NOTICE, "alt1: %g", path->total_cost);
+		add_path(output_rel, path);
+
+		/*
+		 * Alternative #2:
+		 *   Partial GroupAgg -> REDISTRIBUTE MOTION -> Finalize GroupAgg -> GATHER MOTION.
+		 *
+		 * This is like the previous plan, but the final stage is parallelized.
+		 * That's a win if there are a lot of groups. We'll add both paths and
+		 * decide based on the cost estimate.
+		 */
+		group_locus = cdb_choose_grouping_locus(root, initial_agg_path,
+												grouping_sets_partial_target,
+												grouping_sets_groupClause, NIL, NIL,
+												&need_redistribute);
+		if (need_redistribute)
+		{
+			path = cdbpath_create_motion_path(root,
+											  initial_agg_path,
+											  motion_pathkeys,
+											  false,
+											  group_locus);
+
+			path = (Path *) create_sort_path(root,
+											 output_rel,
+											 path,
+											 pathkeys,
+											 -1.0);
+
+			path = (Path *) create_agg_path(root,
+											output_rel,
+											path,
+											ctx->target,
+											AGG_SORTED,
+											AGGSPLIT_FINAL_DESERIAL,
+											false, /* streaming */
+											grouping_sets_groupClause,
+											(List *) parse->havingQual,
+											ctx->agg_final_costs,
+											ctx->dNumGroups,
+											NULL);
+			elog(NOTICE, "alt2: %g", path->total_cost);
+			add_path(output_rel, path);
+		}
 	}
 	else if (parse->hasAggs || parse->groupClause)
 	{
+		CdbPathLocus singleQE_locus;
+
+		/*
+		 * GroupAgg -> GATHER MOTION -> GroupAgg.
+		 *
+		 * This has the advantage that it retains the input order. The
+		 * downside is that it gathers everything to a single node. If that's
+		 * where the final result is needed anyway, that's quite possibly better
+		 * than scattering the partial aggregate results and having another
+		 * motion to gather the final results, though,
+		 *
+		 * Alternatively, we could redistribute based on the GROUP BY key. That
+		 * would have the advantage that the Finalize Agg stage could run in
+		 * parallel. However, it would destroy the sort order, so it's probaly
+		 * not a good idea.
+		 */
+		CdbPathLocus_MakeSingleQE(&singleQE_locus, getgpsegmentCount());
+		path = cdbpath_create_motion_path(root,
+										  initial_agg_path,
+										  motion_pathkeys,
+										  false,
+										  singleQE_locus);
 		path = (Path *) create_agg_path(root,
 										output_rel,
 										path,
@@ -591,13 +651,12 @@ add_twostage_group_agg_path(PlannerInfo *root,
 										ctx->agg_final_costs,
 										ctx->dNumGroups,
 										NULL);
+		add_path(output_rel, path);
 	}
 	else
 	{
 		Assert(false);
 	}
-
-	add_path(output_rel, path);
 }
 
 static void


### PR DESCRIPTION
When creating a plan for a GROUPING SETS query, consider redistributing the partial aggregate results, so that it can be done in parallel. Per discussion at https://github.com/greenplum-db/gpdb/issues/9736.

This is work-in-progress, because I need some help on the cost modeling. With this PR, the planner considers both of these plans:
```
postgres=# set gp_motion_cost_per_row =1;
SET
postgres=# explain select a, b, sum(a+b) from test_info group by rollup(a, b);
                                           QUERY PLAN                                            
-------------------------------------------------------------------------------------------------
 Finalize GroupAggregate  (cost=4341.10..4392.36 rows=1101 width=16)
   Group Key: (GROUPINGSET_ID()), a, b
   ->  Sort  (cost=4341.10..4349.15 rows=3220 width=16)
         Sort Key: (GROUPINGSET_ID()), a, b
         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=776.39..4153.50 rows=3220 width=16)
               ->  Partial GroupAggregate  (cost=776.39..933.58 rows=1074 width=16)
                     Group Key: a, b
                     Group Key: a
                     Group Key: ()
                     ->  Sort  (cost=776.39..801.39 rows=3334 width=8)
                           Sort Key: a, b
                           ->  Seq Scan on test_info  (cost=0.00..112.00 rows=3334 width=8)
 Optimizer: Postgres query optimizer
(13 rows)

```
and:
```
                                                 QUERY PLAN                                                  
-------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=4341.10..5493.36 rows=1101 width=16)
   ->  Finalize GroupAggregate  (cost=4341.10..4392.36 rows=367 width=16)
         Group Key: (GROUPINGSET_ID()), a, b
         ->  Sort  (cost=4341.10..4349.15 rows=1074 width=16)
               Sort Key: (GROUPINGSET_ID()), a, b
               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=776.39..4153.50 rows=1074 width=16)
                     Hash Key: a, b, (GROUPINGSET_ID())
                     ->  Partial GroupAggregate  (cost=776.39..933.58 rows=1074 width=16)
                           Group Key: a, b
                           Group Key: a
                           Group Key: ()
                           ->  Sort  (cost=776.39..801.39 rows=3334 width=8)
                                 Sort Key: a, b
                                 ->  Seq Scan on test_info  (cost=0.00..112.00 rows=3334 width=8)
 Optimizer: Postgres query optimizer
(15 rows)
```
However, note that up to the Finalize Aggregate node, both plans have exactly the same cost! Because of that, the first plan always wins. Our cost model doesn't take into account that the second plan could perform the Sort and Finalize Aggregate nodes in parallel. How should we take that into account?