### PR TITLE
Fix flaky uao_crash_compaction_column test

### DIFF
--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -220,7 +220,8 @@ UPDATE 1
  26 | 11 | c                    
 (11 rows)
 -- crash_vacuum_in_appendonly_insert
-1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert');
+-- verify the old segment files are still visible after the vacuum is aborted.
+1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert') where segno = 1;
  segno | column_num | physical_segno | tupcount | modcount | state 
 -------+------------+----------------+----------+----------+-------
  1     | 0          | 1              | 10       | 2        | 1     
@@ -232,13 +233,13 @@ UPDATE 1
  1     | 2          | 257            | 10       | 2        | 1     
  1     | 2          | 257            | 2        | 2        | 1     
  1     | 2          | 257            | 8        | 2        | 1     
- 2     | 0          | 2              | 0        | 0        | 1     
- 2     | 0          | 2              | 0        | 0        | 1     
- 2     | 1          | 130            | 0        | 0        | 1     
- 2     | 1          | 130            | 0        | 0        | 1     
- 2     | 2          | 258            | 0        | 0        | 1     
- 2     | 2          | 258            | 0        | 0        | 1     
-(15 rows)
+(9 rows)
+-- verify the new segment files contain no tuples.
+1:SELECT sum(tupcount) FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert') where state = 1 and segno = 2;
+ sum 
+-----
+ 0   
+(1 row)
 1:VACUUM crash_vacuum_in_appendonly_insert;
 VACUUM
 1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert');

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -235,7 +235,7 @@ UPDATE 1
  1     | 2          | 257            | 8        | 2        | 1     
 (9 rows)
 -- verify the new segment files contain no tuples.
-1:SELECT sum(tupcount) FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert') where state = 1 and segno = 2;
+1:SELECT sum(tupcount) FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert') where segno = 2;
  sum 
 -----
  0   

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -181,15 +181,20 @@ UPDATE 1
  26 | 11 | c                    
 (11 rows)
 -- crash_vacuum_in_appendonly_insert
-1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_vacuum_in_appendonly_insert');
+-- verify the old segment files are still visible after the vacuum is aborted.
+1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_vacuum_in_appendonly_insert') where segno = 1;
  segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
 ------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
  0          | 1     | 496 | 10       | 2             | 496              | 2        | 3             | 1     
  1          | 1     | 128 | 2        | 2             | 128              | 2        | 3             | 1     
- 1          | 2     | 0   | 0        | 0             | 0                | 0        | 3             | 1     
  2          | 1     | 400 | 8        | 2             | 400              | 2        | 3             | 1     
- 2          | 2     | 0   | 0        | 0             | 0                | 0        | 3             | 1     
-(5 rows)
+(3 rows)
+-- verify the new segment files contain no tuples.
+1:SELECT sum(tupcount) FROM gp_toolkit.__gp_aoseg('crash_vacuum_in_appendonly_insert') where segno = 2;
+ sum 
+-----
+ 0   
+(1 row)
 1:VACUUM crash_vacuum_in_appendonly_insert;
 VACUUM
 1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_vacuum_in_appendonly_insert');

--- a/src/test/isolation2/sql/uao_crash_compaction_column.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_column.sql
@@ -74,7 +74,7 @@ include: helpers/server_helpers.sql;
 -- verify the old segment files are still visible after the vacuum is aborted.
 1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert') where segno = 1;
 -- verify the new segment files contain no tuples.
-1:SELECT sum(tupcount) FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert') where state = 1 and segno = 2;
+1:SELECT sum(tupcount) FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert') where segno = 2;
 1:VACUUM crash_vacuum_in_appendonly_insert;
 1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert');
 1:INSERT INTO crash_vacuum_in_appendonly_insert VALUES(21, 1, 'c'), (26, 1, 'c');

--- a/src/test/isolation2/sql/uao_crash_compaction_column.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_column.sql
@@ -71,7 +71,10 @@ include: helpers/server_helpers.sql;
 1:UPDATE crash_before_cleanup_phase SET b = b+10 WHERE a=26;
 1:SELECT * FROM crash_before_cleanup_phase ORDER BY a,b;
 -- crash_vacuum_in_appendonly_insert
-1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert');
+-- verify the old segment files are still visible after the vacuum is aborted.
+1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert') where segno = 1;
+-- verify the new segment files contain no tuples.
+1:SELECT sum(tupcount) FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert') where state = 1 and segno = 2;
 1:VACUUM crash_vacuum_in_appendonly_insert;
 1:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert');
 1:INSERT INTO crash_vacuum_in_appendonly_insert VALUES(21, 1, 'c'), (26, 1, 'c');

--- a/src/test/isolation2/sql/uao_crash_compaction_row.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_row.sql
@@ -65,7 +65,10 @@
 1:UPDATE crash_before_cleanup_phase SET b = b+10 WHERE a=26;
 1:SELECT * FROM crash_before_cleanup_phase ORDER BY a,b;
 -- crash_vacuum_in_appendonly_insert
-1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_vacuum_in_appendonly_insert');
+-- verify the old segment files are still visible after the vacuum is aborted.
+1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_vacuum_in_appendonly_insert') where segno = 1;
+-- verify the new segment files contain no tuples.
+1:SELECT sum(tupcount) FROM gp_toolkit.__gp_aoseg('crash_vacuum_in_appendonly_insert') where segno = 2;
 1:VACUUM crash_vacuum_in_appendonly_insert;
 1:SELECT * FROM gp_toolkit.__gp_aoseg('crash_vacuum_in_appendonly_insert');
 1:INSERT INTO crash_vacuum_in_appendonly_insert VALUES(21, 1, 'c'), (26, 1, 'c');


### PR DESCRIPTION
In a normal vacuum, for each column, the vacuum will
1) create a new segment file and record it in the gp_aocsseg_xxxxx
   table with a new entry with frozen xmin.
2) compact the tuples in the old segment file and move it to the new
   segment file.
3) drop/truncate the old segment file and mark it as dropped in the
   gp_aocsseg_xxxxx table.

In the uao_crash_compaction_column test, a PANIC is injected between
step 1 and step2 on seg0, so the whole transaction is aborted.

For seg1 and seg2, because step1 is using a frozen xmin, the new segment
file is visible even the vacuum is aborted.

For seg0, things are different. Because the PANIC occurs right behind
the new segment file is created in a very short time, so the buffer cache
for the new record in the gp_aocsseg_xxxx and the buffer cache for the
related xlog have a big chance to not be flushed to the disk, so when the
seg0 is recovered, we will not see the record in the gp_aocsseg_xxxx. But
if the buffer is flushed to the disk because the checkpointer/bgwriter
before the panic, we will see the new segment file record in the
gp_aocsseg_xxxx table.

This is RCA of the flakiness.

Considering the purpose of the test case, this commit separates the query
to two queries:

1. "SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM
   gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert') where
   segno = 1" to verify the old segment is still visible after the vacuum
   is aborted.
2. "SELECT sum(tupcount) FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_ap
   pendonly_insert') where state = 1 and segno = 2" to verify the new
   segment file contains no tuples.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
