### PR TITLE
Make Fault Injection sites cheaper, when no faults have been activated.

### DIFF
--- a/src/backend/access/transam/test/xlog_test.c
+++ b/src/backend/access/transam/test/xlog_test.c
@@ -8,13 +8,6 @@
 static void
 KeepLogSeg_wrapper(XLogRecPtr recptr, XLogSegNo *logSegNo)
 {
-#ifdef FAULT_INJECTOR
-	expect_value(FaultInjector_InjectFaultIfSet, faultName, "keep_log_seg");
-	expect_value(FaultInjector_InjectFaultIfSet, ddlStatement, DDLNotSpecified);
-	expect_value(FaultInjector_InjectFaultIfSet, databaseName, "");
-	expect_value(FaultInjector_InjectFaultIfSet, tableName, "");
-	will_be_called(FaultInjector_InjectFaultIfSet);
-#endif
 	KeepLogSeg(recptr, logSegNo);
 }
 

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -61,6 +61,14 @@ bool am_faulthandler = false;
 
 static	FaultInjectorShmem_s *faultInjectorShmem = NULL;
 
+/*
+ * faultInjectorSlots_ptr points to this until shmem is initialized. Just to
+ * keep any FaultInjector_InjectFaultIfSet calls from crashing.
+ */
+static int dummyslots = 0;
+
+int *faultInjectorSlots_ptr = &dummyslots;
+
 static void FiLockAcquire(void);
 static void FiLockRelease(void);
 
@@ -199,6 +207,8 @@ FaultInjector_ShmemInit(void)
 				(errcode(ERRCODE_OUT_OF_MEMORY),
 				 (errmsg("not enough shared memory for fault injector"))));
 	}	
+
+	faultInjectorSlots_ptr = &faultInjectorShmem->faultInjectorSlots;
 	
 	if (! foundPtr) 
 	{
@@ -230,7 +240,7 @@ FaultInjector_ShmemInit(void)
 }
 
 FaultInjectorType_e
-FaultInjector_InjectFaultIfSet(
+FaultInjector_InjectFaultIfSet_out_of_line(
 							   const char*				 faultName,
 							   DDLStatement_e			 ddlStatement,
 							   const char*				 databaseName,

--- a/src/backend/utils/mmgr/test/runaway_cleaner_test.c
+++ b/src/backend/utils/mmgr/test/runaway_cleaner_test.c
@@ -149,14 +149,6 @@ test__RunawayCleaner_StartCleanup__StartsPrimaryCleanupIfPossible(void **state)
 	gp_command_count = 1;
 	will_return(IsTransactionState, true);
 
-#ifdef FAULT_INJECTOR
-	expect_value(FaultInjector_InjectFaultIfSet, faultName, "runaway_cleanup");
-	expect_value(FaultInjector_InjectFaultIfSet, ddlStatement, DDLNotSpecified);
-	expect_value(FaultInjector_InjectFaultIfSet, databaseName, "");
-	expect_value(FaultInjector_InjectFaultIfSet, tableName, "");
-	will_be_called(FaultInjector_InjectFaultIfSet);
-#endif
-
 	EXPECT_EREPORT(ERROR);
 
 	PG_TRY();
@@ -215,14 +207,6 @@ test__RunawayCleaner_StartCleanup__StartsSecondaryCleanupIfPossible(void **state
 	gp_command_count = 1;
 	will_return(superuser, false);
 	will_return(IsTransactionState, true);
-
-#ifdef FAULT_INJECTOR
-	expect_value(FaultInjector_InjectFaultIfSet, faultName, "runaway_cleanup");
-	expect_value(FaultInjector_InjectFaultIfSet, ddlStatement, DDLNotSpecified);
-	expect_value(FaultInjector_InjectFaultIfSet, databaseName, "");
-	expect_value(FaultInjector_InjectFaultIfSet, tableName, "");
-	will_be_called(FaultInjector_InjectFaultIfSet);
-#endif
 
 	EXPECT_EREPORT(ERROR);
 

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -97,11 +97,11 @@ extern FaultInjectorType_e FaultInjector_InjectFaultIfSet_out_of_line(
 							   const char*				 tableName);
 
 #define FaultInjector_InjectFaultIfSet(faultName, ddlStatement, databaseName, tableName) \
-	(((*faultInjectorSlots_ptr) > 0) ? \
+	(((*numActiveFaults_ptr) > 0) ? \
 	 FaultInjector_InjectFaultIfSet_out_of_line(faultName, ddlStatement, databaseName, tableName) : \
 	 FaultInjectorTypeNotSpecified)
 
-extern int *faultInjectorSlots_ptr;
+extern int *numActiveFaults_ptr;
 
 
 extern char *InjectFault(

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -85,11 +85,24 @@ extern Size FaultInjector_ShmemSize(void);
 
 extern void FaultInjector_ShmemInit(void);
 
-extern FaultInjectorType_e FaultInjector_InjectFaultIfSet(
+/*
+ * To check if a fault has been injected, use FaultInjector_InjectFaultIfSet().
+ * It is designed to fall through as quickly as possible, when no faults are
+ * activated.
+ */
+extern FaultInjectorType_e FaultInjector_InjectFaultIfSet_out_of_line(
 							   const char*				 faultName,
 							   DDLStatement_e			 ddlStatement,
 							   const char*				 databaseName,
 							   const char*				 tableName);
+
+#define FaultInjector_InjectFaultIfSet(faultName, ddlStatement, databaseName, tableName) \
+	(((*faultInjectorSlots_ptr) > 0) ? \
+	 FaultInjector_InjectFaultIfSet_out_of_line(faultName, ddlStatement, databaseName, tableName) : \
+	 FaultInjectorTypeNotSpecified)
+
+extern int *faultInjectorSlots_ptr;
+
 
 extern char *InjectFault(
 	char *faultName, char *type, char *ddlStatement, char *databaseName,


### PR DESCRIPTION
Fault injection is expected to be *very* cheap, we even enable it on
production builds. That's why I was very surprised when I saw 'perf'
report that FaultInjector_InjectFaultIfSet() was consuming about 10% of
CPU time in a performance test I was running on my laptop. I tracked it
to the FaultInjector_InjectFaultIfSet() call in standard_ExecutorRun().
It gets called for every tuple between 10000 and 1000000, on every
segment.

Why is FaultInjector_InjectFaultIfSet() so expenseive? It has a
quick exit in it, when no faults have been activated, but before reaching
the quick exit it calls strlen() on the arguments. That's not cheap.
And the function call isn't completely negligible on hot code paths,
either.

To fix, turn FaultInjector_InjectFaultIfSet() into a macro that's only
few instructions long in the fast path. That should be cheap enough.
