### PR TITLE
Use correct installation directory for regression_tests_gpcloud_centos concourse task

### DIFF
--- a/concourse/scripts/builds/GpBuild.py
+++ b/concourse/scripts/builds/GpBuild.py
@@ -32,13 +32,13 @@ class GpBuild:
         cmd = " ".join(cmd_with_options)
         return self._run_cmd(cmd, "gpdb_src")
 
-    def create_demo_cluster(self, no_mirrors=False):
+    def create_demo_cluster(self, install_dir=INSTALL_DIR, no_mirrors=False):
         NO_MIRROR_STRING=""
         if no_mirrors:
             NO_MIRROR_STRING="NUM_PRIMARY_MIRROR_PAIRS=1 WITH_MIRRORS=false"
         return subprocess.call([
             "runuser gpadmin -c \"source {0}/greenplum_path.sh \
-            && {1} make {2} create-demo-cluster DEFAULT_QD_MAX_CONNECT=150\"".format(INSTALL_DIR, self.source_gcc_env_cmd, NO_MIRROR_STRING)],
+            && {1} make {2} create-demo-cluster DEFAULT_QD_MAX_CONNECT=150\"".format(install_dir, self.source_gcc_env_cmd, NO_MIRROR_STRING)],
             cwd="gpdb_src/gpAux/gpdemo", shell=True)
 
     def _run_gpdb_command(self, command, stdout=None, stderr=None, source_env_cmd='', print_command=True):
@@ -59,7 +59,7 @@ class GpBuild:
         if dbexists:
             source_env_cmd='source {0}/greenplum_path.sh && source ~/.bash_profile '.format(INSTALL_DIR)
         else:
-            status = self.create_demo_cluster(True)
+            status = self.create_demo_cluster(INSTALL_DIR, True)
             fail_on_error(status)
             status = self._run_gpdb_command("createdb")
             fail_on_error(status)

--- a/concourse/scripts/regression_tests_gpcloud.bash
+++ b/concourse/scripts/regression_tests_gpcloud.bash
@@ -37,7 +37,7 @@ function setup_gpadmin_user() {
 }
 
 function make_cluster() {
-  PYTHONPATH=${SCRIPT_DIR}:${PYTHONPATH} python2 -c "from builds.GpBuild import GpBuild; GpBuild(\"planner\").create_demo_cluster()"
+  PYTHONPATH=${SCRIPT_DIR}:${PYTHONPATH} python2 -c "from builds.GpBuild import GpBuild; GpBuild(\"planner\").create_demo_cluster(install_dir='/usr/local/gpdb')"
 }
 
 function configure_with_planner() {


### PR DESCRIPTION
This is a fix to https://github.com/greenplum-db/gpdb/commit/94d23e64721217833abdd65674b78bf32959a457 as the gpcloud tests assume a different installation directory on concourse.

