### PR TITLE
ic-proxy: correct SIGHUP handler

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -406,7 +406,7 @@ ic_proxy_server_main(void)
 	uv_signal_start(&ic_proxy_server_signal_hup, ic_proxy_server_on_signal, SIGHUP);
 
 	uv_signal_init(&ic_proxy_server_loop, &ic_proxy_server_signal_int);
-	uv_signal_start(&ic_proxy_server_signal_hup, ic_proxy_server_on_signal, SIGINT);
+	uv_signal_start(&ic_proxy_server_signal_int, ic_proxy_server_on_signal, SIGINT);
 
 	/* on master */
 	uv_signal_init(&ic_proxy_server_loop, &ic_proxy_server_signal_term);


### PR DESCRIPTION
Fixed the bug that the SIGHUP handler was installed for SIGINT by
mistake, so the ic-proxy bgworkers would die on SIGHUP.

By correcting the signal name, now we could let the ic-proxy bgworkers
reload the postgresql.conf by executing "gpstop -u".

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
