### PR TITLE
ic-proxy: support hostname as proxy addresses

### DIFF
--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -57,19 +57,17 @@ function make_cluster() {
 
       delta=-3000
 
-      psql -tqA -d postgres -P pager=off -F ' ' \
-          -c "select dbid, content, port+\$delta as port, address from gp_segment_configuration order by 1" \
-      | while read -r dbid content port addr; do
-          ip=127.0.0.1
-          echo "\$dbid:\$content:\$ip:\$port"
-        done \
-      | paste -sd, - \
-      | xargs -rI'{}' gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'{}'"
+      psql -tqA -d postgres -P pager=off -F: -R, \
+          -c "select dbid, content, address, port+\$delta as port
+                from gp_segment_configuration
+               order by 1" \
+      | xargs -rI'{}' \
+        gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'{}'"
 
       # also have to enlarge gp_interconnect_tcp_listener_backlog
       gpconfig -c gp_interconnect_tcp_listener_backlog -v 1024
 
-      gpstop -raqi
+      gpstop -u
 EOF
   fi
 

--- a/src/backend/cdb/motion/ic_proxy_addr.c
+++ b/src/backend/cdb/motion/ic_proxy_addr.c
@@ -30,7 +30,74 @@
 /*
  * List<ICProxyAddr *>, the addresses list.
  */
-List	   *ic_proxy_addrs;
+List	   *ic_proxy_addrs = NIL;
+
+/*
+ * List<ICProxyAddr *>, the addresses list that are being resolved.
+ */
+static List *ic_proxy_unknown_addrs = NIL;
+
+/*
+ * Resolved one address.
+ */
+static void
+ic_proxy_addr_on_getaddrinfo(uv_getaddrinfo_t *req,
+							 int status, struct addrinfo *res)
+{
+	ICProxyAddr *addr = CONTAINER_OF((void *) req, ICProxyAddr, req);
+
+	ic_proxy_unknown_addrs = list_delete_ptr(ic_proxy_unknown_addrs, addr);
+
+	if (status != 0)
+	{
+		if (status == UV_ECANCELED)
+		{
+			/* the req is cancelled, nothing to do */
+		}
+		else
+			ic_proxy_log(LOG,
+						 "ic-proxy-addr: seg%d,dbid%d: failed to resolve the hostname \"%s\":%s: %s",
+						 addr->content, addr->dbid,
+						 addr->hostname, addr->service,
+						 uv_strerror(status));
+
+		ic_proxy_free(addr);
+	}
+	else
+	{
+		struct addrinfo *iter;
+
+		/* should we follow the logic in getDnsCachedAddress() ? */
+		for (iter = res; iter; iter = iter->ai_next)
+		{
+			if (iter->ai_family == AF_UNIX)
+				continue;
+
+#if IC_PROXY_LOG_LEVEL <= LOG
+			{
+				char		name[HOST_NAME_MAX] = "unknown";
+				int			port = 0;
+				int			family;
+
+				ic_proxy_extract_addr(iter->ai_addr,
+									  name, sizeof(name), &port, &family);
+				ic_proxy_log(LOG,
+							 "ic-proxy-addr: seg%d,dbid%d: resolved address %s:%s -> %s:%d family=%d",
+							 addr->content, addr->dbid,
+							 addr->hostname, addr->service,
+							 name, port, family);
+			}
+#endif /* IC_PROXY_LOG_LEVEL <= LOG */
+
+			memcpy(&addr->addr, iter->ai_addr, iter->ai_addrlen);
+			ic_proxy_addrs = lappend(ic_proxy_addrs, addr);
+			break;
+		}
+	}
+
+	if (res)
+		uv_freeaddrinfo(res);
+}
 
 /*
  * Reload the addresses from the GUC gp_interconnect_proxy_addresses.
@@ -39,11 +106,8 @@ List	   *ic_proxy_addrs;
  * calling ProcessConfigFile().
  */
 void
-ic_proxy_reload_addresses(void)
+ic_proxy_reload_addresses(uv_loop_t *loop)
 {
-	int			max_content_id;
-	int			uniq_content_count;
-
 	/* reset the old addresses */
 	{
 		ListCell   *cell;
@@ -57,7 +121,21 @@ ic_proxy_reload_addresses(void)
 		ic_proxy_addrs = NIL;
 	}
 
-	max_content_id = IC_PROXY_INVALID_CONTENT;
+	/* cancel any unfinished getaddrinfo reqs */
+	{
+		ListCell   *cell;
+
+		foreach(cell, ic_proxy_unknown_addrs)
+		{
+			ICProxyAddr *addr = lfirst(cell);
+
+			uv_cancel((uv_req_t *) &addr->req);
+			ic_proxy_free(addr);
+		}
+
+		list_free(ic_proxy_unknown_addrs);
+		ic_proxy_unknown_addrs = NIL;
+	}
 
 	/* parse the new addresses */
 	{
@@ -67,7 +145,14 @@ ic_proxy_reload_addresses(void)
 		int			dbid;
 		int			content;
 		int			port;
-		char		ip[HOST_NAME_MAX];
+		char		hostname[HOST_NAME_MAX];
+		struct addrinfo hints;
+
+		memset(&hints, 0, sizeof(hints));
+		hints.ai_family = AF_UNSPEC;
+		hints.ai_socktype = SOCK_STREAM;
+		hints.ai_protocol = 0;
+		hints.ai_flags = 0;
 
 		buf = ic_proxy_alloc(size);
 		memcpy(buf, gp_interconnect_proxy_addresses, size);
@@ -75,51 +160,39 @@ ic_proxy_reload_addresses(void)
 		f = fmemopen(buf, size, "r");
 
 		/*
-		 * format: dbid:segid:ip:port
+		 * format: dbid:segid:hostname:port
 		 */
-		while (fscanf(f, "%d:%d:%[0-9.]:%d,", &dbid, &content, ip, &port) == 4)
+		while (fscanf(f, "%d:%d:%[^:]:%d,",
+					  &dbid, &content, hostname, &port) == 4)
 		{
 			ICProxyAddr *addr = ic_proxy_new(ICProxyAddr);
-			int			ret;
 
 			addr->dbid = dbid;
 			addr->content = content;
+			snprintf(addr->hostname, sizeof(addr->hostname), "%s", hostname);
+			snprintf(addr->service, sizeof(addr->service), "%d", port);
+			ic_proxy_unknown_addrs = lappend(ic_proxy_unknown_addrs, addr);
 
-			ic_proxy_log(LOG, "ic-proxy-server: addr: seg%d,dbid%d: %s:%d",
-						 content, dbid, ip, port);
+			ic_proxy_log(LOG,
+						 "ic-proxy-addr: seg%d,dbid%d: parsed addr: %s:%d",
+						 content, dbid, hostname, port);
 
-			ret = uv_ip4_addr(ip, port, (struct sockaddr_in *) addr);
-			if (ret < 0)
-				ic_proxy_log(WARNING,
-							 "ic-proxy-server: invalid address: seg%d,dbid%d: %s:%d: %s",
-							 content, dbid, ip, port, uv_strerror(ret));
-
-			ic_proxy_addrs = lappend(ic_proxy_addrs, addr);
-
-			max_content_id = Max(max_content_id, content);
+			uv_getaddrinfo(loop, &addr->req, ic_proxy_addr_on_getaddrinfo,
+						   addr->hostname, addr->service, &hints);
 		}
 
 		fclose(f);
 		ic_proxy_free(buf);
 	}
-
-	/*
-	 * We have found the max content id, convert it to a count by adding 2, as
-	 * content ids are counted from -1.
-	 */
-	uniq_content_count = max_content_id + 2;
-
-	ic_proxy_log(LOG, "ic-proxy-server: %d unique content ids",
-				 uniq_content_count);
 }
 
 /*
- * Get the port of current segment.
+ * Get the proxy addr of the current segment.
  *
- * Return -1 if cannot find the port.
+ * Return NULL if cannot find the addr.
  */
-int
-ic_proxy_get_my_port(void)
+const ICProxyAddr *
+ic_proxy_get_my_addr(void)
 {
 	ListCell   *cell;
 	int			dbid = GpIdentity.dbid;
@@ -129,11 +202,11 @@ ic_proxy_get_my_port(void)
 		ICProxyAddr *addr = lfirst(cell);
 
 		if (addr->dbid == dbid)
-			return ic_proxy_addr_get_port(addr);
+			return addr;
 	}
 
-	ic_proxy_log(WARNING, "ic-proxy-addr: cannot get my port");
-	return -1;
+	ic_proxy_log(LOG, "ic-proxy-addr: cannot get my addr");
+	return NULL;
 }
 
 /*
@@ -153,4 +226,57 @@ ic_proxy_addr_get_port(const ICProxyAddr *addr)
 				 "ic-proxy-addr: invalid address family %d for seg%d,dbid%d",
 				 addr->addr.ss_family, addr->content, addr->dbid);
 	return -1;
+}
+
+/*
+ * Extract the name and port from a sockaddr.
+ *
+ * - the hostname is stored in "name", the recommended size is HOST_NAME_MAX;
+ * - the "namelen" is the buffer size of "name";
+ * - the port is stored in "port";
+ * - the address family is stored in "family" if it is not NULL;
+ *
+ * Return 0 on success; otherwise return a negative value, which can be
+ * translated with uv_strerror().  The __out__ fields are always filled.
+ */
+int
+ic_proxy_extract_addr(const struct sockaddr *addr,
+					  char *name, size_t namelen, int *port, int *family)
+{
+	int			ret = UV_EINVAL;
+
+	if (family)
+		*family = addr->sa_family;
+
+	switch (addr->sa_family)
+	{
+		case AF_INET:
+			{
+				const struct sockaddr_in *addr4
+					= (const struct sockaddr_in *) addr;
+
+				ret = uv_ip4_name(addr4, name, namelen);
+				if (ret == 0)
+					*port = ntohs(addr4->sin_port);
+			}
+			break;
+
+		case AF_INET6:
+			{
+				const struct sockaddr_in6 *addr6
+					= (const struct sockaddr_in6 *) addr;
+
+				ret = uv_ip6_name(addr6, name, namelen);
+				if (ret == 0)
+					*port = ntohs(addr6->sin6_port);
+			}
+			break;
+
+		default:
+			snprintf(name, namelen, "unknown");
+			*port = 0;
+			break;
+	}
+
+	return ret;
 }

--- a/src/backend/cdb/motion/ic_proxy_addr.h
+++ b/src/backend/cdb/motion/ic_proxy_addr.h
@@ -23,8 +23,17 @@ struct ICProxyAddr
 	int			dbid;
 	int			content;
 
-	char		hostname[HOST_NAME_MAX];
-	char		service[32];
+	/*
+	 * Below two attributes are arguments to uv_getaddrinfo().
+	 *
+	 * That API allows "service" to be either a port number or a service name,
+	 * like "http".  In our case each segment needs a unique port on its host,
+	 * so it is more convenient to specify port numbers directly, so we only
+	 * support the port numbers in gp_interconnect_proxy_addresses, service
+	 * names will be considered as syntax errors.
+	 */
+	char		hostname[HOST_NAME_MAX];	/* hostname or IP */
+	char		service[32];				/* port number as a string */
 
 	uv_getaddrinfo_t req;
 };

--- a/src/backend/cdb/motion/ic_proxy_addr.h
+++ b/src/backend/cdb/motion/ic_proxy_addr.h
@@ -22,6 +22,11 @@ struct ICProxyAddr
 
 	int			dbid;
 	int			content;
+
+	char		hostname[HOST_NAME_MAX];
+	char		service[32];
+
+	uv_getaddrinfo_t req;
 };
 
 
@@ -31,9 +36,12 @@ struct ICProxyAddr
 extern List		   *ic_proxy_addrs;
 
 
-extern void ic_proxy_reload_addresses(void);
-extern int ic_proxy_get_my_port(void);
+extern void ic_proxy_reload_addresses(uv_loop_t *loop);
+extern const ICProxyAddr *ic_proxy_get_my_addr(void);
 extern int ic_proxy_addr_get_port(const ICProxyAddr *addr);
+extern int ic_proxy_extract_addr(const struct sockaddr *addr,
+								 char *name, size_t namelen,
+								 int *port, int *family);
 
 
 #endif   /* IC_PROXY_ADDR_H */

--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -150,12 +150,19 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 		char		name[HOST_NAME_MAX] = "unknown";
 		int			port = 0;
 		int			family;
+		int			ret;
 
-		ic_proxy_extract_addr((struct sockaddr *) &addr->addr,
-							  name, sizeof(name), &port, &family);
-		ic_proxy_log(LOG,
-					 "ic-proxy-server: setting up peer listener on %s:%s (%s:%d family=%d)",
-					 addr->hostname, addr->service, name, port, family);
+		ret = ic_proxy_extract_addr((struct sockaddr *) &addr->addr,
+									name, sizeof(name), &port, &family);
+		if (ret == 0)
+			ic_proxy_log(LOG,
+						 "ic-proxy-server: setting up peer listener on %s:%s (%s:%d family=%d)",
+						 addr->hostname, addr->service, name, port, family);
+		else
+			ic_proxy_log(WARNING,
+						 "ic-proxy-server: setting up peer listener on %s:%s (%s:%d family=%d) (fail to extract the address: %s)",
+						 addr->hostname, addr->service, name, port, family,
+						 uv_strerror(ret));
 	}
 #endif /* IC_PROXY_LOG_LEVEL <= LOG */
 

--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -128,9 +128,8 @@ ic_proxy_server_on_new_peer(uv_stream_t *server, int status)
 static void
 ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 {
-	struct sockaddr_in addr;
+	const ICProxyAddr *addr;
 	uv_tcp_t   *listener = &ic_proxy_peer_listener;
-	int			port;
 	int			fd = -1;
 	int			ret;
 
@@ -140,20 +139,25 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 	if (ic_proxy_peer_listening)
 		return;
 
-	/* Get the ip from the gp_interconnect_proxy_addresses */
-	port = ic_proxy_get_my_port();
-	if (port < 0)
-		/* Cannot get my port, maybe the setting is invalid */
+	/* Get the addr from the gp_interconnect_proxy_addresses */
+	addr = ic_proxy_get_my_addr();
+	if (addr == NULL)
+		/* Cannot get my addr, maybe the setting is invalid */
 		return;
 
-	/*
-	 * TODO: listen on the ip specified in gp_interconnect_proxy_addresses for
-	 * better security.
-	 */
-	uv_ip4_addr("0.0.0.0", port, &addr);
+#if IC_PROXY_LOG_LEVEL <= LOG
+	{
+		char		name[HOST_NAME_MAX] = "unknown";
+		int			port = 0;
+		int			family;
 
-	ic_proxy_log(LOG, "ic-proxy-server: setting up peer listener on port %d",
-				 port);
+		ic_proxy_extract_addr((struct sockaddr *) &addr->addr,
+							  name, sizeof(name), &port, &family);
+		ic_proxy_log(LOG,
+					 "ic-proxy-server: setting up peer listener on %s:%s (%s:%d family=%d)",
+					 addr->hostname, addr->service, name, port, family);
+	}
+#endif /* IC_PROXY_LOG_LEVEL <= LOG */
 
 	/*
 	 * It is important to set TCP_NODELAY, otherwise we will suffer from
@@ -162,7 +166,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 	uv_tcp_init(loop, listener);
 	uv_tcp_nodelay(listener, true);
 
-	ret = uv_tcp_bind(listener, (struct sockaddr *) &addr, 0);
+	ret = uv_tcp_bind(listener, (struct sockaddr *) &addr->addr, 0);
 	if (ret < 0)
 	{
 		ic_proxy_log(WARNING, "ic-proxy-server: tcp: fail to bind: %s",
@@ -367,7 +371,7 @@ ic_proxy_server_on_signal(uv_signal_t *handle, int signum)
 	{
 		ProcessConfigFile(PGC_SIGHUP);
 
-		ic_proxy_reload_addresses();
+		ic_proxy_reload_addresses(handle->loop);
 
 		ic_proxy_server_peer_listener_init(handle->loop);
 		ic_proxy_server_ensure_peers(handle->loop);
@@ -391,9 +395,9 @@ ic_proxy_server_main(void)
 
 	ic_proxy_pkt_cache_init(IC_PROXY_MAX_PKT_SIZE);
 
-	ic_proxy_reload_addresses();
-
 	uv_loop_init(&ic_proxy_server_loop);
+
+	ic_proxy_reload_addresses(&ic_proxy_server_loop);
 
 	ic_proxy_router_init(&ic_proxy_server_loop);
 	ic_proxy_peer_table_init();

--- a/src/backend/cdb/motion/ic_proxy_peer.c
+++ b/src/backend/cdb/motion/ic_proxy_peer.c
@@ -110,6 +110,9 @@ ic_proxy_peer_table_uninit(void)
 
 /*
  * Update the peer name from the state bits.
+ *
+ * This function is usually called during logging, so it is good practice not
+ * to generate messages in this function.
  */
 static void
 ic_proxy_peer_update_name(ICProxyPeer *peer)
@@ -124,6 +127,11 @@ ic_proxy_peer_update_name(ICProxyPeer *peer)
 	/*
 	 * Show the tcp level connection information in the name, they are not very
 	 * useful, though.
+	 *
+	 * Return codes from ic_proxy_extract_addr() are ignored, as logging should
+	 * be avoided in this place.  On the other hand the failures are reflected
+	 * in the hostnames and ports, as well as the peer name, so we know it
+	 * happens.
 	 */
 	uv_tcp_getsockname(&peer->tcp, (struct sockaddr *) &peeraddr, &addrlen);
 	ic_proxy_extract_addr((struct sockaddr *) &peeraddr,


### PR DESCRIPTION
The GUC gp_interconnect_proxy_addresses is used to set the listener
addresses and ports of all the proxy bgworkers, only IP addresses were
supported previously, which is inconvenient to use.

Now we add the support for hostnames too, the IP addresses are also
supported.

Note that if a hostname is bound to a different IP at runtime, we must
reload the setting with the "gpstop -u" command.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
