### PR TITLE
pt_ctl: rework the wrapper function

### DIFF
--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -331,9 +331,7 @@ def check_and_start_standby():
     standby = array.standbyMaster
     gp.start_standbymaster(standby.hostname,
                            standby.datadir,
-                           standby.port,
-                           standby.dbid,
-                           array.getNumSegmentContents())
+                           standby.port)
     logger.info("Successfully started standby master")
 
 #-------------------------------------------------------------------------
@@ -405,9 +403,7 @@ def create_standby(options):
             g_init_standby_state = INIT_STANDBY_STATE_STARTING_STANDBY
             gp.start_standbymaster(standby.hostname,
                                    standby.datadir,
-                                   standby.port,
-                                   standby.dbid,
-                                   array.getNumSegmentContents())
+                                   standby.port)
         except Exception, ex:
             raise GpInitStandbyException('failed to start standby')
 

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -450,6 +450,7 @@ free_readfile(char **optlines)
 static pgpid_t
 start_postmaster(void)
 {
+	char		launcher[MAXPGPATH] = "";
 	char		cmd[MAXPGPATH];
 
 #ifndef WIN32
@@ -489,18 +490,26 @@ start_postmaster(void)
 	}
 #endif
 
+	if (wrapper != NULL)
+	{
+		if (wrapper_args != NULL)
+			snprintf(launcher, MAXPGPATH, "%s %s", wrapper, wrapper_args);
+		else
+			snprintf(launcher, MAXPGPATH, "%s", wrapper);
+	}
+
 	/*
 	 * Since there might be quotes to handle here, it is easier simply to pass
 	 * everything to a shell to process them.  Use exec so that the postmaster
 	 * has the same PID as the current child process.
 	 */
 	if (log_file != NULL)
-		snprintf(cmd, MAXPGPATH, "exec \"%s\" %s%s < \"%s\" >> \"%s\" 2>&1",
-				 exec_path, pgdata_opt, post_opts,
+		snprintf(cmd, MAXPGPATH, "exec %s \"%s\" %s%s < \"%s\" >> \"%s\" 2>&1",
+				 launcher, exec_path, pgdata_opt, post_opts,
 				 DEVNULL, log_file);
 	else
-		snprintf(cmd, MAXPGPATH, "exec \"%s\" %s%s < \"%s\" 2>&1",
-				 exec_path, pgdata_opt, post_opts, DEVNULL);
+		snprintf(cmd, MAXPGPATH, "exec %s \"%s\" %s%s < \"%s\" 2>&1",
+				 launcher, exec_path, pgdata_opt, post_opts, DEVNULL);
 
 	(void) execl("/bin/sh", "/bin/sh", "-c", cmd, (char *) NULL);
 

--- a/src/bin/pg_ctl/t/001_start_stop.pl
+++ b/src/bin/pg_ctl/t/001_start_stop.pl
@@ -3,7 +3,7 @@ use warnings;
 
 use Config;
 use TestLib;
-use Test::More tests => 17;
+use Test::More tests => 19;
 
 my $tempdir = TestLib::tempdir;
 my $tempdir_short = TestLib::tempdir_short;
@@ -52,3 +52,27 @@ command_ok([ 'pg_ctl', 'restart', '-D', "$tempdir/data", '-w', '-m', 'fast' ],
 	'pg_ctl restart with server running');
 
 system_or_bail 'pg_ctl', 'stop', '-D', "$tempdir/data", '-m', 'fast';
+
+# gpdb specific: verify that --wrapper and --wrapper-args work as expected
+if (not $windows_os)
+{
+	my $keypair = 'TESTKEY=hello';
+	my $file;
+
+	# launch the server with the env command as a wrapper
+	command_ok([ 'pg_ctl', 'start', '-D', "$tempdir/data", '-w',
+			'--wrapper=env', "--wrapper-args=$keypair",
+			'-o', '-c gp_role=utility --gp_dbid=-1 --gp_contentid=-1' ],
+		'pg_ctl start --wrapper');
+
+	# read the pid
+	open($file, '<', "$tempdir/data/postmaster.pid");
+	my $pid = 0 + <$file>;
+	close($file);
+
+	# verify that the envvar is successfully set
+	command_ok([ 'grep', '-z', $keypair, "/proc/$pid/environ" ],
+		'verify wrapper effect');
+
+	system_or_bail 'pg_ctl', 'stop', '-D', "$tempdir/data", '-m', 'fast';
+}


### PR DESCRIPTION
pg_ctl supports two internal cmdline arguments, --wrapper and
--wrapper-args, they are gpdb specific arguments for debugging purpose,
however we lost them since gpdb 5 during the postgres merging.  The
arguments are still accepted, just not being used.

Now we bring the function back.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
