### PR TITLE
[6X Backport]Resolve high `CacheMemoryContext` usage for `ANALYZE` on large partition table.

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -4198,17 +4198,40 @@ merge_leaf_stats(VacAttrStatsP stats,
 	int totalhll_count = 0;
 	foreach (lc, oid_list)
 	{
-		Oid relid = lfirst_oid(lc);
-		colAvgWidth =
-			colAvgWidth +
-			get_attavgwidth(relid, stats->attr->attnum) * relTuples[i];
-		nullCount = nullCount +
-					get_attnullfrac(relid, stats->attr->attnum) * relTuples[i];
+		Oid		leaf_relid = lfirst_oid(lc);
+		int32	stawidth = 0;
+		float4	stanullfrac = 0.0;
 
+		/*
+		 * Here, using the root table's attnum to retrieve the attname. And then use
+		 * the attname to retrieve the real attnum in current leaf table.
+		 * This is required because modification on root partition columns will cause
+		 * inconsistent attnum between root table and new added leaf tables.
+		 */
 		const char *attname = get_relid_attribute_name(stats->attr->attrelid, stats->attr->attnum);
-		AttrNumber child_attno = get_attnum(relid, attname);
 
-		heaptupleStats[i] = get_att_stats(relid, child_attno);
+		/*
+		 * fetch_leaf_attnum and fetch_leaf_att_stats retrieve leaf partition
+		 * table's pg_attribute tuple and pg_statistic tuple through index scan
+		 * instead of system catalog cache. Since if using system catalog cache,
+		 * the total tuple entries insert into the cache will up to:
+		 * (number_of_leaf_tables * number_of_column_in_this_table) pg_attribute tuples
+		 * +
+		 * (number_of_leaf_tables * number_of_column_in_this_table) pg_statistic tuples
+		 * which could use extremely large memroy in CacheMemoryContext.
+		 * This happens when all of the leaf tables are analyzed. And the current function
+		 * will execute for all columns.
+		 *
+		 * fetch_leaf_att_stats copy the original tuple, so remember to free it.
+		 *
+		 * As a side-effect, ANALYZE same root table serveral times in same session is much
+		 * more slower than before since we don't rely on system catalog cache.
+		 *
+		 * But we still using the tuple descriptor in system catalog cache to retrieve
+		 * attribute in fetched tuples. See get_attstatsslot.
+		 */
+		AttrNumber child_attno = fetch_leaf_attnum(leaf_relid, attname);
+		heaptupleStats[i] = fetch_leaf_att_stats(leaf_relid, child_attno);
 
 		// if there is no colstats, we can skip this partition's stats
 		if (!HeapTupleIsValid(heaptupleStats[i]))
@@ -4216,6 +4239,11 @@ merge_leaf_stats(VacAttrStatsP stats,
 			i++;
 			continue;
 		}
+
+		stawidth = ((Form_pg_statistic) GETSTRUCT(heaptupleStats[i]))->stawidth;
+		stanullfrac = ((Form_pg_statistic) GETSTRUCT(heaptupleStats[i]))->stanullfrac;
+		colAvgWidth = colAvgWidth + (stawidth > 0 ? stawidth : 0) * relTuples[i];
+		nullCount = nullCount + (stanullfrac > 0.0 ? stanullfrac : 0.0) * relTuples[i];
 
 		AttStatsSlot hllSlot;
 

--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -11,6 +11,7 @@
 #include "postgres.h"
 
 #include "access/heapam.h"
+#include "catalog/indexing.h"
 #include "catalog/pg_collation.h"
 #include "catalog/pg_statistic.h"
 #include "cdb/cdbhash.h"
@@ -22,6 +23,7 @@
 #include "parser/parse_oper.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
+#include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 #include "utils/hsearch.h"
@@ -1037,6 +1039,91 @@ needs_sample(VacAttrStats **vacattrstats, int attr_cnt)
 }
 
 /*
+ * fetch_leaf_attnum - retrieve leaf table's attribute number by the
+ * attribute name through index scan on pg_attribute table.
+ */
+AttrNumber
+fetch_leaf_attnum(Oid leafRelid, const char* attname)
+{
+	Relation	rel;
+	ScanKeyData skey[2];
+	SysScanDesc sscan;
+	HeapTuple	tuple = NULL;
+	Form_pg_attribute attForm;
+	AttrNumber	result = InvalidAttrNumber;
+
+	rel = heap_open(AttributeRelationId, AccessShareLock);
+
+	ScanKeyInit(&skey[0],
+				Anum_pg_attribute_attrelid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(leafRelid));
+	ScanKeyInit(&skey[1],
+				Anum_pg_attribute_attname,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				CStringGetDatum(attname));
+
+	sscan = systable_beginscan(rel, AttributeRelidNameIndexId, true,
+							   NULL, 2, skey);
+
+	tuple = systable_getnext(sscan);
+	if (HeapTupleIsValid(tuple))
+	{
+		attForm = (Form_pg_attribute) GETSTRUCT(tuple);
+		result = attForm->attnum;
+	}
+
+	systable_endscan(sscan);
+	heap_close(rel, AccessShareLock);
+
+	return result;
+}
+
+/*
+ * fetch_leaf_att_stats - retrieve leaf table's stats info
+ * through index scan on pg_statistic table and copy the tuple.
+ *
+ * Remember to free the returned tuple if not NULL.
+ */
+HeapTuple
+fetch_leaf_att_stats(Oid leafRelid, AttrNumber leafAttNum)
+{
+	Relation	rel;
+	ScanKeyData skey[3];
+	SysScanDesc sscan;
+	HeapTuple	tuple = NULL;
+
+	rel = heap_open(StatisticRelationId, AccessShareLock);
+
+	ScanKeyInit(&skey[0],
+				Anum_pg_statistic_starelid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(leafRelid));
+	ScanKeyInit(&skey[1],
+				Anum_pg_statistic_staattnum,
+				BTEqualStrategyNumber, F_INT2EQ,
+				Int16GetDatum(leafAttNum));
+	ScanKeyInit(&skey[2],
+				Anum_pg_statistic_stainherit,
+				BTEqualStrategyNumber, F_BOOLEQ,
+				BoolGetDatum(false));
+
+	sscan = systable_beginscan(rel, StatisticRelidAttnumInhIndexId, true,
+							   NULL, 3, skey);
+
+	tuple = systable_getnext(sscan);
+	if (HeapTupleIsValid(tuple))
+	{
+		tuple = heap_copytuple(tuple);
+	}
+
+	systable_endscan(sscan);
+	heap_close(rel, AccessShareLock);
+
+	return tuple;
+}
+
+/*
  *	leaf_parts_analyzed() -- checks if all the leaf partitions are analyzed
  *                           for each requested column to be analyzed
  *
@@ -1081,6 +1168,12 @@ leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel)
 	ListCell   *lc,
 			   *lc_col;
 
+	/*
+	 * The first loop only make sure all leaf tables are analyzed through
+	 * pg_class catalog, and don't touch any leaf tables' pg_statistic
+	 * and pg_attribute tuples to avoid overhead cost if there still leaf
+	 * tables not analyzed. Return false once find a leaf table not analyzed.
+	 */
 	foreach(lc, oid_list)
 	{
 		Oid			partRelid = lfirst_oid(lc);
@@ -1091,8 +1184,32 @@ leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel)
 		float4		relTuples = get_rel_reltuples(partRelid);
 		int32		relpages = get_rel_relpages(partRelid);
 
+		/* Partition is not analyzed */
+		if (relTuples == 0.0 && relpages == 0)
+		{
+			if (relid_exclude == InvalidOid)
+				ereport(elevel,
+						(errmsg("partition %s is not analyzed, so ANALYZE will collect sample for stats calculation",
+								get_rel_name(partRelid))));
+			else
+				ereport(elevel,
+						(errmsg("auto merging of leaf partition stats to calculate root partition stats is not possible because partition %s is not analyzed",
+								get_rel_name(partRelid))));
+			return false;
+		}
+	}
+
+	foreach(lc, oid_list)
+	{
+		Oid			partRelid = lfirst_oid(lc);
+
+		if (partRelid == relid_exclude)
+			continue;
+
+		float4		relTuples = get_rel_reltuples(partRelid);
+
 		/* Partition is analyzed and we detect it is empty */
-		if (relTuples == 0.0 && relpages > 0)
+		if (relTuples == 0.0)
 			continue;
 
 		all_parts_empty = false;
@@ -1104,13 +1221,39 @@ leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel)
 			 * analyzed.
 			 */
 			AttrNumber	attnum = lfirst_int(lc_col);
-			const char *attname = get_relid_attribute_name(attrelid, attnum);
-			AttrNumber	child_attno = get_attnum(partRelid, attname);
 
-			HeapTuple	heaptupleStats = get_att_stats(partRelid, child_attno);
+			/*
+			 * Here, using the root table's attnum to retrieve the attname. And then use
+			 * the attname to retrieve the real attnum in current leaf table.
+			 * This is required because modification on root partition columns will cause
+			 * inconsistent attnum between root table and new added leaf tables.
+			 */
+			const char *attname = get_relid_attribute_name(attrelid, attnum);
+
+			/*
+			 * fetch_leaf_attnum and fetch_leaf_att_stats retrieve leaf partition
+			 * table's pg_attribute tuple and pg_statistic tuple through index scan
+			 * instead of system catalog cache. Since if using system catalog cache,
+			 * the total tuple entries insert into the cache will up to:
+			 * (number_of_leaf_tables * number_of_column_in_this_table) pg_attribute tuples
+			 * +
+			 * (number_of_leaf_tables * number_of_column_in_this_table) pg_statistic tuples
+			 * which could use extremely large memroy in CacheMemoryContext.
+			 * This happens when most of the leaf tables are analyzed. And the current loop
+			 * will loop lots of leaf tables.
+			 *
+			 * fetch_leaf_att_stats copy the original tuple, so remember to free it.
+			 *
+			 * As a side-effect, if insert/update/copy several leaf tables which under same
+			 * root partition table in same session will be much slower since auto_stats
+			 * will call this function everytime the leaf table gets update, and we don't
+			 * rely on system catalog cache now.
+			 */
+			AttrNumber	child_attno = fetch_leaf_attnum(partRelid, attname);
+			HeapTuple	heaptupleStats = fetch_leaf_att_stats(partRelid, child_attno);
 
 			/* if there is no colstats */
-			if (!HeapTupleIsValid(heaptupleStats) || relpages == 0)
+			if (!HeapTupleIsValid(heaptupleStats))
 			{
 				if (relid_exclude == InvalidOid)
 					ereport(elevel,

--- a/src/include/commands/analyzeutils.h
+++ b/src/include/commands/analyzeutils.h
@@ -54,6 +54,8 @@ extern int aggregate_leaf_partition_histograms(Oid relationOid,
 											   int rem_mcv,
 											   void **result);
 extern bool needs_sample(VacAttrStats **vacattrstats, int attr_cnt);
+extern AttrNumber fetch_leaf_attnum(Oid leafRelid, const char* attname);
+extern HeapTuple fetch_leaf_att_stats(Oid leafRelid, AttrNumber leafAttNum);
 extern bool leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel);
 
 #endif  /* ANALYZEUTILS_H */


### PR DESCRIPTION
In some cases, merge stats logic for root partition table may consume
very high memory usage in CacheMemoryContext.
This may lead to `Canceling query because of high VMEM usage` when
concurrently ANALYZE partition tables.

For example, there are several root partition tables and they both have
thousands of leaf tables. And these tables are all wide tables that may
contain hundreds of columns.
So when analyze()/auto_stats() leaf tables concurrently,
`leaf_parts_analyzed` will consume lots of memory(catalog catch for
pg_statistic and pg_attribute) under
CacheMemoryContext for each backend, which may hit the protect VMEM
limit.
In `leaf_parts_analyzed`, a single backend's leaf table analysis for a
root partition table, it may add cache entries up to
number_of_leaf_tables * number_of_columns tuples from pg_statistic and
number_of_leaf_tables * number_of_columns tuples from pg_arrtibute.
Set guc `optimizer_analyze_root_partition` or
`optimizer_analyze_enable_merge_of_leaf_stats` to false could skip merge
stats for root table and `leaf_parts_analyzed` will not execute.

To resolve this issue:
1. When checking whether merge stats are available for a root table in
`leaf_parts_analyzed`, check whether all leaf tables are ANALYZEd first,
if they're still un-ANALYZE leaf table exists, return quickly to avoid touch
columns' pg_attribute and pg_statistic per leaf table(this will save lots of time).
And also don't rely on system catalog cache and use the
index to fetch the stats tuple to avoid one-time cache usage(in common cases).

2. When merging a stats in `merge_leaf_stats`, don't rely on system
catalog cache and use the index to fetch the stats tuple.

There are side-effects for not rely on system catalog cache(which are all **rare** situations).
1. If insert/update/copy several leaf tables which under **same
root partition** table in **same session** and all leaf tables are **analyzed**
will be much slower since auto_stats will call `leaf_parts_analyzed` once the leaf
table gets updated, and we don't rely on system catalog cache now.
(`set optimizer_analyze_enable_merge_of_leaf_stats=false` could avoid
this)

2. ANALYZE the same root table several times in the same session is much
slower than before since we don't rely on system catalog cache.

Seems this solution improves the performance for ANALYZE, and
it also makes ANALYZE won't hit the memory issue anymore.

(cherry picked from commit 533a47dd9707e623a1e8a09204e2ee995a09b45a)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
