### PR TITLE
[6X Backport]Coverity: dump_mt_bind should free FILE pointer.

### DIFF
--- a/src/backend/utils/error/debugutils.c
+++ b/src/backend/utils/error/debugutils.c
@@ -278,6 +278,7 @@ void dump_mt_bind(MemTupleBinding *mt_bind, const char *fname)
                     mt_bind->large_bind.null_saves[i]
                );
     }
+	fclose(ofile);
 }
 
 #ifdef USE_ASSERT_CHECKING


### PR DESCRIPTION
(cherry picked from commit 9d801056b29744a0d58a2459a192a8e64142d336)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
