### PR TITLE
Fix DISTINCT plans created on top of pre-sorted inputs.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -4928,20 +4928,16 @@ create_distinct_paths(PlannerInfo *root,
 				if (!cdbpathlocus_collocates_pathkeys(root, path->locus,
 													  distinct_dist_pathkeys, false /* exact_match */ ))
 				{
+					/*
+					 * If the input path's locus is not suitable, gather the
+					 * result. We don't want to redistribute it because that
+					 * would break the input ordering, and we'd need to re-Sort
+					 * it. (We'll consider the explicit-sort case below, on top
+					 * of the cheapest overall path.)
+					 */
 					CdbPathLocus locus;
 
-					if (distinct_dist_exprs)
-					{
-						locus = cdbpathlocus_from_exprs(root,
-														distinct_dist_exprs,
-														distinct_dist_opfamilies,
-														distinct_dist_sortrefs,
-														getgpsegmentCount());
-					}
-					else
-					{
-						CdbPathLocus_MakeSingleQE(&locus, getgpsegmentCount());
-					}
+					CdbPathLocus_MakeSingleQE(&locus, getgpsegmentCount());
 
 					path = cdbpath_create_motion_path(root, path, path->pathkeys, false, locus);
 				}


### PR DESCRIPTION
If you have a pre-sorted input, like Index Scan, and a DISTINCT clause,
the planner would create an invalid plan. A Redistribute Motion node is
breaks the ordering of its input, so such a plan cannot be used as
input to a Unique node.

This is possibly unreachable at the moment, because parse analysis
transforms simple DISTINCT queries to GROUP BY (see call to
transformDistinctToGroupBy() in transformSelectStmt()). I have not been
able to come up with a query that would exercise this codepath; any
simple query is transformed to a GROUP BY, and anything more complicated,
with window functions or aggregates, don't yield sorted input to the
DISTINCT stage. But if you disable the DISTINCT -> GROUP BY transformation
in parse analysis, this query caused an assertion before this commit:

    postgres=# create table distincttest (i int, j int) distributed by (i);
    CREATE TABLE
    postgres=# create index on distincttest (j);
    CREATE INDEX
    postgres=# set gp_enable_multiphase_agg =off; set enable_hashagg=off; set enable_seqscan=off; set enable_bitmapscan=off;
    SET
    SET
    SET
    SET
    postgres=# explain select distinct j from distincttest;
    FATAL:  Unexpected internal error (createplan.c:6871)
    DETAIL:  FailedAssertion("!(numCols >= 0 && numCols <= list_length(pathkeys))", File: "createplan.c", Line: 6871)
    server closed the connection unexpectedly
    	This probably means the server terminated abnormally
    	before or while processing the request.
    The connection to the server was lost. Attempting reset: Succeeded.
