### PR TITLE
Fix gathering statistics sample from segments.

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -624,7 +624,15 @@ do_analyze_rel(Relation onerel, int options, VacuumParams *params,
 	 * all analyzable columns.  We use a lower bound of 100 rows to avoid
 	 * possible overflow in Vitter's algorithm.  (Note: that will also be the
 	 * target in the corner case where there are no analyzable columns.)
+	 *
+	 * GPDB: If the caller specified the 'targrows', just use that.
 	 */
+	if (ctx)
+	{
+		targrows = ctx->targrows;
+	}
+	else /* funny indentation to avoid re-indenting upstream code */
+  {
 	targrows = 100;
 	for (i = 0; i < attr_cnt; i++)
 	{
@@ -641,6 +649,8 @@ do_analyze_rel(Relation onerel, int options, VacuumParams *params,
 				targrows = thisdata->vacattrstats[i]->minrows;
 		}
 	}
+  }
+	/* end of funny indentation */
 
 	/*
 	 * Maintain information if the row of a column exceeds WIDTH_THRESHOLD

--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -109,7 +109,8 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 
 		/* Construct the context to keep across calls. */
-		ctx = (gp_acquire_sample_rows_context *) palloc(sizeof(gp_acquire_sample_rows_context));
+		ctx = (gp_acquire_sample_rows_context *) palloc0(sizeof(gp_acquire_sample_rows_context));
+		ctx->targrows = targrows;
 
 		if (!pg_class_ownercheck(relOid, GetUserId()))
 			aclcheck_error(ACLCHECK_NOT_OWNER, ACL_KIND_CLASS,
@@ -211,7 +212,7 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 	HeapTuple	res;
 
 	/* First return all the sample rows */
-	if (ctx->index < ctx->num_sample_rows && ctx->index < targrows)
+	if (ctx->index < ctx->num_sample_rows)
 	{
 		HeapTuple	relTuple = ctx->sample_rows[ctx->index];
 		int			attno;

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -183,6 +183,7 @@ typedef struct
 {
 	/* Table being sampled */
 	Relation	onerel;
+	int32		targrows;
 
 	/* Sampled rows and estimated total number of rows in the table. */
 	HeapTuple  *sample_rows;

--- a/src/test/regress/expected/bfv_statistic.out
+++ b/src/test/regress/expected/bfv_statistic.out
@@ -421,3 +421,29 @@ select count(*) from pg_class c, gp_dist_random('pg_statistic') s where c.oid = 
 (1 row)
 
 DROP TABLE test_statistic_1;
+-- Test that the histogram looks reasonable.
+--
+-- We once had a bug where the samples gathered from the segments were
+-- truncated, leading to highly biased samples.
+CREATE TABLE uniformtest(i int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO uniformtest SELECT g/100 FROM generate_series(0, 9999) g;
+BEGIN;
+SET LOCAL default_statistics_target=10; -- don't need so many rows for testing
+ANALYZE uniformtest;
+COMMIT;
+-- ANALYZE collects a random sample, so the exact values chosen for the
+-- histogram are nondeterministic. But they should be roughly uniformly
+-- distributed across the range 0-99. Show some characteristic values.
+select case when avg(bound) between 40 and 60 then '40-60' else avg(bound)::text end as avg,
+       case when min(bound) <= 5              then '<= 5'  else min(bound)::text end as min,
+       case when max(bound) >= 95             then '>= 95' else max(bound)::text end as max
+from pg_stats s,
+     unnest(histogram_bounds::text::int4[]) as bound
+where tablename = 'uniformtest';
+  avg  | min  |  max  
+-------+------+-------
+ 40-60 | <= 5 | >= 95
+(1 row)
+

--- a/src/test/regress/expected/bfv_statistic_optimizer.out
+++ b/src/test/regress/expected/bfv_statistic_optimizer.out
@@ -442,3 +442,29 @@ select count(*) from pg_class c, gp_dist_random('pg_statistic') s where c.oid = 
 (1 row)
 
 DROP TABLE test_statistic_1;
+-- Test that the histogram looks reasonable.
+--
+-- We once had a bug where the samples gathered from the segments were
+-- truncated, leading to highly biased samples.
+CREATE TABLE uniformtest(i int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO uniformtest SELECT g/100 FROM generate_series(0, 9999) g;
+BEGIN;
+SET LOCAL default_statistics_target=10; -- don't need so many rows for testing
+ANALYZE uniformtest;
+COMMIT;
+-- ANALYZE collects a random sample, so the exact values chosen for the
+-- histogram are nondeterministic. But they should be roughly uniformly
+-- distributed across the range 0-99. Show some characteristic values.
+select case when avg(bound) between 40 and 60 then '40-60' else avg(bound)::text end as avg,
+       case when min(bound) <= 5              then '<= 5'  else min(bound)::text end as min,
+       case when max(bound) >= 95             then '>= 95' else max(bound)::text end as max
+from pg_stats s,
+     unnest(histogram_bounds::text::int4[]) as bound
+where tablename = 'uniformtest';
+  avg  | min  |  max  
+-------+------+-------
+ 40-60 | <= 5 | >= 95
+(1 row)
+

--- a/src/test/regress/expected/gp_aggregates_costs.out
+++ b/src/test/regress/expected/gp_aggregates_costs.out
@@ -33,16 +33,18 @@ explain select avg(b) from cost_agg_t2 group by c;
 insert into cost_agg_t2 select i, random() * 99999,1 from generate_series(1, 200000) i;
 analyze cost_agg_t2;
 explain select avg(b) from cost_agg_t2 group by c;
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=43614.00..58686.07 rows=463756 width=36)
-   ->  HashAggregate  (cost=43614.00..49410.95 rows=154586 width=36)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=30914.97..32210.13 rows=103613 width=36)
+   ->  Finalize HashAggregate  (cost=30914.97..32210.13 rows=34538 width=36)
          Group Key: c
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..37614.00 rows=400000 width=8)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=19930.20..29255.37 rows=103613 width=36)
                Hash Key: c
-               ->  Seq Scan on cost_agg_t2  (cost=0.00..13614.00 rows=400000 width=8)
+               ->  Partial HashAggregate  (cost=19930.20..23038.59 rows=103613 width=36)
+                     Group Key: c
+                     ->  Seq Scan on cost_agg_t2  (cost=0.00..13614.00 rows=400000 width=8)
  Optimizer: Postgres query optimizer
-(7 rows)
+(9 rows)
 
 drop table cost_agg_t1;
 drop table cost_agg_t2;


### PR DESCRIPTION
Commit 0c27e42adb changed the way that the gp_acquire_sample_rows()
function, called by ANALYZE, collects the sample rows. With the commit,
the sample size was not chosen correctly. The sample size is passed to
gp_acquire_sample_rows() as an argument, 'targrows', but the function did
not pass it down to the do_analyze_rel() function that actually collects
the sample. As a result, do_analyze_rel() collected a larger sample, but
gp_acquire_sample_rows() only returned the first 'targrows' rows of it
to the caller.

For example, if you have three segments and the total desired sample size
is 3000 rows, gp_acquire_sample_rows() is called with targrows=1000. But
do_analyze_rel() nevertheless collected a sample with 3000 rows, but
only the first 1000 rows of it were returned to the QD. The end result was
that the sample was highly biased towards the physical beginning of table.

This adds a test case, which creates and ANALYZEs a table with values
0-99, with 100 copies each distinct value. The table is populated in
order, so there is perfect correlation between the physical order and the
values. Before this patch, ANALYZE built a histogram like this for it:

```
regression=# select histogram_bounds from pg_stats s where tablename = 'uniformtest';
        histogram_bounds
---------------------------------
 {0,3,6,10,13,17,20,24,27,34,40}
(1 row)
```

After this fix:

```
         histogram_bounds
----------------------------------
 {0,8,21,32,42,51,60,71,81,89,99}
(1 row)
```

Commit 0c27e42adb updated the plan in expected output of
'gp_aggregates_costs' test. This reverts it back; the reason it changed was
that the statistics were bogus, and now they're good again. I'm not sure
which plan actually is better for that query. The cost estimates are not
very accurate in either case, but they're inaccurate in different ways. The
query actually returns 300000 rows, the estimate with the bogus stats was
463756 rows and with teh correct stats it's 103613.
