### PR TITLE
PANIC when the shared memory is corrupted

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1634,7 +1634,7 @@ tmShmemSize(void)
 		return 0;
 
 	return
-		MAXALIGN(TMCONTROLBLOCK_BYTES(max_tm_gxacts) + max_tm_gxacts * sizeof(TMGXACT));
+		MAXALIGN(TMCONTROLBLOCK_BYTES(max_tm_gxacts));
 }
 
 
@@ -1676,6 +1676,7 @@ tmShmemInit(void)
 			elog(PANIC, "cannot generate global transaction id");
 		}
 
+		MemSet(shared, 0, tmShmemSize());
 		*shmDistribTimeStamp = (DistributedTransactionTimeStamp)t;
   		elog(DEBUG1, "DTM start timestamp %u", *shmDistribTimeStamp);
 

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -264,7 +264,7 @@ typedef struct TmControlBlock
 
 
 #define TMCONTROLBLOCK_BYTES(num_gxacts) \
-	(offsetof(TmControlBlock, gxact_array) + sizeof(TMGXACT) * (num_gxacts))
+	(offsetof(TmControlBlock, gxact_array) + sizeof(TMGXACT *) * (num_gxacts))
 
 extern DtxContext DistributedTransactionContext;
 


### PR DESCRIPTION
shmNumGxacts and shmGxactArray are accessed under the protection of
shmControlLock, this commit add some defensive code and PANIC at the earliest
when the shared memory is corrupted.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
