### PR TITLE
5X: Give a grace period for declaring mirror down

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -285,6 +285,8 @@ readCdbComponentInfo(bool DNSLookupAsError, HTAB *hostSegsHash)
 		pRow->hostip = NULL;
 		getAddressesForDBid(pRow, DNSLookupAsError ? ERROR : LOG);
 
+		pRow->net_fault_time = (pg_time_t)0;
+
 		/*
 		 * We make sure we get a valid hostip for primary here,
 		 * if hostip for mirrors can not be get, ignore the error.

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -815,7 +815,6 @@ probeProcessResponse(ProbeConnectionInfo *probeInfo)
 	return true;
 }
 
-
 /*
  * Function called by probing thread;
  * iteratively picks next segment pair to probe until all segments are probed;
@@ -911,6 +910,15 @@ probeSegmentFromThread(void *arg)
 				/* probe mirror */
 				probe_result_mirror = probeSegment(mirror);
 				Assert(!PROBE_CHECK_FLAG(probe_result_mirror, PROBE_SEGMENT));
+
+				/* record the first time mirror net fault */
+				if (PROBE_CHECK_FLAG(probe_result_mirror, PROBE_FAULT_NET)
+					&& (mirror->net_fault_time == 0))
+				{
+					mirror->net_fault_time = (pg_time_t) time(NULL) ;
+				}
+				else
+					mirror->net_fault_time = 0;
 
 				if ((probe_result_mirror & PROBE_ALIVE) == 0 && gp_log_fts >= GPVARS_VERBOSITY_VERBOSE)
 				{

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -22,6 +22,7 @@
  */
 
 #include <math.h>
+#include "pgtime.h"
 
 /* cdb_rand returns a random float value between 0 and 1 inclusive */
 #define cdb_rand() ((double) random() / (double) MAX_RANDOM_VALUE)
@@ -62,6 +63,8 @@ typedef struct CdbComponentDatabaseInfo
 
 	char	   *hostaddrs[COMPONENT_DBS_MAX_ADDRS];	/* cached lookup of names */	
 	int16		hostSegs;		/* number of primary segments on the same hosts */
+
+	pg_time_t   net_fault_time; /* store the first net fault time*/
 } CdbComponentDatabaseInfo;
 
 #define SEGMENT_ROLE_PRIMARY 'p'


### PR DESCRIPTION
The idea is same as cd647b1 in 6X. If mirror probe has network fault, 
record the time, and do not declare mirror down in 30 secs.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
