### PR TITLE
[6X Backport] Add knowledge of partition selectors to Orca's DPv2 algorithm (#10263)

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropRelational.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropRelational.h
@@ -20,6 +20,7 @@
 #include "gpopt/base/CFunctionalDependency.h"
 #include "gpopt/base/CPropConstraint.h"
 #include "gpopt/base/CFunctionProp.h"
+#include "gpopt/metadata/CTableDescriptor.h"
 
 namespace gpopt
 {
@@ -67,6 +68,7 @@ namespace gpopt
 			EdptPfp,
 			EdptJoinDepth,
 			EdptFHasPartialIndexes,
+			EdptTableDescriptor,
 			EdptSentinel
 		};
 
@@ -113,6 +115,8 @@ namespace gpopt
 			// true if all logical operators in the group are of type CLogicalDynamicGet,
 			// and the dynamic get has partial indexes
 			BOOL m_fHasPartialIndexes;
+
+			CTableDescriptor *m_table_descriptor;
 
 			// private copy ctor
 			CDrvdPropRelational(const CDrvdPropRelational &);
@@ -173,7 +177,9 @@ namespace gpopt
 			CFunctionProp *DeriveFunctionProperties(CExpressionHandle &);
 
 			// has partial indexes
-			BOOL DeriveHasPartialIndexes(CExpressionHandle &exprhdl);
+			BOOL DeriveHasPartialIndexes(CExpressionHandle &);
+
+			CTableDescriptor *DeriveTableDescriptor(CExpressionHandle &);
 
 		public:
 
@@ -232,6 +238,8 @@ namespace gpopt
 
 			// has partial indexes
 			BOOL HasPartialIndexes() const;
+
+			CTableDescriptor *GetTableDescriptor() const;
 
 			// shorthand for conversion
 			static

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
@@ -335,6 +335,7 @@ namespace gpopt
 			CFunctionalDependencyArray *DeriveFunctionalDependencies();
 			CPartInfo *DerivePartitionInfo();
 			BOOL DeriveHasPartialIndexes();
+			CTableDescriptor *DeriveTableDescriptor();
 
 			// Scalar property accessors - derived as needed
 			CColRefSet *DeriveDefinedColumns();

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
@@ -317,6 +317,9 @@ namespace gpopt
 			BOOL DeriveHasPartialIndexes();
 			BOOL DeriveHasPartialIndexes(ULONG child_index);
 
+			CTableDescriptor *DeriveTableDescriptor();
+			CTableDescriptor *DeriveTableDescriptor(ULONG child_index);
+
 			// Scalar property accessors
 			CColRefSet *DeriveDefinedColumns(ULONG child_index);
 			CColRefSet *DeriveUsedColumns(ULONG child_index);

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogical.h
@@ -281,6 +281,9 @@ namespace gpopt
 			virtual
 			CFunctionProp *DeriveFunctionProperties(CMemoryPool *mp, CExpressionHandle &exprhdl) const;
 
+			virtual
+			CTableDescriptor *DeriveTableDescriptor(CMemoryPool *mp, CExpressionHandle &exprhdl) const;
+
 			//-------------------------------------------------------------------------------------
 			// Derived Stats
 			//-------------------------------------------------------------------------------------
@@ -365,6 +368,10 @@ namespace gpopt
 			// returns the table descriptor for (Dynamic)(BitmapTable)Get operators
 			static
 			CTableDescriptor *PtabdescFromTableGet(COperator *pop);
+
+			// returns the output columns for selected operator
+			static
+			CColRefArray *PoutputColsFromTableGet(COperator *pop);
 			
 			// extract the output columns descriptor from a logical get or dynamic get operator
 			static

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalBitmapTableGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalBitmapTableGet.h
@@ -167,6 +167,18 @@ namespace gpopt
 				return 1;
 			}
 
+			// derive table descriptor
+			virtual
+			CTableDescriptor *DeriveTableDescriptor
+				(
+				CMemoryPool *, // mp
+				CExpressionHandle & // exprhdl
+				)
+				const
+			{
+				return m_ptabdesc;
+			}
+
 			// compute required stat columns of the n-th child
 			virtual
 			CColRefSet *PcrsStat

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEConsumer.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEConsumer.h
@@ -148,6 +148,9 @@ namespace gpopt
 			virtual
 			CPartInfo *DerivePartitionInfo(CMemoryPool *mp, CExpressionHandle &exprhdl) const;
 
+			// derive table descriptor
+			virtual CTableDescriptor *DeriveTableDescriptor(CMemoryPool *mp, CExpressionHandle &exprhdl) const;
+
 			// compute required stats columns of the n-th child
 			virtual
 			CColRefSet *PcrsStat

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEProducer.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalCTEProducer.h
@@ -149,6 +149,8 @@ namespace gpopt
 				return PpartinfoPassThruOuter(exprhdl);
 			}
 
+			virtual
+			CTableDescriptor *DeriveTableDescriptor(CMemoryPool *mp,	CExpressionHandle &exprhdl)	const;
 			// compute required stats columns of the n-th child
 			virtual
 			CColRefSet *PcrsStat

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGet.h
@@ -115,6 +115,18 @@ namespace gpopt
 				return 1;
 			}
 
+			// derive table descriptor
+			virtual
+			CTableDescriptor *DeriveTableDescriptor
+				(
+				CMemoryPool *, // mp
+				CExpressionHandle & // exprhdl
+				)
+				const
+			{
+				return m_ptabdesc;
+			}
+
 			//-------------------------------------------------------------------------------------
 			// Required Relational Properties
 			//-------------------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
@@ -220,7 +220,18 @@ namespace gpopt
 			{
 				return 1;
 			}
-			
+
+			// derive table descriptor
+			virtual
+			CTableDescriptor *DeriveTableDescriptor
+				(
+				CMemoryPool *, // mp
+				CExpressionHandle & // exprhdl
+				)
+				const
+			{
+				return m_ptabdesc;
+			}
 
 	}; // class CLogicalDynamicGetBase
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalGet.h
@@ -189,6 +189,18 @@ namespace gpopt
 				return 1;
 			}
 
+			// derive table descriptor
+			virtual
+			CTableDescriptor *DeriveTableDescriptor
+				(
+				CMemoryPool *, // mp
+				CExpressionHandle & // exprhdl
+				)
+				const
+			{
+				return m_ptabdesc;
+			}
+
 			//-------------------------------------------------------------------------------------
 			// Required Relational Properties
 			//-------------------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalSelect.h
@@ -39,11 +39,17 @@ namespace gpopt
 
 			ExprPredToExprPredPartMap *m_phmPexprPartPred;
 
+			// table descriptor
+			CTableDescriptor *m_ptabdesc;
+
 		public:
 
 			// ctor
 			explicit
 			CLogicalSelect(CMemoryPool *mp);
+
+			// ctor
+			CLogicalSelect(CMemoryPool *mp, CTableDescriptor *ptabdesc);
 
 			// dtor
 			virtual
@@ -60,6 +66,12 @@ namespace gpopt
 			const CHAR *SzId() const
 			{
 				return "CLogicalSelect";
+			}
+
+			// return table's descriptor
+			CTableDescriptor *Ptabdesc() const
+			{
+				return m_ptabdesc;
 			}
 
 			//-------------------------------------------------------------------------------------
@@ -88,6 +100,18 @@ namespace gpopt
 				const
 			{
 				return PpcDeriveConstraintFromPredicates(mp, exprhdl);
+			}
+
+			// derive table descriptor
+			virtual
+			CTableDescriptor *DeriveTableDescriptor
+				(
+				CMemoryPool *, // mp
+				CExpressionHandle &exprhdl
+				)
+				const
+			{
+				return exprhdl.DeriveTableDescriptor(0);
 			}
 
 			// compute partition predicate to pass down to n-th child

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysical.h
@@ -239,9 +239,6 @@ namespace gpopt
 				ULONG ulScalarIndex
 				);
 
-			// compute distribution spec from the table descriptor
-			static
-			CDistributionSpec *PdsCompute(CMemoryPool *mp, const CTableDescriptor *ptabdesc, CColRefArray *pdrgpcrOutput);
 
 			// helper for a simple case of computing child's required sort order
 			static
@@ -453,6 +450,10 @@ namespace gpopt
 				ULONG ulOptReq
 				)
 				const = 0;
+
+			// compute distribution spec from the table descriptor
+			static
+			CDistributionSpec *PdsCompute(CMemoryPool *mp, const CTableDescriptor *ptabdesc, CColRefArray *pdrgpcrOutput);
 
 			// compute required sort order of the n-th child
 			virtual

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -132,7 +132,9 @@ namespace gpopt
 				EJoinOrderQuery            = 1,  // this expression uses the "query" join order
 				EJoinOrderMincard          = 2,  // this expression has the "mincard" property
 				EJoinOrderGreedyAvoidXProd = 4,  // best "greedy" expression with minimal cross products
-				EJoinOrderStats            = 8   // this expression is used to calculate the statistics
+				EJoinOrderHasPS            = 8,  // best expression with special consideration for DPE
+				EJoinOrderDP               = 16, // best solution using DP
+				EJoinOrderStats            = 32   // this expression is used to calculate the statistics
 												 // (row count) for the group
 			};
 
@@ -163,7 +165,7 @@ namespace gpopt
 				SGroupAndExpression(SGroupInfo *g, ULONG ix) : m_group_info(g), m_expr_index(ix) {}
 				SGroupAndExpression(const SGroupAndExpression &other) : m_group_info(other.m_group_info),
 																		  m_expr_index(other.m_expr_index) {}
-				SExpressionInfo *GetExprInfo() const { return (*m_group_info->m_best_expr_info_array)[m_expr_index]; }
+				SExpressionInfo *GetExprInfo() const { return m_expr_index == gpos::ulong_max ? NULL : (*m_group_info->m_best_expr_info_array)[m_expr_index]; }
 				BOOL IsValid() { return NULL != m_group_info && gpos::ulong_max != m_expr_index; }
 				BOOL operator == (const SGroupAndExpression &other) const
 				{ return m_group_info == other.m_group_info && m_expr_index == other.m_expr_index; }
@@ -187,10 +189,23 @@ namespace gpopt
 				// in the future, we may add more properties relevant to the cost here,
 				// like distribution spec, partition selectors
 
+				// Stores part keys for atoms that are partitioned tables. NULL otherwise.
+				CPartKeysArray *m_atom_part_keys_array;
+
 				// cost of the expression
 				CDouble m_cost;
 
+				//cost adjustment for the effect of partition selectors, this is always <= 0.0
+				CDouble m_cost_adj_PS;
+
+				// base table rows, -1 if not atom or get/select
+				CDouble m_atom_base_table_rows;
+
+				// stores atom ids that are fufilled by a PS in this expression
+				CBitSet *m_contain_PS;
+
 				SExpressionInfo(
+								CMemoryPool *mp,
 								CExpression *expr,
 								const SGroupAndExpression &left_child_expr_info,
 								const SGroupAndExpression &right_child_expr_info,
@@ -199,29 +214,45 @@ namespace gpopt
 								   m_left_child_expr(left_child_expr_info),
 								   m_right_child_expr(right_child_expr_info),
 								   m_properties(properties),
-								   m_cost(0.0)
+								   m_atom_part_keys_array(NULL),
+								   m_cost(0.0),
+								   m_cost_adj_PS(0.0),
+								   m_atom_base_table_rows(-1.0),
+								   m_contain_PS(NULL)
+
 				{
+					m_contain_PS = GPOS_NEW(mp) CBitSet(mp);
+					this->UnionPSProperties(left_child_expr_info.GetExprInfo());
+					this->UnionPSProperties(right_child_expr_info.GetExprInfo());
 				}
 
 				SExpressionInfo(
+								CMemoryPool *mp,
 								CExpression *expr,
 								SExpressionProperties &properties
 								) : m_expr(expr),
 									m_properties(properties),
-									m_cost(0.0)
+									m_atom_part_keys_array(NULL),
+									m_cost(0.0),
+									m_cost_adj_PS(0.0),
+									m_atom_base_table_rows(-1.0),
+									m_contain_PS(NULL)
 				{
+					m_contain_PS = GPOS_NEW(mp) CBitSet(mp);
 				}
 
 				~SExpressionInfo()
 				{
 					m_expr->Release();
+					CRefCount::SafeRelease(m_contain_PS);
 				}
 
 				// cost (use -1 for greedy solutions to ensure we keep all of them)
 				CDouble GetCostForHeap() { return m_properties.IsGreedy() ? -1.0 : GetCost(); }
 
-				CDouble GetCost() { return m_cost; }
+				CDouble GetCost() { return m_cost + m_cost_adj_PS; }
 
+				void UnionPSProperties(SExpressionInfo *other) {m_contain_PS->Union(other->m_contain_PS); }
 				BOOL ChildrenAreEqual(const SExpressionInfo &other) const
 				{ return m_left_child_expr == other.m_left_child_expr && m_right_child_expr == other.m_right_child_expr; }
 			};
@@ -253,6 +284,7 @@ namespace gpopt
 								  m_lowest_expr_cost(-1.0)
 					{
 						m_best_expr_info_array = GPOS_NEW(mp) SExpressionInfoArray(mp);
+
 					}
 
 					~SGroupInfo()
@@ -353,6 +385,10 @@ namespace gpopt
 			// top K expressions at the top level
 			CKHeap<SExpressionInfoArray, SExpressionInfo> *m_top_k_expressions;
 
+			// top K expressions at top level that contain promising dynamic partiion selectors
+			// if there are no promising dynamic partition selectors, this will be empty
+			CKHeap<SExpressionInfoArray, SExpressionInfo> *m_top_k_part_expressions;
+
 			// current penalty for cross products (depends on enumeration algorithm)
 			CDouble m_cross_prod_penalty;
 
@@ -421,6 +457,8 @@ namespace gpopt
 			SGroupInfo *LookupOrCreateGroupInfo(SLevelInfo *levelInfo, CBitSet *atoms, SExpressionInfo *stats_expr_info);
 			// add a new expression to a group, unless there already is an existing expression that dominates it
 			void AddExprToGroupIfNecessary(SGroupInfo *group_info, SExpressionInfo *new_expr_info);
+
+			void PopulateDPEInfo(SExpressionInfo *join_expr_info, SGroupInfo *left_group_info, SGroupInfo *right_group_info);
 
 			void FinalizeDPLevel(ULONG level);
 

--- a/src/backend/gporca/libgpopt/src/base/CDrvdPropRelational.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDrvdPropRelational.cpp
@@ -137,6 +137,8 @@ CDrvdPropRelational::Derive
 
 	DeriveHasPartialIndexes(exprhdl);
 
+	DeriveTableDescriptor(exprhdl);
+
 	m_is_complete = true;
 }
 
@@ -635,5 +637,25 @@ CDrvdPropRelational::DeriveHasPartialIndexes(CExpressionHandle &exprhdl)
 	}
 
 	return m_fHasPartialIndexes;
+}
+
+// table descriptor
+CTableDescriptor *
+CDrvdPropRelational::GetTableDescriptor() const
+{
+	GPOS_RTL_ASSERT(IsComplete());
+	return m_table_descriptor;
+}
+
+CTableDescriptor *
+CDrvdPropRelational::DeriveTableDescriptor(CExpressionHandle &exprhdl)
+{
+	if (!m_is_prop_derived->ExchangeSet(EdptTableDescriptor))
+	{
+		CLogical *popLogical = CLogical::PopConvert(exprhdl.Pop());
+		m_table_descriptor = popLogical->DeriveTableDescriptor(m_mp, exprhdl);
+	}
+
+	return m_table_descriptor;
 }
 // EOF

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -2264,10 +2264,17 @@ CUtils::PexprLogicalSelect
 	GPOS_ASSERT(NULL != pexpr);
 	GPOS_ASSERT(NULL != pexprPredicate);
 
+	CTableDescriptor *ptabdesc = NULL;
+	if (pexpr->Pop()->Eopid() == CLogical::EopLogicalSelect || pexpr->Pop()->Eopid() == CLogical::EopLogicalGet || pexpr->Pop()->Eopid() == CLogical::EopLogicalDynamicGet)
+	{
+		ptabdesc = pexpr->DeriveTableDescriptor();
+		// there are some cases where we don't populate LogicalSelect currently
+		GPOS_ASSERT_IMP(pexpr->Pop()->Eopid() != CLogical::EopLogicalSelect,NULL != ptabdesc);
+	}
 	return GPOS_NEW(mp) CExpression
 						(
 						mp,
-						GPOS_NEW(mp) CLogicalSelect(mp),
+						GPOS_NEW(mp) CLogicalSelect(mp, ptabdesc),
 						pexpr,
 						pexprPredicate
 						);

--- a/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
@@ -1660,6 +1660,14 @@ CExpression::DeriveHasPartialIndexes()
 	return m_pdprel->DeriveHasPartialIndexes(exprhdl);
 }
 
+CTableDescriptor *
+CExpression::DeriveTableDescriptor()
+{
+	CExpressionHandle exprhdl(m_mp);
+	exprhdl.Attach(this);
+	return m_pdprel->DeriveTableDescriptor(exprhdl);
+}
+
 // Scalar property accessors - derived as needed
 CColRefSet *
 CExpression::DeriveDefinedColumns()

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
@@ -2030,6 +2030,27 @@ CExpressionHandle::DeriveHasPartialIndexes()
 	return GetRelationalProperties()->HasPartialIndexes();
 }
 
+CTableDescriptor *
+CExpressionHandle::DeriveTableDescriptor()
+{
+	if (NULL != Pexpr())
+	{
+		return Pexpr()->DeriveTableDescriptor();
+	}
+
+	return GetRelationalProperties()->GetTableDescriptor();
+}
+
+CTableDescriptor *
+CExpressionHandle::DeriveTableDescriptor(ULONG child_index)
+{
+	if (NULL != Pexpr())
+	{
+		return (*Pexpr())[child_index]->DeriveTableDescriptor();
+	}
+
+	return GetRelationalProperties(child_index)->GetTableDescriptor();
+}
 // Scalar property accessors
 
 CColRefSet *

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -33,6 +33,7 @@
 #include "gpopt/operators/CLogicalGet.h"
 #include "gpopt/operators/CLogicalDynamicGet.h"
 #include "gpopt/operators/CLogicalNAryJoin.h"
+#include "gpopt/operators/CLogicalSelect.h"
 #include "gpopt/operators/CExpression.h"
 #include "gpopt/operators/CExpressionHandle.h"
 #include "gpopt/operators/CPredicateUtils.h"
@@ -1002,6 +1003,26 @@ CLogical::DeriveFunctionProperties
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CLogical::DeriveTableDescriptor
+//
+//	@doc:
+//		Derive table descriptor for tables used by operator
+//
+//---------------------------------------------------------------------------
+CTableDescriptor *
+CLogical::DeriveTableDescriptor
+	(
+	CMemoryPool *,
+	CExpressionHandle &
+	)
+	const
+{
+	//currently return null unless there is a single table being used. Later we may want
+	//to make this return a set of table descriptors and pass them up all operators
+	return NULL;
+}
+//---------------------------------------------------------------------------
+//	@function:
 //		CLogical::PfpDeriveFromScalar
 //
 //	@doc:
@@ -1403,8 +1424,9 @@ CLogical::PtabdescFromTableGet
 			return CLogicalBitmapTableGet::PopConvert(pop)->Ptabdesc();
 		case CLogical::EopLogicalDynamicBitmapTableGet:
 			return CLogicalDynamicBitmapTableGet::PopConvert(pop)->Ptabdesc();
+		case CLogical::EopLogicalSelect:
+			return CLogicalSelect::PopConvert(pop)->Ptabdesc();
 		default:
-			GPOS_ASSERT(false && "Unsupported operator in CLogical::PtabdescFromTableGet");
 			return NULL;
 	}
 }

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalCTEConsumer.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalCTEConsumer.cpp
@@ -256,6 +256,19 @@ CLogicalCTEConsumer::DeriveJoinDepth
 	return pexpr->DeriveJoinDepth();
 }
 
+// derive table descriptor
+CTableDescriptor *
+CLogicalCTEConsumer::DeriveTableDescriptor
+	(
+	CMemoryPool *, //mp
+	CExpressionHandle & //exprhdl
+	)
+	const
+{
+	CExpression *pexpr = COptCtxt::PoctxtFromTLS()->Pcteinfo()->PexprCTEProducer(m_id);
+	GPOS_ASSERT(NULL != pexpr);
+	return pexpr->DeriveTableDescriptor();
+}
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalCTEProducer.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalCTEProducer.cpp
@@ -158,6 +158,18 @@ CLogicalCTEProducer::DeriveMaxCard
 	return exprhdl.DeriveMaxCard(0);
 }
 
+CTableDescriptor *
+CLogicalCTEProducer::DeriveTableDescriptor
+	(
+	CMemoryPool *, // mp
+	CExpressionHandle &exprhdl
+	)
+	const
+{
+	// pass on table descriptor of first child
+	return exprhdl.DeriveTableDescriptor(0);
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CLogicalCTEProducer::Matches

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalSelect.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalSelect.cpp
@@ -39,7 +39,20 @@ CLogicalSelect::CLogicalSelect
 	CMemoryPool *mp
 	)
 	:
-	CLogicalUnary(mp)
+	CLogicalUnary(mp),
+	m_ptabdesc(NULL)
+{
+	m_phmPexprPartPred = GPOS_NEW(mp) ExprPredToExprPredPartMap(mp);
+}
+
+CLogicalSelect::CLogicalSelect
+	(
+	CMemoryPool *mp,
+	CTableDescriptor *ptabdesc
+	)
+	:
+	CLogicalUnary(mp),
+	m_ptabdesc(ptabdesc)
 {
 	m_phmPexprPartPred = GPOS_NEW(mp) ExprPredToExprPredPartMap(mp);
 }

--- a/src/backend/gporca/libgpopt/src/xforms/CXformExpandNAryJoinDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformExpandNAryJoinDPv2.cpp
@@ -155,6 +155,7 @@ CXformExpandNAryJoinDPv2::Transform
 		nextJoinOrder->Release();
 		pxfres->Add(pexprNormalized);
 	}
+
 }
 
 // EOF

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -2891,7 +2891,8 @@ CXformUtils::PexprBuildIndexPlan
 	BOOL fDynamicGet = (COperator::EopLogicalDynamicGet == op_id);
 	GPOS_ASSERT_IMP(!fDynamicGet, NULL == ppartcnstrIndex);
 
-	CTableDescriptor *ptabdesc = CLogical::PtabdescFromTableGet(pexprGet->Pop());
+	CTableDescriptor *ptabdesc = pexprGet->DeriveTableDescriptor();
+	GPOS_ASSERT(NULL != ptabdesc);
 	CColRefArray *pdrgpcrOutput = NULL;
 	CWStringConst *alias = NULL;
 	ULONG ulPartIndex = gpos::ulong_max;
@@ -3926,7 +3927,8 @@ CXformUtils::PexprSelect2BitmapBoolOp
 	CExpression *pexprScalar = (*pexpr)[1];
 	CLogical *popGet = CLogical::PopConvert(pexprRelational->Pop());
 
-	CTableDescriptor *ptabdesc = CLogical::PtabdescFromTableGet(popGet);
+	CTableDescriptor *ptabdesc = pexprRelational->DeriveTableDescriptor();
+	GPOS_ASSERT(NULL != ptabdesc);
 	const ULONG ulIndices = ptabdesc->IndexCount();
 	if (0 == ulIndices)
 	{

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -1256,7 +1256,7 @@ CStatisticsUtils::DeriveStatsForBitmapTableGet
 {
 	GPOS_ASSERT(CLogical::EopLogicalBitmapTableGet == expr_handle.Pop()->Eopid() ||
 				CLogical::EopLogicalDynamicBitmapTableGet == expr_handle.Pop()->Eopid());
-	CTableDescriptor *table_descriptor = CLogical::PtabdescFromTableGet(expr_handle.Pop());
+	CTableDescriptor *table_descriptor = expr_handle.DeriveTableDescriptor();
 
 	// the index of the condition
 	ULONG child_cond_index = 0;


### PR DESCRIPTION
This is a direct backport of 9c4453211e627887990599773ab1ffa5ee310bb0

Orca's DP algorithms currently generate logical alternatives based only on cardinality; they do not take into account motions/partition selectors as these are physical properties handled later in the optimization process. Since DPv2 doesn't generate all possible alternatives for the optimization stage, we end up generating alternatives that do not support partition selection or can only place poor partition selectors.

This PR introduces partition knowledge into the DPv2 algorithm. If there is a possible partition selector, it will generate an alternative that considers it, in addition to the previous alternatives.

We introduce new properties, m_contain_PS  to indicate whether a SExpressionInfo contains a PS for a particular expression. We consider an expression to have a possible partition selector if the join expression columns and the partition table's partition key overlap. If they do, we mark this expression as containing a PS for a particular PT.

We consider a good PS one which is selective. Eg:
```
- DTS
- PS
   -TS
     - Pred
```

would be selective. However, if there is no selective predicate, we do not consider this as a promising PS.

For now, we add just a single alternative that satisfies this property and only consider linear trees.