### PR TITLE
ic-proxy: type checking in ic_proxy_new()

### DIFF
--- a/src/backend/cdb/motion/ic_proxy.h
+++ b/src/backend/cdb/motion/ic_proxy.h
@@ -31,7 +31,7 @@
 
 #define ic_proxy_alloc(size) palloc(size)
 #define ic_proxy_free(ptr) pfree(ptr)
-#define ic_proxy_new(type) ic_proxy_alloc(sizeof(type))
+#define ic_proxy_new(type) ((type *) ic_proxy_alloc(sizeof(type)))
 
 #define ic_proxy_log(elevel, msg...) do { \
 	if (elevel >= IC_PROXY_LOG_LEVEL) \


### PR DESCRIPTION
A typical mistake on allocating typed memory is as below:

    int64 *ptr = malloc(sizeof(int32));

To prevent this, now we make ic_proxy_new() a typed allocator, it always
return a pointer of the specified type, for example:

    int64 *p1 = ic_proxy_new(int64); /* good */
    int64 *p2 = ic_proxy_new(int32); /* bad, gcc will raise a warning */

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
