### PR TITLE
6X:Check if RelOptInfo exits before replace subplan for grouping set query

### DIFF
--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -791,7 +791,10 @@ make_list_aggs_for_rollup(PlannerInfo *root,
 
 			/* update subplan if current_lefttree has been modified */
 			splan = findFirstSubqueryScan(root, current_lefttree);
-			if (splan != NULL && splan->subplan != root->simple_rel_array[1]->subplan)
+			if (splan != NULL &&
+					root->simple_rel_array[1] != NULL &&
+					root->simple_rte_array[1] != NULL &&
+					splan->subplan != root->simple_rel_array[1]->subplan)
 				root->simple_rel_array[1]->subplan = splan->subplan;
 
 			/* Add an Agg node */

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6195,3 +6195,35 @@ select a, (select b from bar_gset where foo_gset.a = bar_gset.b) from foo_gset g
 
 drop table foo_gset;
 drop table bar_gset;
+-- GROUPING SETS meets sub-subplan
+create table foo_gset (c1 int, c2 int) distributed by (c1);
+insert into foo_gset select i,i from generate_series(1, 10) i;
+select *
+from (select * from (select c1, sum(c2) c2 from foo_gset group by c1 ) t2 ) t3
+group by c2, rollup((c1))
+order by 1, 2;
+ c1 | c2 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+    |  1
+    |  2
+    |  3
+    |  4
+    |  5
+    |  6
+    |  7
+    |  8
+    |  9
+    | 10
+(20 rows)
+
+drop table foo_gset;

--- a/src/test/regress/sql/olap_group.sql
+++ b/src/test/regress/sql/olap_group.sql
@@ -685,3 +685,14 @@ select a, (select b from bar_gset where foo_gset.a = bar_gset.b) from foo_gset g
 
 drop table foo_gset;
 drop table bar_gset;
+
+-- GROUPING SETS meets sub-subplan
+create table foo_gset (c1 int, c2 int) distributed by (c1);
+insert into foo_gset select i,i from generate_series(1, 10) i;
+
+select *
+from (select * from (select c1, sum(c2) c2 from foo_gset group by c1 ) t2 ) t3
+group by c2, rollup((c1))
+order by 1, 2;
+
+drop table foo_gset;


### PR DESCRIPTION
For grouping set query, we need to replace our private subplan into
a plan tree. But for subplan's RelOptInfo will not create if the
sub-plan does not have any relation in its fromlist.

Check pointer in simple_rte_array and simple_rel_array to promise
which is not null before replacement.

Fix #10491 
## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
