### PR TITLE
Using libuv 1.18 API in ic-proxy

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -326,7 +326,7 @@ ic_proxy_backend_on_interrupt_timer(uv_timer_t *timer)
 {
 	ChunkTransportState *pTransportStates;
 
-	pTransportStates = uv_handle_get_data((uv_handle_t *)timer);
+	pTransportStates = timer->data;
 	ML_CHECK_FOR_INTERRUPTS(pTransportStates->teardownActive);
 }
 
@@ -338,7 +338,7 @@ ic_proxy_backend_on_cancel_from_qd_timer(uv_timer_t *timer)
 {
 	ChunkTransportState *pTransportStates;
 
-	pTransportStates = uv_handle_get_data((uv_handle_t *)timer);
+	pTransportStates = timer->data;
 	checkForCancelFromQD(pTransportStates);
 }
 
@@ -457,18 +457,18 @@ ic_proxy_backend_init_context(ChunkTransportState *state)
 
 	/* init libuv loop */
 	uv_loop_init(&context->loop);
-	uv_loop_set_data(&context->loop, (void *)context);
+	context->loop.data = context;
 
 	/* interrupt timer */
 	uv_timer_init(&context->loop, &context->interruptTimer);
-	uv_handle_set_data((uv_handle_t *)&context->interruptTimer, (void *)context->transportState);
+	context->interruptTimer.data = context->transportState;
 	uv_timer_start(&context->interruptTimer, ic_proxy_backend_on_interrupt_timer, 0, 500);
 	uv_unref((uv_handle_t *)&context->interruptTimer);
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
 		uv_timer_init(&context->loop, &context->cancelFromQDTimer);
-		uv_handle_set_data((uv_handle_t *)&context->cancelFromQDTimer, (void *)context->transportState);
+		context->cancelFromQDTimer.data = context->transportState;
 		uv_timer_start(&context->cancelFromQDTimer, ic_proxy_backend_on_cancel_from_qd_timer, 0, 2000);
 		uv_unref((uv_handle_t *)&context->cancelFromQDTimer);
 	}

--- a/src/backend/cdb/motion/ic_proxy_router.c
+++ b/src/backend/cdb/motion/ic_proxy_router.c
@@ -248,7 +248,7 @@ static void
 ic_proxy_router_on_write(uv_write_t *req, int status)
 {
 	ICProxyWriteReq *wreq = (ICProxyWriteReq *) req;
-	ICProxyPkt *pkt = uv_req_get_data((uv_req_t *) req);
+	ICProxyPkt *pkt = req->data;
 
 	if (status < 0)
 		ic_proxy_log(LOG, "ic-proxy-router: fail to send %s: %s",
@@ -292,8 +292,8 @@ ic_proxy_router_write(uv_stream_t *stream, ICProxyPkt *pkt, int32 offset,
 	ic_proxy_log(LOG, "ic-proxy-router: sending %s", ic_proxy_pkt_to_str(pkt));
 
 	wreq = ic_proxy_new(ICProxyWriteReq);
-	uv_req_set_data((uv_req_t *) wreq, pkt);
 
+	wreq->req.data = pkt;
 	wreq->callback = callback;
 	wreq->opaque = opaque;
 

--- a/src/backend/cdb/motion/ic_proxy_server.h
+++ b/src/backend/cdb/motion/ic_proxy_server.h
@@ -21,26 +21,6 @@
 #include "ic_proxy_packet.h"
 #include "ic_proxy_router.h"
 
-#if UV_VERSION_HEX < 0x011300
-static inline void
-uv_req_set_data(uv_req_t *req, void* data)
-{
-	req->data = data;
-}
-
-static inline void *
-uv_req_get_data(const uv_req_t *req)
-{
-	return req->data;
-}
-
-static inline uv_loop_t *
-uv_handle_get_loop(const uv_handle_t* handle)
-{
-	return handle->loop;
-}
-#endif
-
 typedef struct ICProxyPeer ICProxyPeer;
 typedef struct ICProxyClient ICProxyClient;
 typedef struct ICProxyDelay ICProxyDelay;


### PR DESCRIPTION
ic-proxy is developed with libuv, the minimal supported libuv version is
1.18.0. But in commit 608514, we introduce new API in libuv 1.19, which
break compatibility on os like Ubuntu 18.04 whose default libuv version
is 1.18.

We should keep our code base align with libuv 1.18, and replace the new
API in libuv 1.19. The API change is mainly about how to access data field
in uv handle and uv loop. The new API uses function interface like
`uv_handle_set_data` and `uv_handle_get_data` to access data filed, while
the old API in 1.18 access the data filed directly. Note that in the latest
libuv version 1.38.2, the old API and new API are both supported. And libuv
is stable enough to support the old API for a long time.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
