### PR TITLE
Fix postgres_fdw's libpq issue

### DIFF
--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -5,7 +5,7 @@ OBJS = postgres_fdw.o option.o deparse.o connection.o shippable.o $(WIN32RES)
 PGFILEDESC = "postgres_fdw - foreign data wrapper for PostgreSQL"
 
 PG_CPPFLAGS = -I$(libpq_srcdir)
-SHLIB_LINK_INTERNAL = $(libpq)
+SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
 
 EXTENSION = postgres_fdw
 DATA = postgres_fdw--1.0.sql

--- a/contrib/postgres_fdw/postgres_fdw.h
+++ b/contrib/postgres_fdw/postgres_fdw.h
@@ -18,7 +18,12 @@
 #include "nodes/relation.h"
 #include "utils/relcache.h"
 
+
+#ifndef FRONTEND
+#define FRONTEND
 #include "libpq-fe.h"
+#undef FRONTEND
+#endif
 
 /*
  * FDW-specific planner information kept in RelOptInfo.fdw_private for a

--- a/contrib/postgres_fdw/postgres_fdw.h
+++ b/contrib/postgres_fdw/postgres_fdw.h
@@ -20,8 +20,9 @@
 
 /* postgres_fdw is compiled as a backend, it needs the server's
  * header files such as executor/tuptable.h. It also needs libpq
- * to connect to a remote postgres database, so it's staticly linked
- * to libpq.a which is compiled as a frontend using -DFRONTEND.
+ * to connect to a remote postgres database, so it's statically
+ * linked to libpq.a which is compiled as a frontend using
+ * -DFRONTEND.
  *
  * But the struct PQconninfoOption's length is different between
  * backend and frontend, there is no "connofs" field in frontend.

--- a/contrib/postgres_fdw/postgres_fdw.h
+++ b/contrib/postgres_fdw/postgres_fdw.h
@@ -32,13 +32,17 @@
  *
  * We define FRONTEND here to include frontend libpq header files.
  */
+#ifdef LIBPQ_FE_H
+#error "postgres_fdw.h" must be included before "libpq-fe.h"
+#endif /* LIBPQ_FE_H */
+
 #ifndef FRONTEND
 #define FRONTEND
 #include "libpq-fe.h"
 #undef FRONTEND
 #else
 #include "libpq-fe.h"
-#endif
+#endif /* FRONTEND */
 
 /*
  * FDW-specific planner information kept in RelOptInfo.fdw_private for a

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -217,10 +217,8 @@ typedef struct _PQconninfoOption
 								 * hide value "D"  Debug option - don't show
 								 * by default */
 	int			dispsize;		/* Field size in characters for dialog	*/
-#ifndef FRONTEND  /* modules other than backend have this macro */
 	off_t		connofs;		/* Offset into PGconn struct, -1 if not there
 								 * (Greenplum specified) */
-#endif
 } PQconninfoOption;
 
 /* ----------------

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -217,8 +217,10 @@ typedef struct _PQconninfoOption
 								 * hide value "D"  Debug option - don't show
 								 * by default */
 	int			dispsize;		/* Field size in characters for dialog	*/
+#ifndef FRONTEND  /* modules other than backend have this macro */
 	off_t		connofs;		/* Offset into PGconn struct, -1 if not there
 								 * (Greenplum specified) */
+#endif
 } PQconninfoOption;
 
 /* ----------------


### PR DESCRIPTION
When using posgres_fdw, it reports the following error:
unsupported frontend protocol 28675.0: server supports 2.0 to 3.0

root casue: Even if postgres_fdw.so is dynamic linked to libpq.so
which is compiled with the option -DFRONTEND, but when it's loaded
in gpdb and run, it will use the backend libpq which is compiled together
with postgres program and reports the error.

We statically link libpq into postgres_fdw and hide all the symbols
of libpq.a with --exclude-libs=libpq.a to make it uses the frontend
libpq.

As postgres_fdw is compiled as a backend without -DFRONTEND, and linked
to libpq which is a frontend, but _PQconninfoOption's length is
different between backend and frontend as there is a macro in it.
The backend's _PQconninfoOption has field connofs, but the frontend
doesn't. This leads to the crash of postgres_fdw. So we delete the
frontend macro in _PQconninfoOption.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
