### PR TITLE
Fix crash when creating partitioned table in utility mode

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -418,6 +418,17 @@ transformCreateStmt(CreateStmt *stmt, const char *queryString, bool createPartit
 	{
 		int			numsegments = -1;
 
+		/*
+		 * Child table in a partition created in utility mode doesn't have a
+		 * policy
+		 */
+		if (Gp_role != GP_ROLE_DISPATCH &&
+			!IsBinaryUpgrade &&
+			stmt->is_part_child)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+					 errmsg("cannot create partition table in utility mode")));
+
 		AssertImply(stmt->is_part_parent,
 					stmt->distributedBy == NULL);
 		AssertImply(stmt->is_part_child,

--- a/src/test/isolation2/expected/misc.out
+++ b/src/test/isolation2/expected/misc.out
@@ -45,3 +45,9 @@ CREATE
 -----------------
  pg_toast_temp_0 
 (1 row)
+
+--
+-- Validate GPDB doesn't crash when creating partitioned table in utility mode
+--
+0U: create table utilitymode_pt_lt_tab (col1 int, col2 decimal) distributed by (col1) partition by list(col2) (partition part1 values(1));
+ERROR:  cannot create partition table in utility mode

--- a/src/test/isolation2/sql/misc.sql
+++ b/src/test/isolation2/sql/misc.sql
@@ -32,3 +32,9 @@
       JOIN pg_namespace n2
         ON n2.nspname = 'pg_toast_temp_0' || substring(n1.nspname FROM 10)
      WHERE c.relname = 'utilitymode_tmp_tab';
+
+--
+-- Validate GPDB doesn't crash when creating partitioned table in utility mode
+--
+0U: create table utilitymode_pt_lt_tab (col1 int, col2 decimal)
+	distributed by (col1) partition by list(col2) (partition part1 values(1));


### PR DESCRIPTION
When transforming DISTRIBUTED BY clause in utility mode, NULL would be returned
as only QD can have policies. As a result, the child table in a partitioned
table would have NULL distributedBy, which would trigger assertion failure or
cause crash with current codes.

This patch fixes that by emitting an error message in that case to avoid the
crash.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
