### PR TITLE
[6X Backport]Error out when changing datatype of column with constraint.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -11887,6 +11887,22 @@ ATPostAlterTypeCleanup(List **wqueue, AlteredTableInfo *tab, LOCKMODE lockmode)
 		conislocal = con->conislocal;
 		ReleaseSysCache(tup);
 
+		if (contype == CONSTRAINT_PRIMARY || contype == CONSTRAINT_UNIQUE)
+		{
+			/*
+			 * Currently, GPDB doesn't support alter type on primary key and unique
+			 * constraint column. Because it requires drop - recreate logic.
+			 * The drop currently only performs on master which lead error when
+			 * recreating index (since recreate index will dispatch to segments and
+			 * there still old constraint index exists)
+			 * Related issue: https://github.com/greenplum-db/gpdb/issues/10561.
+			 */
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("cannot alter column with primary key or unique constraint"),
+					 errhint("DROP the constraint first, and recreate it after the ALTER")));
+		}
+
 		/*
 		 * If the constraint is inherited (only), we don't want to inject a
 		 * new definition here; it'll get recreated when ATAddCheckConstraint

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -857,7 +857,8 @@ ERROR:  cannot create unique index on system column
 -- this errors out in Greenplum for a different reason: we don't support
 -- SET DATA TYPE on an indexed column yet
 alter table atacc1 alter column test type integer using 0;
-ERROR:  relation "atacc_test1" already exists  (seg2 127.0.1.1:25434 pid=8596)
+ERROR:  cannot alter column with primary key or unique constraint
+HINT:  DROP the constraint first, and recreate it after the ALTER
 drop table atacc1;
 -- let's do one where the unique constraint fails when added
 create table atacc1 ( test int ) distributed by (test);

--- a/src/test/regress/expected/alter_table_gp.out
+++ b/src/test/regress/expected/alter_table_gp.out
@@ -33,6 +33,21 @@ ERROR:  constraint "dup_constraint" for relation "dupconstr" already exists
 -- cleanup
 drop table dupconstr;
 --
+-- Alter datatype of column with constraint should raise meaningful error
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/10561
+--
+create table contype (i int4 primary key, j int check (j < 100));
+alter table contype alter i type numeric; --error
+ERROR:  cannot alter column with primary key or unique constraint
+HINT:  DROP the constraint first, and recreate it after the ALTER
+insert into contype values (1, 1), (2, 2), (3, 3);
+-- after insert data, alter primary key/unique column's type will go through a special check logic
+alter table contype alter i type numeric; --error
+ERROR:  changing the type of a column that is used in a UNIQUE or PRIMARY KEY constraint is not allowed
+alter table contype alter j type numeric;
+-- cleanup
+drop table contype;
+--
 -- Test ALTER COLUMN TYPE after dropped column with text datatype (see MPP-19146)
 --
 create domain mytype as text;

--- a/src/test/regress/sql/alter_table_gp.sql
+++ b/src/test/regress/sql/alter_table_gp.sql
@@ -31,6 +31,20 @@ alter table dupconstr add constraint dup_constraint primary key (i);
 -- cleanup
 drop table dupconstr;
 
+--
+-- Alter datatype of column with constraint should raise meaningful error
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/10561
+--
+create table contype (i int4 primary key, j int check (j < 100));
+alter table contype alter i type numeric; --error
+
+insert into contype values (1, 1), (2, 2), (3, 3);
+-- after insert data, alter primary key/unique column's type will go through a special check logic
+alter table contype alter i type numeric; --error
+
+alter table contype alter j type numeric;
+-- cleanup
+drop table contype;
 
 --
 -- Test ALTER COLUMN TYPE after dropped column with text datatype (see MPP-19146)


### PR DESCRIPTION
Raise a meaningful error message for this case.
GPDB doesn't support alter type on primary key and unique
constraint column. Because it requires to drop - recreate logic.
The drop currently only performs on master which lead error when
recreating index (since recreate index will dispatch to segments and
there still an old constraint index exists).

This fixes the issue https://github.com/greenplum-db/gpdb/issues/10561.

Reviewed-by: Hubert Zhang <hzhang@pivotal.io>
(cherry picked from commit 32446a321d492226d3f26d91f3b0deeabce90fd4)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
