### PR TITLE
[6X Backport]Fix CREATE EXTENSION gp_internal_tools changes search_path

### DIFF
--- a/gpcontrib/gp_internal_tools/expected/gp_session_state_memory.out
+++ b/gpcontrib/gp_internal_tools/expected/gp_session_state_memory.out
@@ -1,6 +1,6 @@
 -- Before the extension is loaded no information is available
 select * from session_state.session_level_memory_consumption limit 0;
-ERROR:  schema "session_state" does not exist
+ERROR:  relation "session_state.session_level_memory_consumption" does not exist
 LINE 1: select * from session_state.session_level_memory_consumption...
                       ^
 CREATE EXTENSION gp_internal_tools;
@@ -21,6 +21,6 @@ having count(1) = (select count(1) from gp_segment_configuration where preferred
 DROP EXTENSION gp_internal_tools;
 -- Should error out as we uninstalled
 select * from session_state.session_level_memory_consumption limit 0;
-ERROR:  schema "session_state" does not exist
+ERROR:  relation "session_state.session_level_memory_consumption" does not exist
 LINE 1: select * from session_state.session_level_memory_consumption...
                       ^

--- a/gpcontrib/gp_internal_tools/gp_internal_tools--1.0.0.sql
+++ b/gpcontrib/gp_internal_tools/gp_internal_tools--1.0.0.sql
@@ -1,5 +1,5 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
-\echo Use "CREATE EXTENSION file_fdw" to load this file. \quit
+\echo Use "CREATE EXTENSION gp_internal_tools" to load this file. \quit
 
 
 --------------------------------------------------------------------------------
@@ -105,3 +105,5 @@ pg_stat_activity as S
 ON M.sessionid = S.sess_id;
 
 GRANT SELECT ON session_level_memory_consumption TO public;
+
+SET search_path TO DEFAULT;

--- a/gpcontrib/gp_internal_tools/uninstall_gp_session_state.sql
+++ b/gpcontrib/gp_internal_tools/uninstall_gp_session_state.sql
@@ -9,3 +9,5 @@ DROP FUNCTION session_state_memory_entries_f_on_segments();
 DROP SCHEMA session_state;
 
 COMMIT;
+
+SET search_path TO DEFAULT;


### PR DESCRIPTION
1. SQL script in /gpcontrib/gp_internal_tools/gp_internal_tools--1.0.0.sql
and /gpcontrib/uninstall_gp_session_state.sql changes current search_path,
this commit set search_path to default at the end of the above two SQL scripts
2.fix typos in /gpcontrib/gp_internal_tools/gp_internal_tools--1.0.0.sql
3.fix the expect caused by this fix.

This fixes the issue: https://github.com/greenplum-db/gpdb/issues/10575.

(cherry picked from commit 9d9662f0bf217ed40b25f6e6cba01f1308a56126)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
