### PR TITLE
Allow hot standby (and more...) to make replication related TAP tests pass

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6916,8 +6916,17 @@ StartupXLOG(void)
 			 */
 			StartupCLOG();
 			StartupSUBTRANS(oldestActiveXID);
-			DistributedLog_Startup(oldestActiveXID,
-								   ShmemVariableCache->nextXid);
+			/*
+			 * Do not initialize DistributedLog subsystem. Hot standby /
+			 * mirror cannot advance distributed xmin because QD does not
+			 * dispatch queries to mirrors.	 To align with upstream, we still
+			 * want a functional hot standby as far as a single primary/mirror
+			 * pair is concerned.  Initializing distributed log subsystem
+			 * affects oldest xmin computation in hot standby, the oldest xmin
+			 * never advances.	Therefore, avoid initializing distributed log
+			 * in hot standby.	If, in future, queries from QD need to be
+			 * dispatched to mirrors, this will have to change.
+			 */
 
 			/*
 			 * If we're beginning at a shutdown checkpoint, we know that

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -452,6 +452,17 @@ SyncRepInitConfig(void)
 	 * for handling replies from standby.
 	 */
 	priority = SyncRepGetStandbyPriority();
+
+	/*
+	 * Greenplum: master/standby replication is considered synchronous even
+	 * when synchronous_standby_names GUC is not set.
+	 */
+	if (IS_QUERY_DISPATCHER() && MyWalSnd->is_for_gp_walreceiver)
+	{
+		Assert(priority == 0);
+		priority = 1;
+	}
+	
 	if (MyWalSnd->sync_standby_priority != priority)
 	{
 		LWLockAcquire(SyncRepLock, LW_EXCLUSIVE);
@@ -839,15 +850,46 @@ SyncRepGetSyncStandbys(bool *am_sync)
  * priority sequence. Return priority if set, or zero to indicate that
  * we are not a potential sync standby.
  *
- * **Note:- Currently, GPDB does NOT apply the concept of standby priority as
- *   we allow max 1 walsender to be alive at a time. Hence, this function returns
- *   1.**
+ * Compare the parameter SyncRepStandbyNames against the application_name
+ * for this WALSender, or allow any name if we find a wildcard "*".
  */
 static int
 SyncRepGetStandbyPriority(void)
 {
-	/* Currently set the priority to 1 */
-	return 1;
+	const char *standby_name;
+	int			priority;
+	bool		found = false;
+
+	/*
+	 * Since synchronous cascade replication is not allowed, we always set the
+	 * priority of cascading walsender to zero.
+	 */
+	if (am_cascading_walsender)
+		return 0;
+
+	if (!SyncStandbysDefined() || SyncRepConfig == NULL)
+		return 0;
+
+	standby_name = SyncRepConfig->member_names;
+	for (priority = 1; priority <= SyncRepConfig->nmembers; priority++)
+	{
+		if (pg_strcasecmp(standby_name, application_name) == 0 ||
+			strcmp(standby_name, "*") == 0)
+		{
+			found = true;
+			break;
+		}
+		standby_name += strlen(standby_name) + 1;
+	}
+
+	if (!found)
+		return 0;
+
+	/*
+	 * In quorum-based sync replication, all the standbys in the list have the
+	 * same priority, one.
+	 */
+	return (SyncRepConfig->syncrep_method == SYNC_REP_PRIORITY) ? priority : 1;
 }
 
 /*

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -3552,7 +3552,7 @@ RelationCacheInitializePhase3(void)
 	 * Relation cache initialization or any sort of heap access is
 	 * dangerous before recovery is finished.
 	 */
-	if (!IsBootstrapProcessingMode() && RecoveryInProgress())
+	if (!EnableHotStandby && !IsBootstrapProcessingMode() && RecoveryInProgress())
 		elog(ERROR, "relation cache initialization during recovery or non-bootstrap processes.");
 
 	/*


### PR DESCRIPTION
Hot standby mode is explicitly prohibited in Greenplum.  In order to align better with upstream, let's lift that restriction.  This PR allows hot standby to be turned on with `hot_standby = on` GUC in a standby that is initialized using `pg_basebackup`.  By default, the GUC remains off, so that mirrors in a Greenplum cluster continue to prohibit user connections.

We need to get tests under `src/test/recovery` to pass in the iteration branch for ongoing PostgreSQL 12 merge.  This change is significant enough to merit a separate PR on master instead of hiding it in the big merge commit.

Note that the tests under `src/test/recovery` continue to fail on master as they depend on some enhancements that are newly made in the iteration branch.  These tests are not included in ICW currently but will be included after the merge.

This is marked as WIP because there is more to come.  I'm working on a change that aligns `synchronous_standby_names` GUC assignment logic closer to upstream.