### PR TITLE
Update the comments of tempnam warning

### DIFF
--- a/src/bin/pg_dump/Makefile
+++ b/src/bin/pg_dump/Makefile
@@ -16,9 +16,6 @@ subdir = src/bin/pg_dump
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
-# the use of tempnam in pg_backup_tar.c causes a warning when using newer versions of GCC
-override CPPFLAGS := -Wno-deprecated-declarations -I$(libpq_srcdir) $(CPPFLAGS)
-
 ifeq ($(PORTNAME),openbsd)
 override CFLAGS += -pthread
 endif

--- a/src/bin/pg_dump/pg_backup_tar.c
+++ b/src/bin/pg_dump/pg_backup_tar.c
@@ -502,6 +502,10 @@ newTempFile(void)
 		 * Use of the tempnam() function generates a warning in GCC; the code
 		 * surrounding this use addresses the exposure of which the warning
 		 * informs.
+		 *
+		 * Note: it's a linker warning, `-Wno-deprecated-declarations` has no
+		 * effect, and overriding the `.gnu.warning.foobar` binary section
+		 * doesn't work with other compilers.
 		 */
 		tempFileName = tempnam(tmpdir, "GPDB_");
 		if (tempFileName == NULL)


### PR DESCRIPTION
It's a linker warning, `-Wno-deprecated-declarations` has no effect, and
overriding the `.gnu.warning.foobar` binary section doesn't work with
other compilers.

Remove the hack in the makefile, it doesn't work.
