### PR TITLE
Fix dblink's libpq issue on gpdb 6X

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -7,6 +7,7 @@
 subdir =
 top_builddir = .
 include $(top_builddir)/src/Makefile.global
+OS := $(shell uname -s)
 
 $(call recurse,all install,src config)
 
@@ -19,7 +20,11 @@ all:
 	$(MAKE) -C contrib/formatter_fixedwidth all
 	$(MAKE) -C contrib/fuzzystrmatch all
 	$(MAKE) -C contrib/extprotocol all	
+ifeq ($(OS),Darwin)
+	@echo "dblink can't be built on Mac"
+else
 	$(MAKE) -C contrib/dblink all
+endif
 	$(MAKE) -C contrib/indexscan all
 	$(MAKE) -C contrib/pageinspect all  # needed by src/test/isolation
 	$(MAKE) -C contrib/pg_upgrade_support all
@@ -59,7 +64,9 @@ install:
 	$(MAKE) -C contrib/formatter_fixedwidth $@
 	$(MAKE) -C contrib/fuzzystrmatch $@
 	$(MAKE) -C contrib/extprotocol $@
+ifneq ($(OS),Darwin)
 	$(MAKE) -C contrib/dblink $@
+endif
 	$(MAKE) -C contrib/indexscan $@ 
 	$(MAKE) -C contrib/pageinspect $@  # needed by src/test/isolation
 	$(MAKE) -C contrib/pg_upgrade_support $@
@@ -150,7 +157,10 @@ $(call recurse,check-world,src/test src/pl src/interfaces/ecpg contrib src/bin g
 ICW_TARGETS  = src/test src/pl src/interfaces/gppc
 ICW_TARGETS += contrib/amcheck contrib/auto_explain contrib/citext
 ICW_TARGETS += contrib/formatter_fixedwidth
-ICW_TARGETS += contrib/extprotocol contrib/dblink
+ICW_TARGETS += contrib/extprotocol
+ifneq ($(OS),Darwin)
+	ICW_TARGETS += contrib/dblink
+endif
 ICW_TARGETS += contrib/indexscan contrib/hstore contrib/pgcrypto
 # sslinfo depends on openssl
 ifeq ($(with_openssl), yes)

--- a/contrib/dblink/Makefile
+++ b/contrib/dblink/Makefile
@@ -1,12 +1,15 @@
 # contrib/dblink/Makefile
-
-MODULE_big = dblink
-OBJS	= dblink.o
-PG_CPPFLAGS = -I$(libpq_srcdir)
-SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
+# disbale dblink on MaxOS as --exclude-libs and -Bstatic are not supported
+OS := $(shell uname)
+ifneq ($(OS),Darwin)
+	MODULE_big = dblink
+	OBJS	= dblink.o
+	PG_CPPFLAGS = -I$(libpq_srcdir)
+	SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
 
 EXTENSION = dblink
 DATA = dblink--1.1.sql dblink--1.0--1.1.sql dblink--unpackaged--1.0.sql
+endif
 
 REGRESS = paths dblink
 REGRESS_OPTS = --dlpath=$(top_builddir)/src/test/regress \

--- a/contrib/dblink/Makefile
+++ b/contrib/dblink/Makefile
@@ -3,7 +3,7 @@
 MODULE_big = dblink
 OBJS	= dblink.o
 PG_CPPFLAGS = -I$(libpq_srcdir)
-SHLIB_LINK_INTERNAL = $(libpq)
+SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
 
 EXTENSION = dblink
 DATA = dblink--1.1.sql dblink--1.0--1.1.sql dblink--unpackaged--1.0.sql

--- a/contrib/dblink/Makefile
+++ b/contrib/dblink/Makefile
@@ -1,15 +1,17 @@
 # contrib/dblink/Makefile
 # disable dblink on MaxOS as --exclude-libs and -Bstatic are not supported
 OS := $(shell uname -s)
-ifneq ($(OS),Darwin)
-	MODULE_big = dblink
-	OBJS	= dblink.o
-	PG_CPPFLAGS = -I$(libpq_srcdir)
-	SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
-
-	EXTENSION = dblink
-	DATA = dblink--1.1.sql dblink--1.0--1.1.sql dblink--unpackaged--1.0.sql
+ifeq ($(OS),Darwin)
+$(error "dblink can't be built on Mac")
 endif
+
+MODULE_big = dblink
+OBJS	= dblink.o
+PG_CPPFLAGS = -I$(libpq_srcdir)
+SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
+
+EXTENSION = dblink
+DATA = dblink--1.1.sql dblink--1.0--1.1.sql dblink--unpackaged--1.0.sql
 
 REGRESS = paths dblink
 REGRESS_OPTS = --dlpath=$(top_builddir)/src/test/regress \

--- a/contrib/dblink/Makefile
+++ b/contrib/dblink/Makefile
@@ -1,14 +1,14 @@
 # contrib/dblink/Makefile
-# disbale dblink on MaxOS as --exclude-libs and -Bstatic are not supported
-OS := $(shell uname)
+# disable dblink on MaxOS as --exclude-libs and -Bstatic are not supported
+OS := $(shell uname -s)
 ifneq ($(OS),Darwin)
 	MODULE_big = dblink
 	OBJS	= dblink.o
 	PG_CPPFLAGS = -I$(libpq_srcdir)
 	SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
 
-EXTENSION = dblink
-DATA = dblink--1.1.sql dblink--1.0--1.1.sql dblink--unpackaged--1.0.sql
+	EXTENSION = dblink
+	DATA = dblink--1.1.sql dblink--1.0--1.1.sql dblink--unpackaged--1.0.sql
 endif
 
 REGRESS = paths dblink

--- a/contrib/dblink/dblink.c
+++ b/contrib/dblink/dblink.c
@@ -34,7 +34,31 @@
 
 #include <limits.h>
 
+/* dblink is compiled as a backend, it needs the server's
+ * header files. It also needs libpq to connect to a
+ * remote postgres database, so it's statically linked to
+ * libpq.a which is compiled as a frontend using -DFRONTEND.
+ *
+ * But the struct PQconninfoOption's length is different between
+ * backend and frontend, there is no "connofs" field in frontend.
+ * When dblink calls the function "PQconndefaults" implemented
+ * in libpq.a and uses the returned PQconninfoOption variable, it crashs,
+ * because the PQconninfoOption variable returned by libpq.a doesn't contain
+ * the "connofs" value, but the dblink thinks it has, so it crashes.
+ *
+ * We define FRONTEND here to include frontend libpq header files.
+ */
+#ifdef LIBPQ_FE_H
+#error "libpq-fe.h" shouldn't be included before "dblink.c"
+#endif /* LIBPQ_FE_H */
+
+#ifndef FRONTEND
+#define FRONTEND
 #include "libpq-fe.h"
+#undef FRONTEND
+#else
+#include "libpq-fe.h"	#include "libpq-fe.h"
+#endif /* FRONTEND */
 
 #include "access/htup_details.h"
 #include "access/reloptions.h"

--- a/contrib/dblink/dblink.c
+++ b/contrib/dblink/dblink.c
@@ -49,7 +49,7 @@
  * We define FRONTEND here to include frontend libpq header files.
  */
 #ifdef LIBPQ_FE_H
-#error "libpq-fe.h" shouldn't be included before "dblink.c"
+#error "libpq-fe.h" should not be included before "dblink.c"
 #endif /* LIBPQ_FE_H */
 
 #ifndef FRONTEND


### PR DESCRIPTION
When using dblink to connect to a postgres database, it reports the
following error:
unsupported frontend protocol 28675.0: server supports 2.0 to 3.0

Even if dblink.so is dynamic linked to libpq.so which is compiled
with the option -DFRONTEND, but when it's loaded in gpdb and run,
it will use the backend libpq which is compiled together with
postgres program and reports the error. So we define FRONTEND
before defining libpq-fe.h.

This pr is almost the same as the pr:
https://github.com/greenplum-db/gpdb/pull/10617
which is used to fix postgres_fdw issue

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
