### PR TITLE
(5x backport) Print CTID when we detect data distribution wrong for UPDATE|DELETE.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3054,8 +3054,12 @@ lnext:	;
 					   */
 					  segid = DatumGetInt32(datum);
 					  if (segid != GpIdentity.segindex)
-					    elog(ERROR, "distribution key of the tuple doesn't belong to "
-						 "current segment (actually from seg%d)", segid);
+					    elog(ERROR,
+						 "distribution key of the tuple (%u, %u) doesn't belong to "
+						 "current segment (actually from seg%d)",
+						 BlockIdGetBlockNumber(&(tupleid->ip_blkid)),
+						 tupleid->ip_posid,
+						 segid);
 				}
 			}
 

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -132,8 +132,12 @@ ExecDML(DMLState *node)
 			Assert(!isnull);
 
 			if (segid != GpIdentity.segindex)
-				elog(ERROR, "distribution key of the tuple doesn't belong to "
-					 "current segment (actually from seg%d)", segid);
+			  elog(ERROR,
+			       "distribution key of the tuple (%u, %u) doesn't belong to "
+			       "current segment (actually from seg%d)",
+			       BlockIdGetBlockNumber(&(tupleid->ip_blkid)),
+			       tupleid->ip_posid,
+			       segid);
 		}
 
 		/* Correct tuple count by ignoring deletes when splitting tuples. */

--- a/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
@@ -95,7 +95,7 @@ Optimizer status: PQO version 3.86.0
 begin;
 BEGIN
 delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=127638) (cdbdisp.c:254)
+ERROR:  distribution key of the tuple (0, 1) doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=127638) (cdbdisp.c:254)
 abort;
 ABORT
 
@@ -126,7 +126,7 @@ Optimizer status: PQO version 3.86.0
 begin;
 BEGIN
 update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=127638) (cdbdisp.c:254)
+ERROR:  distribution key of the tuple (0, 1) doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=127638) (cdbdisp.c:254)
 abort;
 ABORT
 
@@ -147,7 +147,7 @@ Optimizer status: PQO version 3.86.0
 begin;
 BEGIN
 update tab1 set b = 999;
-ERROR:  distribution key of the tuple doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=127638) (cdbdisp.c:254)
+ERROR:  distribution key of the tuple (0, 1) doesn't belong to current segment (actually from seg1) (nodeDML.c:136)  (seg0 127.0.1.1:25432 pid=127638) (cdbdisp.c:254)
 abort;
 ABORT
 


### PR DESCRIPTION
When update or delete statement errors out because of the CTID is
not belong to the local segment, we should also print out the CTID
of the tuple so that it will be much easier to locate the wrong-
distributed data via:
  `select * from t where gp_segment_id = xxx and ctid='(aaa,bbb)'`.

--------------------

Master branch PR: https://github.com/greenplum-db/gpdb/pull/10582 is merged.

Wait for next week's shipping decision.
