### PR TITLE
Modify error context callback functions to not assume that they can f…

### DIFF
--- a/src/backend/catalog/pg_proc.c
+++ b/src/backend/catalog/pg_proc.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/catalog/pg_proc.c,v 1.148.2.2 2010/05/11 04:57:51 itagaki Exp $
+ *	  $PostgreSQL: pgsql/src/backend/catalog/pg_proc.c,v 1.173 2010/03/19 22:54:40 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -47,6 +47,12 @@
 Datum		fmgr_internal_validator(PG_FUNCTION_ARGS);
 Datum		fmgr_c_validator(PG_FUNCTION_ARGS);
 Datum		fmgr_sql_validator(PG_FUNCTION_ARGS);
+
+typedef struct
+{
+	char	   *proname;
+	char	   *prosrc;
+} parse_error_callback_arg;
 
 static void sql_function_parse_error_callback(void *arg);
 static int match_prosrc_to_query(const char *prosrc, const char *queryText,
@@ -783,6 +789,7 @@ fmgr_sql_validator(PG_FUNCTION_ARGS)
 	bool		isnull;
 	Datum		tmp;
 	char	   *prosrc;
+	parse_error_callback_arg callback_arg;
 	ErrorContextCallback sqlerrcontext;
 	bool		haspolyarg;
 	int			i;
@@ -837,8 +844,11 @@ fmgr_sql_validator(PG_FUNCTION_ARGS)
 		/*
 		 * Setup error traceback support for ereport().
 		 */
+		callback_arg.proname = NameStr(proc->proname);
+		callback_arg.prosrc = prosrc;
+
 		sqlerrcontext.callback = sql_function_parse_error_callback;
-		sqlerrcontext.arg = tuple;
+		sqlerrcontext.arg = (void *) &callback_arg;
 		sqlerrcontext.previous = error_context_stack;
 		error_context_stack = &sqlerrcontext;
 
@@ -876,25 +886,14 @@ fmgr_sql_validator(PG_FUNCTION_ARGS)
 static void
 sql_function_parse_error_callback(void *arg)
 {
-	HeapTuple	tuple = (HeapTuple) arg;
-	Form_pg_proc proc = (Form_pg_proc) GETSTRUCT(tuple);
-	bool		isnull;
-	Datum		tmp;
-	char	   *prosrc;
+	parse_error_callback_arg *callback_arg = (parse_error_callback_arg *) arg;
 
 	/* See if it's a syntax error; if so, transpose to CREATE FUNCTION */
-	tmp = SysCacheGetAttr(PROCOID, tuple, Anum_pg_proc_prosrc, &isnull);
-	if (isnull)
-		elog(ERROR, "null prosrc");
-	prosrc = DatumGetCString(DirectFunctionCall1(textout, tmp));
-
-	if (!function_parse_error_transpose(prosrc))
+	if (!function_parse_error_transpose(callback_arg->prosrc))
 	{
 		/* If it's not a syntax error, push info onto context stack */
-		errcontext("SQL function \"%s\"", NameStr(proc->proname));
+		errcontext("SQL function \"%s\"", callback_arg->proname);
 	}
-
-	pfree(prosrc);
 }
 
 /*

--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	  $PostgreSQL: pgsql/src/backend/executor/functions.c,v 1.120 2008/01/01 19:45:49 momjian Exp $
+ *	  $PostgreSQL: pgsql/src/backend/executor/functions.c,v 1.143 2010/03/19 22:54:40 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -68,6 +68,7 @@ typedef struct local_es
  */
 typedef struct
 {
+	char	   *fname;			/* function name (for error msgs) */
 	char	   *src;			/* function body text (for error msgs) */
 
 	Oid		   *argtypes;		/* resolved types of arguments */
@@ -258,6 +259,7 @@ init_sql_fcache(FmgrInfo *finfo)
 	bool		isNull;
 
 	fcache = (SQLFunctionCachePtr) palloc0(sizeof(SQLFunctionCache));
+	finfo->fn_extra = (void *) fcache;
 
 	/*
 	 * get the procedure tuple corresponding to the given function Oid
@@ -268,6 +270,11 @@ init_sql_fcache(FmgrInfo *finfo)
 	if (!HeapTupleIsValid(procedureTuple))
 		elog(ERROR, "cache lookup failed for function %u", foid);
 	procedureStruct = (Form_pg_proc) GETSTRUCT(procedureTuple);
+
+	/*
+	 * copy function name immediately for use by error reporting callback
+	 */
+	fcache->fname = pstrdup(NameStr(procedureStruct->proname));
 
 	/*
 	 * get the result type from the procedure tuple, and check for polymorphic
@@ -414,8 +421,6 @@ init_sql_fcache(FmgrInfo *finfo)
 											  fcache->readonly_func);
 
 	ReleaseSysCache(procedureTuple);
-
-	finfo->fn_extra = (void *) fcache;
 }
 
 
@@ -954,39 +959,24 @@ sql_exec_error_callback(void *arg)
 {
 	FmgrInfo   *flinfo = (FmgrInfo *) arg;
 	SQLFunctionCachePtr fcache = (SQLFunctionCachePtr) flinfo->fn_extra;
-	HeapTuple	func_tuple;
-	Form_pg_proc functup;
-	char	   *fn_name;
 	int			syntaxerrposition;
 
-	/* Need access to function's pg_proc tuple */
-	func_tuple = SearchSysCache(PROCOID,
-								ObjectIdGetDatum(flinfo->fn_oid),
-								0, 0, 0);
-	if (!HeapTupleIsValid(func_tuple))
-		return;					/* shouldn't happen */
-	functup = (Form_pg_proc) GETSTRUCT(func_tuple);
-	fn_name = NameStr(functup->proname);
+	/*
+	 * We can do nothing useful if init_sql_fcache() didn't get as far as
+	 * saving the function name
+	 */
+	if (fcache == NULL || fcache->fname == NULL)
+		return;
 
 	/*
 	 * If there is a syntax error position, convert to internal syntax error
 	 */
 	syntaxerrposition = geterrposition();
-	if (syntaxerrposition > 0)
+	if (syntaxerrposition > 0 && fcache->src != NULL)
 	{
-		bool		isnull;
-		Datum		tmp;
-		char	   *prosrc;
-
-		tmp = SysCacheGetAttr(PROCOID, func_tuple, Anum_pg_proc_prosrc,
-							  &isnull);
-		if (isnull)
-			elog(ERROR, "null prosrc");
-		prosrc = DatumGetCString(DirectFunctionCall1(textout, tmp));
 		errposition(0);
 		internalerrposition(syntaxerrposition);
-		internalerrquery(prosrc);
-		pfree(prosrc);
+		internalerrquery(fcache->src);
 	}
 
 	/*
@@ -996,7 +986,7 @@ sql_exec_error_callback(void *arg)
 	 * ExecutorEnd are blamed on the appropriate query; see postquel_start and
 	 * postquel_end.)
 	 */
-	if (fcache)
+	if (fcache->func_state)
 	{
 		execution_state *es;
 		int			query_num;
@@ -1008,7 +998,7 @@ sql_exec_error_callback(void *arg)
 			if (es->qd)
 			{
 				errcontext("SQL function \"%s\" statement %d",
-						   fn_name, query_num);
+						   fcache->fname, query_num);
 				break;
 			}
 			es = es->next;
@@ -1020,16 +1010,18 @@ sql_exec_error_callback(void *arg)
 			 * couldn't identify a running query; might be function entry,
 			 * function exit, or between queries.
 			 */
-			errcontext("SQL function \"%s\"", fn_name);
+			errcontext("SQL function \"%s\"", fcache->fname);
 		}
 	}
 	else
 	{
-		/* must have failed during init_sql_fcache() */
-		errcontext("SQL function \"%s\" during startup", fn_name);
+		/*
+		 * Assume we failed during init_sql_fcache().  (It's possible that
+		 * the function actually has an empty body, but in that case we may
+		 * as well report all errors as being "during startup".)
+		 */
+		errcontext("SQL function \"%s\" during startup", fcache->fname);
 	}
-
-	ReleaseSysCache(func_tuple);
 }
 
 


### PR DESCRIPTION
…etch

catalog entries via SearchSysCache and related operations.  Although, at the
time that these callbacks are called by elog.c, we have not officially aborted
the current transaction, it still seems rather risky to initiate any new
catalog fetches.  In all these cases the needed information is readily
available in the caller and so it's just a matter of a bit of extra notation
to pass it to the callback.

Per crash report from Dennis Koegel.  I've concluded that the real fix for
his problem is to clear the error context stack at entry to proc_exit, but
it still seems like a good idea to make the callbacks a bit less fragile
for other cases.

Backpatch to 8.4.  We could go further back, but the patch doesn't apply
cleanly.  In the absence of proof that this fixes something and isn't just
paranoia, I'm not going to expend the effort.

(cherry picked from commit a836abe9f6934b51a0f92cb50c8514cd6f14c8b6)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
