### PR TITLE
Fix the flaky test of walreceiver

### DIFF
--- a/src/test/walrep/expected/walreceiver.out
+++ b/src/test/walrep/expected/walreceiver.out
@@ -1,6 +1,4 @@
 -- negative cases
-SELECT test_receive();
-ERROR:  could not receive data from WAL stream: connection pointer is NULL (libpqwalreceiver.c:631)
 SELECT test_send();
 ERROR:  could not send data to WAL stream: connection pointer is NULL (libpqwalreceiver.c:650)
 SELECT test_disconnect();
@@ -102,8 +100,6 @@ create table testwalreceiver(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into testwalreceiver select * from generate_series(0, 9);
--- the reason is the same as the above vacuum
-vacuum freeze;
 -- Connect and receive the xlogs, validate everything was received from start to
 -- end
 SELECT test_connect('');
@@ -122,12 +118,6 @@ SELECT test_send();
  test_send 
 -----------
  t
-(1 row)
-
-SELECT test_receive();
- test_receive 
---------------
-            0
 (1 row)
 
 SELECT test_disconnect();

--- a/src/test/walrep/expected/walreceiver.out
+++ b/src/test/walrep/expected/walreceiver.out
@@ -102,6 +102,8 @@ create table testwalreceiver(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into testwalreceiver select * from generate_series(0, 9);
+-- the reason is the same as the above vacuum
+vacuum freeze;
 -- Connect and receive the xlogs, validate everything was received from start to
 -- end
 SELECT test_connect('');
@@ -125,7 +127,7 @@ SELECT test_send();
 SELECT test_receive();
  test_receive 
 --------------
- f
+            0
 (1 row)
 
 SELECT test_disconnect();

--- a/src/test/walrep/gplibpq.c
+++ b/src/test/walrep/gplibpq.c
@@ -93,14 +93,17 @@ test_disconnect(PG_FUNCTION_ARGS)
 	PG_RETURN_BOOL(true);
 }
 
+/* returns -1, 0 or 1 */
 Datum
 test_receive(PG_FUNCTION_ARGS)
 {
-	int			result;
+	int		result;
 	char	   *buf;
 	pgsocket	wait_fd;
 
 	result = walrcv_receive(&buf, &wait_fd);
+	if (result > 0)
+		result = 1;
 
 	PG_RETURN_INT32(result);
 }

--- a/src/test/walrep/gplibpq.c
+++ b/src/test/walrep/gplibpq.c
@@ -97,7 +97,7 @@ test_disconnect(PG_FUNCTION_ARGS)
 Datum
 test_receive(PG_FUNCTION_ARGS)
 {
-	int		result;
+	int			result;
 	char	   *buf;
 	pgsocket	wait_fd;
 

--- a/src/test/walrep/gplibpq.c
+++ b/src/test/walrep/gplibpq.c
@@ -51,14 +51,12 @@ void _PG_init(void);
 
 Datum test_connect(PG_FUNCTION_ARGS);
 Datum test_disconnect(PG_FUNCTION_ARGS);
-Datum test_receive(PG_FUNCTION_ARGS);
 Datum test_send(PG_FUNCTION_ARGS);
 Datum test_receive_and_verify(PG_FUNCTION_ARGS);
 Datum test_xlog_ao(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(test_connect);
 PG_FUNCTION_INFO_V1(test_disconnect);
-PG_FUNCTION_INFO_V1(test_receive);
 PG_FUNCTION_INFO_V1(test_send);
 PG_FUNCTION_INFO_V1(test_receive_and_verify);
 PG_FUNCTION_INFO_V1(test_xlog_ao);
@@ -91,21 +89,6 @@ test_disconnect(PG_FUNCTION_ARGS)
 	walrcv_disconnect();
 
 	PG_RETURN_BOOL(true);
-}
-
-/* returns -1, 0 or 1 */
-Datum
-test_receive(PG_FUNCTION_ARGS)
-{
-	int			result;
-	char	   *buf;
-	pgsocket	wait_fd;
-
-	result = walrcv_receive(&buf, &wait_fd);
-	if (result > 0)
-		result = 1;
-
-	PG_RETURN_INT32(result);
 }
 
 Datum

--- a/src/test/walrep/input/setup.source
+++ b/src/test/walrep/input/setup.source
@@ -4,7 +4,7 @@ create or replace function test_connect(text) RETURNS bool AS
 create or replace function test_disconnect() RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 
-create or replace function test_receive() RETURNS bool AS
+create or replace function test_receive() RETURNS int4 AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 
 create or replace function test_send() RETURNS bool AS

--- a/src/test/walrep/input/setup.source
+++ b/src/test/walrep/input/setup.source
@@ -4,9 +4,6 @@ create or replace function test_connect(text) RETURNS bool AS
 create or replace function test_disconnect() RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 
-create or replace function test_receive() RETURNS int4 AS
- '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
-
 create or replace function test_send() RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 

--- a/src/test/walrep/output/setup.source
+++ b/src/test/walrep/output/setup.source
@@ -2,8 +2,6 @@ create or replace function test_connect(text) RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 create or replace function test_disconnect() RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
-create or replace function test_receive() RETURNS int4 AS
- '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 create or replace function test_send() RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 create or replace function test_receive_and_verify(pg_lsn, pg_lsn) RETURNS bool AS

--- a/src/test/walrep/output/setup.source
+++ b/src/test/walrep/output/setup.source
@@ -2,7 +2,7 @@ create or replace function test_connect(text) RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 create or replace function test_disconnect() RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
-create or replace function test_receive() RETURNS bool AS
+create or replace function test_receive() RETURNS int4 AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;
 create or replace function test_send() RETURNS bool AS
  '@abs_builddir@/gplibpq@DLSUFFIX@' LANGUAGE C VOLATILE STRICT NO SQL;

--- a/src/test/walrep/sql/walreceiver.sql
+++ b/src/test/walrep/sql/walreceiver.sql
@@ -55,10 +55,17 @@ select pg_current_xlog_location() as lsn;
 create table testwalreceiver(a int);
 insert into testwalreceiver select * from generate_series(0, 9);
 
+-- the reason is the same as the above vacuum
+vacuum freeze;
+
 -- Connect and receive the xlogs, validate everything was received from start to
 -- end
 SELECT test_connect('');
 SELECT test_receive_and_verify(:'lsn', pg_current_xlog_location());
 SELECT test_send();
 SELECT test_receive();
+-- start_ignore
+-- print the current xlog location, mainly for debugging the flaky test
+select pg_current_xlog_location() as lsn;
+-- end_ignore
 SELECT test_disconnect();

--- a/src/test/walrep/sql/walreceiver.sql
+++ b/src/test/walrep/sql/walreceiver.sql
@@ -1,5 +1,4 @@
 -- negative cases
-SELECT test_receive();
 SELECT test_send();
 SELECT test_disconnect();
 
@@ -55,17 +54,9 @@ select pg_current_xlog_location() as lsn;
 create table testwalreceiver(a int);
 insert into testwalreceiver select * from generate_series(0, 9);
 
--- the reason is the same as the above vacuum
-vacuum freeze;
-
 -- Connect and receive the xlogs, validate everything was received from start to
 -- end
 SELECT test_connect('');
 SELECT test_receive_and_verify(:'lsn', pg_current_xlog_location());
 SELECT test_send();
-SELECT test_receive();
--- start_ignore
--- print the current xlog location, mainly for debugging the flaky test
-select pg_current_xlog_location() as lsn;
--- end_ignore
 SELECT test_disconnect();


### PR DESCRIPTION
walreceiver is quite sensitive to any WAL write. After create a table
and insert some tuples, it doesn't run a vacuum. There may be other
cases that cause some WAL traffic. One of the WAL records is
relevant to the hot-standby to record `RUNNING_XACTS`

The last `test_receive()` only tests there should be no WAL traffic
after receiving the WAL records to the current xlog location. It still
has a gap that a new WAL record transmitted to the walreceiver.
It's not meaningful to run `test_receive()`, since the function
`test_receive_and_verify()` has verified that all the WAL traffic
to the latest xlog location is received. So, removed test_receive().

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
