### PR TITLE
Fix flaky test: dbms_pipe_session_B

### DIFF
--- a/gpcontrib/orafce/sql/dbms_pipe_session_B.sql
+++ b/gpcontrib/orafce/sql/dbms_pipe_session_B.sql
@@ -14,8 +14,15 @@ CREATE OR REPLACE FUNCTION receiveFrom(pipename text) RETURNS void AS $$
 DECLARE
         typ INTEGER;
 BEGIN
+        WHILE true LOOP
+            SELECT dbms_pipe.receive_message(pipename, 0) INTO typ;
+            -- 0 means data is available
+            IF typ = 0 THEN
+                EXIT;
+            END IF;
+            PERFORM pg_sleep(0.5);
+        END LOOP;
          WHILE true LOOP
-                PERFORM dbms_pipe.receive_message(pipename,2);
                 SELECT dbms_pipe.next_item_type() INTO typ;
                 IF typ = 0 THEN EXIT;
                 ELSIF typ=9 THEN RAISE NOTICE 'RECEIVE %: %', typ, dbms_pipe.unpack_message_number();
@@ -25,6 +32,7 @@ BEGIN
                 ELSIF typ=23 THEN RAISE NOTICE 'RECEIVE %: %', typ, encode(dbms_pipe.unpack_message_bytea(),'escape');
                 ELSIF typ=24 THEN RAISE NOTICE 'RECEIVE %: %', typ, dbms_pipe.unpack_message_record();
                 END IF;
+                PERFORM dbms_pipe.receive_message(pipename, 2);
         END LOOP;
         PERFORM dbms_pipe.purge(pipename);
 END;


### PR DESCRIPTION
There is a race condition between receiveFrom() and
dbms_pipe_session_A::createImplicitPipe(). Sleep an extra seconds
is not reliable. So wait until the data is available.
This PR changes the semantics of receiveFrom(), i.e. wait until
the data is available, no timeout happens.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
