### PR TITLE
Fix connection string for gpsd

### DIFF
--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -16,7 +16,6 @@ import pgdb
 gpsd_version = '%prog 1.0'
 
 sysnslist = "('pg_toast', 'pg_bitmapindex', 'pg_temp_1', 'pg_catalog', 'information_schema')"
-orca = False
 # unset search path due to CVE-2018-1058
 pgoptions = '-c gp_role=utility -c search_path='
 
@@ -40,19 +39,16 @@ def getVersion(envOpts):
 
 
 def dumpSchema(connectionInfo, envOpts):
-    dmp_cmd = 'pg_dump -h %s -p %s -U %s -s -x --gp-syntax -O %s' % connectionInfo
-    p = subprocess.Popen(dmp_cmd, shell=True, stderr=subprocess.PIPE, env=envOpts)
+    dump_cmd = 'pg_dump -h {host} -p {port} -U {user} -s -x -O {database}'.format(**connectionInfo)
+    p = subprocess.Popen(dump_cmd, shell=True, stderr=subprocess.PIPE, env=envOpts)
     if p.wait() is not 0:
         sys.stderr.write('\nError while dumping schema.\n\n' + p.communicate()[1] + '\n\n')
         sys.exit(1)
 
 
 def dumpGlobals(connectionInfo, envOpts):
-    if orca:
-        dmp_cmd = 'pg_dumpall -h %s -p %s -U %s -l %s -g --no-gp-syntax' % connectionInfo
-    else:
-        dmp_cmd = 'pg_dumpall -h %s -p %s -U %s -l %s -g --gp-syntax' % connectionInfo
-    p = subprocess.Popen(dmp_cmd, shell=True, stderr=subprocess.PIPE, env=envOpts)
+    dump_cmd = 'pg_dumpall -h {host} -p {port} -U {user} -l {database} -g'.format(**connectionInfo)
+    p = subprocess.Popen(dump_cmd, shell=True, stderr=subprocess.PIPE, env=envOpts)
     if p.wait() is not 0:
         sys.stderr.write('\nError while dumping globals.\n\n' + p.communicate()[1] + '\n\n')
         sys.exit(1)
@@ -161,18 +157,6 @@ def parseCmdLine():
                  default=False, help='Include HLL stats')
     return p
 
-
-def isOrcaPresent(versionString):
-    if 'HAWQ' in versionString:
-        return True
-    match = re.search('(?<=Greenplum Database )[0-9.]+', versionString)
-    if match and len(match.group()):
-        return LooseVersion(match.group()) >= LooseVersion('4.3')
-    # No HAWQ and we can't find the GPDB Version
-    sys.stderr.write('Cannot determine HAWQ/GPDB version.  Exiting.\n')
-    sys.exit(1)
-
-
 def main():
     parser = parseCmdLine()
     options, args = parser.parse_args()
@@ -193,19 +177,15 @@ def main():
 
     version = getVersion(envOpts)
 
-    # Let's update the global variable so we can tell if we're using ORCA aware or not
-    global orca
-    orca = isOrcaPresent(version)
-
-    if orca:
-        envOpts['PGOPTIONS'] = pgoptions + ' -c optimizer=off'
-
     timestamp = datetime.datetime.today()
 
-    # setup the connection info tuple with options
-    connectionInfo = (host, port, user, db)
-    connectionString = ':'.join([host, port, db, user, '', pgoptions, ''])
-
+    connectionInfo = {
+    'user': user,
+    'host': host,
+    'port': port,
+    'database': db,
+    'options': pgoptions
+    }
     sys.stdout.writelines(['\n-- Greenplum database Statistics Dump',
                            '\n-- Copyright (C) 2007 - 2014 Pivotal'
                            '\n-- Database: ' + db,
@@ -235,7 +215,7 @@ def main():
     sys.stdout.flush()
 
     try:
-        with closing(pgdb.connect(connectionString)) as connection:
+        with closing(pgdb.connect(**connectionInfo)) as connection:
             with closing(connection.cursor()) as cursor:
                 dumpTupleCount(cursor)
                 dumpStats(cursor, inclHLL)


### PR DESCRIPTION
gpsd was failing because the connectionString that we passed to pgdb.connect
had the parameters in the wrong order. It started failing after upgrading to a
higher version of PyGreSQL. So use a dictionary instead in order to avoid
sending in the parameters incorrectly.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
