### PR TITLE
Release tcp_event after socket closing in gpsmon to remove it from event loop

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpsmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpsmon.c
@@ -646,6 +646,8 @@ static void gx_gettcpcmd(SOCKET sock, short event, void* arg)
 		{
 			close(gx.tcp_sock);
 			gx.tcp_sock=0;
+			if (event_del(&gx.tcp_event))
+				gpsmon_fatal(FLINE, "event_del failed");
 		}
 		return;
 	}


### PR DESCRIPTION
After second establishment of tcp connection from gpmmon to gpsmon the
last one enters to infinite loop inside libevent routine of timeout
event processing. The reason was in calling event_set function under new
connection establishment on currently working (not released) tcp_event
that rewrites internal flags of that event and puts it into unconsistent
state.

The current fix releases tcp_event from participating in event loop
(takes to unpending state) under connection closing from gpsmon by
timeout so that the next new connection have to set tpc_event in event
loop again.
