### PR TITLE
Document that CLUSTER against AO table is not MVCC safe

### DIFF
--- a/doc/src/sgml/ref/cluster.sgml
+++ b/doc/src/sgml/ref/cluster.sgml
@@ -184,9 +184,9 @@ CLUSTER [VERBOSE]
    </para>
 
   <para>
-   <command>CLUSTER<command/> against AO tables is not MVCC-safe. After clustering,
-   the table will appear empty to concurrent transactions, if they are using
-   a snapshot taken before the truncation occurred.
+   <command>CLUSTER<command/> against append-optimized tables is not MVCC-safe.
+   After clustering, the table will appear empty to concurrent transactions, if
+   they are using a snapshot taken before the clustering started.
    See <xref linkend="mvcc-caveats"> for more details.
   </para>
 

--- a/doc/src/sgml/ref/cluster.sgml
+++ b/doc/src/sgml/ref/cluster.sgml
@@ -183,6 +183,13 @@ CLUSTER [VERBOSE]
     are periodically reclustered.
    </para>
 
+  <para>
+   <command>CLUSTER<command/> against AO tables is not MVCC-safe. After clustering,
+   the table will appear empty to concurrent transactions, if they are using
+   a snapshot taken before the truncation occurred.
+   See <xref linkend="mvcc-caveats"> for more details.
+  </para>
+
  </refsect1>
 
  <refsect1>

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
@@ -84,9 +84,9 @@
           to abort. <codeph>DECLARE...FOR UPDATE</codeph> and triggers
           are not supported with append-optimized tables. <codeph>CLUSTER</codeph> on
           append-optimized tables is only supported over B-tree indexes and is not MVCC-safe.
-          <codeph>CLUSTER<codeph/> against AO tables is not MVCC-safe. After clustering,
-          the AO table will appear empty to concurrent transactions, if they are using
-          a snapshot taken before the truncation occurred.</p>
+          <codeph>CLUSTER<codeph/> against append-optimized tables is not MVCC-safe. After clustering,
+          the append-optimized table will appear empty to concurrent transactions, if they are using
+          a snapshot taken before the clustering started.</p>
       </section>
     </body>
   </topic>

--- a/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
+++ b/gpdb-doc/dita/admin_guide/ddl/ddl-storage.xml
@@ -83,7 +83,10 @@
           tables in a repeatable read  or serizalizable transaction and will cause the transaction
           to abort. <codeph>DECLARE...FOR UPDATE</codeph> and triggers
           are not supported with append-optimized tables. <codeph>CLUSTER</codeph> on
-          append-optimized tables is only supported over B-tree indexes.</p>
+          append-optimized tables is only supported over B-tree indexes and is not MVCC-safe.
+          <codeph>CLUSTER<codeph/> against AO tables is not MVCC-safe. After clustering,
+          the AO table will appear empty to concurrent transactions, if they are using
+          a snapshot taken before the truncation occurred.</p>
       </section>
     </body>
   </topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CLUSTER.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CLUSTER.xml
@@ -83,7 +83,7 @@ same table page, and so you save disk accesses and speed up the query.
                                         <codeph>CLUSTER</codeph> without any parameters, so that the
                                 desired tables are periodically reclustered.</p>
                                 <note><codeph>CLUSTER</codeph> on append-optmized storage tables is not MVCC-safe and is only supported on B-tree indexes.
-                                After clustering, the AO table will appear empty to concurrent transactions, if they are using a snapshot taken before the truncation occurred.</note>
+                                After clustering, the append-optimized table will appear empty to concurrent transactions, if they are using a snapshot taken before the clustering started.</note>
                                 </section><section id="section6"><title>Examples</title><p>Cluster the table <codeph>employees</codeph> on the basis of its index
         <codeph>emp_ind</codeph>:</p><codeblock>CLUSTER emp_ind ON emp;</codeblock><p>Cluster a large table by recreating it and loading it in the correct index
 order:</p><codeblock>CREATE TABLE newtable AS SELECT * FROM table ORDER BY column;

--- a/gpdb-doc/dita/ref_guide/sql_commands/CLUSTER.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CLUSTER.xml
@@ -7,8 +7,8 @@ Not a recommended operation in Greenplum Database.</p><section id="section2"><ti
 CLUSTER [VERBOSE] <varname>tablename</varname>
 
 CLUSTER [VERBOSE]</codeblock></section><section id="section3"><title>Description</title><p><codeph>CLUSTER</codeph> orders a heap storage table based on an index.
-<codeph>CLUSTER</codeph> on non-B-tree indexes is not supported on append-optmized storage
-tables. Clustering an index means that the records are physically ordered
+<codeph>CLUSTER</codeph> on append-optmized storage tables is not MVCC-safe and is only supported on B-tree indexes.
+Clustering an index means that the records are physically ordered
 on disk according to the index information. If the records you need are
 distributed randomly on disk, then the database has to seek across the
 disk to get the records requested. If those records are stored more closely
@@ -81,7 +81,10 @@ same table page, and so you save disk accesses and speed up the query.
                                 you can cluster the tables you want clustered manually the first
                                 time, then set up a periodic maintenance script that executes
                                         <codeph>CLUSTER</codeph> without any parameters, so that the
-                                desired tables are periodically reclustered.</p><note><codeph>CLUSTER</codeph> on non-B-tree indexes is not supported with append-optimized tables.</note></section><section id="section6"><title>Examples</title><p>Cluster the table <codeph>employees</codeph> on the basis of its index
+                                desired tables are periodically reclustered.</p>
+                                <note><codeph>CLUSTER</codeph> on append-optmized storage tables is not MVCC-safe and is only supported on B-tree indexes.
+                                After clustering, the AO table will appear empty to concurrent transactions, if they are using a snapshot taken before the truncation occurred.</note>
+                                </section><section id="section6"><title>Examples</title><p>Cluster the table <codeph>employees</codeph> on the basis of its index
         <codeph>emp_ind</codeph>:</p><codeblock>CLUSTER emp_ind ON emp;</codeblock><p>Cluster a large table by recreating it and loading it in the correct index
 order:</p><codeblock>CREATE TABLE newtable AS SELECT * FROM table ORDER BY column;
 DROP table;

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
@@ -765,8 +765,8 @@ CREATE [ [GLOBAL | LOCAL] {TEMPORARY | TEMP} | UNLOGGED ] TABLE [IF NOT EXISTS]
         <li>For append-optimized tables, <codeph>UPDATE</codeph> and <codeph>DELETE</codeph> are not
           allowed in a repeatable read or serializable transaction and will cause the transaction to
           abort. <codeph>DECLARE...FOR UPDATE</codeph>, and triggers are
-          not supported with append-optimized tables. <codeph>CLUSTER</codeph> on
-          append-optimized tables is only supported over B-tree indexes.</li>
+          not supported with append-optimized tables. <codeph>CLUSTER</codeph> on append-optmized
+          storage tables is not MVCC-safe and is only supported on B-tree indexes.</li>
         <li>To insert data into a partitioned table, you specify the root partitioned table, the
           table created with the <codeph>CREATE TABLE</codeph> command. You also can specify a leaf
           child table of the partitioned table in an <codeph>INSERT</codeph> command. An error is


### PR DESCRIPTION
Pull request #9996 introduced CLUSTER command for AO tables, but did not document
that they are not MVCC safe. The problem is discussed at #10262. This pull request
proposes possible documentation of MVCC unsafety of the CLUSTER command.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [x] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
