### PR TITLE
Fix postgres fdw on gpdb 6X

### DIFF
--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -4,7 +4,7 @@ MODULE_big = postgres_fdw
 OBJS = postgres_fdw.o option.o deparse.o connection.o
 
 PG_CPPFLAGS = -I$(libpq_srcdir)
-SHLIB_LINK_INTERNAL = $(libpq)
+SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
 
 EXTENSION = postgres_fdw
 DATA = postgres_fdw--1.0.sql

--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -1,13 +1,16 @@
 # contrib/postgres_fdw/Makefile
+# disable postgre_fdw on MaxOS as --exclude-libs and -Bstatic are not supported
+OS := $(shell uname -s)
+ifneq ($(OS),Darwin)
+	MODULE_big = postgres_fdw
+	OBJS = postgres_fdw.o option.o deparse.o connection.o
 
-MODULE_big = postgres_fdw
-OBJS = postgres_fdw.o option.o deparse.o connection.o
+	PG_CPPFLAGS = -I$(libpq_srcdir)
+	SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
 
-PG_CPPFLAGS = -I$(libpq_srcdir)
-SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
-
-EXTENSION = postgres_fdw
-DATA = postgres_fdw--1.0.sql
+	EXTENSION = postgres_fdw
+	DATA = postgres_fdw--1.0.sql
+endif
 
 REGRESS = postgres_fdw gp_postgres_fdw
 

--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -2,15 +2,17 @@
 # disable postgre_fdw on MaxOS as --exclude-libs and -Bstatic are not supported
 OS := $(shell uname -s)
 ifneq ($(OS),Darwin)
-	MODULE_big = postgres_fdw
-	OBJS = postgres_fdw.o option.o deparse.o connection.o
-
-	PG_CPPFLAGS = -I$(libpq_srcdir)
-	SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
-
-	EXTENSION = postgres_fdw
-	DATA = postgres_fdw--1.0.sql
+$(error "postgres_fdw can't be built on Mac")
 endif
+
+MODULE_big = postgres_fdw
+OBJS = postgres_fdw.o option.o deparse.o connection.o
+
+PG_CPPFLAGS = -I$(libpq_srcdir)
+SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
+
+EXTENSION = postgres_fdw
+DATA = postgres_fdw--1.0.sql
 
 REGRESS = postgres_fdw gp_postgres_fdw
 

--- a/contrib/postgres_fdw/postgres_fdw.h
+++ b/contrib/postgres_fdw/postgres_fdw.h
@@ -18,7 +18,32 @@
 #include "nodes/relation.h"
 #include "utils/rel.h"
 
+/* postgres_fdw is compiled as a backend, it needs the server's
+ * header files such as executor/tuptable.h. It also needs libpq
+ * to connect to a remote postgres database, so it's statically
+ * linked to libpq.a which is compiled as a frontend using
+ * -DFRONTEND.
+ *
+ * But the struct PQconninfoOption's length is different between
+ * backend and frontend, there is no "connofs" field in frontend.
+ * When postgres_fdw calls the function "PQconndefaults" implemented
+ * in libpq.a and uses the returned PQconninfoOption variable, it crashs,
+ * because the PQconninfoOption variable returned by libpq.a doesn't contain
+ * the "connofs" value, but the postgres_fdw thinks it has, so it crashes.
+ *
+ * We define FRONTEND here to include frontend libpq header files.
+ */
+#ifdef LIBPQ_FE_H
+#error "postgres_fdw.h" must be included before "libpq-fe.h"
+#endif /* LIBPQ_FE_H */
+
+#ifndef FRONTEND
+#define FRONTEND
 #include "libpq-fe.h"
+#undef FRONTEND
+#else
+#include "libpq-fe.h"
+#endif /* FRONTEND */
 
 /* in postgres_fdw.c */
 extern int	set_transmission_modes(void);


### PR DESCRIPTION
When using posgres_fdw, it reports the following error:
unsupported frontend protocol 28675.0: server supports 2.0 to 3.0

root cause: Even if postgres_fdw.so is dynamic linked to libpq.so
which is compiled with the option -DFRONTEND, but when it's loaded
in gpdb and run, it will use the backend libpq which is compiled together
with postgres program and reports the error.

We statically link libpq into postgres_fdw and hide all the symbols
of libpq.a with --exclude-libs=libpq.a to make it uses the frontend
libpq.

As postgres_fdw is compiled as a backend without -DFRONTEND, and linked
to libpq which is a frontend, but _PQconninfoOption's length is
different between backend and frontend as there is a macro in it.
The backend's _PQconninfoOption has field connofs, but the frontend
doesn't. This leads to the crash of postgres_fdw. One solution is to
remove the FRONTEND macro in struct PQconninfoOption to make PQconninfoOption
is the same in the backend and frontend, but that brings an ABI change. To avoid that,
we add the FRONTEND macro on including libpq header files, so that postgres_fdw
can process the libpq's variables returned by libpq.a's functions as frontend.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
