### PR TITLE
gp_replica_check: skip checking unlogged tables

### DIFF
--- a/gpcontrib/gp_replica_check/gp_replica_check.c
+++ b/gpcontrib/gp_replica_check/gp_replica_check.c
@@ -45,7 +45,8 @@
 								|| pg_strncasecmp(filename, "t_", 2) == 0 \
 								|| pg_strncasecmp(filename, ".", 1) == 0 \
 								|| pg_strncasecmp(filename + strlen(filename) - 4, "_fsm", 4) == 0 \
-								|| pg_strncasecmp(filename + strlen(filename) - 3, "_vm", 3) == 0)
+								|| pg_strncasecmp(filename + strlen(filename) - 3, "_vm", 3) == 0 \
+								|| pg_strncasecmp(filename + strlen(filename) - 5, "_init", 5) == 0)
 
 PG_MODULE_MAGIC;
 
@@ -521,6 +522,10 @@ get_relfilenode_map()
 			 || classtuple->relkind == RELKIND_COMPOSITE_TYPE)
 			|| (classtuple->relstorage != RELSTORAGE_HEAP
 				&& !relstorage_is_ao(classtuple->relstorage)))
+			continue;
+
+		/* unlogged tables do not propagate to replica servers */
+		if (classtuple->relpersistence == RELPERSISTENCE_UNLOGGED)
 			continue;
 
 		RelfilenodeEntry *rentry;

--- a/src/test/regress/expected/create_table.out
+++ b/src/test/regress/expected/create_table.out
@@ -261,8 +261,8 @@ DROP TABLE as_select1;
 --CREATE TABLE oid_pk (f1 INT, PRIMARY KEY(oid)) WITH OIDS;
 --DROP TABLE oid_pk;
 -- Test github issue #7340. truncating a toast unlogged table fails.
+-- Leave the table on purpose for pg_dump and gp_replica_check tests.
 CREATE UNLOGGED TABLE unlogged_toast (a text);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 TRUNCATE unlogged_toast;
-DROP TABLE unlogged_toast;

--- a/src/test/regress/sql/create_table.sql
+++ b/src/test/regress/sql/create_table.sql
@@ -272,6 +272,6 @@ DROP TABLE as_select1;
 --DROP TABLE oid_pk;
 
 -- Test github issue #7340. truncating a toast unlogged table fails.
+-- Leave the table on purpose for pg_dump and gp_replica_check tests.
 CREATE UNLOGGED TABLE unlogged_toast (a text);
 TRUNCATE unlogged_toast;
-DROP TABLE unlogged_toast;


### PR DESCRIPTION
Unlogged tables do not propagate to replica servers, skip the check.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
