### PR TITLE
gpcheckcat: list is unhashable, convert it to a string

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -3717,7 +3717,7 @@ class CatInconsistentIssue:
             return idstr
 
         for i in range(0, len(self.columns) - 1):
-            colset = set(j[i] for j in self.rows)
+            colset = set(str(j[i]) for j in self.rows)
             if len(colset) > 1:
                 for row in self.rows:
                     myprint("%20s is '%s' on %s" % (self.columns[i], row[i], format_segids(row[-1])))


### PR DESCRIPTION
`j[i]`, could be the query result of array_agg(), which is a unhashable
list, convert it to a string first.

```
>>> row_of_ids = [[0,1],[1,2]]
>>> colset = set(j for j in row_of_ids)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unhashable type: 'list'
```

```
>>> row_of_ids = [[0,1],[1,2]]
>>> colset = set(str(j) for j in row_of_ids)
>>>
```

Note that since PyGreSQL 5.0 this method will return the values of array
type columns as Python lists.

ref: https://pygresql.org/contents/pg/query.html
