### PR TITLE
docs - new GUC max_slot_wal_keep_size

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -6625,8 +6625,9 @@
     <body>
       <p>Sets the maximum size in megabytes of Write-Ahead Logging (WAL) files on disk per segment
         instance that can be reserved when Greenplum streams data to the mirror segment instance or
-        standby master to keep it current with the corresponding primary segment instance or master.
-        The default is -1, Greenplum can retain an unlimited amount of WAL files on disk.</p>
+        standby master to keep it synchronized with the corresponding primary segment instance or
+        master. The default is -1, Greenplum can retain an unlimited amount of WAL files on
+        disk.</p>
       <p>If the file size exceeds the maximum size, the files are released and are available for
         deletion. A mirror or standby may no longer be able to continue replication due to removal
         of required WAL files.</p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -387,6 +387,8 @@
               <xref href="#max_resource_queues"/>
             </li>
             <li>
+              <xref href="#max_slot_wal_keep_size"/></li>
+            <li>
               <xref href="#max_stack_depth"/>
             </li>
             <li>
@@ -6612,6 +6614,39 @@
               <entry colname="col1">integer</entry>
               <entry colname="col2">9</entry>
               <entry colname="col3">master<p>system</p><p>restart</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="max_slot_wal_keep_size">
+    <title>max_slot_wal_keep_size</title>
+    <body>
+      <p>Sets the maximum size in megabytes of Write-Ahead Logging (WAL) files on disk per segment
+        instance that can be reserved when Greenplum streams data to the mirror segment instance or
+        standby master to keep it current with the corresponding primary segment instance or master.
+        The default is -1, Greenplum can retain an unlimited amount of WAL files on disk.</p>
+      <p>If the file size exceeds the maximum size, the files are released and are available for
+        deletion. A mirror or standby may no longer be able to continue replication due to removal
+        of required WAL files.</p>
+      <table id="table_dwl_5vt_4mb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Integer</entry>
+              <entry colname="col2">-1</entry>
+              <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1530,7 +1530,10 @@
         <strow>
           <stentry>
             <p>
-              <xref href="guc-list.xml#repl_catchup_within_range" type="section"
+              <xref href="guc-list.xml#max_slot_wal_keep_size" type="section"
+                >max_slot_wal_keep_size</xref>
+            </p>
+            <p><xref href="guc-list.xml#repl_catchup_within_range" type="section"
                 >repl_catchup_within_range</xref>
             </p>
             <p>


### PR DESCRIPTION
GUC to control WAL log disk size. Per segment instance.

This is 6X_STABLE only

Dev PR https://github.com/greenplum-db/gpdb/pull/10234