### PR TITLE
gpcloud: use memcpy to avoid -Wstringop-truncation

### DIFF
--- a/gpcontrib/gpcloud/src/s3key_reader.cpp
+++ b/gpcontrib/gpcloud/src/s3key_reader.cpp
@@ -219,7 +219,7 @@ uint64_t S3KeyReader::read(char* buf, uint64_t count) {
         if (this->transferredKeyLen >= fileLen) {
             if (!this->hasEol && !this->eolAppended) {
                 uint64_t eolLen = strlen(eolString);
-                strncpy(buf, eolString, eolLen);
+                memcpy(buf, eolString, eolLen);
 
                 this->eolAppended = true;
 


### PR DESCRIPTION
Latest version of GCC detects string truncation and gives warnings.
However here is by design, use memcpy instead to avoid the warning.