### PR TITLE
Print CTID when we detect data distribution wrong for UPDATE|DELETE.

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -732,8 +732,12 @@ ExecDelete(ItemPointer tupleid,
 	 * utility mode) or there is bug in code, etc.
 	 */
 	if (segid != GpIdentity.segindex)
-		elog(ERROR, "distribution key of the tuple doesn't belong to "
-			 "current segment (actually from seg%d)", segid);
+		elog(ERROR,
+			 "distribution key of the tuple (%u, %u) doesn't belong to "
+			 "current segment (actually from seg%d)",
+			 BlockIdGetBlockNumber(&(tupleid->ip_blkid)),
+			 tupleid->ip_posid,
+			 segid);
 
 	/*
 	 * get information on the (current) result relation
@@ -1269,8 +1273,12 @@ ExecUpdate(ItemPointer tupleid,
 	 * utility mode) or there is bug in code, etc.
 	 */
 	if (segid != GpIdentity.segindex)
-		elog(ERROR, "distribution key of the tuple doesn't belong to "
-			 "current segment (actually from seg%d)", segid);
+		elog(ERROR,
+			 "distribution key of the tuple (%u, %u) doesn't belong to "
+			 "current segment (actually from seg%d)",
+			 BlockIdGetBlockNumber(&(tupleid->ip_blkid)),
+			 tupleid->ip_posid,
+			 segid);
 
 	/*
 	 * get information on the (current) result relation

--- a/src/test/isolation2/expected/modify_table_data_corrupt.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt.out
@@ -81,7 +81,7 @@ explain (costs off) delete from tab1 using tab2, tab3 where tab1.a = tab2.a and 
 begin;
 BEGIN
 delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.b;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:737)  (seg1 127.0.1.1:7003 pid=56444) (nodeModifyTable.c:737)
+ERROR:  distribution key of the tuple (0, 1) doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:735)  (seg1 127.0.1.1:7003 pid=89508) (nodeModifyTable.c:735)
 abort;
 ABORT
 
@@ -108,7 +108,7 @@ explain (costs off) update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.
 begin;
 BEGIN
 update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.b;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:1284)  (seg1 127.0.1.1:7003 pid=56444) (nodeModifyTable.c:1284)
+ERROR:  distribution key of the tuple (0, 1) doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:1276)  (seg1 127.0.1.1:7003 pid=89508) (nodeModifyTable.c:1276)
 abort;
 ABORT
 

--- a/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
@@ -137,7 +137,7 @@ explain (costs off) delete from tab1 using tab2, tab3 where tab1.a = tab2.a and 
 begin;
 BEGIN
 delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:737)  (seg1 127.0.1.1:7003 pid=57517) (nodeModifyTable.c:737)
+ERROR:  distribution key of the tuple (0, 1) doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:735)  (seg1 127.0.1.1:7003 pid=89090) (nodeModifyTable.c:735)
 abort;
 ABORT
 
@@ -166,7 +166,7 @@ explain (costs off) update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.
 begin;
 BEGIN
 update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:737)  (seg1 127.0.1.1:7003 pid=47425) (nodeModifyTable.c:737)
+ERROR:  distribution key of the tuple (0, 1) doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:735)  (seg1 127.0.1.1:7003 pid=89090) (nodeModifyTable.c:735)
 abort;
 ABORT
 
@@ -190,7 +190,7 @@ explain (costs off) update tab1 set b = b + 1;
 begin;
 BEGIN
 update tab1 set b = b + 1;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:737)  (seg1 127.0.1.1:7003 pid=47425) (nodeModifyTable.c:737)
+ERROR:  distribution key of the tuple (0, 1) doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:735)  (seg1 127.0.1.1:7003 pid=89090) (nodeModifyTable.c:735)
 abort;
 ABORT
 


### PR DESCRIPTION
When update or delete statement errors out because of the CTID is
not belong to the local segment, we should also print out the CTID
of the tuple so that it will be much easier to locate the wrong-
distributed data via:
  `select * from t where gp_segment_id = xxx and ctid='(aaa,bbb)'`.
