### PR TITLE
Don't mutate fdw_private on building CDB plan

### DIFF
--- a/src/backend/cdb/cdbplan.c
+++ b/src/backend/cdb/cdbplan.c
@@ -845,7 +845,12 @@ plan_tree_mutator(Node *node,
 				SCANMUTATE(newfdwscan, fdwscan);
 
 				MUTATE(newfdwscan->fdw_exprs, fdwscan->fdw_exprs, List *);
-				MUTATE(newfdwscan->fdw_private, fdwscan->fdw_private, List *);
+
+				/*
+				 * Don't mutate fdw_private, it's private to the FDW. Must make
+				 * a copy of it, though.
+				 */
+				newfdwscan->fdw_private = copyObject(fdwscan->fdw_private);
 				newfdwscan->fsSystemCol = fdwscan->fsSystemCol;
 
 				return (Node *) newfdwscan;


### PR DESCRIPTION
Currently `FDW` in `6X_STABLE` expects that foreign plan's `fdw_private` field contains a private list of `DefElem` nodes (options) that should not be CDB mutated. We don't try to mutate it in `master` but still mutate in `6X` that causes `ERROR:  unrecognized node type: 920`. Backport described behaviour from master.

Steps to reproduce:
```
create extension file_fdw;
create server file foreign data wrapper file_fdw;
create foreign table t_file (a int) server file options(
mpp_execute 'all segments', filename '/tmp/1_<SEGID>.csv',
format 'csv');
\! echo '0' > /tmp/1_0.csv
\! echo '1' > /tmp/1_1.csv
\! echo '2' > /tmp/1_2.csv
select count(*) from t_file;
ERROR:  unrecognized node type: 920 (nodeFuncs.c:2932)
```