### PR TITLE
docs - gp_fts_replication_attempt_count guc info

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -259,6 +259,9 @@
               <xref href="#gp_fts_probe_timeout"/>
             </li>
             <li>
+              <xref href="#gp_fts_replication_attempt_count"/>
+            </li>
+            <li>
               <xref href="#gp_global_deadlock_detector_period"/>
             </li>
             <li>
@@ -3325,6 +3328,36 @@
               <entry colname="col1">10 - 3600 seconds</entry>
               <entry colname="col2">20 secs</entry>
               <entry colname="col3">master<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gp_fts_replication_attempt_count">
+    <title>gp_fts_replication_attempt_count</title>
+    <body>
+      <p>Specifies the maximum number of times that Greenplum Database attempts
+        to establish a primary-mirror replication connection. When this count
+        is exceeded, the fault detection process (<codeph>ftsprobe</codeph>)
+        stops retrying and marks the mirror down.</p>
+      <table id="gp_fts_replication_attempt_count_tbl">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">0 - 100</entry>
+              <entry colname="col2">10</entry>
+              <entry colname="col3">master<p>system</p><p>reload</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1415,11 +1415,15 @@
             </stentry>
             <stentry>
               <p>
+                <xref href="guc-list.xml#gp_fts_probe_threadcount" type="section"
+                  >gp_fts_probe_threadcount</xref>
+              </p>
+              <p>
                 <xref href="guc-list.xml#gp_fts_probe_timeout" format="dita"/>
               </p>
               <p>
-                <xref href="guc-list.xml#gp_fts_probe_threadcount" type="section"
-                  >gp_fts_probe_threadcount</xref>
+                <xref href="guc-list.xml#gp_fts_replication_attempt_count" type="section"
+                  >gp_fts_replication_attempt_count</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_log_fts" format="dita"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -109,6 +109,7 @@
             <topicref href="guc-list.xml#gp_fts_probe_retries"/>
             <topicref href="guc-list.xml#gp_fts_probe_threadcount"/>
             <topicref href="guc-list.xml#gp_fts_probe_timeout"/>
+            <topicref href="guc-list.xml#gp_fts_replication_attempt_count"/>
             <topicref href="guc-list.xml#gp_global_deadlock_detector_period"/>
             <topicref href="guc-list.xml#gp_hashjoin_tuples_per_bucket"/>
             <topicref href="guc-list.xml#gp_ignore_error_table"/>


### PR DESCRIPTION
add reference docs for new guc gp_fts_replication_attempt_count.  didn't reference or document the gp_fts_mark_mirror_down_grace_period guc, because the user wouldn't need to tune that.

wasn't clear to me if/where this info might fit in our existing admin guide docs.