### PR TITLE
[6X backport] Add a test for replication lag

### DIFF
--- a/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
+++ b/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
@@ -1,0 +1,169 @@
+include: helpers/server_helpers.sql;
+CREATE
+
+-- Test this scenario:
+-- mirror has latency replaying the WAL from the primary, the master is reset
+-- from PANIC, master will start the DTX recovery process to recover the
+-- in-progress two-phase transactions.
+-- The FTS process should be able to continue probe and 'sync off' the mirror
+-- while the 'dtx recovery' process is hanging recovering distributed transactions.
+
+-- modify fts gucs to speed up the test.
+1: alter system set gp_fts_probe_interval to 10;
+ALTER
+1: alter system set gp_fts_probe_retries to 1;
+ALTER
+1: select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+
+1: create table t_wait_lsn(a int);
+CREATE
+
+-- suspend segment 0 before performing 'COMMIT PREPARED'
+2: select gp_inject_fault_infinite('finish_prepared_start_of_function', 'suspend', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1&: insert into t_wait_lsn values(2),(1);  <waiting ...>
+2: select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- let walreceiver on mirror 0 skip WAL flush
+2: select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- resume 'COMMIT PREPARED', session 1 will hang on 'SyncRepWaitForLSN'
+2: select gp_inject_fault_infinite('finish_prepared_start_of_function', 'reset', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+0U: select count(*) from pg_prepared_xacts;
+ count 
+-------
+ 1     
+(1 row)
+
+-- stop mirror
+3: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE content=0 AND role = 'm';
+ pg_ctl 
+--------
+ OK     
+(1 row)
+-- trigger master reset
+3: select gp_inject_fault('before_read_command', 'panic', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- verify master panic happens. The PANIC message does not emit sometimes so
+-- mask it.
+-- start_matchsubs
+-- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- end_matchsubs
+3: select 1;
+PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+-- wait for master finish crash recovery
+-1U: select wait_until_standby_in_state('streaming');
+ wait_until_standby_in_state 
+-----------------------------
+ streaming                   
+(1 row)
+
+-- wait for FTS to 'sync off' the mirror, meanwhile, dtx recovery process will
+-- restart repeatedly.
+-- the query should succeed finally since dtx recovery process is able to quit.
+-- this's what we want to test.
+4: select count(*) from t_wait_lsn;
+ count 
+-------
+ 2     
+(1 row)
+
+1<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+!\retcode gprecoverseg -a;
+-- start_ignore
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Starting gprecoverseg with args: -a
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5441.g9dc261e1f2 build dev'
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.6beta4 (Greenplum Database 7.0.0-alpha.0+dev.5441.g9dc261e1f2 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 6.2.0, 64-bit compiled on Jan 23 2020 07:13:04'
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Heap checksum setting is consistent between master and the segments that are candidates for recoverseg
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Greenplum instance recovery parameters
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Recovery type              = Standard
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Recovery 1 of 1
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Synchronization mode                 = Incremental
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance host                 = 09c5497cf854
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance address              = 09c5497cf854
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Failed instance port                 = 7005
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance host        = 09c5497cf854
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance address     = 09c5497cf854
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Source instance port        = 7002
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-   Recovery Target                      = in-place
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-1 segment(s) to recover
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Ensuring 1 failed segment(s) are stopped
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Ensuring that shared memory is cleaned up for stopped segments
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Updating configuration with new mirrors
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Updating mirrors
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Running pg_rewind on required mirrors
+20200123:08:12:03:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Starting mirrors
+20200123:08:12:03:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-era is 2f92440ff12fbc4d_200123081054
+20200123:08:12:03:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Commencing parallel segment instance startup, please wait...
+20200123:08:12:03:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Process results...
+20200123:08:12:03:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Triggering FTS probe
+20200123:08:12:03:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-******************************************************************
+20200123:08:12:03:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Updating segments for streaming is completed.
+20200123:08:12:03:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-For segments updated successfully, streaming will continue in the background.
+20200123:08:12:03:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Use  gpstate -s  to check the streaming progress.
+20200123:08:12:03:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-******************************************************************
+
+-- end_ignore
+(exited with code 0)
+-- loop while segments come in sync
+4: select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+4: select count(*) from t_wait_lsn;
+ count 
+-------
+ 2     
+(1 row)
+4: drop table t_wait_lsn;
+DROP
+
+4: alter system reset gp_fts_probe_interval;
+ALTER
+4: alter system reset gp_fts_probe_retries;
+ALTER
+4: select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -205,6 +205,7 @@ test: segwalrep/failover_with_many_records
 test: segwalrep/dtm_recovery_on_standby
 test: segwalrep/commit_blocking_on_standby
 test: segwalrep/max_slot_wal_keep_size
+test: segwalrep/dtx_recovery_wait_lsn
 test: pg_basebackup
 test: pg_basebackup_with_tablespaces
 test: fts_manual_probe

--- a/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
+++ b/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
@@ -1,0 +1,61 @@
+include: helpers/server_helpers.sql;
+
+-- Test this scenario:
+-- mirror has latency replaying the WAL from the primary, the master is reset
+-- from PANIC, master will start the DTX recovery process to recover the
+-- in-progress two-phase transactions. 
+-- The FTS process should be able to continue probe and 'sync off' the mirror
+-- while the 'dtx recovery' process is hanging recovering distributed transactions.
+
+-- modify fts gucs to speed up the test.
+1: alter system set gp_fts_probe_interval to 10;
+1: alter system set gp_fts_probe_retries to 1;
+1: select pg_reload_conf();
+
+1: create table t_wait_lsn(a int);
+
+-- suspend segment 0 before performing 'COMMIT PREPARED'
+2: select gp_inject_fault_infinite('finish_prepared_start_of_function', 'suspend', dbid) from gp_segment_configuration where content=0 and role='p';
+1&: insert into t_wait_lsn values(2),(1);
+2: select gp_wait_until_triggered_fault('finish_prepared_start_of_function', 1, dbid) from gp_segment_configuration where content=0 and role='p';
+
+-- let walreceiver on mirror 0 skip WAL flush
+2: select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid) from gp_segment_configuration where content=0 and role='m';
+-- resume 'COMMIT PREPARED', session 1 will hang on 'SyncRepWaitForLSN'
+2: select gp_inject_fault_infinite('finish_prepared_start_of_function', 'reset', dbid) from gp_segment_configuration where content=0 and role='p';
+
+0U: select count(*) from pg_prepared_xacts;
+
+-- stop mirror
+3: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE content=0 AND role = 'm';
+-- trigger master reset
+3: select gp_inject_fault('before_read_command', 'panic', 1);
+-- verify master panic happens. The PANIC message does not emit sometimes so
+-- mask it.
+-- start_matchsubs
+-- m/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n/
+-- s/PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'\n//
+-- end_matchsubs
+3: select 1;
+
+-- wait for master finish crash recovery
+-1U: select wait_until_standby_in_state('streaming');
+
+-- wait for FTS to 'sync off' the mirror, meanwhile, dtx recovery process will
+-- restart repeatedly.
+-- the query should succeed finally since dtx recovery process is able to quit.
+-- this's what we want to test.
+4: select count(*) from t_wait_lsn;
+
+1<:
+
+!\retcode gprecoverseg -a;
+-- loop while segments come in sync
+4: select wait_until_all_segments_synchronized();
+
+4: select count(*) from t_wait_lsn;
+4: drop table t_wait_lsn;
+
+4: alter system reset gp_fts_probe_interval;
+4: alter system reset gp_fts_probe_retries;
+4: select pg_reload_conf();


### PR DESCRIPTION
When the mirror is down and the master is reset, the 'dtx recovery' process
will hang because the primary can't sync the WAL to the mirror. The FTS
should be able to probe and 'sync off' the mirror.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
