### PR TITLE
Exclude master-only tables from pg_depend comparison in gpcheckcat

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2390,6 +2390,12 @@ def checkTableMissingEntry(cat):
         db = connect2(GV.cfg[GV.master_dbid], utilityMode=False)
         curs = db.query(qry)
         nrows = curs.ntuples()
+        results = curs.getresult()
+        fields = curs.listfields()
+
+        if nrows != 0:
+            results = filterSpuriousFailures(catname, fields, results)
+            nrows = len(results)
 
         if nrows == 0:
             logger.info('[OK] Checking for missing or extraneous entries for ' + catname)
@@ -2406,9 +2412,7 @@ def checkTableMissingEntry(cat):
             logger.info(('[%s] Checking for missing or extraneous entries for ' + catname) %
                         ('WARNING' if log_level == logging.WARNING else 'FAIL'))
             logger_with_level('  %s has %d issue(s)' % (catname, nrows))
-            fields = curs.listfields()
             gplog.log_literal(logger, log_level, "    " + " | ".join(fields))
-            results = curs.getresult()
             for row in results:
                 gplog.log_literal(logger, log_level, "    " + " | ".join(map(str, row)))
             processMissingDuplicateEntryResult(catname, fields, results, "missing")
@@ -3447,6 +3451,28 @@ def getResourceTypeOid(oid):
     except Exception, e:
         setError(ERROR_NOREPAIR)
         myprint('  Execution error: ' + str(e))
+
+
+def filterSpuriousFailures(catname, colnames, results):
+    if catname == 'pg_depend':
+        # Catalog tables having content only on master
+        # (e.g. pg_statistic*) should be excluded from pg_depend
+        # comparisons between master and segments.
+        legitFailures = []
+        masterOnlyOids = map(lambda cat: cat._oid,
+                             filter(lambda cat: cat.isMasterOnly(),
+                                    GV.catalog.getCatalogTables()))
+        for row in results:
+            legit = True
+            if row[colnames.index('classid')] in masterOnlyOids:
+                logger.info('excluding master-only entry from missing_pg_depend: %s' % str(row))
+                legit = False
+            if legit:
+                 legitFailures.append(row)
+    else:
+        legitFailures = results
+
+    return legitFailures
 
 
 #-------------------------------------------------------------------------------

--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -135,7 +135,7 @@ class GPCatalog():
            SELECT version()
         """
         catalog_query = """
-           SELECT relname, relisshared FROM pg_class 
+           SELECT oid, relname, relisshared FROM pg_class
            WHERE relnamespace=11 and relkind = 'r' 
         """
 
@@ -154,10 +154,11 @@ class GPCatalog():
 
         # Construct our internal representation of the catalog
         
-        for [relname, relisshared] in curs.getresult():
+        for [oid, relname, relisshared] in curs.getresult():
             self._tables[relname] = GPCatalogTable(self, relname)
             # Note: stupid API returns t/f for boolean value
             self._tables[relname]._setShared(relisshared == 't')
+            self._tables[relname]._setOid(oid)
         
         # The tidycat.pl utility has been used to generate a json file 
         # describing aspects of the catalog that we can not currently
@@ -544,6 +545,9 @@ class GPCatalogTable():
 
     def _setMasterOnly(self, value=True):
         self._master = value
+
+    def _setOid(self, oid):
+        self._oid = oid
 
     def _setShared(self, value):
         self._isshared = value


### PR DESCRIPTION
Master-only tables such as pg_statistic* may appear in pg_depend. E.g. in PostgreSQL v12 merge iteration we found that `pg_depend` may contain rows with `classid` as `pg_statistic_ext` (a newly added catalog table).  This patch attempts the following goal.  If a table is known to be master-only, missing_extraneous_pg_depend test should exclude its content from comparison with segments.

