### PR TITLE
[6X only] Fix flaky test max_slot_wal_keep_size

### DIFF
--- a/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
+++ b/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
@@ -174,10 +174,10 @@ select wait_until_segment_synchronized(0);
  p    | p              | u      
  m    | m              | u      
 (2 rows)
-1: SELECT state, sync_state, sync_error FROM gp_stat_replication WHERE gp_segment_id = 0;
- state     | sync_state | sync_error 
------------+------------+------------
- streaming | sync       | none       
+1: SELECT state, sync_error FROM gp_stat_replication WHERE gp_segment_id = 0;
+ state     | sync_error 
+-----------+------------
+ streaming | none       
 (1 row)
 
 -- failover to the mirror and check the data on the primary is replicated to the mirror

--- a/src/test/isolation2/sql/segwalrep/max_slot_wal_keep_size.sql
+++ b/src/test/isolation2/sql/segwalrep/max_slot_wal_keep_size.sql
@@ -73,7 +73,7 @@ select wait_until_segment_synchronized(0);
 
 -- the mirror is up and the replication is back
 1: SELECT role, preferred_role, status FROM gp_segment_configuration WHERE content = 0;
-1: SELECT state, sync_state, sync_error FROM gp_stat_replication WHERE gp_segment_id = 0;
+1: SELECT state, sync_error FROM gp_stat_replication WHERE gp_segment_id = 0;
 
 -- failover to the mirror and check the data on the primary is replicated to the mirror
 1: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop');


### PR DESCRIPTION
In the test, check 'sync_state' in pg_stat_replication is unnecessary and it
makes the test flaky, so remove it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
