### PR TITLE
Harden analyzedb further against dropped/recreated tables

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -203,10 +203,6 @@ def get_partition_state_tuples(pg_port, dbname, catalog_schema, partition_info):
     partition_list = list()
     dburl = dbconn.DbURL(port=pg_port, dbname=dbname)
     num_sqls = 0
-    # ---- TODO: remove this before merging. Drop/create tables here to see the issue
-    import time
-    time.sleep(8)
-    # ----
     conn = dbconn.connect(dburl)
     for (oid, schemaname, partition_name, tupletable) in partition_info:
         try:

--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -203,26 +203,35 @@ def get_partition_state_tuples(pg_port, dbname, catalog_schema, partition_info):
     partition_list = list()
     dburl = dbconn.DbURL(port=pg_port, dbname=dbname)
     num_sqls = 0
-    with closing(dbconn.connect(dburl)) as conn:
-        for (oid, schemaname, partition_name, tupletable) in partition_info:
-            try:
-                modcount_sql = "select to_char(coalesce(sum(modcount::bigint), 0), '999999999999999999999') from gp_dist_random('%s.%s')" % (catalog_schema, tupletable)
-                modcount = dbconn.querySingleton(conn, modcount_sql)
-            except pg.DatabaseError as e:
-                if "does not exist" in str(e):
-                    logger.debug("Table %s.%s (%s) no longer exists", schemaname, partition_name, tupletable)
-                else:
-                    logger.error(str(e))
+    # ---- TODO: remove this before merging. Drop/create tables here to see the issue
+    import time
+    time.sleep(8)
+    # ----
+    conn = dbconn.connect(dburl)
+    for (oid, schemaname, partition_name, tupletable) in partition_info:
+        try:
+            modcount_sql = "select to_char(coalesce(sum(modcount::bigint), 0), '999999999999999999999') from gp_dist_random('%s.%s')" % (catalog_schema, tupletable)
+            modcount = dbconn.querySingleton(conn, modcount_sql)
+        except pg.DatabaseError as e:
+            if "does not exist" in str(e):
+                logger.info("Table %s.%s (%s) no longer exists and will not be analyzed", schemaname, partition_name, tupletable)
             else:
-                num_sqls += 1
-                if num_sqls == 1000: # The choice of batch size was chosen arbitrarily
-                    logger.debug('Completed executing batch of 1000 tuple count SQLs')
-                    conn.commit()
-                    num_sqls = 0
-                if modcount:
-                    modcount = modcount.strip()
-                validate_modcount(schemaname, partition_name, modcount)
-                partition_list.append((schemaname, partition_name, modcount))
+                logger.error(str(e))
+            if conn:
+                conn.close()
+            # If there's an exception, the transaction is closed so we need to reconnect
+            conn = dbconn.connect(dburl)
+        else:
+            num_sqls += 1
+            if num_sqls == 1000: # The choice of batch size was chosen arbitrarily
+                logger.debug('Completed executing batch of 1000 tuple count SQLs')
+                conn.commit()
+                num_sqls = 0
+            if modcount:
+                modcount = modcount.strip()
+            validate_modcount(schemaname, partition_name, modcount)
+            partition_list.append((schemaname, partition_name, modcount))
+    conn.close()
     return partition_list
 
 def validate_modcount(schema, tablename, cnt):
@@ -683,8 +692,9 @@ class AnalyzeDb(Operation):
         for schema_table in (x for x in self.success_list if
                              x not in heap_partitions and x not in root_partition_col_dict):
             # update modcount for tables that are successfully analyzed
-            new_modcount = curr_ao_state_dict[schema_table]
-            prev_ao_state_dict[schema_table] = new_modcount
+            if schema_table in curr_ao_state_dict:
+                new_modcount = curr_ao_state_dict[schema_table]
+                prev_ao_state_dict[schema_table] = new_modcount
 
             # update last op for tables that are successfully analyzed
             last_op_info = curr_last_op_dict[schema_table]  # {'CREATE':'<entry>', 'ALTER':'<entry>', ...}

--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -203,31 +203,30 @@ def get_partition_state_tuples(pg_port, dbname, catalog_schema, partition_info):
     partition_list = list()
     dburl = dbconn.DbURL(port=pg_port, dbname=dbname)
     num_sqls = 0
-    conn = dbconn.connect(dburl)
-    for (oid, schemaname, partition_name, tupletable) in partition_info:
-        try:
-            modcount_sql = "select to_char(coalesce(sum(modcount::bigint), 0), '999999999999999999999') from gp_dist_random('%s.%s')" % (catalog_schema, tupletable)
-            modcount = dbconn.querySingleton(conn, modcount_sql)
-        except pg.DatabaseError as e:
-            if "does not exist" in str(e):
-                logger.info("Table %s.%s (%s) no longer exists and will not be analyzed", schemaname, partition_name, tupletable)
+    with closing(dbconn.connect(dburl)) as conn:
+        for (oid, schemaname, partition_name, tupletable) in partition_info:
+            try:
+                modcount_sql = "select to_char(coalesce(sum(modcount::bigint), 0), '999999999999999999999') from gp_dist_random('%s.%s')" % (catalog_schema, tupletable)
+                modcount = dbconn.querySingleton(conn, modcount_sql)
+            except pg.DatabaseError as e:
+                if "does not exist" in str(e):
+                    logger.info("Table %s.%s (%s) no longer exists and will not be analyzed", schemaname, partition_name, tupletable)
+                else:
+                    logger.error(str(e))
+                if conn:
+                    conn.close()
+                # If there's an exception, the transaction is closed so we need to reconnect
+                conn = dbconn.connect(dburl)
             else:
-                logger.error(str(e))
-            if conn:
-                conn.close()
-            # If there's an exception, the transaction is closed so we need to reconnect
-            conn = dbconn.connect(dburl)
-        else:
-            num_sqls += 1
-            if num_sqls == 1000: # The choice of batch size was chosen arbitrarily
-                logger.debug('Completed executing batch of 1000 tuple count SQLs')
-                conn.commit()
-                num_sqls = 0
-            if modcount:
-                modcount = modcount.strip()
-            validate_modcount(schemaname, partition_name, modcount)
-            partition_list.append((schemaname, partition_name, modcount))
-    conn.close()
+                num_sqls += 1
+                if num_sqls == 1000: # The choice of batch size was chosen arbitrarily
+                    logger.debug('Completed executing batch of 1000 tuple count SQLs')
+                    conn.commit()
+                    num_sqls = 0
+                if modcount:
+                    modcount = modcount.strip()
+                validate_modcount(schemaname, partition_name, modcount)
+                partition_list.append((schemaname, partition_name, modcount))
     return partition_list
 
 def validate_modcount(schema, tablename, cnt):


### PR DESCRIPTION
Commit 445fc7c hardened some parts of analyzedb. However, it missed a
couple of cases.

1) When the statement to get the modcount from the pg_aoseg table failed
due to a dropped table, the transaction was also terminated. This caused
further modcount queries to fail and while those tables were analyzed,
it would error and not properly record the mod count. Therefore, we now
restart the transaction when it errors.

2) If the table is dropped and then recreated while analyzedb is running
(or some other mechanism that results in the table being successfully
analyzed, but the pg_aoseg table did not exist during the initial
check), the logic to update the modcount may fail. Now, we skip the
update for the table if this occurs. In this case, the modcount would
not be recorded and the next analyzedb run will consider the table
modified (or dirty) and re-analyze it, which is the desired behavior.

I manually verified that this fixes the issue by re-creating the AO partition table during the "sleep" portion of the first commit. However, we don't have any injection mechanism in analyzedb, which makes this difficult to test using the behave framework. Would we want to introduce injection points in this code or add a side-channel injection to the test framework (eg: poll for a query that contains a specific text, then immediatly drop the table), though that could result in flakiness.