### PR TITLE
[6X only] Avoid ABI change

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5322,7 +5322,7 @@ parse_int(const char *value, int *result, int flags, const char **hintmsg)
 		 * Note: the multiple-switch coding technique here is a bit tedious,
 		 * but seems necessary to avoid intermediate-value overflows.
 		 */
-		if (flags & GUC_UNIT_MEMORY)
+		if (flags & GUC_UNIT_MEMORY_NEW)
 		{
 			/* Set hint for use if no match or trailing garbage */
 			if (hintmsg)
@@ -5338,7 +5338,7 @@ parse_int(const char *value, int *result, int flags, const char **hintmsg)
 			if (strncmp(endptr, "kB", 2) == 0)
 			{
 				endptr += 2;
-				switch (flags & GUC_UNIT_MEMORY)
+				switch (flags & GUC_UNIT_MEMORY_NEW)
 				{
 					case GUC_UNIT_BLOCKS:
 						val /= (BLCKSZ / 1024);
@@ -5354,7 +5354,7 @@ parse_int(const char *value, int *result, int flags, const char **hintmsg)
 			else if (strncmp(endptr, "MB", 2) == 0)
 			{
 				endptr += 2;
-				switch (flags & GUC_UNIT_MEMORY)
+				switch (flags & GUC_UNIT_MEMORY_NEW)
 				{
 					case GUC_UNIT_KB:
 						val *= KB_PER_MB;
@@ -5370,7 +5370,7 @@ parse_int(const char *value, int *result, int flags, const char **hintmsg)
 			else if (strncmp(endptr, "GB", 2) == 0)
 			{
 				endptr += 2;
-				switch (flags & GUC_UNIT_MEMORY)
+				switch (flags & GUC_UNIT_MEMORY_NEW)
 				{
 					case GUC_UNIT_KB:
 						val *= KB_PER_GB;
@@ -5389,7 +5389,7 @@ parse_int(const char *value, int *result, int flags, const char **hintmsg)
 			else if (strncmp(endptr, "TB", 2) == 0)
 			{
 				endptr += 2;
-				switch (flags & GUC_UNIT_MEMORY)
+				switch (flags & GUC_UNIT_MEMORY_NEW)
 				{
 					case GUC_UNIT_KB:
 						val *= KB_PER_TB;
@@ -8198,7 +8198,7 @@ GetConfigOptionByNum(int varnum, const char **values, bool *noshow)
 	{
 		static char buf[8];
 
-		switch (conf->flags & (GUC_UNIT_MEMORY | GUC_UNIT_TIME))
+		switch (conf->flags & (GUC_UNIT_MEMORY_NEW | GUC_UNIT_TIME))
 		{
 			case GUC_UNIT_KB:
 				values[2] = "kB";
@@ -8609,9 +8609,9 @@ _ShowOption(struct config_generic * record, bool use_units)
 					const char *unit;
 
 					if (use_units && result > 0 &&
-						(record->flags & GUC_UNIT_MEMORY))
+						(record->flags & GUC_UNIT_MEMORY_NEW))
 					{
-						switch (record->flags & GUC_UNIT_MEMORY)
+						switch (record->flags & GUC_UNIT_MEMORY_NEW)
 						{
 							case GUC_UNIT_BLOCKS:
 								result *= BLCKSZ / 1024;
@@ -8703,12 +8703,12 @@ _ShowOption(struct config_generic * record, bool use_units)
 					char		unit[4];
 					double		result = *conf->variable;
 
-					if (use_units && result > 0 && (record->flags & GUC_UNIT_MEMORY))
+					if (use_units && result > 0 && (record->flags & GUC_UNIT_MEMORY_NEW))
 					{
                         double result_gb;
                         double result_mb;
 
-                        switch (record->flags & GUC_UNIT_MEMORY)
+                        switch (record->flags & GUC_UNIT_MEMORY_NEW)
 						{
 							case GUC_UNIT_BLOCKS:
 								result *= BLCKSZ / 1024;

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -207,24 +207,27 @@ typedef enum
 #define GUC_SUPERUSER_ONLY		0x0100	/* show only to superusers */
 #define GUC_IS_NAME				0x0200	/* limit string to NAMEDATALEN-1 */
 
-#define GUC_UNIT_KB             0x1000  /* value is in kilobytes */
-#define GUC_UNIT_BLOCKS         0x2000  /* value is in blocks */
-#define GUC_UNIT_XBLOCKS        0x3000  /* value is in xlog blocks */
-#define GUC_UNIT_MB             0x4000  /* value is in megabytes */
-#define GUC_UNIT_MEMORY         0x7000  /* mask for size-related units */
+#define GUC_UNIT_KB				0x0400	/* value is in kilobytes */
+#define GUC_UNIT_BLOCKS			0x0800	/* value is in blocks */
+#define GUC_UNIT_XBLOCKS		0x0C00	/* value is in xlog blocks */
+#define GUC_UNIT_MEMORY			0x0C00	/* mask for KB, BLOCKS, XBLOCKS */
 
-#define GUC_UNIT_MS				0x10000	/* value is in milliseconds */
-#define GUC_UNIT_S				0x20000	/* value is in seconds */
-#define GUC_UNIT_MIN			0x40000	/* value is in minutes */
-#define GUC_UNIT_TIME			0x70000	/* mask for MS, S, MIN */
+#define GUC_UNIT_MS				0x1000	/* value is in milliseconds */
+#define GUC_UNIT_S				0x2000	/* value is in seconds */
+#define GUC_UNIT_MIN			0x4000	/* value is in minutes */
+#define GUC_UNIT_TIME			0x7000	/* mask for MS, S, MIN */
 
-#define GUC_NOT_WHILE_SEC_REST	0x80000	/* can't set if security restricted */
-#define GUC_DISALLOW_IN_AUTO_FILE	0x00100000	/* can't set in PG_AUTOCONF_FILENAME */
+#define GUC_NOT_WHILE_SEC_REST	0x8000	/* can't set if security restricted */
+#define GUC_DISALLOW_IN_AUTO_FILE	0x00010000	/* can't set in PG_AUTOCONF_FILENAME */
 
 /* GPDB speific */
-#define GUC_GPDB_NEED_SYNC     0x00200000  /* guc value is synced between master and primary */
-#define GUC_GPDB_NO_SYNC       0x00400000  /* guc value is not synced between master and primary */
-#define GUC_DISALLOW_USER_SET  0x00800000 /* Do not allow this GUC to be set by the user */
+#define GUC_GPDB_NEED_SYNC     0x00020000  /* guc value is synced between master and primary */
+#define GUC_GPDB_NO_SYNC       0x00040000  /* guc value is not synced between master and primary */
+#define GUC_DISALLOW_USER_SET  0x00080000 /* Do not allow this GUC to be set by the user */
+
+#define GUC_UNIT_MB			   0x00100000 /* value is in metabytes */
+/* to avoid ABI change, add a new macro to include GUC_UNIT_MB*/
+#define GUC_UNIT_MEMORY_NEW	   (GUC_UNIT_MEMORY | GUC_UNIT_MB)
 
 /* GUC lists for gp_guc_list_show().  (List of struct config_generic) */
 extern List    *gp_guc_list_for_explain;


### PR DESCRIPTION
In commit 3ef5e26, we changed the value of some macro in guc.h, that would
introduce ABI change if 3rd-party libaraies are using the macros.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
