### PR TITLE
[6X Only] Fix missing xlog files with orphaned prepared transactions after cras…

### DIFF
--- a/src/test/isolation2/expected/segwalrep/checkpoint_remove_xlog.out
+++ b/src/test/isolation2/expected/segwalrep/checkpoint_remove_xlog.out
@@ -1,0 +1,179 @@
+-- Test a bug that checkpoint removes xlog segment files which still
+-- has orphaned prepared transactions. See below comments for details.
+
+include: helpers/server_helpers.sql;
+CREATE
+
+!\retcode gpconfig -c wal_keep_segments -v 0 --skipvalidation;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
+
+create extension if not exists gp_inject_fault;
+CREATE
+create table t_checkpoint1 (a int);
+CREATE
+create table t_checkpoint2 (a int);
+CREATE
+
+-- generate an temporarily orphaned prepared transaction.  we expect it to be
+-- triggered twice since we'd generate two orphaned prepared transactions.
+select gp_inject_fault('dtm_broadcast_prepare', 'suspend', '', '', '', 1, 2, 0, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- assume (2), (1) are on different segments and one tuple is on the first segment.
+-- the test finally double-check that.
+1&: insert into t_checkpoint1 values(2),(1);  <waiting ...>
+select gp_wait_until_triggered_fault('dtm_broadcast_prepare', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- trigger xlog file switch on the first segment. see below comment for explanation.
+-- start_ignore
+0U: select pg_switch_xlog();
+ pg_switch_xlog 
+----------------
+ 0/2C0AB170     
+(1 row)
+-- end_ignore
+
+-- generate another temporarily orphaned prepared transaction. the PREPARE
+-- transaction xlog will be located on a different xlog segment file than the
+-- one that has the previous orphaned prepared transaction. Previously there is
+-- a bug: after crash recovery finishes, the startup process will create an
+-- end-of-recovery checkpoint. the checkpoint will recycle/remove xlog files
+-- according to orphaned prepared transaction LSNs, replication slot data, some
+-- related GUC values, etc. The orphaned prepared transaction LSN data
+-- (TwoPhaseState->prepXacts, etc) for checkpoint are populated in startup
+-- process RecoverPreparedTransactions(), but the function is called after the
+-- end-of-recovery checkpoint creation so xlog files with orphaned prepared
+-- transactions could be recycled/removed. this might cause "requested WAL
+-- segment pg_xlog/000000010000000000000009 has already been removed" kind of
+-- error when bringing up the primary during single postgres running in
+-- 'gprecoverseg -a -v' pg_rewind if failover happens).
+-- As to why we need the new orphaned prepared transaction on another xlog
+-- file?  If a xlog file was opened, even the file is unlinked, we could still
+-- read the file with the file descriptor, so to reproduce this issue we need
+-- PrescanPreparedTransactions(), which scans all xlog files that have prepared
+-- transaction before the end-of-recovery creation, closes the opened file
+-- descriptor of the xlog file that includes the first orphaned prepared
+-- transation and thus later RecoverPreparedTransactions() will fail when
+-- opening the missing xlog file that has the first orphaned prepared
+-- transaction.  Refer xlogutils.c:XLogRead() for context.
+2&: insert into t_checkpoint2 values(2),(1);  <waiting ...>
+select gp_wait_until_triggered_fault('dtm_broadcast_prepare', 2, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- trigger xlog file switch on the first segment.
+-- start_ignore
+0U: select pg_switch_xlog();
+ pg_switch_xlog 
+----------------
+ 0/30000220     
+(1 row)
+-- end_ignore
+
+-- issue a checkpoint since a new checkpoint depends on previous checkpoint.redo
+-- for xlog file recycling/removing.
+checkpoint;
+CHECKPOINT
+
+-- shutdown primary and make sure the segment is down
+-1U: select pg_ctl((SELECT datadir from gp_segment_configuration c where c.role='p' and c.content=0), 'stop', 'immediate');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+select role, preferred_role from gp_segment_configuration where content = 0;
+ role | preferred_role 
+------+----------------
+ m    | p              
+ p    | m              
+(2 rows)
+
+-- double confirm that promote succeeds.
+-- also double confirm that
+--  1. tuples (2) and (1) are located on two segments (thus we are testing 2pc with prepared transaction).
+--  2. there are tuples on the first segment (we have been testing on the first segment).
+insert into t_checkpoint1 values(2),(1);
+INSERT 2
+select gp_segment_id, * from t_checkpoint1;
+ gp_segment_id | a 
+---------------+---
+ 0             | 2 
+ 1             | 1 
+(2 rows)
+
+select gp_inject_fault('dtm_broadcast_prepare', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+INSERT 2
+2<:  <... completed>
+INSERT 2
+
+-- confirm the "orphaned" prepared trnasaction commits finally.
+select * from t_checkpoint1;
+ a 
+---
+ 2 
+ 2 
+ 1 
+ 1 
+(4 rows)
+select * from t_checkpoint2;
+ a 
+---
+ 1 
+ 2 
+(2 rows)
+
+-- recovery the nodes. it should succeed without "requested WAL segment
+-- pg_xlog/000000010000000000000009 has already been removed" kind of error.
+!\retcode gprecoverseg -a -v;
+(exited with code 0)
+select wait_until_segment_synchronized(0);
+ wait_until_segment_synchronized 
+---------------------------------
+ OK                              
+(1 row)
+
+!\retcode gprecoverseg -ar;
+(exited with code 0)
+select wait_until_segment_synchronized(0);
+ wait_until_segment_synchronized 
+---------------------------------
+ OK                              
+(1 row)
+
+-- verify the first segment is recovered to the original state.
+select role, preferred_role from gp_segment_configuration where content = 0;
+ role | preferred_role 
+------+----------------
+ p    | p              
+ m    | m              
+(2 rows)
+
+-- cleanup
+!\retcode gpconfig -r wal_keep_segments --skipvalidation;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
+drop table t_checkpoint1;
+DROP
+drop table t_checkpoint2;
+DROP

--- a/src/test/isolation2/expected/segwalrep/restartpoint_remove_xlog.out
+++ b/src/test/isolation2/expected/segwalrep/restartpoint_remove_xlog.out
@@ -122,17 +122,19 @@ select * from t_restart;
 -- recovery the nodes
 !\retcode gprecoverseg -a;
 (exited with code 0)
-
--- loop while segments come in sync
-do $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select count(*) = 2 from gp_segment_configuration where content = 0 and mode = 's') then /* in func */ return; /* in func */ end if; /* in func */ perform gp_request_fts_probe_scan(); /* in func */ end loop; /* in func */ end; /* in func */ $$;
-DO
+select wait_until_segment_synchronized(0);
+ wait_until_segment_synchronized 
+---------------------------------
+ OK                              
+(1 row)
 
 !\retcode gprecoverseg -ar;
 (exited with code 0)
-
--- loop while segments come in sync
-do $$ begin /* in func */ for i in 1..120 loop /* in func */ if (select count(*) = 2 from gp_segment_configuration where content = 0 and mode = 's') then /* in func */ return; /* in func */ end if; /* in func */ perform gp_request_fts_probe_scan(); /* in func */ end loop; /* in func */ end; /* in func */ $$;
-DO
+select wait_until_segment_synchronized(0);
+ wait_until_segment_synchronized 
+---------------------------------
+ OK                              
+(1 row)
 
 -- verify the first segment is recovered to the original state.
 select role, preferred_role from gp_segment_configuration where content = 0;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -197,9 +197,10 @@ test: segwalrep/recoverseg_from_file
 test: segwalrep/mirror_promotion
 test: segwalrep/cancel_commit_pending_replication
 test: segwalrep/twophase_tolerance_with_mirror_promotion
+# Put these checkpoint/restartpoint related tests together since if there is
+# just a checkpoint, subsequent checkpoint is usually faster.
+test: segwalrep/checkpoint_remove_xlog
 test: segwalrep/restartpoint_remove_xlog
-# Both restartpoint_remove_xlog and checkpoint_with_prepare run checkpoint so
-# put them together to make the subsequent checkpoint faster.
 test: segwalrep/checkpoint_with_prepare
 test: segwalrep/failover_with_many_records
 test: segwalrep/dtm_recovery_on_standby

--- a/src/test/isolation2/sql/segwalrep/checkpoint_remove_xlog.sql
+++ b/src/test/isolation2/sql/segwalrep/checkpoint_remove_xlog.sql
@@ -1,0 +1,101 @@
+-- Test a bug that checkpoint removes xlog segment files which still
+-- has orphaned prepared transactions. See below comments for details.
+
+include: helpers/server_helpers.sql;
+
+!\retcode gpconfig -c wal_keep_segments -v 0 --skipvalidation;
+!\retcode gpstop -u;
+
+create extension if not exists gp_inject_fault;
+create table t_checkpoint1 (a int);
+create table t_checkpoint2 (a int);
+
+-- generate an temporarily orphaned prepared transaction.  we expect it to be
+-- triggered twice since we'd generate two orphaned prepared transactions.
+select gp_inject_fault('dtm_broadcast_prepare', 'suspend', '', '', '', 1, 2, 0, dbid)
+  from gp_segment_configuration where role = 'p' and content = -1;
+-- assume (2), (1) are on different segments and one tuple is on the first segment.
+-- the test finally double-check that.
+1&: insert into t_checkpoint1 values(2),(1);
+select gp_wait_until_triggered_fault('dtm_broadcast_prepare', 1, dbid)
+  from gp_segment_configuration where role = 'p' and content = -1;
+
+-- trigger xlog file switch on the first segment. see below comment for explanation.
+-- start_ignore
+0U: select pg_switch_xlog();
+-- end_ignore
+
+-- generate another temporarily orphaned prepared transaction. the PREPARE
+-- transaction xlog will be located on a different xlog segment file than the
+-- one that has the previous orphaned prepared transaction. Previously there is
+-- a bug: after crash recovery finishes, the startup process will create an
+-- end-of-recovery checkpoint. the checkpoint will recycle/remove xlog files
+-- according to orphaned prepared transaction LSNs, replication slot data, some
+-- related GUC values, etc. The orphaned prepared transaction LSN data
+-- (TwoPhaseState->prepXacts, etc) for checkpoint are populated in startup
+-- process RecoverPreparedTransactions(), but the function is called after the
+-- end-of-recovery checkpoint creation so xlog files with orphaned prepared
+-- transactions could be recycled/removed. this might cause "requested WAL
+-- segment pg_xlog/000000010000000000000009 has already been removed" kind of
+-- error when bringing up the primary during single postgres running in
+-- 'gprecoverseg -a -v' pg_rewind if failover happens).
+-- As to why we need the new orphaned prepared transaction on another xlog
+-- file?  If a xlog file was opened, even the file is unlinked, we could still
+-- read the file with the file descriptor, so to reproduce this issue we need
+-- PrescanPreparedTransactions(), which scans all xlog files that have prepared
+-- transaction before the end-of-recovery creation, closes the opened file
+-- descriptor of the xlog file that includes the first orphaned prepared
+-- transation and thus later RecoverPreparedTransactions() will fail when
+-- opening the missing xlog file that has the first orphaned prepared
+-- transaction.  Refer xlogutils.c:XLogRead() for context.
+2&: insert into t_checkpoint2 values(2),(1);
+select gp_wait_until_triggered_fault('dtm_broadcast_prepare', 2, dbid)
+  from gp_segment_configuration where role = 'p' and content = -1;
+
+-- trigger xlog file switch on the first segment.
+-- start_ignore
+0U: select pg_switch_xlog();
+-- end_ignore
+
+-- issue a checkpoint since a new checkpoint depends on previous checkpoint.redo
+-- for xlog file recycling/removing.
+checkpoint;
+
+-- shutdown primary and make sure the segment is down
+-1U: select pg_ctl((SELECT datadir from gp_segment_configuration c
+  where c.role='p' and c.content=0), 'stop', 'immediate');
+select gp_request_fts_probe_scan();
+select role, preferred_role from gp_segment_configuration where content = 0;
+
+-- double confirm that promote succeeds.
+-- also double confirm that
+--  1. tuples (2) and (1) are located on two segments (thus we are testing 2pc with prepared transaction).
+--  2. there are tuples on the first segment (we have been testing on the first segment).
+insert into t_checkpoint1 values(2),(1);
+select gp_segment_id, * from t_checkpoint1;
+
+select gp_inject_fault('dtm_broadcast_prepare', 'reset', dbid)
+  from gp_segment_configuration where role = 'p' and content = -1;
+1<:
+2<:
+
+-- confirm the "orphaned" prepared trnasaction commits finally.
+select * from t_checkpoint1;
+select * from t_checkpoint2;
+
+-- recovery the nodes. it should succeed without "requested WAL segment
+-- pg_xlog/000000010000000000000009 has already been removed" kind of error.
+!\retcode gprecoverseg -a -v;
+select wait_until_segment_synchronized(0);
+
+!\retcode gprecoverseg -ar;
+select wait_until_segment_synchronized(0);
+
+-- verify the first segment is recovered to the original state.
+select role, preferred_role from gp_segment_configuration where content = 0;
+
+-- cleanup
+!\retcode gpconfig -r wal_keep_segments --skipvalidation;
+!\retcode gpstop -u;
+drop table t_checkpoint1;
+drop table t_checkpoint2;

--- a/src/test/isolation2/sql/segwalrep/restartpoint_remove_xlog.sql
+++ b/src/test/isolation2/sql/segwalrep/restartpoint_remove_xlog.sql
@@ -64,32 +64,10 @@ select * from t_restart;
 
 -- recovery the nodes
 !\retcode gprecoverseg -a;
-
--- loop while segments come in sync
-do $$
-begin /* in func */
-  for i in 1..120 loop /* in func */
-    if (select count(*) = 2 from gp_segment_configuration where content = 0 and mode = 's') then /* in func */
-      return; /* in func */
-    end if; /* in func */
-    perform gp_request_fts_probe_scan(); /* in func */
-  end loop; /* in func */
-end; /* in func */
-$$;
+select wait_until_segment_synchronized(0);
 
 !\retcode gprecoverseg -ar;
-
--- loop while segments come in sync
-do $$
-begin /* in func */
-  for i in 1..120 loop /* in func */
-    if (select count(*) = 2 from gp_segment_configuration where content = 0 and mode = 's') then /* in func */
-      return; /* in func */
-    end if; /* in func */
-    perform gp_request_fts_probe_scan(); /* in func */
-  end loop; /* in func */
-end; /* in func */
-$$;
+select wait_until_segment_synchronized(0);
 
 -- verify the first segment is recovered to the original state.
 select role, preferred_role from gp_segment_configuration where content = 0;


### PR DESCRIPTION
…h recovery

After crash recovery finishes, the startup process will create an
end-of-recovery checkpoint. The checkpoint will recycle/remove xlog files
according to orphaned prepared transaction LSNs, replication slot data, etc.
The orphaned prepared transaction LSN data (TwoPhaseState->prepXacts, etc) for
checkpoint are populated in the startup process RecoverPreparedTransactions(),
but the function is called after the end-of-recovery checkpoint creation so
xlog files with orphaned prepared transactions might be recycled/removed. This
can cause "requested WAL segment pg_xlog/000000010000000000000009 has already
been removed" kind of error when bringing up the crashed primary. For example
if you run 'gprecoverseg -a -v', you might be able to see failure with stack as
below. In more details, this happens when running the single mode postgres in
pg_rewind.
	2    0x5673a1 postgres <symbol not found> (xlogutils.c:572)
	3    0x567b2f postgres read_local_xlog_page (xlogutils.c:870)
	4    0x5658f3 postgres <symbol not found> (xlogreader.c:503)
	5    0x56518a postgres XLogReadRecord (xlogreader.c:226)
	6    0x54d725 postgres RecoverPreparedTransactions (twophase.c:1955)
	7    0x55b0b7 postgres StartupXLOG (xlog.c:7760)
	8    0xb0087f postgres InitPostgres (postinit.c:704)
	9    0x97a97c postgres PostgresMain (postgres.c:4829)

Fixing this by prescanning the prepared transaction data from xlogs directly
for checkpoint creation if it's still InRecovery (i.e. when
TwoPhaseState->prepXacts is not populated).

Please note that "orphaned" might be temporary (usually happens on an
environment with heavy write-operation load) or permanent unless master dtx
recovery (implies a product bug).