### PR TITLE
(6x backport) Print CTID when we detect data distribution wrong for UPDATE|DELETE.

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -598,8 +598,12 @@ ExecDelete(ItemPointer tupleid,
 	 * utility mode) or there is bug in code, etc.
 	 */
 	if (segid != GpIdentity.segindex)
-		elog(ERROR, "distribution key of the tuple doesn't belong to "
-			 "current segment (actually from seg%d)", segid);
+		elog(ERROR,
+			 "distribution key of the tuple (%u, %u) doesn't belong to "
+			 "current segment (actually from seg%d)",
+			 BlockIdGetBlockNumber(&(tupleid->ip_blkid)),
+			 tupleid->ip_posid,
+			 segid);
 
 	/*
 	 * get information on the (current) result relation
@@ -1240,8 +1244,12 @@ ExecUpdate(ItemPointer tupleid,
 	 * utility mode) or there is bug in code, etc.
 	 */
 	if (segid != GpIdentity.segindex)
-		elog(ERROR, "distribution key of the tuple doesn't belong to "
-			 "current segment (actually from seg%d)", segid);
+		elog(ERROR,
+			 "distribution key of the tuple (%u, %u) doesn't belong to "
+			 "current segment (actually from seg%d)",
+			 BlockIdGetBlockNumber(&(tupleid->ip_blkid)),
+			 tupleid->ip_posid,
+			 segid);
 
 	/*
 	 * abort the operation if not running transactions

--- a/src/test/isolation2/expected/modify_table_data_corrupt.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt.out
@@ -201,7 +201,7 @@ explain (costs off) update tab1 set b = b + 1;
 begin;
 BEGIN
 update tab1 set b = b + 1;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:602)  (seg1 127.0.1.1:6003 pid=82396) (nodeModifyTable.c:602)
+ERROR:  distribution key of the tuple (0, 1) doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:601)  (seg1 127.0.1.1:6003 pid=120943) (nodeModifyTable.c:601)
 abort;
 ABORT
 

--- a/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
@@ -158,7 +158,7 @@ explain (costs off) delete from tab1 using tab2, tab3 where tab1.a = tab2.a and 
 begin;
 BEGIN
 delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:602)  (seg1 127.0.1.1:6003 pid=86447) (nodeModifyTable.c:602)
+ERROR:  distribution key of the tuple (0, 1) doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:602)  (seg1 127.0.1.1:6003 pid=86447) (nodeModifyTable.c:602)
 abort;
 ABORT
 
@@ -188,7 +188,7 @@ explain (costs off) update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.
 begin;
 BEGIN
 update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:602)  (seg1 127.0.1.1:6003 pid=78344) (nodeModifyTable.c:602)
+ERROR:  distribution key of the tuple (0, 1) doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:602)  (seg1 127.0.1.1:6003 pid=78344) (nodeModifyTable.c:602)
 abort;
 ABORT
 
@@ -209,7 +209,7 @@ explain (costs off) update tab1 set b = b + 1;
 begin;
 BEGIN
 update tab1 set b = b + 1;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:602)  (seg1 127.0.1.1:6003 pid=78344) (nodeModifyTable.c:602)
+ERROR:  distribution key of the tuple (0, 1) doesn't belong to current segment (actually from seg0) (nodeModifyTable.c:602)  (seg1 127.0.1.1:6003 pid=78344) (nodeModifyTable.c:602)
 abort;
 ABORT
 


### PR DESCRIPTION
When update or delete statement errors out because of the CTID is
not belong to the local segment, we should also print out the CTID
of the tuple so that it will be much easier to locate the wrong-
distributed data via:
  `select * from t where gp_segment_id = xxx and ctid='(aaa,bbb)'`.

-------

Master branch pr is: https://github.com/greenplum-db/gpdb/pull/10582 is merged.

Wait for next week's shipping decision.
