### PR TITLE
[BUGFIX] Release tcp_event after socket closing in gpsmon to remove it from event loop

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpsmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpsmon.c
@@ -646,6 +646,8 @@ static void gx_gettcpcmd(SOCKET sock, short event, void* arg)
 		{
 			close(gx.tcp_sock);
 			gx.tcp_sock=0;
+			if (event_del(&gx.tcp_event))
+				gpsmon_fatal(FLINE, "event_del failed");
 		}
 		return;
 	}


### PR DESCRIPTION
## Problem description

After losing tcp connection between gpmmon and gpsmon and subsequent its reestablishment the gpsmon enters to infinite loop inside libevent routine of timeout event processing. The reason was in calling `event_set` function (that internally calls `event_assign` one) under new connection establishment on currently working (not released) `tcp_event` object that [rewrites](https://github.com/libevent/libevent/blob/7e6c5fb/event.c#L2172) internal flags of that event and puts it into inconsistent state.

The current fix releases `tcp_event` from participating in event loop (takes to unpending state) under connection closing from gpsmon by timeout so that the next new connection have to set `tpc_event` in event loop again.
In more detail, we have to delete `tcp_event` from all the queues on callback when connection is closing and have to use correct flags for that. So if we don't call `event_del` in a place where socket is closing the flags would be overridden on the next `event_set` call and event stucks in inconsistent state inside internal queues and blocks everything. So the idea of this PR is to call `event_del->event_del_internal->event_queue_remove` using old flags.

## Steps to reproduce

1. Emulate link disconnection between gpmmon and gpsmon via gpsmon stopping (kill -STOP <pid of some gpsmon>)
2. Wait for gpmmon detects connection problem. Quantum parameter can be reduced to wait less time.
3. Resume gpsmon kill -CONT <pid of some gpsmon>
4. After some timeout gpsmon wastes 100% cpu in user space and snapshot of its backtrace looks like this:
  ```
#0  event_active_nolock_ (ev=0x55c18caae270 <gx+208>, res=1, ncalls=1) at event.c:3008
#1  0x00007f1664fc67d4 in timeout_process (base=0x55c18cdcd8a0) at event.c:3243
#2  0x00007f1664fc3786 in event_base_loop (base=0x55c18cdcd8a0, flags=0) at event.c:2044
#3  0x00007f1664fc3365 in event_loop (flags=0) at event.c:1941
#4  0x00007f1664fc2f0f in event_dispatch () at event.c:1833
#5  0x000055c18caa7482 in gx_main (port=8888, signature=4842374434529772012) at gpsmon.c:1596
#6  0x000055c18caa7b79 in main (argc=10, argv=0x7ffef78eae38) at gpsmon.c:1766
  ```
  The process infinitely cycles inside [this loop](https://github.com/libevent/libevent/blob/7e6c5fb/event.c#L3234-L3244).

## Affected versions

Besides of 6X branch the current fix have to be backported to 5X one.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
