### PR TITLE
Output gpfdist log in regress test

### DIFF
--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -16,6 +16,8 @@ REGRESS_OPTS = --init-file=init_file
 installcheck: watchdog
 ifeq ($(enable_gpfdist),yes)
 ifeq ($(with_openssl),yes)
+	rm -rf data/gpfdist_ssl/certs_matching
+	mkdir data/gpfdist_ssl/certs_matching
 	cp -rf $(MASTER_DATA_DIRECTORY)/gpfdists/* data/gpfdist_ssl/certs_matching
 	# for verify_gpfdists_cert=off
 	cp data/gpfdist_ssl/certs_matching/root.crt data/gpfdist_ssl/certs_not_matching

--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -16,7 +16,8 @@ REGRESS_OPTS = --init-file=init_file
 installcheck: watchdog
 ifeq ($(enable_gpfdist),yes)
 ifeq ($(with_openssl),yes)
-	cp -rf $(MASTER_DATA_DIRECTORY)/gpfdists data/gpfdist_ssl/certs_matching
+	cp -rf $(MASTER_DATA_DIRECTORY)/gpfdists/* data/gpfdist_ssl/certs_matching
+	# for verify_gpfdists_cert=off
 	cp data/gpfdist_ssl/certs_matching/root.crt data/gpfdist_ssl/certs_not_matching
 endif
 endif

--- a/src/bin/gpfdist/regress/input/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_ssl.source
@@ -31,12 +31,12 @@
 -- 'gpfdists' protocol
 -- --------------------------------------
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_matching </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_matching -l /tmp/gpfdist_certs_matching.log</dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_not_matching_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_not_matching </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_not_matching -l /tmp/gpfdist_certs_not_matching.log</dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 

--- a/src/bin/gpfdist/regress/input/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_ssl.source
@@ -31,12 +31,12 @@
 -- 'gpfdists' protocol
 -- --------------------------------------
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_matching -l /tmp/gpfdist_certs_matching.log</dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_matching -l /tmp/gpfdist_certs_matching.log </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_not_matching_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_not_matching -l /tmp/gpfdist_certs_not_matching.log</dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_not_matching -l /tmp/gpfdist_certs_not_matching.log </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 

--- a/src/bin/gpfdist/regress/output/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/output/gpfdist_ssl.source
@@ -7,11 +7,11 @@
 -- 'gpfdists' protocol
 -- --------------------------------------
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_matching -l /tmp/gpfdist_certs_matching.log</dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_matching -l /tmp/gpfdist_certs_matching.log </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_not_matching_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_not_matching -l /tmp/gpfdist_certs_not_matching.log</dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_not_matching -l /tmp/gpfdist_certs_not_matching.log </dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_stop (x text)

--- a/src/bin/gpfdist/regress/output/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/output/gpfdist_ssl.source
@@ -7,11 +7,11 @@
 -- 'gpfdists' protocol
 -- --------------------------------------
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_matching </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_matching -l /tmp/gpfdist_certs_matching.log</dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_not_matching_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_not_matching </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_not_matching -l /tmp/gpfdist_certs_not_matching.log</dev/null >/dev/null 2>&1 &);  sleep 5;  ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_stop (x text)


### PR DESCRIPTION
* do curl 127.0.0.1:7070 can not work for gpfdists, we just sleep for 5s
* cp -rf $(MASTER_DATA_DIRECTORY)/gpfdists/* will copy all files in
  in gpfdists instead of gpfdists folder into dest folder.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
