### PR TITLE
docs - support proxies for GPDB interconnect

### DIFF
--- a/gpdb-doc/dita/admin_guide/admin_guide.ditamap
+++ b/gpdb-doc/dita/admin_guide/admin_guide.ditamap
@@ -23,6 +23,7 @@
             <topicref href="access_db/access_db.ditamap" format="ditamap"/>
             <topicref href="configure.ditamap" format="ditamap"/>
             <topicref href="managing/compression.xml"/>
+            <topicref href="managing/proxy-ic.xml"/>
             <topicref href="highavail/highavail.ditamap" format="ditamap"/>
             <topicref href="managing/backup.ditamap" format="ditamap"/>
             <topicref href="expand/expand.ditamap" format="ditamap"/>

--- a/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
@@ -18,12 +18,11 @@
       <li><xref href="#topic10" format="dita"/> provides information about planning the data
         redistribution after the new segment hosts have been initialized.</li>
     </ul>
-    <note type="important">When expanding a Greenplum Database system, do not use proxies with the
-      Greenplum interconnect. Also, after adding new segment instances to the Greenplum system, you
-      must update the server configuration parameter <codeph>gp_interconnect_addresses</codeph> to
-      include the new segment instances before enabling Greenplum interconnect proxies.. For
-      information about Greenplum interconnect proxies, see <xref
-        href="../managing/proxy-ic.xml#topic1"/>.</note>
+    <note type="important">When expanding a Greenplum Database system, you must disable interconnect
+      proxies before adding new hosts and segment instances to the system, and you must update the
+        <codeph>gp_interconnect_proxy_addresses</codeph> parameter with the newly-added segment
+      instances before you re-enable interconnect proxies. For information about Greenplum
+      interconnect proxies, see <xref href="../managing/proxy-ic.xml#topic1"/>.</note>
   </body>
   <topic id="topic4" xml:lang="en">
     <title>System Expansion Checklist</title>

--- a/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
@@ -18,11 +18,17 @@
       <li><xref href="#topic10" format="dita"/> provides information about planning the data
         redistribution after the new segment hosts have been initialized.</li>
     </ul>
-    <note type="important">When expanding a Greenplum Database system, you must disable interconnect
-      proxies before adding new hosts and segment instances to the system, and you must update the
-        <codeph>gp_interconnect_proxy_addresses</codeph> parameter with the newly-added segment
-      instances before you re-enable interconnect proxies. For information about Greenplum
-      interconnect proxies, see <xref href="../managing/proxy-ic.xml#topic1"/>.</note>
+    <note type="important">When expanding a Greenplum Database system, you must disable Greenplum
+      interconnect proxies before adding new hosts and segment instances to the system, and you must
+      update the <codeph>gp_interconnect_proxy_addresses</codeph> parameter with the newly-added
+      segment instances before you re-enable interconnect proxies. For example, these commands
+      disable Greenplum interconnect proxies by setting the interconnect to the default
+        (<codeph>UDPIFC</codeph>) and reloading the <codeph>postgresql.conf</codeph> file to update
+      the Greenplum system
+        configuration.<codeblock><codeph><xref href="../../utility_guide/ref/gpconfig.xml">gpconfig</xref></codeph> -r gp_interconnect_type
+<codeph><xref href="../../utility_guide/ref/gpstop.xml">gpstop</xref></codeph> -u</codeblock><p>For
+        information about Greenplum interconnect proxies, see <xref
+          href="../managing/proxy-ic.xml#topic1"/>.</p></note>
   </body>
   <topic id="topic4" xml:lang="en">
     <title>System Expansion Checklist</title>

--- a/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
+++ b/gpdb-doc/dita/admin_guide/expand/expand-planning.xml
@@ -18,6 +18,12 @@
       <li><xref href="#topic10" format="dita"/> provides information about planning the data
         redistribution after the new segment hosts have been initialized.</li>
     </ul>
+    <note type="important">When expanding a Greenplum Database system, do not use proxies with the
+      Greenplum interconnect. Also, after adding new segment instances to the Greenplum system, you
+      must update the server configuration parameter <codeph>gp_interconnect_addresses</codeph> to
+      include the new segment instances before enabling Greenplum interconnect proxies.. For
+      information about Greenplum interconnect proxies, see <xref
+        href="../managing/proxy-ic.xml#topic1"/>.</note>
   </body>
   <topic id="topic4" xml:lang="en">
     <title>System Expansion Checklist</title>

--- a/gpdb-doc/dita/admin_guide/managing/proxy-ic.xml
+++ b/gpdb-doc/dita/admin_guide/managing/proxy-ic.xml
@@ -52,12 +52,13 @@
           <li><xref href="#topic_z4l_lcg_4mb/set_gpdb_proxy" format="dita">Setting Interconnect
               Proxies for the System</xref></li>
         </ul></p>
-      <section id="set_proxy_address"><title>Setting the Interconnect Proxy Addresses</title><p>Set
-          the <codeph>gp_interconnect_proxy_addresses</codeph> parameter to specify the proxy ports
-          for the master and segment instances. The syntax for the value has the following format
-          and you must specify the parameter value as a single-quoted
-          string.</p><codeblock>&lt;db_id>:&lt;cont_id>:&lt;seg_ip>:&lt;port>[,&lt;dbid>:&lt;segid>:&lt;ip>:&lt;port> ... ]</codeblock><p>For
-          the master, standby master, and segment instance, the first three fields,
+      <section id="set_proxy_address">
+        <title>Setting the Interconnect Proxy Addresses</title>
+        <p>Set the <codeph>gp_interconnect_proxy_addresses</codeph> parameter to specify the proxy
+          ports for the master and segment instances. The syntax for the value has the following
+          format and you must specify the parameter value as a single-quoted string.</p>
+        <codeblock>&lt;db_id>:&lt;cont_id>:&lt;seg_ip>:&lt;port>[,&lt;dbid>:&lt;segid>:&lt;ip>:&lt;port> ... ]</codeblock>
+        <p>For the master, standby master, and segment instance, the first three fields,
             <varname>db_id</varname>, <varname>cont_id</varname>, and <varname>seg_ip</varname> can
           be found in the <codeph><xref
               href="../../ref_guide/system_catalogs/gp_segment_configuration.xml"
@@ -73,41 +74,86 @@
                 <codeph>address</codeph> is a hostname, use the IP address of the hostname.</li>
             <li><varname>port</varname> is the TCP/IP port for the segment instance proxy that you
               specify.</li>
-          </ul></p><p>This is an example script that you can run on the Greenplum master host to
-          create a string that can be used as the value for the
-            <codeph>gp_interconnect_proxy_addresses</codeph>
-        parameter.</p><codeblock>#!/usr/bin/env bash
-# This script creates a string that can be used to with the gp_interconnect_proxy_addresses GUC
-: ${delta:=-1000}
+          </ul></p>
+        <p>This is an example PL/Python function that displays or sets the segment instance proxy
+          port values for the <codeph>gp_interconnect_proxy_addresses</codeph> parameter. To create
+          and run the function, you must enable PL/Python in the database with the <codeph>CREATE
+            EXTENSION plpythonu</codeph> command.</p>
+        <codeblock>--
+-- A PL/Python function to setup the interconnect proxy addresses.
+-- Requires the Python modules os and socket.
+--
+-- Usage:
+--   select my_setup_ic_proxy(-1000, '');              -- display IC proxy values for segments
+--   select my_setup_ic_proxy(-1000, 'update proxy');  -- update the gp_interconnect_proxy_addresses parameter
+--
+-- The first argument, "delta", is used to calculate the proxy port with this formula:
+--
+--   proxy_port = postmaster_port + delta
+--
+-- The second argument, "action", is used to update the gp_interconnect_proxy_addresses parameter.
+-- The parameter is not updated unless "action" is 'update proxy'.
+-- Note that running  "gpstop -u" is required for the update to take effect. 
+-- A Greenplum system restart will also work.
+--
+create or replace function my_setup_ic_proxy(delta int, action text)
+returns table(dbid smallint, content smallint, ip text, port int) as $$
+    import os
+    import socket
 
-# get the segment configuration information from 
-psql -tqA -d postgres -P pager=off -F ' ' \
-    -c "select dbid, content, port+$delta as port, address from gp_segment_configuration order by 1" \
-| while read -r dbid content port addr; do
-    # convert the segment hostnames to IP addresses. Assumes ping can access all the segment hosts.
-    ip=$(ping "$addr" -4c1 | head -n1 | cut -d' ' -f3 | sed -r 's/^.(.*).$/\1/')
-    ip=${ip##* }
+    results = []
+    value = ''
 
-    echo "$dbid:$content:$ip:$port"
-  done \
-| paste -sd, - \
-# Echo proxy port string to the command line.
-| xargs -rI'{}' echo "'{}'"
-# sets the gp_interconnect_proxy_addresses parameter
-# | xargs -rI'{}' gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'{}'"
-</codeblock>This
-        example <codeph><xref href="../../utility_guide/ref/gpconfig.xml">gpconfig</xref></codeph>
-        command sets the value for <codeph>gp_interconnect_proxy_addresses</codeph> as a
-        single-quoted string that is enclosed in double quotes. The Greenplum system consists of a
-        master and a single segment instance.
-          <codeblock>gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'1:-1:192.168.180.50:35432,2:0:192.168.180.54:35000'"</codeblock><p>After
-          setting the <codeph>gp_interconnect_proxy_addresses</codeph> parameter, restart the system
-          with the <codeph>gpstop -ra</codeph> command.</p></section>
+    segs = plpy.execute('''SELECT dbid, content, port, address
+                              FROM gp_segment_configuration
+                            ORDER BY 1''')
+    for seg in segs:
+        dbid = seg['dbid']
+        content = seg['content']
+        port = seg['port']
+        address = seg['address']
+
+        # lookup ip of the address
+        ip = socket.gethostbyname(address)
+
+        # decide the proxy port
+        port = port + delta
+
+        # append to the result list
+        results.append((dbid, content, ip, port))
+
+        # build the value for the GUC
+        if value:
+            value += ','
+        value += '{}:{}:{}:{}'.format(dbid, content, ip, port)
+
+    if action.lower() == 'update proxy':
+        os.system('''gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'{}'"'''.format(value))
+        plpy.notice('''the settings are applied, please reload with 'gpstop -u' to take effect.''')
+    else:
+        plpy.notice('''if the settings are correct, re-run with 'update proxy' to apply.''')
+    return results
+$$ language plpythonu execute on master;</codeblock>
+        <p>After you create the function in a database, this command lists the segment instance
+          values for the <codeph>gp_interconnect_proxy_addresses</codeph> parameter.
+          <codeblock>select my_setup_ic_proxy(-1000, '');</codeblock></p>
+        <p>This command runs the function to set the
+          parameter.<codeblock>select my_setup_ic_proxy(-1000, 'update proxy');</codeblock></p>
+        <p>As an alternative, you can run the <codeph><xref
+              href="../../utility_guide/ref/gpconfig.xml">gpconfig</xref></codeph> utility to set
+          the <codeph>gp_interconnect_proxy_addresses</codeph> parameter. To set the value as a
+          string, the value is a single-quoted string that is enclosed in double quotes. The example
+          Greenplum system consists of a master and a single segment instance. </p>
+        <codeblock>gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'1:-1:192.168.180.50:35432,2:0:192.168.180.54:35000'"</codeblock>
+        <p>After setting the <codeph>gp_interconnect_proxy_addresses</codeph> parameter, reload the
+            <codeph>postgresql.conf</codeph> file with the <codeph>gpstop -u</codeph> command. This
+          command does not stop and restart the Greenplum system.</p>
+      </section>
       <section id="test_proxy">
         <title>Testing the Interconnect Proxies</title>
         <p>To test the proxy ports configured for the system, you can set the
             <codeph>PGOPTIONS</codeph> environment variable when you start a <codeph>psql</codeph>
-          session in a command shell. This command set sets the environment variable to enable
+          session in a command shell. This command sets the environment variable to enable
           interconnect proxies, starts <codeph>psql</codeph>, and logs into the database
             <codeph>mytest</codeph>.</p>
         <codeblock>PGOPTIONS="-c gp_interconnect_type=proxy" psql -d mytest</codeblock>
@@ -123,7 +169,8 @@ psql -tqA -d postgres -P pager=off -F ' ' \
         <p>
           <codeblock>gpconfig -c  gp_interconnect_type -v proxy</codeblock>
         </p>
-        <p>Restart the system with the <codeph>gpstop -ra</codeph> command.</p>
+        <p>Reload the <codeph>postgresql.conf</codeph> file with the <codeph>gpstop -u</codeph>
+          command. This command does not stop and restart the Greenplum system.</p>
       </section>
     </body>
   </topic>

--- a/gpdb-doc/dita/admin_guide/managing/proxy-ic.xml
+++ b/gpdb-doc/dita/admin_guide/managing/proxy-ic.xml
@@ -15,7 +15,7 @@
       connections to other QEs. For a description of Greenplum query processing and parallel query
       processing, see <xref href="../query/topics/parallel-proc.xml"/>.</p>
     <p>By default, connections between the QD on the master and QEs on segment instances and between
-      QEs on different segment instances requires a separate network port. You can configure a
+      QEs on different segment instances require a separate network port. You can configure a
       Greenplum system to use proxies when Greenplum communicates between the QD and QEs and between
       QEs on different segment instances. The interconnect proxies require only one network
       connection for Greenplum internal communication between two segment instances, so it consumes
@@ -31,10 +31,10 @@
               href="../../ref_guide/config_params/guc-list.xml#gp_interconnect_type" format="dita"
             /></codeph> to <codeph>proxy</codeph>.</li>
       </ul></p>
-    <note>If you expand a Greenplum Database system, do not use proxies with the Greenplum
-      interconnect. Also, after adding new segment instances to the Greenplum system, you must
-      update the server configuration parameter <codeph>gp_interconnect_addresses</codeph> to
-      include the new segment instances before enabling Greenplum interconnect proxies.</note>
+    <note>When expanding a Greenplum Database system, you must disable interconnect proxies before
+      adding new hosts and segment instances to the system, and you must update the
+        <codeph>gp_interconnect_proxy_addresses</codeph> parameter with the newly-added segment
+      instances before you re-enable interconnect proxies. </note>
   </body>
   <topic id="topic_z4l_lcg_4mb">
     <title>Example</title>
@@ -52,13 +52,12 @@
           <li><xref href="#topic_z4l_lcg_4mb/set_gpdb_proxy" format="dita">Setting Interconnect
               Proxies for the System</xref></li>
         </ul></p>
-      <section id="set_proxy_address">
-        <title>Setting the Interconnect Proxy Addresses</title>
-        <p>Set the <codeph>gp_interconnect_addresses</codeph> parameter to specify the proxy ports
+      <section id="set_proxy_address"><title>Setting the Interconnect Proxy Addresses</title><p>Set
+          the <codeph>gp_interconnect_proxy_addresses</codeph> parameter to specify the proxy ports
           for the master and segment instances. The syntax for the value has the following format
-          and you must specify the parameter value as a single-quoted string.</p>
-        <codeblock>&lt;db_id>:&lt;cont_id>:&lt;seg_ip>:&lt;port>[,&lt;dbid>:&lt;segid>:&lt;ip>:&lt;port> ... ]</codeblock>
-        <p>For the master, standby master and segment instance, the first three fields,
+          and you must specify the parameter value as a single-quoted
+          string.</p><codeblock>&lt;db_id>:&lt;cont_id>:&lt;seg_ip>:&lt;port>[,&lt;dbid>:&lt;segid>:&lt;ip>:&lt;port> ... ]</codeblock><p>For
+          the master, standby master, and segment instance, the first three fields,
             <varname>db_id</varname>, <varname>cont_id</varname>, and <varname>seg_ip</varname> can
           be found in the <codeph><xref
               href="../../ref_guide/system_catalogs/gp_segment_configuration.xml"
@@ -69,22 +68,15 @@
               table.</li>
             <li><varname>cont_id</varname> is the <codeph>content</codeph> column in the catalog
               table.</li>
-            <li><varname>seg_ip</varname> is the IP address corresponding to
+            <li><varname>seg_ip</varname> is the IP address corresponding to the
                 <codeph>address</codeph> column in the catalog table. If the
                 <codeph>address</codeph> is a hostname, use the IP address of the hostname.</li>
             <li><varname>port</varname> is the TCP/IP port for the segment instance proxy that you
               specify.</li>
-          </ul></p>
-        <p>This example <codeph><xref href="../../utility_guide/ref/gpconfig.xml"
-            >gpconfig</xref></codeph> command sets the value for
-            <codeph>gp_interconnect_proxy_addresses</codeph> as a single-quoted string that is
-          enclosed in double quotes. The Greenplum system consists of a master and a single segment
-          instance.
-          <codeblock>gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'1:-1:192.168.180.50:35432,2:0:192.168.180.54:35000'"</codeblock></p>
-        <p>This is an example script that you can run on the Greenplum master host to create a
-          string that can be used as the value for the
-            <codeph>gp_interconnect_proxy_addresses</codeph> parameter.</p>
-        <codeblock>#!/usr/bin/env bash
+          </ul></p><p>This is an example script that you can run on the Greenplum master host to
+          create a string that can be used as the value for the
+            <codeph>gp_interconnect_proxy_addresses</codeph>
+        parameter.</p><codeblock>#!/usr/bin/env bash
 # This script creates a string that can be used to with the gp_interconnect_proxy_addresses GUC
 : ${delta:=-1000}
 
@@ -103,10 +95,14 @@ psql -tqA -d postgres -P pager=off -F ' ' \
 | xargs -rI'{}' echo "'{}'"
 # sets the gp_interconnect_proxy_addresses parameter
 # | xargs -rI'{}' gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'{}'"
-</codeblock>
-        <p>After setting the <codeph>gp_interconnect_proxy_addresses</codeph> parameter, restart the
-          system with the <codeph>gpstop -ra</codeph> command.</p>
-      </section>
+</codeblock>This
+        example <codeph><xref href="../../utility_guide/ref/gpconfig.xml">gpconfig</xref></codeph>
+        command sets the value for <codeph>gp_interconnect_proxy_addresses</codeph> as a
+        single-quoted string that is enclosed in double quotes. The Greenplum system consists of a
+        master and a single segment instance.
+          <codeblock>gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'1:-1:192.168.180.50:35432,2:0:192.168.180.54:35000'"</codeblock><p>After
+          setting the <codeph>gp_interconnect_proxy_addresses</codeph> parameter, restart the system
+          with the <codeph>gpstop -ra</codeph> command.</p></section>
       <section id="test_proxy">
         <title>Testing the Interconnect Proxies</title>
         <p>To test the proxy ports configured for the system, you can set the

--- a/gpdb-doc/dita/admin_guide/managing/proxy-ic.xml
+++ b/gpdb-doc/dita/admin_guide/managing/proxy-ic.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+  PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<topic id="topic1">
+  <title id="eb20941">Configuring Proxies for the Greenplum Interconnect</title>
+  <shortdesc>You can configure a Greenplum system to use proxies for interconnect communication to
+    reduce the use of connections and ports during query processing.</shortdesc>
+  <body>
+    <p>The Greenplum <i>interconnect</i> (the networking layer) refers to the inter-process
+      communication between segments and the network infrastructure on which this communication
+      relies. For information about the Greenplum architecture and interconnect, see <xref
+        href="../intro/arch_overview.xml" format="dita"/>. </p>
+    <p>In general, when running a query, a QD (query dispatcher) on the Greenplum master creates
+      connections to one or more QE (query executor) processes on segments, and a QE can create
+      connections to other QEs. For a description of Greenplum query processing and parallel query
+      processing, see <xref href="../query/topics/parallel-proc.xml"/>.</p>
+    <p>By default, connections between the QD on the master and QEs on segment instances and between
+      QEs on different segment instances requires a separate network port. You can configure a
+      Greenplum system to use proxies when Greenplum communicates between the QD and QEs and between
+      QEs on different segment instances. The interconnect proxies require only one network
+      connection for Greenplum internal communication between two segment instances, so it consumes
+      fewer connections and ports than <codeph>TCP</codeph> mode, and has better performance than
+        <codeph>UDPIFC</codeph> mode in a high-latency network. </p>
+    <p>To enable interconnect proxies for the Greenplum system, set these system configuration
+        parameters.<ul id="ul_vqk_34f_4mb">
+        <li>List the proxy ports with the parameter <codeph><xref
+              href="../../ref_guide/config_params/guc-list.xml#gp_interconnect_proxy_addresses"
+              format="dita"/></codeph>. You must specify a proxy port for the master, standby
+          master, and all segment instances.</li>
+        <li>Set the parameter <codeph><xref
+              href="../../ref_guide/config_params/guc-list.xml#gp_interconnect_type" format="dita"
+            /></codeph> to <codeph>proxy</codeph>.</li>
+      </ul></p>
+    <note>If you expand a Greenplum Database system, do not use proxies with the Greenplum
+      interconnect. Also, after adding new segment instances to the Greenplum system, you must
+      update the server configuration parameter <codeph>gp_interconnect_addresses</codeph> to
+      include the new segment instances before enabling Greenplum interconnect proxies.</note>
+  </body>
+  <topic id="topic_z4l_lcg_4mb">
+    <title>Example</title>
+    <body>
+      <p>This example sets up a Greenplum system to use proxies for the Greenplum interconnect when
+        running queries. The example sets the <codeph><xref
+            href="../../ref_guide/config_params/guc-list.xml#gp_interconnect_proxy_addresses"
+            format="dita"/></codeph> parameter and tests the proxies before setting the
+            <codeph><xref href="../../ref_guide/config_params/guc-list.xml#gp_interconnect_type"
+            format="dita"/></codeph> parameter for the Greenplum system.<ul id="ul_mtf_wsm_4mb">
+          <li><xref href="#topic_z4l_lcg_4mb/set_proxy_address" format="dita">Setting the
+              Interconnect Proxy Addresses</xref></li>
+          <li><xref href="#topic_z4l_lcg_4mb/test_proxy" format="dita">Testing the Interconnect
+              Proxies</xref></li>
+          <li><xref href="#topic_z4l_lcg_4mb/set_gpdb_proxy" format="dita">Setting Interconnect
+              Proxies for the System</xref></li>
+        </ul></p>
+      <section id="set_proxy_address">
+        <title>Setting the Interconnect Proxy Addresses</title>
+        <p>Set the <codeph>gp_interconnect_addresses</codeph> parameter to specify the proxy ports
+          for the master and segment instances. The syntax for the value has the following format
+          and you must specify the parameter value as a single-quoted string.</p>
+        <codeblock>&lt;db_id>:&lt;cont_id>:&lt;seg_ip>:&lt;port>[,&lt;dbid>:&lt;segid>:&lt;ip>:&lt;port> ... ]</codeblock>
+        <p>For the master, standby master and segment instance, the first three fields,
+            <varname>db_id</varname>, <varname>cont_id</varname>, and <varname>seg_ip</varname> can
+          be found in the <codeph><xref
+              href="../../ref_guide/system_catalogs/gp_segment_configuration.xml"
+              >gp_segment_configuration</xref></codeph> catalog table. The fourth field,
+            <varname>port</varname>, is the proxy port for the Greenplum master or a segment
+            instance.<ul id="ul_hxd_2qm_4mb">
+            <li><varname>db_id</varname> is the <codeph>dbid</codeph> column in the catalog
+              table.</li>
+            <li><varname>cont_id</varname> is the <codeph>content</codeph> column in the catalog
+              table.</li>
+            <li><varname>seg_ip</varname> is the IP address corresponding to
+                <codeph>address</codeph> column in the catalog table. If the
+                <codeph>address</codeph> is a hostname, use the IP address of the hostname.</li>
+            <li><varname>port</varname> is the TCP/IP port for the segment instance proxy that you
+              specify.</li>
+          </ul></p>
+        <p>This example <codeph><xref href="../../utility_guide/ref/gpconfig.xml"
+            >gpconfig</xref></codeph> command sets the value for
+            <codeph>gp_interconnect_proxy_addresses</codeph> as a single-quoted string that is
+          enclosed in double quotes. The Greenplum system consists of a master and a single segment
+          instance.
+          <codeblock>gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'1:-1:192.168.180.50:35432,2:0:192.168.180.54:35000'"</codeblock></p>
+        <p>This is an example script that you can run on the Greenplum master host to create a
+          string that can be used as the value for the
+            <codeph>gp_interconnect_proxy_addresses</codeph> parameter.</p>
+        <codeblock>#!/usr/bin/env bash
+# This script creates a string that can be used to with the gp_interconnect_proxy_addresses GUC
+: ${delta:=-1000}
+
+# get the segment configuration information from 
+psql -tqA -d postgres -P pager=off -F ' ' \
+    -c "select dbid, content, port+$delta as port, address from gp_segment_configuration order by 1" \
+| while read -r dbid content port addr; do
+    # convert the segment hostnames to IP addresses. Assumes ping can access all the segment hosts.
+    ip=$(ping "$addr" -4c1 | head -n1 | cut -d' ' -f3 | sed -r 's/^.(.*).$/\1/')
+    ip=${ip##* }
+
+    echo "$dbid:$content:$ip:$port"
+  done \
+| paste -sd, - \
+# Echo proxy port string to the command line.
+| xargs -rI'{}' echo "'{}'"
+# sets the gp_interconnect_proxy_addresses parameter
+# | xargs -rI'{}' gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'{}'"
+</codeblock>
+        <p>After setting the <codeph>gp_interconnect_proxy_addresses</codeph> parameter, restart the
+          system with the <codeph>gpstop -ra</codeph> command.</p>
+      </section>
+      <section id="test_proxy">
+        <title>Testing the Interconnect Proxies</title>
+        <p>To test the proxy ports configured for the system, you can set the
+            <codeph>PGOPTIONS</codeph> environment variable when you start a <codeph>psql</codeph>
+          session in a command shell. This command set sets the environment variable to enable
+          interconnect proxies, starts <codeph>psql</codeph>, and logs into the database
+            <codeph>mytest</codeph>.</p>
+        <codeblock>PGOPTIONS="-c gp_interconnect_type=proxy" psql -d mytest</codeblock>
+        <p>You can run queries in the shell to test the system. For example, you can run a query
+          that accesses all the primary segment instances. This query displays the segment IDs and
+          number of rows on the segment instance from the table
+          <codeph>sales</codeph>.<codeblock># SELECT gp_segment_id, COUNT(*) FROM sales GROUP BY gp_segment_id ;</codeblock></p>
+      </section>
+      <section id="set_gpdb_proxy">
+        <title>Setting Interconnect Proxies for the System</title>
+        <p>After you have tested the interconnect proxies for the system, set the server
+          configuration parameter for the system with the <codeph>gpconfig</codeph> utility.</p>
+        <p>
+          <codeblock>gpconfig -c  gp_interconnect_type -v proxy</codeblock>
+        </p>
+        <p>Restart the system with the <codeph>gpstop -ra</codeph> command.</p>
+      </section>
+    </body>
+  </topic>
+</topic>

--- a/gpdb-doc/dita/admin_guide/managing/proxy-ic.xml
+++ b/gpdb-doc/dita/admin_guide/managing/proxy-ic.xml
@@ -134,8 +134,13 @@ returns table(dbid smallint, content smallint, ip text, port int) as $$
         plpy.notice('''if the settings are correct, re-run with 'update proxy' to apply.''')
     return results
 $$ language plpythonu execute on master;</codeblock>
-        <p>After you create the function in a database, this command lists the segment instance
-          values for the <codeph>gp_interconnect_proxy_addresses</codeph> parameter.
+        <note>When you run the function, you should connect to the database using the Greenplum
+          interconnect type <codeph>UDPIFC</codeph> or <codeph>TCP</codeph>. This example uses
+            <codeph>psql</codeph> to connect to the database <codeph>mytest</codeph> with the
+          interconnect type
+          <codeph>UDPIFC</codeph>.<codeblock>PGOPTIONS="-c gp_interconnect_type=udpifc" psql -d mytest</codeblock></note>
+        <p>Running this command lists the segment instance values for the
+            <codeph>gp_interconnect_proxy_addresses</codeph> parameter.
           <codeblock>select my_setup_ic_proxy(-1000, '');</codeblock></p>
         <p>This command runs the function to set the
           parameter.<codeblock>select my_setup_ic_proxy(-1000, 'update proxy');</codeblock></p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -3671,10 +3671,10 @@
           <codeph>proxy</codeph>. Otherwise, this parameter is ignored. The default value is an
         empty string (""). </p>
       <p>When the <codeph>gp_interconnect_type</codeph> parameter is set to <codeph>proxy</codeph>,
-        You must specify a proxy port for the master, standby master and all primary and mirror
+        You must specify a proxy port for the master, standby master, and all primary and mirror
         segment instances in this format:</p>
       <codeblock>&lt;db_id>:&lt;cont_id>:&lt;seg_ip>:&lt;port>[,&lt;dbid>:&lt;segid>:&lt;ip>:&lt;port> ... ]</codeblock>
-      <p>For the master, standby master and segment instance, the first three fields,
+      <p>For the master, standby master, and segment instance, the first three fields,
           <varname>db_id</varname>, <varname>cont_id</varname>, and <varname>seg_ip</varname> can be
         found in the <codeph><xref href="../system_catalogs/gp_segment_configuration.xml"
             >gp_segment_configuration</xref></codeph> catalog table. The fourth field,
@@ -3827,9 +3827,9 @@
         segment instances - less than that if the query workload involves complex, multi-slice
         queries.</p>
       <p>The <codeph>PROXY</codeph> value specifies using the TCP protocol, and when running
-        queries, use a proxy for Greenplum interconnect communication between the master instance
-        and segment instances and between two segments. When this parameter is set to
-          <codeph>PROXY</codeph>, you must specify the proxy ports the for the master and segment
+        queries, using a proxy for Greenplum interconnect communication between the master instance
+        and segment instances and between two segment instances. When this parameter is set to
+          <codeph>PROXY</codeph>, you must specify the proxy ports for the master and segment
         instances with the server configuration parameter <codeph><xref
             href="#gp_interconnect_proxy_addresses" format="dita"/></codeph>. For information about
         configuring and using proxies with the Greenplum interconnect, see <xref

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -3663,6 +3663,65 @@
       </table>
     </body>
   </topic>
+  <topic id="gp_interconnect_proxy_addresses">
+    <title>gp_interconnect_proxy_addresses</title>
+    <body>
+      <p>Sets the proxy ports that Greenplum Database uses when the server configuration parameter
+            <codeph><xref href="#gp_interconnect_type" format="dita"/></codeph> is set to
+          <codeph>proxy</codeph>. Otherwise, this parameter is ignored. The default value is an
+        empty string (""). </p>
+      <p>When the <codeph>gp_interconnect_type</codeph> parameter is set to <codeph>proxy</codeph>,
+        You must specify a proxy port for the master, standby master and all primary and mirror
+        segment instances in this format:</p>
+      <codeblock>&lt;db_id>:&lt;cont_id>:&lt;seg_ip>:&lt;port>[,&lt;dbid>:&lt;segid>:&lt;ip>:&lt;port> ... ]</codeblock>
+      <p>For the master, standby master and segment instance, the first three fields,
+          <varname>db_id</varname>, <varname>cont_id</varname>, and <varname>seg_ip</varname> can be
+        found in the <codeph><xref href="../system_catalogs/gp_segment_configuration.xml"
+            >gp_segment_configuration</xref></codeph> catalog table. The fourth field,
+          <varname>port</varname>, is the proxy port for the Greenplum master or a segment
+          instance.<ul id="ul_zly_vpm_4mb">
+          <li><varname>db_id</varname> is the <codeph>dbid</codeph> column in the catalog
+            table.</li>
+          <li><varname>cont_id</varname> is the <codeph>content</codeph> column in the catalog
+            table.</li>
+          <li><varname>seg_ip</varname> is the IP address corresponding to <codeph>address</codeph>
+            column in the catalog table. If the <codeph>address</codeph> is a hostname, use the IP
+            address of the hostname.</li>
+          <li><varname>port</varname> is the TCP/IP port for the segment instance proxy that you
+            specify.</li>
+        </ul></p>
+      <note type="important">The <varname>seg_ip</varname> must be an IP address, not a hostname.
+        Also, If the mapping of a segment instance hostname to the IP address changes, you must
+        update the IP address in the parameter value.</note>
+      <p>You must specify the value as a single-quoted string. This <codeph>gpconfig</codeph>
+        command sets the value for <codeph>gp_interconnect_proxy_addresses</codeph> as a
+        single-quoted string. The Greenplum system consists of a master and a single segment
+        instance.<codeblock>gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'1:-1:192.168.180.50:35432,2:0:192.168.180.54:35000'"</codeblock></p>
+      <p>For an example of setting <codeph>gp_interconnect_proxy_addresses</codeph>, see <xref
+          href="../../admin_guide/managing/proxy-ic.xml"/>.</p>
+      <table id="table_dlg_dch_mmb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">string (maximum length - 16384 bytes)</entry>
+              <entry colname="col2"/>
+              <entry colname="col3">local<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
   <topic id="gp_interconnect_queue_depth">
     <title>gp_interconnect_queue_depth</title>
     <body>
@@ -3767,6 +3826,14 @@
       <p>With TCP as the interconnect protocol, Greenplum Database has an upper limit of 1000
         segment instances - less than that if the query workload involves complex, multi-slice
         queries.</p>
+      <p>The <codeph>PROXY</codeph> value specifies using the TCP protocol, and when running
+        queries, use a proxy for Greenplum interconnect communication between the master instance
+        and segment instances and between two segments. When this parameter is set to
+          <codeph>PROXY</codeph>, you must specify the proxy ports the for the master and segment
+        instances with the server configuration parameter <codeph><xref
+            href="#gp_interconnect_proxy_addresses" format="dita"/></codeph>. For information about
+        configuring and using proxies with the Greenplum interconnect, see <xref
+          href="../../admin_guide/managing/proxy-ic.xml"/>.</p>
       <table id="table_jn5_frn_xv">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -3781,7 +3848,7 @@
           </thead>
           <tbody>
             <row>
-              <entry colname="col1">UDPIFC<p>TCP</p></entry>
+              <entry colname="col1">UDPIFC<p>TCP</p><p>PROXY</p></entry>
               <entry colname="col2">UDPIFC</entry>
               <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1338,6 +1338,9 @@
                   >gp_interconnect_fc_method</xref>
               </p>
               <p>
+                <xref href="guc-list.xml#gp_interconnect_proxy_addresses" type="section"
+                  >gp_interconnect_proxy_addresses</xref></p>
+              <p>
                 <xref href="guc-list.xml#gp_interconnect_queue_depth" type="section"
                   >gp_interconnect_queue_depth</xref>
               </p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -116,6 +116,7 @@
             <topicref href="guc-list.xml#gp_instrument_shmem_size"/>
             <topicref href="guc-list.xml#gp_interconnect_debug_retry_interval"/>
             <topicref href="guc-list.xml#gp_interconnect_fc_method"/>
+            <topicref href="guc-list.xml#gp_interconnect_proxy_addresses"/>
             <topicref href="guc-list.xml#gp_interconnect_queue_depth"/>
             <topicref href="guc-list.xml#gp_interconnect_setup_timeout"/>
             <topicref href="guc-list.xml#gp_interconnect_snd_queue_depth"/>

--- a/gpdb-doc/dita/utility_guide/ref/gpexpand.xml
+++ b/gpdb-doc/dita/utility_guide/ref/gpexpand.xml
@@ -49,6 +49,12 @@
           <li><codeph>gppkg</codeph></li>
           <li><codeph>gprestore</codeph></li>
         </ul></note>
+      <note type="important">When expanding a Greenplum Database system, do not use proxies with the
+        Greenplum interconnect. Also, after adding new segment instances to the Greenplum system,
+        you must update the server configuration parameter
+          <codeph>gp_interconnect_addresses</codeph> to include the new segment instances before
+        enabling Greenplum interconnect proxies. For information about Greenplum interconnect
+        proxies, see <xref href="../../admin_guide/managing/proxy-ic.xml"/>.</note>
       <p>For information about preparing a system for expansion, see <xref
           href="../../admin_guide/expand/expand-main.xml" scope="peer">Expanding a Greenplum
           System</xref><ph otherprops="op-print"> in the <cite>Greenplum Database Administrator

--- a/gpdb-doc/dita/utility_guide/ref/gpexpand.xml
+++ b/gpdb-doc/dita/utility_guide/ref/gpexpand.xml
@@ -49,12 +49,12 @@
           <li><codeph>gppkg</codeph></li>
           <li><codeph>gprestore</codeph></li>
         </ul></note>
-      <note type="important">When expanding a Greenplum Database system, do not use proxies with the
-        Greenplum interconnect. Also, after adding new segment instances to the Greenplum system,
-        you must update the server configuration parameter
-          <codeph>gp_interconnect_addresses</codeph> to include the new segment instances before
-        enabling Greenplum interconnect proxies. For information about Greenplum interconnect
-        proxies, see <xref href="../../admin_guide/managing/proxy-ic.xml"/>.</note>
+      <note type="important">When expanding a Greenplum Database system, you must disable
+        interconnect proxies before adding new hosts and segment instances to the system, and you
+        must update the <codeph>gp_interconnect_proxy_addresses</codeph> parameter with the
+        newly-added segment instances before you re-enable interconnect proxies. For information
+        about Greenplum interconnect proxies, see <xref
+          href="../../admin_guide/managing/proxy-ic.xml"/>.</note>
       <p>For information about preparing a system for expansion, see <xref
           href="../../admin_guide/expand/expand-main.xml" scope="peer">Expanding a Greenplum
           System</xref><ph otherprops="op-print"> in the <cite>Greenplum Database Administrator

--- a/gpdb-doc/dita/utility_guide/ref/gpexpand.xml
+++ b/gpdb-doc/dita/utility_guide/ref/gpexpand.xml
@@ -49,7 +49,7 @@
           <li><codeph>gppkg</codeph></li>
           <li><codeph>gprestore</codeph></li>
         </ul></note>
-      <note type="important">When expanding a Greenplum Database system, you must disable
+      <note type="important">When expanding a Greenplum Database system, you must disable Greenplum
         interconnect proxies before adding new hosts and segment instances to the system, and you
         must update the <codeph>gp_interconnect_proxy_addresses</codeph> parameter with the
         newly-added segment instances before you re-enable interconnect proxies. For information


### PR DESCRIPTION
-New topic in Admin. Guide.
-New GUC gp_interconnect_proxy_addresses
-Updated GUC gp_interconnect_type - new value PROXY

Also added note to gpexpand documents - do no use proxy during expand.

Link to HTML docs on temporary docs draft review site.

Will be backported to 6X_STABLE

Interconnect Proxy
https://docs-msk-gpdb7-dev-ic-proxy.cfapps.io/7-0/admin_guide/managing/proxy-ic.html
https://docs-msk-gpdb7-dev-ic-proxy.cfapps.io/7-0/ref_guide/config_params/guc-list.html#gp_interconnect_proxy_addresses
https://docs-msk-gpdb7-dev-ic-proxy.cfapps.io/7-0/ref_guide/config_params/guc-list.html#gp_interconnect_type

gpexpand
https://docs-msk-gpdb7-dev-ic-proxy.cfapps.io/7-0/admin_guide/expand/expand-planning.html
https://docs-msk-gpdb7-dev-ic-proxy.cfapps.io/7-0/utility