### PR TITLE
[gpopt] Translate children of DXL Sequence in order.

### DIFF
--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11431,18 +11431,18 @@ EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilte
          ->  Shared Scan (share slice:id 1:0)  (cost=0.00..862.00 rows=4 width=1)
                ->  Hash Join  (cost=0.00..862.00 rows=4 width=8)
                      Hash Cond: (onetimefilter1_1.a = onetimefilter2_1.a)
-                     ->  Seq Scan on onetimefilter1 onetimefilter1_1  (cost=0.00..431.00 rows=4 width=8)
+                     ->  Seq Scan on onetimefilter1  (cost=0.00..431.00 rows=4 width=8)
                      ->  Hash  (cost=431.00..431.00 rows=4 width=4)
-                           ->  Seq Scan on onetimefilter2 onetimefilter2_1  (cost=0.00..431.00 rows=4 width=4)
+                           ->  Seq Scan on onetimefilter2  (cost=0.00..431.00 rows=4 width=4)
          ->  Hash Join  (cost=0.00..862.00 rows=4 width=12)
                Hash Cond: (onetimefilter1.b = onetimefilter2.b)
                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=8)
                      Hash Key: onetimefilter1.b
-                     ->  Seq Scan on onetimefilter1  (cost=0.00..431.00 rows=4 width=8)
+                     ->  Seq Scan on onetimefilter1 onetimefilter1_1  (cost=0.00..431.00 rows=4 width=8)
                ->  Hash  (cost=431.00..431.00 rows=4 width=4)
                      ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
                            Hash Key: onetimefilter2.b
-                           ->  Seq Scan on onetimefilter2  (cost=0.00..431.00 rows=4 width=4)
+                           ->  Seq Scan on onetimefilter2 onetimefilter2_1  (cost=0.00..431.00 rows=4 width=4)
                SubPlan 1
                  ->  Result  (cost=0.00..431.01 rows=1 width=4)
                        ->  Limit  (cost=0.00..431.01 rows=1 width=1)

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2217,10 +2217,10 @@ SELECT count(a1.i)
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Sequence
          ->  Shared Scan (share slice:id 1:0)
-               ->  Seq Scan on foo foo_1
+               ->  Seq Scan on foo
          ->  Sequence
                ->  Shared Scan (share slice:id 1:1)
-                     ->  Seq Scan on foo
+                     ->  Seq Scan on foo foo_1
                ->  Append
                      ->  Hash Join
                            Hash Cond: (share0_ref2.i = share1_ref2.i)


### PR DESCRIPTION
We currently translate the last child of a sequence node before all
other children. This stands out as highly unusual because DXL node
translations normally have no order dependencies, and so they typically
are translated in order ("the normal for-loop"). There was a comment
rationalizing this, which only furthers confusion. We dug deep, and
found that there was no apparent reason we did that.

This patch removes the special handling of the last child, and rolls it
back into "the normal for-loop". This both results in clearer code, and
it removes a hurdle for the Postgres 12 merge where we needed a dynamic
table scan to be translated _after_ its corresponding static partition
selector. That is not great either, but we have a path forward to
eliminate the implicit order dependency there post-merge.

Co-authored-by: Alexandra Wang <walexandra@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
