### PR TITLE
Push predicate of LOJ through inner GbAgg

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/AggonExternalTableNoMotion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AggonExternalTableNoMotion.mdp
@@ -303,7 +303,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1350.876031" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1350.876033" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -316,7 +316,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1350.876030" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1350.876031" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="37" Alias="ColRef_0037">
@@ -327,7 +327,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1350.876000" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1350.876001" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/AnySubqueryWithSubqueryInScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubqueryWithSubqueryInScalar.mdp
@@ -356,7 +356,7 @@
     <dxl:Plan Id="0" SpaceSize="420">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6896.001505" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="6896.001513" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -367,7 +367,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6896.001490" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="6896.001498" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -403,20 +403,20 @@
           </dxl:TableScan>
           <dxl:Materialize Eager="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000358" Rows="3.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000360" Rows="3.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
             <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000357" Rows="3.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000359" Rows="3.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000339" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000341" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
@@ -431,7 +431,7 @@
                 </dxl:HashCondList>
                 <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000058" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="25" Alias="count">
@@ -442,7 +442,7 @@
                   <dxl:SortingColumnList/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
@@ -455,7 +455,7 @@
                     <dxl:Filter/>
                     <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="30" Alias="ColRef_0030">
@@ -466,7 +466,7 @@
                       <dxl:SortingColumnList/>
                       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns/>
                         <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfMultipleSetRetFuncs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfMultipleSetRetFuncs.mdp
@@ -132,7 +132,7 @@ select count(*) from ( select unnest(arr) i, unnest(arr) j  from (    select str
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.000011" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000013" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -145,7 +145,7 @@ select count(*) from ( select unnest(arr) i, unnest(arr) j  from (    select str
         <dxl:Filter/>
         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000010" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000011" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList>
@@ -178,7 +178,7 @@ select count(*) from ( select unnest(arr) i, unnest(arr) j  from (    select str
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="arr">
-                  <dxl:ConstValue TypeMdid="0.1009.1.0" Value="AAAAOAEAAAAAAAAAGQAAAAQAAAABAAAAAAAABmFhAAAAAAAGYmIAAAAAAAZj&#10;YwAAAAAABmRkAAA="/>
+                  <dxl:ConstValue TypeMdid="0.1009.1.0" Value="AAAAOAEAAAAAAAAAGQAAAAQAAAABAAAAAAAABmFhAAAAAAAGYmIAAAAAAAZj&#xA;YwAAAAAABmRkAAA="/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfMultipleSetRetFuncsAndUnusedScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfMultipleSetRetFuncsAndUnusedScalar.mdp
@@ -145,7 +145,7 @@ select count(*) from (select unnest(arr) i, 1 j from (select string_to_array('aa
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.000011" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000013" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -158,7 +158,7 @@ select count(*) from (select unnest(arr) i, 1 j from (select string_to_array('aa
         <dxl:Filter/>
         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000010" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000011" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfSetRefFuncsOnTopTbl.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfSetRefFuncsOnTopTbl.mdp
@@ -277,7 +277,7 @@ select count(*) from (select unnest(string_to_array(c, '|')) i, d from foo) t;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -290,7 +290,7 @@ select count(*) from (select unnest(string_to_array(c, '|')) i, d from foo) t;
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="11" Alias="ColRef_0011">
@@ -301,7 +301,7 @@ select count(*) from (select unnest(string_to_array(c, '|')) i, d from foo) t;
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000016" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfSetRetFuncsAndUnusedScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfSetRetFuncsAndUnusedScalar.mdp
@@ -124,7 +124,7 @@ explain select count(*) from (select generate_series(1, 10) i) t1, (select 1 j) 
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -137,7 +137,7 @@ explain select count(*) from (select generate_series(1, 10) i) t1, (select 1 j) 
         <dxl:Filter/>
         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000011" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList>
@@ -146,7 +146,7 @@ explain select count(*) from (select generate_series(1, 10) i) t1, (select 1 j) 
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+          <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="1"/>
             </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfSingleSetRetFuncs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfSingleSetRetFuncs.mdp
@@ -127,7 +127,7 @@ select count(*) from (select generate_series(1, 10) i) t1, (select generate_seri
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -140,7 +140,7 @@ select count(*) from (select generate_series(1, 10) i) t1, (select generate_seri
         <dxl:Filter/>
         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/MultiLevelSubqueryWithSetRetFuncs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/MultiLevelSubqueryWithSetRetFuncs.mdp
@@ -313,7 +313,7 @@ select count(*) from (select (select unnest(string_to_array(c, '|')) ii from foo
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -326,7 +326,7 @@ select count(*) from (select (select unnest(string_to_array(c, '|')) ii from foo
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -337,7 +337,7 @@ select count(*) from (select (select unnest(string_to_array(c, '|')) ii from foo
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000016" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/MultiLevelSubqueryWithSetRetFuncsAndScalarFuncs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/MultiLevelSubqueryWithSetRetFuncsAndScalarFuncs.mdp
@@ -296,7 +296,7 @@ select count(*) from (select (select 1 as p) i, unnest(string_to_array(c, '|')) 
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -309,7 +309,7 @@ select count(*) from (select (select 1 as p) i, unnest(string_to_array(c, '|')) 
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="14" Alias="ColRef_0014">
@@ -320,7 +320,7 @@ select count(*) from (select (select 1 as p) i, unnest(string_to_array(c, '|')) 
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000016" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
@@ -683,7 +683,7 @@
     <dxl:Plan Id="0" SpaceSize="8">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="10" VarTypeModList="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="438.426956" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="438.426958" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:Columns>
           <dxl:Column ColId="13" Attno="1" ColName="avg" TypeMdid="0.1700.1.0"/>
@@ -696,7 +696,7 @@
         </dxl:ProjList>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="438.411331" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="438.411333" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="avg">
@@ -710,7 +710,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="438.411327" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="438.411329" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="avg">
@@ -721,7 +721,7 @@
             <dxl:SortingColumnList/>
             <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="438.411306" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="438.411308" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns/>
               <dxl:ProjList>
@@ -734,7 +734,7 @@
               <dxl:Filter/>
               <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="438.411305" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="438.411306" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="11" Alias="ColRef_0011">
@@ -745,7 +745,7 @@
                 <dxl:SortingColumnList/>
                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="438.411275" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="438.411276" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns/>
                   <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CTE-with-random-filter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-with-random-filter.mdp
@@ -343,7 +343,7 @@ explain with t as (select * from foo) select count(*) from t where random() < 0.
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000716" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000718" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -356,7 +356,7 @@ explain with t as (select * from foo) select count(*) from t where random() < 0.
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000715" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000716" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="17" Alias="ColRef_0017">
@@ -367,7 +367,7 @@ explain with t as (select * from foo) select count(*) from t where random() < 0.
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000685" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000686" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
@@ -3765,7 +3765,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
     <dxl:Plan Id="0" SpaceSize="19837440">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="57937329.740768" Rows="2959212724800.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="57937329.740864" Rows="2959212724800.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="122" Alias="?column?">
@@ -3776,14 +3776,14 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="46100478.841568" Rows="2959212724800.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="46100478.841664" Rows="2959212724800.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList/>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="35072479.420480" Rows="2959212724800.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="35072479.420576" Rows="2959212724800.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
@@ -3806,33 +3806,33 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
             </dxl:TableScan>
             <dxl:Materialize Eager="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="14147.738846" Rows="361329.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="14147.738862" Rows="361329.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="14147.618403" Rows="361329.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="14147.618419" Rows="361329.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:Append IsTarget="false" IsZapped="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="14145.462473" Rows="120443.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="14145.462489" Rows="120443.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList/>
                   <dxl:Filter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="7064.686786" Rows="118963.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="7064.686794" Rows="118963.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
                     <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="7064.647131" Rows="118963.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="7064.647139" Rows="118963.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList/>
                       <dxl:Filter/>
@@ -3841,14 +3841,14 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                       </dxl:JoinFilter>
                       <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="894.082840" Rows="3.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="894.082842" Rows="3.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="894.082787" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="894.082789" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter>
@@ -3860,7 +3860,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                           <dxl:OneTimeFilter/>
                           <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="894.082754" Rows="1.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="894.082756" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="186" Alias="ColRef_0186">
@@ -3885,7 +3885,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                             <dxl:OneTimeFilter/>
                             <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="894.082746" Rows="1.000000" Width="16"/>
+                                <dxl:Cost StartupCost="0" TotalCost="894.082748" Rows="1.000000" Width="16"/>
                               </dxl:Properties>
                               <dxl:GroupingColumns/>
                               <dxl:ProjList>
@@ -3903,7 +3903,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                               <dxl:Filter/>
                               <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="894.082739" Rows="1.000000" Width="16"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="894.082740" Rows="1.000000" Width="16"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="187" Alias="ColRef_0187">
@@ -3917,7 +3917,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                 <dxl:SortingColumnList/>
                                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="894.082679" Rows="1.000000" Width="16"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="894.082680" Rows="1.000000" Width="16"/>
                                   </dxl:Properties>
                                   <dxl:GroupingColumns/>
                                   <dxl:ProjList>
@@ -4137,14 +4137,14 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                   </dxl:Result>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="7080.735540" Rows="1480.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="7080.735548" Rows="1480.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="7080.735046" Rows="1480.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="7080.735054" Rows="1480.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="41"/>
@@ -4161,7 +4161,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                       <dxl:Filter/>
                       <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="7080.616259" Rows="1480.000000" Width="11"/>
+                          <dxl:Cost StartupCost="0" TotalCost="7080.616267" Rows="1480.000000" Width="11"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="41" Alias="element_id">
@@ -4183,7 +4183,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                         </dxl:HashExprList>
                         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="7080.599274" Rows="1480.000000" Width="11"/>
+                            <dxl:Cost StartupCost="0" TotalCost="7080.599282" Rows="1480.000000" Width="11"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns>
                             <dxl:GroupingColumn ColId="41"/>
@@ -4200,7 +4200,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                           <dxl:Filter/>
                           <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="7070.860650" Rows="118963.000000" Width="11"/>
+                              <dxl:Cost StartupCost="0" TotalCost="7070.860658" Rows="118963.000000" Width="11"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="66" Alias="?column?">
@@ -4214,7 +4214,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                             <dxl:OneTimeFilter/>
                             <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="7070.424452" Rows="118963.000000" Width="7"/>
+                                <dxl:Cost StartupCost="0" TotalCost="7070.424460" Rows="118963.000000" Width="7"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="41" Alias="element_id">
@@ -4246,20 +4246,20 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                               </dxl:TableScan>
                               <dxl:Materialize Eager="false">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="894.082841" Rows="3.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="894.082843" Rows="3.000000" Width="1"/>
                                 </dxl:Properties>
                                 <dxl:ProjList/>
                                 <dxl:Filter/>
                                 <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="894.082840" Rows="3.000000" Width="1"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="894.082842" Rows="3.000000" Width="1"/>
                                   </dxl:Properties>
                                   <dxl:ProjList/>
                                   <dxl:Filter/>
                                   <dxl:SortingColumnList/>
                                   <dxl:Result>
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="894.082787" Rows="1.000000" Width="1"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="894.082789" Rows="1.000000" Width="1"/>
                                     </dxl:Properties>
                                     <dxl:ProjList/>
                                     <dxl:Filter>
@@ -4271,7 +4271,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                     <dxl:OneTimeFilter/>
                                     <dxl:Result>
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="894.082754" Rows="1.000000" Width="8"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="894.082756" Rows="1.000000" Width="8"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
                                         <dxl:ProjElem ColId="180" Alias="ColRef_0180">
@@ -4296,7 +4296,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                       <dxl:OneTimeFilter/>
                                       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="894.082746" Rows="1.000000" Width="16"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="894.082748" Rows="1.000000" Width="16"/>
                                         </dxl:Properties>
                                         <dxl:GroupingColumns/>
                                         <dxl:ProjList>
@@ -4314,7 +4314,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                         <dxl:Filter/>
                                         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="894.082739" Rows="1.000000" Width="16"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="894.082740" Rows="1.000000" Width="16"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
                                             <dxl:ProjElem ColId="181" Alias="ColRef_0181">
@@ -4328,7 +4328,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                           <dxl:SortingColumnList/>
                                           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="894.082679" Rows="1.000000" Width="16"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="894.082680" Rows="1.000000" Width="16"/>
                                             </dxl:Properties>
                                             <dxl:GroupingColumns/>
                                             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CastedInClauseWithMCV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CastedInClauseWithMCV.mdp
@@ -702,7 +702,7 @@ explain select * from n1 where a in (1, (select count(*) from n1));
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1294.018798" Rows="1002.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1294.018800" Rows="1002.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -716,7 +716,7 @@ explain select * from n1 where a in (1, (select count(*) from n1));
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.973989" Rows="1002.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.973991" Rows="1002.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -740,7 +740,7 @@ explain select * from n1 where a in (1, (select count(*) from n1));
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.166860" Rows="3.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.166862" Rows="3.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="18" Alias="count">
@@ -751,7 +751,7 @@ explain select * from n1 where a in (1, (select count(*) from n1));
             <dxl:SortingColumnList/>
             <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.166431" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.166433" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns/>
               <dxl:ProjList>
@@ -764,7 +764,7 @@ explain select * from n1 where a in (1, (select count(*) from n1));
               <dxl:Filter/>
               <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.166430" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.166431" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="19" Alias="ColRef_0019">
@@ -775,7 +775,7 @@ explain select * from n1 where a in (1, (select count(*) from n1));
                 <dxl:SortingColumnList/>
                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.166400" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.166401" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns/>
                   <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/Correlated-LASJ-With-Outer-Col.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlated-LASJ-With-Outer-Col.mdp
@@ -590,7 +590,7 @@ select * from t1 where a not in (select a from t2 where t2.b<>t1.b group by t2.a
     <dxl:Plan Id="4" SpaceSize="12">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.088483" Rows="111.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.088484" Rows="111.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -609,7 +609,7 @@ select * from t1 where a not in (select a from t2 where t2.b<>t1.b group by t2.a
             </dxl:ParamList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.078593" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.078594" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="28" Alias="ColRef_0028">
@@ -620,7 +620,7 @@ select * from t1 where a not in (select a from t2 where t2.b<>t1.b group by t2.a
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.078593" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.078594" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -636,7 +636,7 @@ select * from t1 where a not in (select a from t2 where t2.b<>t1.b group by t2.a
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.074941" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.074942" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -650,12 +650,12 @@ select * from t1 where a not in (select a from t2 where t2.b<>t1.b group by t2.a
                             <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                             <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
                           </dxl:Comparison>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                           <dxl:If TypeMdid="0.16.1.0">
                             <dxl:IsNull>
                               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                             </dxl:IsNull>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                             <dxl:If TypeMdid="0.16.1.0">
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
                                 <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
@@ -673,7 +673,7 @@ select * from t1 where a not in (select a from t2 where t2.b<>t1.b group by t2.a
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.074940" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.074941" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/Correlated-LASJ-With-Outer-Const.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlated-LASJ-With-Outer-Const.mdp
@@ -602,7 +602,7 @@ select * from t1 where 10 not in (select a from t2 where t2.b<>t1.b group by t2.
     <dxl:Plan Id="4" SpaceSize="12">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.088483" Rows="111.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.088484" Rows="111.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -620,7 +620,7 @@ select * from t1 where 10 not in (select a from t2 where t2.b<>t1.b group by t2.
             </dxl:ParamList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.078593" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.078594" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="28" Alias="ColRef_0028">
@@ -631,7 +631,7 @@ select * from t1 where 10 not in (select a from t2 where t2.b<>t1.b group by t2.
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.078593" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.078594" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -647,7 +647,7 @@ select * from t1 where 10 not in (select a from t2 where t2.b<>t1.b group by t2.
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.074941" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.074942" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -661,12 +661,12 @@ select * from t1 where 10 not in (select a from t2 where t2.b<>t1.b group by t2.
                             <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                             <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
                           </dxl:Comparison>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                           <dxl:If TypeMdid="0.16.1.0">
                             <dxl:IsNull>
                               <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
                             </dxl:IsNull>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                             <dxl:If TypeMdid="0.16.1.0">
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
                                 <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
@@ -684,7 +684,7 @@ select * from t1 where 10 not in (select a from t2 where t2.b<>t1.b group by t2.
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.074940" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.074941" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/Correlated-LASJ-With-Outer-Expr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlated-LASJ-With-Outer-Expr.mdp
@@ -600,7 +600,7 @@ select * from t1 where a + 10 not in (select a from t2 where t2.b<>t1.b group by
     <dxl:Plan Id="4" SpaceSize="12">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.088483" Rows="111.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.088484" Rows="111.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -619,7 +619,7 @@ select * from t1 where a + 10 not in (select a from t2 where t2.b<>t1.b group by
             </dxl:ParamList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.078593" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.078594" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="28" Alias="ColRef_0028">
@@ -630,7 +630,7 @@ select * from t1 where a + 10 not in (select a from t2 where t2.b<>t1.b group by
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.078593" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.078594" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -646,7 +646,7 @@ select * from t1 where a + 10 not in (select a from t2 where t2.b<>t1.b group by
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.074941" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.074942" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -660,7 +660,7 @@ select * from t1 where a + 10 not in (select a from t2 where t2.b<>t1.b group by
                             <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                             <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
                           </dxl:Comparison>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                           <dxl:If TypeMdid="0.16.1.0">
                             <dxl:IsNull>
                               <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
@@ -668,7 +668,7 @@ select * from t1 where a + 10 not in (select a from t2 where t2.b<>t1.b group by
                                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
                               </dxl:OpExpr>
                             </dxl:IsNull>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                             <dxl:If TypeMdid="0.16.1.0">
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
                                 <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
@@ -686,7 +686,7 @@ select * from t1 where a + 10 not in (select a from t2 where t2.b<>t1.b group by
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.074940" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.074941" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiNotIn-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiNotIn-True.mdp
@@ -558,7 +558,7 @@ create table customer
     <dxl:Plan Id="0" SpaceSize="4">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.000441" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.000442" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="pn">
@@ -579,7 +579,7 @@ create table customer
             </dxl:ParamList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000297" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000298" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="13" Alias="cn">
@@ -595,7 +595,7 @@ create table customer
                   </dxl:ParamList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000195" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="42" Alias="ColRef_0042">
@@ -606,7 +606,7 @@ create table customer
                     <dxl:OneTimeFilter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000195" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="41" Alias="ColRef_0041">
@@ -622,7 +622,7 @@ create table customer
                       <dxl:OneTimeFilter/>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000162" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000163" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="41" Alias="ColRef_0041">
@@ -636,12 +636,12 @@ create table customer
                                   <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
                                   <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
                                 </dxl:Comparison>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                                 <dxl:If TypeMdid="0.16.1.0">
                                   <dxl:IsNull>
                                     <dxl:Ident ColId="13" ColName="cn" TypeMdid="0.23.1.0"/>
                                   </dxl:IsNull>
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                                   <dxl:If TypeMdid="0.16.1.0">
                                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
                                       <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.20.1.0"/>
@@ -659,7 +659,7 @@ create table customer
                         <dxl:OneTimeFilter/>
                         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000161" Rows="1.000000" Width="16"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000162" Rows="1.000000" Width="16"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns/>
                           <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-2.mdp
@@ -408,7 +408,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr <> c.u_v
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="8659.155642" Rows="400.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="8659.155650" Rows="400.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -425,7 +425,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr <> c.u_v
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="8659.112538" Rows="400.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="8659.112546" Rows="400.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -451,7 +451,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr <> c.u_v
                 </dxl:ParamList>
                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="440.232444" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="440.232445" Rows="2.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns/>
                   <dxl:ProjList>
@@ -568,7 +568,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr <> c.u_v
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.396607" Rows="1000.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.396608" Rows="1000.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -593,7 +593,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr <> c.u_v
                   </dxl:ParamList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.336993" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.336994" Rows="2.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="21" Alias="substr">
@@ -608,7 +608,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr <> c.u_v
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.336985" Rows="2.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.336986" Rows="2.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns/>
                       <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DQA-NonRedistributableCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-NonRedistributableCol.mdp
@@ -237,7 +237,7 @@ explain select count(distinct h) from testhstore;
     <dxl:Plan Id="0" SpaceSize="14">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DQA-SplitScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-SplitScalar.mdp
@@ -337,7 +337,7 @@ drop table if exists foo;
     <dxl:Plan Id="0" SpaceSize="13">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.120390" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.120391" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarOnDistCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarOnDistCol.mdp
@@ -212,7 +212,7 @@
     <dxl:Plan Id="0" SpaceSize="5">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -225,7 +225,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="ColRef_0010">
@@ -236,7 +236,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithAggAndGuc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithAggAndGuc.mdp
@@ -344,7 +344,7 @@
     <dxl:Plan Id="0" SpaceSize="13">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="438.791035" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="438.791036" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithGuc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-SplitScalarWithGuc.mdp
@@ -336,7 +336,7 @@ explain select count(distinct b ) from foo;
     <dxl:Plan Id="0" SpaceSize="13">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="438.327583" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="438.327584" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DistinctAgg-NonSplittable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DistinctAgg-NonSplittable.mdp
@@ -698,7 +698,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.068068" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.068069" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DqaMax.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DqaMax.mdp
@@ -603,7 +603,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="451.658682" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="451.658684" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -616,7 +616,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="451.658682" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="451.658683" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="11" Alias="ColRef_0011">
@@ -627,7 +627,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="451.658667" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="451.658668" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DqaMin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DqaMin.mdp
@@ -603,7 +603,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="451.658682" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="451.658684" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -616,7 +616,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="451.658682" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="451.658683" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="11" Alias="ColRef_0011">
@@ -627,7 +627,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="451.658667" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="451.658668" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/DqaSubqueryMax.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DqaSubqueryMax.mdp
@@ -638,7 +638,7 @@
     <dxl:Plan Id="0" SpaceSize="24">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="903842.531783" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="903842.533831" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="12" Alias="?column?">
@@ -649,7 +649,7 @@
         <dxl:OneTimeFilter/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="903842.531779" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="903842.533827" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList/>
           <dxl:Filter/>
@@ -658,7 +658,7 @@
           </dxl:JoinFilter>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="451.658715" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="451.658717" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter>
@@ -670,7 +670,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="451.658682" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="451.658684" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:GroupingColumns/>
               <dxl:ProjList>
@@ -683,7 +683,7 @@
               <dxl:Filter/>
               <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="451.658682" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="451.658683" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="13" Alias="ColRef_0013">
@@ -694,7 +694,7 @@
                 <dxl:SortingColumnList/>
                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="451.658667" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="451.658668" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns/>
                   <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/Equivalence-class-project-over-LOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equivalence-class-project-over-LOJ.mdp
@@ -374,7 +374,7 @@
     <dxl:Plan Id="0" SpaceSize="10">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.000573" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000575" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -387,7 +387,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.000572" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000573" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="29" Alias="ColRef_0029">
@@ -398,7 +398,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.000542" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000543" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-SubquerySingleton.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-SubquerySingleton.mdp
@@ -314,7 +314,7 @@
     <dxl:Plan Id="0" SpaceSize="24">
       <dxl:MergeJoin JoinType="Full" UniqueOuter="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000642" Rows="3.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000646" Rows="3.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="l">
@@ -334,7 +334,7 @@
         </dxl:MergeCondList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="sum">
@@ -349,7 +349,7 @@
           <dxl:LimitOffset/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -362,7 +362,7 @@
             <dxl:Filter/>
             <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="21" Alias="ColRef_0021">
@@ -373,7 +373,7 @@
               <dxl:SortingColumnList/>
               <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>
@@ -413,7 +413,7 @@
         </dxl:Sort>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="count">
@@ -428,7 +428,7 @@
           <dxl:LimitOffset/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -441,7 +441,7 @@
             <dxl:Filter/>
             <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="20" Alias="ColRef_0020">
@@ -452,7 +452,7 @@
               <dxl:SortingColumnList/>
               <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-SubqueryWithRedistribute.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-SubqueryWithRedistribute.mdp
@@ -292,7 +292,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000832" Rows="3.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000834" Rows="3.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="l">
@@ -309,7 +309,7 @@
         <dxl:SortingColumnList/>
         <dxl:MergeJoin JoinType="Full" UniqueOuter="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000564" Rows="3.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000566" Rows="3.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="sum">
@@ -332,7 +332,7 @@
           </dxl:MergeCondList>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000087" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="sum">
@@ -347,7 +347,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000087" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="sum">
@@ -363,7 +363,7 @@
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>
@@ -376,7 +376,7 @@
                 <dxl:Filter/>
                 <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="19" Alias="ColRef_0019">
@@ -387,7 +387,7 @@
                   <dxl:SortingColumnList/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/GinIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndex.mdp
@@ -246,7 +246,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.127103" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="68.127105" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -259,7 +259,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.127102" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="68.127103" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -270,7 +270,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127072" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="68.127073" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/GinIndexPathOpfamily.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndexPathOpfamily.mdp
@@ -246,7 +246,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.127103" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="68.127105" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -259,7 +259,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.127102" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="68.127103" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -270,7 +270,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127072" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="68.127073" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/GinIndexSearchModeAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndexSearchModeAll.mdp
@@ -246,7 +246,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="68.127103" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="68.127105" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -259,7 +259,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="68.127102" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="68.127103" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -270,7 +270,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127072" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="68.127073" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/InClauseWithMCV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InClauseWithMCV.mdp
@@ -675,7 +675,7 @@ explain select * from bar where a in (1, (select count(*) from bar));
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.787403" Rows="1002.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.787405" Rows="1002.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -686,7 +686,7 @@ explain select * from bar where a in (1, (select count(*) from bar));
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.772467" Rows="1002.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.772469" Rows="1002.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -705,7 +705,7 @@ explain select * from bar where a in (1, (select count(*) from bar));
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.137527" Rows="3.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.137529" Rows="3.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="16" Alias="count">
@@ -716,7 +716,7 @@ explain select * from bar where a in (1, (select count(*) from bar));
             <dxl:SortingColumnList/>
             <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.137097" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.137099" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns/>
               <dxl:ProjList>
@@ -729,7 +729,7 @@ explain select * from bar where a in (1, (select count(*) from bar));
               <dxl:Filter/>
               <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.137096" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.137097" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="17" Alias="ColRef_0017">
@@ -740,7 +740,7 @@ explain select * from bar where a in (1, (select count(*) from bar));
                 <dxl:SortingColumnList/>
                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.137067" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.137068" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns/>
                   <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs1.mdp
@@ -454,7 +454,7 @@ SQL:
     <dxl:Plan Id="0" SpaceSize="1556">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.007238" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.007242" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="sum">
@@ -468,7 +468,7 @@ SQL:
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.007166" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.007170" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="sum">
@@ -562,7 +562,7 @@ SQL:
           </dxl:CTEProducer>
           <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.002020" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.002024" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="sum">
@@ -576,7 +576,7 @@ SQL:
             <dxl:SortingColumnList/>
             <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.001976" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.001980" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="sum">
@@ -592,7 +592,7 @@ SQL:
               </dxl:JoinFilter>
               <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000597" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000599" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>
@@ -605,7 +605,7 @@ SQL:
                 <dxl:Filter/>
                 <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000596" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000597" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="30" Alias="ColRef_0030">
@@ -616,7 +616,7 @@ SQL:
                   <dxl:SortingColumnList/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000560" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000561" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
@@ -666,7 +666,7 @@ SQL:
               </dxl:Aggregate>
               <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.001300" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.001302" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>
@@ -679,7 +679,7 @@ SQL:
                 <dxl:Filter/>
                 <dxl:Materialize Eager="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.001299" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.001300" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="29" Alias="ColRef_0029">
@@ -689,7 +689,7 @@ SQL:
                   <dxl:Filter/>
                   <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.001291" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.001292" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="29" Alias="ColRef_0029">
@@ -700,7 +700,7 @@ SQL:
                     <dxl:SortingColumnList/>
                     <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.001255" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.001256" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns/>
                       <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/NoPushdownPredicateWithCTEAnchor.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoPushdownPredicateWithCTEAnchor.mdp
@@ -446,7 +446,7 @@
     <dxl:Plan Id="0" SpaceSize="274176">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5297852.190616" Rows="3.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="5297852.190622" Rows="3.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="19" Alias="a">
@@ -466,7 +466,7 @@
         </dxl:HashCondList>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2648926.129905" Rows="3.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="2648926.129907" Rows="3.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="a">
@@ -523,7 +523,7 @@
           </dxl:CTEProducer>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2648495.129855" Rows="3.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="2648495.129857" Rows="3.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="19" Alias="a">
@@ -535,7 +535,7 @@
             </dxl:ProjList>
             <dxl:CTEProducer CTEId="1" Columns="18">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="18" Alias="max_a">
@@ -544,7 +544,7 @@
               </dxl:ProjList>
               <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>
@@ -557,7 +557,7 @@
                 <dxl:Filter/>
                 <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="121" Alias="ColRef_0121">
@@ -568,7 +568,7 @@
                   <dxl:SortingColumnList/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
@@ -747,7 +747,7 @@
         </dxl:Sequence>
         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2648926.059900" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="2648926.059904" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList>
@@ -760,7 +760,7 @@
           <dxl:Filter/>
           <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2648926.059900" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="2648926.059903" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="123" Alias="ColRef_0123">
@@ -771,7 +771,7 @@
             <dxl:SortingColumnList/>
             <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2648926.059885" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="2648926.059888" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:GroupingColumns/>
               <dxl:ProjList>
@@ -784,7 +784,7 @@
               <dxl:Filter/>
               <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2648926.059885" Rows="3.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2648926.059887" Rows="3.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="79" Alias="a">
@@ -838,7 +838,7 @@
                 </dxl:CTEProducer>
                 <dxl:Sequence>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2648495.059867" Rows="3.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="2648495.059869" Rows="3.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="79" Alias="a">
@@ -847,7 +847,7 @@
                   </dxl:ProjList>
                   <dxl:CTEProducer CTEId="3" Columns="78">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000057" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="78" Alias="max_a">
@@ -856,7 +856,7 @@
                     </dxl:ProjList>
                     <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000057" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="78" Alias="max_a">
@@ -867,7 +867,7 @@
                       <dxl:SortingColumnList/>
                       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns/>
                         <dxl:ProjList>
@@ -880,7 +880,7 @@
                         <dxl:Filter/>
                         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="122" Alias="ColRef_0122">
@@ -891,7 +891,7 @@
                           <dxl:SortingColumnList/>
                           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="1.000000" Width="4"/>
                             </dxl:Properties>
                             <dxl:GroupingColumns/>
                             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/NonSplittableAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NonSplittableAgg.mdp
@@ -236,7 +236,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="466.124000" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="466.124001" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-AggWithExistentialSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-AggWithExistentialSubquery.mdp
@@ -431,7 +431,7 @@
     <dxl:Plan Id="0" SpaceSize="42">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.001201" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.001203" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -444,7 +444,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.001200" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.001201" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="27" Alias="ColRef_0027">
@@ -455,7 +455,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.001170" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.001171" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -468,11 +468,11 @@
                           <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.16.1.0"/>
                         </dxl:IsNull>
                       </dxl:Not>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" Value="true"/>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" Value="false"/>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
                     </dxl:If>
                     <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1700.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.1700.1.0" IsNull="false" Value="AAAACAAAAAA=" DoubleValue="0.000000"/>
+                    <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACAAAAAA=" DoubleValue="0.000000"/>
                   </dxl:If>
                 </dxl:AggFunc>
               </dxl:ProjElem>
@@ -807,19 +807,19 @@
                                 </dxl:Properties>
                                 <dxl:ProjList/>
                                 <dxl:PartEqFilters>
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" Value="true"/>
+                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                 </dxl:PartEqFilters>
                                 <dxl:PartFilters>
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" Value="true"/>
+                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                 </dxl:PartFilters>
                                 <dxl:ResidualFilter>
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" Value="true"/>
+                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                 </dxl:ResidualFilter>
                                 <dxl:PropagationExpression>
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" Value="1"/>
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                                 </dxl:PropagationExpression>
                                 <dxl:PrintableFilter>
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" Value="true"/>
+                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                 </dxl:PrintableFilter>
                               </dxl:PartitionSelector>
                               <dxl:DynamicTableScan PartIndexId="1">
@@ -870,10 +870,10 @@
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="21" Alias="?column?">
-                                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" Value="1"/>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                               </dxl:ProjElem>
                               <dxl:ProjElem ColId="24" Alias="ColRef_0024">
-                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" Value="true"/>
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                               </dxl:ProjElem>
                               <dxl:ProjElem ColId="13" Alias="c">
                                 <dxl:Ident ColId="13" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
@@ -410,7 +410,7 @@ explain select count(*) from r_p, s c, s d, s e where r_p.a = c.c and r_p.a = d.
     <dxl:Plan Id="0" SpaceSize="78553138">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.012335" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.012337" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -423,7 +423,7 @@ explain select count(*) from r_p, s c, s d, s e where r_p.a = c.c and r_p.a = d.
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.012334" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.012335" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="42" Alias="ColRef_0042">
@@ -434,7 +434,7 @@ explain select count(*) from r_p, s c, s d, s e where r_p.a = c.c and r_p.a = d.
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.012304" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.012305" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
@@ -195,7 +195,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="441344.165616" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="441344.167664" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="3" Alias="?column?">
@@ -209,7 +209,7 @@
         <dxl:OneTimeFilter/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="441344.165615" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="441344.167663" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -234,7 +234,7 @@
           </dxl:Result>
           <dxl:Assert ErrorCode="P0003">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000070" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000072" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -251,7 +251,7 @@
             </dxl:AssertConstraintList>
             <dxl:Window PartitionColumns="">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000062" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000064" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="12" Alias="row_number">
@@ -264,7 +264,7 @@
               <dxl:Filter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000062" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000064" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -289,7 +289,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000054" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000056" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns/>
                   <dxl:ProjList>
@@ -307,7 +307,7 @@
                   <dxl:Filter/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000047" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000048" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/RemoveUnusedProjElements.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RemoveUnusedProjElements.mdp
@@ -266,7 +266,7 @@ select sum(a) from (select a, b*c, c||d from woo) as too;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000072" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -279,7 +279,7 @@ select sum(a) from (select a, b*c, c||d from woo) as too;
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000072" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="14" Alias="ColRef_0014">
@@ -290,7 +290,7 @@ select sum(a) from (select a, b*c, c||d from woo) as too;
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000035" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTableAggregate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTableAggregate.mdp
@@ -198,7 +198,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.002366" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.002368" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -211,7 +211,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.002365" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.002366" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="ColRef_0010">
@@ -222,7 +222,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.002276" Rows="3.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.002277" Rows="3.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/SubqAll-InsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAll-InsideScalarExpression.mdp
@@ -388,7 +388,7 @@
     <dxl:Plan Id="0" SpaceSize="23">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324032.428517" Rows="1.000000" Width="15"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.429541" Rows="1.000000" Width="15"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -405,7 +405,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.428461" Rows="1.000000" Width="15"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.429485" Rows="1.000000" Width="15"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -431,7 +431,7 @@
                       </dxl:ParamList>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000098" Rows="3.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000099" Rows="3.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="29" Alias="ColRef_0029">
@@ -445,12 +445,12 @@
                                   <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
                                   <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
                                 </dxl:Comparison>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                                 <dxl:If TypeMdid="0.16.1.0">
                                   <dxl:IsNull>
                                     <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                                   </dxl:IsNull>
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                                   <dxl:If TypeMdid="0.16.1.0">
                                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
                                       <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.20.1.0"/>
@@ -468,7 +468,7 @@
                         <dxl:OneTimeFilter/>
                         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000097" Rows="3.000000" Width="16"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000098" Rows="3.000000" Width="16"/>
                           </dxl:Properties>
                           <dxl:GroupingColumns/>
                           <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/SubqEnforceSubplan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqEnforceSubplan.mdp
@@ -271,7 +271,7 @@ explain select * from foo,bar where b = (select min(b) from bar where a = b);
     <dxl:Plan Id="0" SpaceSize="40">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324475.447475" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324475.448499" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -285,7 +285,7 @@ explain select * from foo,bar where b = (select min(b) from bar where a = b);
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324475.447445" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324475.448469" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -305,7 +305,7 @@ explain select * from foo,bar where b = (select min(b) from bar where a = b);
           </dxl:HashCondList>
           <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324044.447040" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324044.448064" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -324,7 +324,7 @@ explain select * from foo,bar where b = (select min(b) from bar where a = b);
             </dxl:HashExprList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324044.447027" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324044.448051" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -338,7 +338,7 @@ explain select * from foo,bar where b = (select min(b) from bar where a = b);
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324044.447027" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324044.448051" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="25" Alias="ColRef_0025">
@@ -349,7 +349,7 @@ explain select * from foo,bar where b = (select min(b) from bar where a = b);
                       </dxl:ParamList>
                       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000311" Rows="3.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000312" Rows="3.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns/>
                         <dxl:ProjList>
@@ -434,7 +434,7 @@ explain select * from foo,bar where b = (select min(b) from bar where a = b);
                 <dxl:OneTimeFilter/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324044.447024" Rows="1000.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324044.448048" Rows="1000.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
@@ -529,7 +529,7 @@
     <dxl:Plan Id="0" SpaceSize="218">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356698074.463431" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356698074.463433" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -547,7 +547,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356698074.463423" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356698074.463424" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="44" Alias="ColRef_0044">
@@ -561,7 +561,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356698074.463364" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356698074.463365" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
@@ -592,7 +592,7 @@
     <dxl:Plan Id="0" SpaceSize="222">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356695741.507501" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356695741.507503" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -610,7 +610,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356695741.507494" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356695741.507495" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="54" Alias="ColRef_0054">
@@ -624,7 +624,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356695741.507435" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356695741.507436" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -641,7 +641,7 @@
                           <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
                           <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
                         </dxl:Comparison>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                         <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                       </dxl:If>
                       <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
@@ -653,7 +653,7 @@
     <dxl:Plan Id="0" SpaceSize="1554">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2712065383.057338" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2712065383.057340" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -671,7 +671,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2712065383.057331" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2712065383.057332" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="63" Alias="ColRef_0063">
@@ -685,7 +685,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2712065383.057271" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="2712065383.057272" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -702,7 +702,7 @@
                           <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
                           <dxl:Ident ColId="51" ColName="ColRef_0051" TypeMdid="0.20.1.0"/>
                         </dxl:Comparison>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                         <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                       </dxl:If>
                       <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
@@ -2465,7 +2465,7 @@
     <dxl:Plan Id="0" SpaceSize="1734">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356710918.164982" Rows="10002.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356710918.166006" Rows="10002.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -2482,7 +2482,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356710917.717692" Rows="10002.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356710917.718716" Rows="10002.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -2510,7 +2510,7 @@
                   </dxl:ParamList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324049.882899" Rows="3.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324049.882900" Rows="3.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="39" Alias="ColRef_0039">
@@ -2524,12 +2524,12 @@
                               <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.20.1.0"/>
                               <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
                             </dxl:Comparison>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                             <dxl:If TypeMdid="0.16.1.0">
                               <dxl:IsNull>
                                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                               </dxl:IsNull>
-                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                               <dxl:If TypeMdid="0.16.1.0">
                                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
                                   <dxl:Ident ColId="37" ColName="ColRef_0037" TypeMdid="0.20.1.0"/>
@@ -2547,7 +2547,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324049.882898" Rows="3.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324049.882899" Rows="3.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns/>
                       <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/SubqueryNoPullUpTableValueFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryNoPullUpTableValueFunction.mdp
@@ -142,7 +142,7 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000113" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000115" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="4" Alias="?column?">
@@ -159,7 +159,7 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
         <dxl:OneTimeFilter/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000112" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000114" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="5" Alias="ColRef_0005">
@@ -168,9 +168,9 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
+          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000096" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000098" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="count">
@@ -195,7 +195,7 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
             </dxl:Result>
             <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000006" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns/>
               <dxl:ProjList>
@@ -208,7 +208,7 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
               <dxl:Filter/>
               <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/SubqueryOuterRefLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryOuterRefLimit.mdp
@@ -296,7 +296,7 @@
     <dxl:Plan Id="0" SpaceSize="7">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324051.586306" Rows="3.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324051.587330" Rows="3.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -310,7 +310,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324051.586172" Rows="3.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324051.587196" Rows="3.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -324,7 +324,7 @@
                 </dxl:ParamList>
                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000132" Rows="3.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000133" Rows="3.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns/>
                   <dxl:ProjList>
@@ -389,7 +389,7 @@
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324051.586160" Rows="1000.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324051.587184" Rows="1000.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/SubqueryOuterRefTVF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryOuterRefTVF.mdp
@@ -241,7 +241,7 @@
     <dxl:Plan Id="0" SpaceSize="14">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356717370.464695" Rows="2.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356717370.465719" Rows="2.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -255,7 +255,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356717370.464605" Rows="2.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356717370.465629" Rows="2.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -269,7 +269,7 @@
                 </dxl:ParamList>
                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324057.288099" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324057.288100" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns/>
                   <dxl:ProjList>
@@ -342,7 +342,7 @@
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356717370.464597" Rows="1000.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356717370.465621" Rows="1000.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
@@ -1277,7 +1277,7 @@ WHERE
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="120488">
+    <dxl:Plan Id="0" SpaceSize="122512">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1415.900752" Rows="197964.000000" Width="148"/>

--- a/src/backend/gporca/data/dxl/minidump/VolatileFunctionsBelowScalarAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/VolatileFunctionsBelowScalarAgg.mdp
@@ -248,7 +248,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:DMLInsert Columns="3" ActionCol="5" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.015659" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.015660" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -270,7 +270,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000034" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000035" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="3" Alias="f1">
@@ -284,7 +284,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000030" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000031" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="f1">
@@ -300,7 +300,7 @@
             </dxl:HashExprList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000010" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="f1">
@@ -313,7 +313,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>

--- a/src/backend/gporca/data/dxl/minidump/WinFunc-Redistribute-Sort-CTE-Producer.mdp
+++ b/src/backend/gporca/data/dxl/minidump/WinFunc-Redistribute-Sort-CTE-Producer.mdp
@@ -458,7 +458,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
     <dxl:Plan Id="0" SpaceSize="11376">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3141.988407" Rows="333333.333333" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="3141.988409" Rows="333333.333333" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="27" Alias="row_number">
@@ -475,7 +475,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3106.068407" Rows="333333.333333" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="3106.068409" Rows="333333.333333" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="27" Alias="row_number">
@@ -570,7 +570,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
           </dxl:CTEProducer>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2670.831813" Rows="333333.333333" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="2670.831815" Rows="333333.333333" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="27" Alias="row_number">
@@ -752,7 +752,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
             </dxl:CTEProducer>
             <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1322.425797" Rows="333333.333333" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1322.425799" Rows="333333.333333" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="row_number">
@@ -820,7 +820,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
               </dxl:Window>
               <dxl:Materialize Eager="true">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="434.768464" Rows="2.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="434.768466" Rows="2.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="29" Alias="count">
@@ -830,7 +830,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
                 <dxl:Filter/>
                 <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="434.768456" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="434.768458" Rows="2.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="29" Alias="count">
@@ -841,7 +841,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
                   <dxl:SortingColumnList/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="434.768037" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="434.768039" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
@@ -854,7 +854,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
                     <dxl:Filter/>
                     <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="434.768036" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="434.768037" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="98" Alias="ColRef_0098">
@@ -865,7 +865,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
                       <dxl:SortingColumnList/>
                       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="434.768000" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="434.768001" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:GroupingColumns/>
                         <dxl:ProjList>

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
@@ -612,10 +612,13 @@ CCostModelGPDB::CostScalarAgg
 	const CDouble dHashAggInputTupWidthCostUnit = pcmgpdb->GetCostModelParams()->PcpLookup(CCostModelParamsGPDB::EcpHashAggInputTupWidthCostUnit)->Get();
 	GPOS_ASSERT(0 < dHashAggInputTupWidthCostUnit);
 
+	// tie breaker to prevent selecting ScalarAgg when costs are "identical"
+	const DOUBLE tiebreaker = 0.000001;
+
 	// scalarAgg cost is correlated with rows and width of the input tuples and the number of columns used in aggregate
 	// It also depends on the complexity of the aggregate algorithm, which is hard to model yet shared by all the aggregate
 	// operators, thus we ignore this part of cost for all.
-	CCost costLocal = CCost(pci->NumRebinds() * (num_rows_outer * dWidthOuter * ulAggCols * ulAggFunctions * dHashAggInputTupWidthCostUnit));
+	CCost costLocal = CCost(pci->NumRebinds() * (num_rows_outer * dWidthOuter * ulAggCols * ulAggFunctions * dHashAggInputTupWidthCostUnit) + tiebreaker);
 
 	CCost costChild = CostChildren(mp, exprhdl, pci, pcmgpdb->GetCostModelParams());
 	return costLocal + costChild;

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
@@ -223,6 +223,7 @@ namespace gpopt
 				ExfLeftOuterJoinWithInnerSelect2DynamicBitmapIndexGetApply,
 				ExfLeftOuterJoinWithInnerSelect2DynamicIndexGetApply,
 				ExfIndexGet2IndexOnlyScan,
+				ExfLeftOuterJoinWithInnerGbAgg2IndexGetApply,
 				ExfInvalid,
 				ExfSentinel = ExfInvalid
 			};

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoin2BitmapIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoin2BitmapIndexGetApply.h
@@ -35,7 +35,7 @@ namespace gpopt
 	//---------------------------------------------------------------------------
 	class CXformInnerJoin2BitmapIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalInnerJoin, CLogicalIndexApply, CLogicalGet,
-		false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+		false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 	{
 		private:
 			// private copy ctor
@@ -47,7 +47,7 @@ namespace gpopt
 			CXformInnerJoin2BitmapIndexGetApply(CMemoryPool *mp)
 				:CXformJoin2IndexApplyBase
 				 <CLogicalInnerJoin, CLogicalIndexApply, CLogicalGet,
-				 false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+				 false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoin2DynamicBitmapIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoin2DynamicBitmapIndexGetApply.h
@@ -35,7 +35,7 @@ namespace gpopt
 	//---------------------------------------------------------------------------
 	class CXformInnerJoin2DynamicBitmapIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalInnerJoin, CLogicalIndexApply, CLogicalDynamicGet,
-		false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+		false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 	{
 		private:
 			// private copy ctor
@@ -47,7 +47,7 @@ namespace gpopt
 			CXformInnerJoin2DynamicBitmapIndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				 <CLogicalInnerJoin, CLogicalIndexApply, CLogicalDynamicGet,
-				 false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+				 false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoin2DynamicIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoin2DynamicIndexGetApply.h
@@ -28,7 +28,7 @@ namespace gpopt
 	//---------------------------------------------------------------------------
 	class CXformInnerJoin2DynamicIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalInnerJoin, CLogicalIndexApply, CLogicalDynamicGet,
-		false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+		false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 	{
 
 		private:
@@ -43,7 +43,7 @@ namespace gpopt
 			CXformInnerJoin2DynamicIndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				 <CLogicalInnerJoin, CLogicalIndexApply, CLogicalDynamicGet,
-				 false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+				 false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoin2IndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoin2IndexGetApply.h
@@ -28,7 +28,7 @@ namespace gpopt
 	//---------------------------------------------------------------------------
 	class CXformInnerJoin2IndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalInnerJoin, CLogicalIndexApply, CLogicalGet,
-		false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+		false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 	{
 
 		private:
@@ -43,7 +43,7 @@ namespace gpopt
 			CXformInnerJoin2IndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				 <CLogicalInnerJoin, CLogicalIndexApply, CLogicalGet,
-				 false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+				 false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoin2PartialDynamicIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoin2PartialDynamicIndexGetApply.h
@@ -41,7 +41,7 @@ namespace gpopt
 	//---------------------------------------------------------------------------
 	class CXformInnerJoin2PartialDynamicIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalInnerJoin, CLogicalIndexApply, CLogicalDynamicGet,
-		false /*fWithSelect*/, true /*is_partial*/, IMDIndex::EmdindBtree>
+		false /*fWithSelect*/, false /*fWithGbAgg*/, true /*is_partial*/, IMDIndex::EmdindBtree>
 	{
 		public:
 			// ctor
@@ -49,7 +49,7 @@ namespace gpopt
 			CXformInnerJoin2PartialDynamicIndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				 <CLogicalInnerJoin, CLogicalIndexApply, CLogicalDynamicGet,
-				 false /*fWithSelect*/, true /*is_partial*/, IMDIndex::EmdindBtree>
+				 false /*fWithSelect*/, false /*fWithGbAgg*/, true /*is_partial*/, IMDIndex::EmdindBtree>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoinWithInnerSelect2BitmapIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoinWithInnerSelect2BitmapIndexGetApply.h
@@ -37,7 +37,7 @@ namespace gpopt
 	//---------------------------------------------------------------------------
 	class CXformInnerJoinWithInnerSelect2BitmapIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalInnerJoin, CLogicalIndexApply, CLogicalGet,
-		true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+		true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 	{
 		private:
 			// private copy ctor
@@ -52,7 +52,7 @@ namespace gpopt
 			CXformInnerJoinWithInnerSelect2BitmapIndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				 <CLogicalInnerJoin, CLogicalIndexApply, CLogicalGet,
-				 true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+				 true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoinWithInnerSelect2DynamicBitmapIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoinWithInnerSelect2DynamicBitmapIndexGetApply.h
@@ -37,7 +37,7 @@ namespace gpopt
 	//---------------------------------------------------------------------------
 	class CXformInnerJoinWithInnerSelect2DynamicBitmapIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalInnerJoin, CLogicalIndexApply, CLogicalDynamicGet,
-		true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+		true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 	{
 		private:
 			// private copy ctor
@@ -52,7 +52,7 @@ namespace gpopt
 			CXformInnerJoinWithInnerSelect2DynamicBitmapIndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				 <CLogicalInnerJoin, CLogicalIndexApply, CLogicalDynamicGet,
-				 true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+				 true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoinWithInnerSelect2DynamicIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoinWithInnerSelect2DynamicIndexGetApply.h
@@ -35,7 +35,7 @@ namespace gpopt
 	//---------------------------------------------------------------------------
 	class CXformInnerJoinWithInnerSelect2DynamicIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalInnerJoin, CLogicalIndexApply, CLogicalDynamicGet,
-		true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+		true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 	{
 		private:
 			// private copy ctor
@@ -50,7 +50,7 @@ namespace gpopt
 			CXformInnerJoinWithInnerSelect2DynamicIndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				 <CLogicalInnerJoin, CLogicalIndexApply, CLogicalDynamicGet,
-				 true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+				 true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoinWithInnerSelect2IndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoinWithInnerSelect2IndexGetApply.h
@@ -35,7 +35,7 @@ namespace gpopt
 	//---------------------------------------------------------------------------
 	class CXformInnerJoinWithInnerSelect2IndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalInnerJoin, CLogicalIndexApply, CLogicalGet,
-		true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+		true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 	{
 		private:
 			// private copy ctor
@@ -47,7 +47,7 @@ namespace gpopt
 			CXformInnerJoinWithInnerSelect2IndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				 <CLogicalInnerJoin, CLogicalIndexApply, CLogicalGet,
-				 true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+				 true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoinWithInnerSelect2PartialDynamicIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoinWithInnerSelect2PartialDynamicIndexGetApply.h
@@ -42,7 +42,7 @@ namespace gpopt
 	//---------------------------------------------------------------------------
 	class CXformInnerJoinWithInnerSelect2PartialDynamicIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalInnerJoin, CLogicalIndexApply, CLogicalDynamicGet,
-		true /*fWithSelect*/, true /*is_partial*/, IMDIndex::EmdindBtree>
+		true /*fWithSelect*/, false /*fWithGbAgg*/, true /*is_partial*/, IMDIndex::EmdindBtree>
 	{
 		public:
 			// ctor
@@ -50,7 +50,7 @@ namespace gpopt
 			CXformInnerJoinWithInnerSelect2PartialDynamicIndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				 <CLogicalInnerJoin, CLogicalIndexApply, CLogicalDynamicGet,
-				 true /*fWithSelect*/, true /*is_partial*/, IMDIndex::EmdindBtree>
+				 true /*fWithSelect*/, false /*fWithGbAgg*/, true /*is_partial*/, IMDIndex::EmdindBtree>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
@@ -41,7 +41,8 @@ namespace gpopt
 				CColRefSet *outer_refs,
 				CColRefSet *pcrsReqd,
 				ULONG ulIndices,
-				CXformResult *pxfres
+				CXformResult *pxfres,
+				BOOL fWithGbAgg
 				) const;
 
 			// helper to add IndexApply expression to given xform results container
@@ -60,7 +61,8 @@ namespace gpopt
 				const IMDRelation *pmdrel,
 				const IMDIndex *pmdindex,
 				CPartConstraint *ppartcnstrIndex,
-				CXformResult *pxfres
+				CXformResult *pxfres,
+				BOOL fWithGbAgg
 				) const;
 
 			// helper to add IndexApply expression to given xform results container
@@ -182,7 +184,8 @@ namespace gpopt
 				CTableDescriptor *PtabdescInner,
 				CLogicalDynamicGet *popDynamicGet,
 				CXformResult *pxfres,
-				gpmd::IMDIndex::EmdindexType emdtype
+				gpmd::IMDIndex::EmdindexType emdtype,
+				BOOL fWithGbAgg
 				) const;
 
 			// helper to add IndexApply expression to given xform results container

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyBase.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyBase.h
@@ -10,12 +10,13 @@
 #include "gpos/base.h"
 #include "gpopt/operators/CLogicalDynamicGet.h"
 #include "gpopt/xforms/CXformJoin2IndexApply.h"
+#include "gpopt/operators/CLogicalGbAgg.h"
 
 namespace gpopt
 {
 	using namespace gpos;
 
-	template<class TJoin, class TApply, class TGet, BOOL fWithSelect, BOOL is_partial, IMDIndex::EmdindexType eidxtype>
+	template<class TJoin, class TApply, class TGet, BOOL fWithSelect, BOOL fWithGbAgg, BOOL is_partial, IMDIndex::EmdindexType eidxtype>
 	class CXformJoin2IndexApplyBase : public CXformJoin2IndexApply
 	{
 		private:
@@ -118,7 +119,7 @@ namespace gpopt
 
 			// ctor
 			explicit
-			CXformJoin2IndexApplyBase<TJoin, TApply, TGet, fWithSelect, is_partial, eidxtype>(CMemoryPool *mp)
+			CXformJoin2IndexApplyBase<TJoin, TApply, TGet, fWithSelect, fWithGbAgg, is_partial, eidxtype>(CMemoryPool *mp)
 			:
 			// pattern
 			CXformJoin2IndexApply
@@ -133,13 +134,23 @@ namespace gpopt
 				GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CPatternTree(mp)) // outer child
 				:
 				GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CPatternLeaf(mp)), // outer child
-					fWithSelect
+					(fWithSelect)
 					?
 					GPOS_NEW(mp) CExpression  // inner child with Select operator
 						(
 						mp,
 						GPOS_NEW(mp) CLogicalSelect(mp),
 						GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) TGet(mp)), // Get below Select
+						GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CPatternTree(mp))  // predicate
+						)
+					:
+					(fWithGbAgg)
+					?
+					GPOS_NEW(mp) CExpression  // inner child with GbAgg operator
+						(
+						mp,
+						GPOS_NEW(mp) CLogicalGbAgg(mp),
+						GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) TGet(mp)), // Get below GbAgg
 						GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CPatternTree(mp))  // predicate
 						)
 					:
@@ -151,7 +162,7 @@ namespace gpopt
 
 			// dtor
 			virtual
-			~CXformJoin2IndexApplyBase<TJoin, TApply, TGet, fWithSelect, is_partial, eidxtype>()
+			~CXformJoin2IndexApplyBase<TJoin, TApply, TGet, fWithSelect, fWithGbAgg, is_partial, eidxtype>()
 			{}
 
 			// actual transform
@@ -172,7 +183,7 @@ namespace gpopt
 				CExpression *pexprGet = pexprInner;
 				CExpression *pexprAllPredicates = pexprScalar;
 
-				if (fWithSelect)
+				if (fWithSelect || fWithGbAgg)
 				{
 					pexprGet = (*pexprInner)[0];
 					pexprAllPredicates = CPredicateUtils::PexprConjunction(mp, pexprScalar, (*pexprInner)[1]);
@@ -223,7 +234,8 @@ namespace gpopt
 						ptabdescInner,
 						popDynamicGet,
 						pxfres,
-						eidxtype
+						eidxtype,
+						fWithGbAgg
 						);
 				}
 				CRefCount::SafeRelease(pexprAllPredicates);

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoin2BitmapIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoin2BitmapIndexGetApply.h
@@ -21,7 +21,7 @@ namespace gpopt
 
 	class CXformLeftOuterJoin2BitmapIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalGet,
-		false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+		false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 	{
 		private:
 			// private copy ctor
@@ -33,7 +33,7 @@ namespace gpopt
 			CXformLeftOuterJoin2BitmapIndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalGet,
-				false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+				false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoin2DynamicBitmapIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoin2DynamicBitmapIndexGetApply.h
@@ -18,7 +18,7 @@ namespace gpopt
 
 	class CXformLeftOuterJoin2DynamicBitmapIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalDynamicGet,
-		false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+		false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 	{
 		private:
 			// private copy ctor
@@ -30,7 +30,7 @@ namespace gpopt
 			CXformLeftOuterJoin2DynamicBitmapIndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalDynamicGet,
-				false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+				false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoin2DynamicIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoin2DynamicIndexGetApply.h
@@ -16,7 +16,7 @@ namespace gpopt
 
 	class CXformLeftOuterJoin2DynamicIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalDynamicGet,
-		false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+		false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 	{
 
 		private:
@@ -31,7 +31,7 @@ namespace gpopt
 			CXformLeftOuterJoin2DynamicIndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalDynamicGet,
-				false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+				false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoin2IndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoin2IndexGetApply.h
@@ -16,7 +16,7 @@ namespace gpopt
 
 	class CXformLeftOuterJoin2IndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalGet,
-		false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+		false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 	{
 
 		private:
@@ -31,7 +31,7 @@ namespace gpopt
 			CXformLeftOuterJoin2IndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalGet,
-				false /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+				false /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply.h
@@ -1,0 +1,63 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//
+//	Transform Left Outer Join with a GbAgg on the inner branch to
+//	Btree IndexGet Apply
+//
+//---------------------------------------------------------------------------
+
+#ifndef GPOPT_CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply_H
+#define GPOPT_CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply_H
+
+#include "gpos/base.h"
+#include "gpopt/xforms/CXformJoin2IndexApplyBase.h"
+
+namespace gpopt
+{
+	using namespace gpos;
+
+	class CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply : public CXformJoin2IndexApplyBase
+		<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalGet,
+		false /*fWithSelect*/, true /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+	{
+		private:
+			// private copy ctor
+			CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply
+				(
+				const CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply &
+				);
+
+		public:
+			// ctor
+			explicit
+			CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply(CMemoryPool *mp)
+				: CXformJoin2IndexApplyBase
+				<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalGet,
+				false /*fWithSelect*/, true /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+				(mp)
+			{}
+
+			// dtor
+			virtual
+			~CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply()
+			{}
+
+			// ident accessors
+			virtual
+			EXformId Exfid() const
+			{
+				return ExfLeftOuterJoinWithInnerGbAgg2IndexGetApply;
+			}
+
+			virtual
+			const CHAR *SzId() const
+			{
+				return "CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply";
+			}
+	}; // class CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply
+}
+
+#endif // !GPOPT_CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoinWithInnerSelect2BitmapIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoinWithInnerSelect2BitmapIndexGetApply.h
@@ -19,7 +19,7 @@ namespace gpopt
 
 	class CXformLeftOuterJoinWithInnerSelect2BitmapIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalGet,
-		true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+		true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 	{
 		private:
 			// private copy ctor
@@ -34,7 +34,7 @@ namespace gpopt
 			CXformLeftOuterJoinWithInnerSelect2BitmapIndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalGet,
-				true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+				true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoinWithInnerSelect2DynamicBitmapIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoinWithInnerSelect2DynamicBitmapIndexGetApply.h
@@ -19,7 +19,7 @@ namespace gpopt
 
 	class CXformLeftOuterJoinWithInnerSelect2DynamicBitmapIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalDynamicGet,
-		true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+		true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 	{
 		private:
 			// private copy ctor
@@ -34,7 +34,7 @@ namespace gpopt
 			CXformLeftOuterJoinWithInnerSelect2DynamicBitmapIndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalDynamicGet,
-				true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
+				true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBitmap>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoinWithInnerSelect2DynamicIndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoinWithInnerSelect2DynamicIndexGetApply.h
@@ -19,7 +19,7 @@ namespace gpopt
 
 	class CXformLeftOuterJoinWithInnerSelect2DynamicIndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalDynamicGet,
-		true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+		true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 	{
 		private:
 			// private copy ctor
@@ -31,7 +31,7 @@ namespace gpopt
 			CXformLeftOuterJoinWithInnerSelect2DynamicIndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalDynamicGet,
-				true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+				true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoinWithInnerSelect2IndexGetApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformLeftOuterJoinWithInnerSelect2IndexGetApply.h
@@ -18,7 +18,7 @@ namespace gpopt
 
 	class CXformLeftOuterJoinWithInnerSelect2IndexGetApply : public CXformJoin2IndexApplyBase
 		<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalGet,
-		true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+		true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 	{
 		private:
 			// private copy ctor
@@ -30,7 +30,7 @@ namespace gpopt
 			CXformLeftOuterJoinWithInnerSelect2IndexGetApply(CMemoryPool *mp)
 				: CXformJoin2IndexApplyBase
 				<CLogicalLeftOuterJoin, CLogicalIndexApply, CLogicalGet,
-				true /*fWithSelect*/, false /*is_partial*/, IMDIndex::EmdindBtree>
+				true /*fWithSelect*/, false /*fWithGbAgg*/, false /*is_partial*/, IMDIndex::EmdindBtree>
 				(mp)
 			{}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -337,7 +337,8 @@ namespace gpopt
 				IMDIndex::EmdindexType emdindtype,
 				PDynamicIndexOpConstructor pdiopc,
 				PStaticIndexOpConstructor psiopc,
-				PRewrittenIndexPath prip
+				PRewrittenIndexPath prip,
+				BOOL fWithGbAgg
 				);
 
 			// create a dynamic operator for a btree index plan
@@ -857,7 +858,8 @@ namespace gpopt
 				const IMDIndex *pmdindex,
 				const IMDRelation *pmdrel,
 				BOOL fAllowPartialIndex,
-				CPartConstraint *ppcartcnstrIndex
+				CPartConstraint *ppcartcnstrIndex,
+				BOOL fWithGbAgg
 				)
 			{
 				return PexprBuildIndexPlan
@@ -877,7 +879,8 @@ namespace gpopt
 						IMDIndex::EmdindBtree,
 						PopDynamicBtreeIndexOpConstructor,
 						PopStaticBtreeIndexOpConstructor,
-						PexprRewrittenBtreeIndexPath
+						PexprRewrittenBtreeIndexPath,
+						fWithGbAgg
 						);
 			}
 			

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
@@ -136,6 +136,7 @@
 #include "gpopt/xforms/CXformLeftOuterJoin2IndexGetApply.h"
 #include "gpopt/xforms/CXformLeftOuterJoinWithInnerSelect2BitmapIndexGetApply.h"
 #include "gpopt/xforms/CXformLeftOuterJoinWithInnerSelect2IndexGetApply.h"
+#include "gpopt/xforms/CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply.h"
 #include "gpopt/xforms/CXformLeftOuterJoin2DynamicBitmapIndexGetApply.h"
 #include "gpopt/xforms/CXformLeftOuterJoin2DynamicIndexGetApply.h"
 #include "gpopt/xforms/CXformLeftOuterJoinWithInnerSelect2DynamicBitmapIndexGetApply.h"

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalLeftOuterJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalLeftOuterJoin.cpp
@@ -98,6 +98,7 @@ CLogicalLeftOuterJoin::PxfsCandidates
 	(void) xform_set->ExchangeSet(CXform::ExfLeftOuterJoin2DynamicIndexGetApply);
 	(void) xform_set->ExchangeSet(CXform::ExfLeftOuterJoinWithInnerSelect2DynamicBitmapIndexGetApply);
 	(void) xform_set->ExchangeSet(CXform::ExfLeftOuterJoinWithInnerSelect2DynamicIndexGetApply);
+	(void) xform_set->ExchangeSet(CXform::ExfLeftOuterJoinWithInnerGbAgg2IndexGetApply);
 
 	return xform_set;
 }

--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -298,6 +298,7 @@ CXformFactory::Instantiate()
 	Add(GPOS_NEW(m_mp) CXformLeftOuterJoinWithInnerSelect2DynamicBitmapIndexGetApply(m_mp));
 	Add(GPOS_NEW(m_mp) CXformLeftOuterJoinWithInnerSelect2DynamicIndexGetApply(m_mp));
 	Add(GPOS_NEW(m_mp) CXformIndexGet2IndexOnlyScan(m_mp));
+	Add(GPOS_NEW(m_mp) CXformLeftOuterJoinWithInnerGbAgg2IndexGetApply(m_mp));
 
 	GPOS_ASSERT(NULL != m_rgpxf[CXform::ExfSentinel - 1] &&
 				"Not all xforms have been instantiated");

--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
@@ -109,7 +109,8 @@ CXformJoin2IndexApply::CreateHomogeneousIndexApplyAlternatives
 	CTableDescriptor *ptabdescInner,
 	CLogicalDynamicGet *popDynamicGet,
 	CXformResult *pxfres,
-	IMDIndex::EmdindexType emdtype
+	IMDIndex::EmdindexType emdtype,
+	BOOL fWithGbAgg
 	) const
 {
 	GPOS_ASSERT(NULL != pexprOuter);
@@ -154,7 +155,8 @@ CXformJoin2IndexApply::CreateHomogeneousIndexApplyAlternatives
 			outer_refs,
 			pcrsReqd,
 			ulIndices,
-			pxfres
+			pxfres,
+			fWithGbAgg
 			);
 	}
 	else
@@ -201,7 +203,8 @@ CXformJoin2IndexApply::CreateHomogeneousBtreeIndexApplyAlternatives
 	CColRefSet *outer_refs,
 	CColRefSet *pcrsReqd,
 	ULONG ulIndices,
-	CXformResult *pxfres
+	CXformResult *pxfres,
+	BOOL fWithGbAgg
 	) const
 {
 	// array of expressions in the scalar expression
@@ -243,7 +246,8 @@ CXformJoin2IndexApply::CreateHomogeneousBtreeIndexApplyAlternatives
 			pmdrel,
 			pmdindex,
 			ppartcnstrIndex,
-			pxfres
+			pxfres,
+			fWithGbAgg
 			);
 	}
 
@@ -275,7 +279,8 @@ CXformJoin2IndexApply::CreateAlternativesForBtreeIndex
 	const IMDRelation *pmdrel,
 	const IMDIndex *pmdindex,
 	CPartConstraint *ppartcnstrIndex,
-	CXformResult *pxfres
+	CXformResult *pxfres,
+	BOOL fWithGbAgg
 	) const
 {
 	CExpression *pexprLogicalIndexGet = CXformUtils::PexprLogicalIndexGet
@@ -291,7 +296,8 @@ CXformJoin2IndexApply::CreateAlternativesForBtreeIndex
 						 pmdindex,
 						 pmdrel,
 						 false /*fAllowPartialIndex*/,
-						 ppartcnstrIndex
+						 ppartcnstrIndex,
+						 fWithGbAgg
 						);
 	if (NULL != pexprLogicalIndexGet)
 	{

--- a/src/backend/gporca/libgpopt/src/xforms/CXformSelect2DynamicIndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformSelect2DynamicIndexGet.cpp
@@ -153,7 +153,8 @@ CXformSelect2DynamicIndexGet::Transform
 							pmdindex,
 							pmdrel,
 							false /*fAllowPartialIndex*/,
-							ppartcnstrIndex
+							ppartcnstrIndex,
+							false /* fWithGbAgg */
 							);
 		if (NULL != pexprDynamicIndexGet)
 		{

--- a/src/backend/gporca/libgpopt/src/xforms/CXformSelect2IndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformSelect2IndexGet.cpp
@@ -140,7 +140,8 @@ CXformSelect2IndexGet::Transform
 						 pmdindex,
 						 pmdrel,
 						 false /*fAllowPartialIndex*/,
-						 NULL /*ppartcnstrIndex*/
+						 NULL /*ppartcnstrIndex*/,
+						 false /* fWithGbAgg */
 						);
 		if (NULL != pexprIndexGet)
 		{

--- a/src/test/regress/expected/indexjoin.out
+++ b/src/test/regress/expected/indexjoin.out
@@ -166,4 +166,25 @@ SELECT * from with_index_table td JOIN no_index_table ro ON td.y = ro.a AND td.x
  1 | 1 |         1 |         1 |         1 | 1 | 1
 (1 row)
 
+-- Test Index Scan on table in the right tree of a NestLoop join with an aggregate.
+CREATE TABLE table_with_simple_index (col text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX simple_index ON table_with_simple_index USING btree (col);
+INSERT INTO table_with_simple_index VALUES ('a_value');
+EXPLAIN (costs off)
+SELECT t.col FROM table_with_simple_index t LEFT JOIN (SELECT t.col FROM table_with_simple_index t GROUP BY t.col) g ON g.col = t.col;
+                              QUERY PLAN
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Only Scan using simple_index on table_with_simple_index t
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+SELECT t.col FROM table_with_simple_index t LEFT JOIN (SELECT t.col FROM table_with_simple_index t GROUP BY t.col) g ON g.col = t.col;
+   col   
+---------
+ a_value
+(1 row)
+
 reset all;

--- a/src/test/regress/expected/indexjoin_optimizer.out
+++ b/src/test/regress/expected/indexjoin_optimizer.out
@@ -170,4 +170,30 @@ SELECT * from with_index_table td JOIN no_index_table ro ON td.y = ro.a AND td.x
  1 | 1 |         1 |         1 |         1 | 1 | 1
 (1 row)
 
+-- Test Index Scan on table in the right tree of a NestLoop join with an aggregate.
+CREATE TABLE table_with_simple_index (col text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX simple_index ON table_with_simple_index USING btree (col);
+INSERT INTO table_with_simple_index VALUES ('a_value');
+EXPLAIN (costs off)
+SELECT t.col FROM table_with_simple_index t LEFT JOIN (SELECT t.col FROM table_with_simple_index t GROUP BY t.col) g ON g.col = t.col;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop Left Join
+         Join Filter: true
+         ->  Seq Scan on table_with_simple_index
+         ->  Aggregate
+               ->  Index Scan using simple_index on table_with_simple_index table_with_simple_index_1
+                     Index Cond: (col = table_with_simple_index.col)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+SELECT t.col FROM table_with_simple_index t LEFT JOIN (SELECT t.col FROM table_with_simple_index t GROUP BY t.col) g ON g.col = t.col;
+   col   
+---------
+ a_value
+(1 row)
+
 reset all;

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -4496,33 +4496,31 @@ select d.* from d left join (select distinct * from b) s
 explain (costs off)
 select d.* from d left join (select * from b group by b.id, b.c_id) s
   on d.a = s.id;
-                   QUERY PLAN                   
-------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop Left Join
          Join Filter: true
          ->  Seq Scan on d
-         ->  Aggregate
-               ->  Index Scan using b_pkey on b
-                     Index Cond: (id = d.a)
- Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+         ->  Index Scan using b_pkey on b
+               Index Cond: (id = d.a)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
+(7 rows)
 
 -- similarly, but keying off a DISTINCT clause
 explain (costs off)
 select d.* from d left join (select distinct * from b) s
   on d.a = s.id;
-                   QUERY PLAN                   
-------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop Left Join
          Join Filter: true
          ->  Seq Scan on d
-         ->  Aggregate
-               ->  Index Scan using b_pkey on b
-                     Index Cond: (id = d.a)
- Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+         ->  Index Scan using b_pkey on b
+               Index Cond: (id = d.a)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
+(7 rows)
 
 -- check join removal works when uniqueness of the join condition is enforced
 -- by a UNION

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -4496,31 +4496,33 @@ select d.* from d left join (select distinct * from b) s
 explain (costs off)
 select d.* from d left join (select * from b group by b.id, b.c_id) s
   on d.a = s.id;
-                      QUERY PLAN                      
-------------------------------------------------------
+                   QUERY PLAN                   
+------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop Left Join
          Join Filter: true
          ->  Seq Scan on d
-         ->  Index Scan using b_pkey on b
-               Index Cond: (id = d.a)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
-(7 rows)
+         ->  Aggregate
+               ->  Index Scan using b_pkey on b
+                     Index Cond: (id = d.a)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
 
 -- similarly, but keying off a DISTINCT clause
 explain (costs off)
 select d.* from d left join (select distinct * from b) s
   on d.a = s.id;
-                      QUERY PLAN                      
-------------------------------------------------------
+                   QUERY PLAN                   
+------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop Left Join
          Join Filter: true
          ->  Seq Scan on d
-         ->  Index Scan using b_pkey on b
-               Index Cond: (id = d.a)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
-(7 rows)
+         ->  Aggregate
+               ->  Index Scan using b_pkey on b
+                     Index Cond: (id = d.a)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
 
 -- check join removal works when uniqueness of the join condition is enforced
 -- by a UNION

--- a/src/test/regress/sql/indexjoin.sql
+++ b/src/test/regress/sql/indexjoin.sql
@@ -2549,4 +2549,13 @@ explain (costs off)
 SELECT * from with_index_table td JOIN no_index_table ro ON td.y = ro.a AND td.x = ro.b;
 SELECT * from with_index_table td JOIN no_index_table ro ON td.y = ro.a AND td.x = ro.b;
 
+-- Test Index Scan on table in the right tree of a NestLoop join with an aggregate.
+CREATE TABLE table_with_simple_index (col text);
+CREATE INDEX simple_index ON table_with_simple_index USING btree (col);
+INSERT INTO table_with_simple_index VALUES ('a_value');
+
+EXPLAIN (costs off)
+SELECT t.col FROM table_with_simple_index t LEFT JOIN (SELECT t.col FROM table_with_simple_index t GROUP BY t.col) g ON g.col = t.col;
+SELECT t.col FROM table_with_simple_index t LEFT JOIN (SELECT t.col FROM table_with_simple_index t GROUP BY t.col) g ON g.col = t.col;
+
 reset all;


### PR DESCRIPTION
Pattern matching rules for Join2IndexApply used to assume that for a LOJ
the immediate inner child must be a Get in order to be considered for an
index apply transformation. This meant that even for the case of a GbAgg
on top of a Get (like following query), we would not consider index
apply.

```
+--CLogicalLeftOuterJoin
   |--CLogicalGet
   |--CLogicalGbAgg( Global )
   |  |--CLogicalGet
   |  +--CScalarProjectList
   +--CScalarCmp (=)
      |--CScalarIdent
      +--CScalarIdent
```

This commit adds the pattern to match such a scenario and pushes the
predicate down to the underlying Get. The net effect is that it permits
an index scan when available on the underlying inner child table of LOJ.

```
                     QUERY PLAN
-----------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  Nested Loop Left Join
         Join Filter: true
         ->  Seq Scan on tab
         ->  Aggregate
               ->  Index Scan using ind on tab tab_1
                     Index Cond: (col = tab.col)
```

Co-authored-by: Ashuka Xue <axue@vmware.com>
