### PR TITLE
upgrade: pg_strdup should not be run on the bool params

### DIFF
--- a/contrib/pg_upgrade/greenplum/option_gp.c
+++ b/contrib/pg_upgrade/greenplum/option_gp.c
@@ -29,7 +29,7 @@ initialize_greenplum_user_options(void)
 }
 
 bool
-process_greenplum_option(greenplumOption option, char *option_value)
+process_greenplum_option(greenplumOption option)
 {
 	switch (option)
 	{

--- a/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -68,7 +68,7 @@ typedef enum {
 
 /* option_gp.c */
 void initialize_greenplum_user_options(void);
-bool process_greenplum_option(greenplumOption option, char *option_value);
+bool process_greenplum_option(greenplumOption option);
 bool is_greenplum_dispatcher_mode(void);
 bool is_checksum_mode(checksumMode mode);
 bool is_show_progress_mode(void);

--- a/contrib/pg_upgrade/option.c
+++ b/contrib/pg_upgrade/option.c
@@ -197,7 +197,7 @@ parseCommandLine(int argc, char *argv[])
 				break;
 
 			default:
-				if (!process_greenplum_option(option, pg_strdup(optarg)))
+				if (!process_greenplum_option(option))
 					pg_fatal("Try \"%s --help\" for more information.\n",
 							 os_info.progname);
 				break;


### PR DESCRIPTION
optarg is a global and is not required to be passed to
process_greenplum_option. Also, for bool parameters pg_strdup must not
be called else it will fail with cannot duplicate null pointer (internal error)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
