### PR TITLE
Support External Partitioned Tables in ORCA

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -476,6 +476,11 @@ CConfigParamMapping::PackConfigParamInBitset(
 	// enable using opfamilies in distribution specs for GPDB 6
 	traceflag_bitset->ExchangeSet(EopttraceConsiderOpfamiliesForDistribution);
 
+	// disable external partitioned tables until feature complete
+	traceflag_bitset->ExchangeClear(EopttraceEnableExternalPartitionedTables);
+	traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfMultiExternalGet2MultiExternalScan));
+	traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(CXform::ExfExpandDynamicGetWithExternalPartitions));
+
 	return traceflag_bitset;
 }
 

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -863,6 +863,18 @@ gpdb::GetRelationPartContraints(Oid rel_oid, List **default_levels)
 	return NULL;
 }
 
+Node *
+gpdb::GetLeafPartContraints(Oid rel_oid, List **default_levels)
+{
+	GP_WRAP_START;
+	{
+		/* catalog tables: pg_partition, pg_partition_rule, pg_constraint */
+		return get_leaf_part_constraints(rel_oid, default_levels);
+	}
+	GP_WRAP_END;
+	return NULL;
+}
+
 bool
 gpdb::HasExternalPartition(Oid oid)
 {
@@ -875,6 +887,17 @@ gpdb::HasExternalPartition(Oid oid)
 	return false;
 }
 
+List *
+gpdb::GetExternalPartitions(Oid oid)
+{
+	GP_WRAP_START;
+	{
+		/* catalog tables: pg_partition, pg_partition_rule */
+		return rel_get_external_partitions(oid);
+	}
+	GP_WRAP_END;
+	return NIL;
+}
 
 bool
 gpdb::IsLeafPartition(Oid oid)

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -124,6 +124,8 @@ CTranslatorDXLToPlStmt::InitTranslators()
 		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLTblScan},
 		{EdxlopPhysicalExternalScan,
 		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLTblScan},
+		{EdxlopPhysicalMultiExternalScan,
+		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLTblScan},
 		{EdxlopPhysicalIndexScan,
 		 &gpopt::CTranslatorDXLToPlStmt::TranslateDXLIndexScan},
 		{EdxlopPhysicalIndexOnlyScan,

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -120,7 +120,8 @@ CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 	// generate an MDId for the table desc.
 	OID rel_oid = rte->relid;
 
-	if (gpdb::HasExternalPartition(rel_oid))
+	if (!GPOS_FTRACE(EopttraceEnableExternalPartitionedTables) &&
+		gpdb::HasExternalPartition(rel_oid))
 	{
 		// fall back to the planner for queries with partition tables that has an external table in one of its leaf
 		// partitions.

--- a/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
@@ -81,7 +81,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true"/>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true"/>
       </dxl:Relation>
       <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
         <dxl:LeftType Mdid="0.23.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/ExternalPartitionTableNoPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExternalPartitionTableNoPredicate.mdp
@@ -1,0 +1,678 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+  DROP EXTERNAL TABLE IF EXISTS my_sales_ext;
+  DROP TABLE IF EXISTS sales;
+
+  \set loc1 'file://' `hostname` '/tmp/sales0.csv'
+  \set loc2 'file://' `hostname` '/tmp/sales1.csv'
+  \set loc3 'file://' `hostname` '/tmp/sales2.csv'
+
+  CREATE TABLE sales (id int, year int, region text)
+    DISTRIBUTED BY (id) 
+    PARTITION BY RANGE (year) 
+    ( PARTITION yr START (2010) END (2013) EVERY (1) ) ;
+
+  CREATE EXTERNAL TABLE my_sales_ext (id int, year int, region text)
+   LOCATION ( :'loc1', :'loc2', :'loc3')
+   FORMAT 'csv' (HEADER);
+
+  ALTER TABLE sales ALTER PARTITION yr_2 
+     EXCHANGE PARTITION yr_2 
+     WITH TABLE my_sales_ext WITHOUT VALIDATION;
+
+  ALTER TABLE sales RENAME PARTITION yr_2 TO  yr_2_ext ;
+
+  EXPLAIN SELECT * FROM sales;
+
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,103001,103014,103022,103027,103029,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.523.1.0" Name="&lt;=" ComparisonType="LEq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.149.1.0"/>
+        <dxl:Commutator Mdid="0.525.1.0"/>
+        <dxl:InverseOp Mdid="0.521.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.150.1.0"/>
+        <dxl:Commutator Mdid="0.523.1.0"/>
+        <dxl:InverseOp Mdid="0.97.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.8" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.1" Name="year" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.0" Name="id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.3" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="1000000.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.2" Name="region" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.65602.1.0" Name="sales" Rows="1000000.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.65602.1.0" Name="sales" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="r" ConvertHashToRandom="true" NumberLeafPartitions="3">
+        <dxl:Columns>
+          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="year" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="region" Attno="3" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint DefaultPartition="" Unbounded="false">
+          <dxl:And>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="year" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="year" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2013"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+        <dxl:ExternalPartitions>
+          <dxl:ExternalPartition Mdid="0.65630.1.0"/>
+        </dxl:ExternalPartitions>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.5" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.4" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ExternalRelation Mdid="0.65630.1.0" Name="sales_1_prt_yr_2_ext" DistributionPolicy="Random" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="year" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="region" Attno="3" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints>
+          <dxl:CheckConstraint Mdid="0.65633.1.0"/>
+        </dxl:CheckConstraints>
+        <dxl:PartConstraint DefaultPartition="" Unbounded="false">
+          <dxl:And>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="year" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2011"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="year" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:ExternalRelation>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.7" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="id" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="year" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="region" TypeMdid="0.25.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="2" ColName="year" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.65602.1.0" TableName="sales">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="year" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="region" TypeMdid="0.25.1.0" ColWidth="8"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="898.546970" Rows="160000.000000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="id">
+            <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="year">
+            <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="region">
+            <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="889.006703" Rows="160000.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="id">
+              <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="year">
+              <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="region">
+              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:OneTimeFilter/>
+          <dxl:Sequence>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="882.486703" Rows="400000.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="id">
+                <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="year">
+                <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="region">
+                <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:PartitionSelector RelationMdid="0.65602.1.0" PartitionLevels="1" ScanId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:PartEqFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:PartEqFilters>
+              <dxl:PartFilters>
+                <dxl:Or>
+                  <dxl:And>
+                    <dxl:Or>
+                      <dxl:And>
+                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+                        </dxl:Comparison>
+                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                      </dxl:And>
+                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+                      </dxl:Comparison>
+                    </dxl:Or>
+                    <dxl:Or>
+                      <dxl:And>
+                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+                        </dxl:Comparison>
+                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                      </dxl:And>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+                      </dxl:Comparison>
+                    </dxl:Or>
+                  </dxl:And>
+                  <dxl:Or>
+                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                  </dxl:Or>
+                </dxl:Or>
+              </dxl:PartFilters>
+              <dxl:ResidualFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:ResidualFilter>
+              <dxl:PropagationExpression>
+                <dxl:If TypeMdid="0.23.1.0">
+                  <dxl:And>
+                    <dxl:Not>
+                      <dxl:DefaultPart Level="0"/>
+                    </dxl:Not>
+                    <dxl:Or>
+                      <dxl:And>
+                        <dxl:Or>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                            </dxl:Comparison>
+                            <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                          </dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                          </dxl:Comparison>
+                        </dxl:Or>
+                        <dxl:Or>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2011"/>
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                            </dxl:Comparison>
+                            <dxl:Not>
+                              <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                            </dxl:Not>
+                          </dxl:And>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2011"/>
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                          </dxl:Comparison>
+                        </dxl:Or>
+                      </dxl:And>
+                      <dxl:And>
+                        <dxl:Or>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                            </dxl:Comparison>
+                            <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                          </dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                          </dxl:Comparison>
+                        </dxl:Or>
+                        <dxl:Or>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2013"/>
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                            </dxl:Comparison>
+                            <dxl:Not>
+                              <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                            </dxl:Not>
+                          </dxl:And>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2013"/>
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                          </dxl:Comparison>
+                        </dxl:Or>
+                      </dxl:And>
+                    </dxl:Or>
+                  </dxl:And>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  <dxl:If TypeMdid="0.23.1.0">
+                    <dxl:And>
+                      <dxl:Not>
+                        <dxl:DefaultPart Level="0"/>
+                      </dxl:Not>
+                      <dxl:And>
+                        <dxl:Or>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2011"/>
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                            </dxl:Comparison>
+                            <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                          </dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2011"/>
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                          </dxl:Comparison>
+                        </dxl:Or>
+                        <dxl:Or>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                            </dxl:Comparison>
+                            <dxl:Not>
+                              <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                            </dxl:Not>
+                          </dxl:And>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                          </dxl:Comparison>
+                        </dxl:Or>
+                      </dxl:And>
+                    </dxl:And>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                  </dxl:If>
+                </dxl:If>
+              </dxl:PropagationExpression>
+              <dxl:PrintableFilter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+                </dxl:Comparison>
+              </dxl:PrintableFilter>
+            </dxl:PartitionSelector>
+            <dxl:Append IsTarget="false" IsZapped="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="882.486703" Rows="400000.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="id">
+                  <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="year">
+                  <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="region">
+                  <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:DynamicTableScan PartIndexId="2" PrintablePartIndexId="1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="2.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="id">
+                    <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="year">
+                    <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="region">
+                    <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.65602.1.0" TableName="sales">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="year" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="2" Attno="3" ColName="region" TypeMdid="0.25.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:DynamicTableScan>
+              <dxl:ExternalScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="439.433333" Rows="1000000.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="id">
+                    <dxl:Ident ColId="10" ColName="id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="11" Alias="year">
+                    <dxl:Ident ColId="11" ColName="year" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="12" Alias="region">
+                    <dxl:Ident ColId="12" ColName="region" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.65630.1.0" TableName="sales_1_prt_yr_2_ext">
+                  <dxl:Columns>
+                    <dxl:Column ColId="10" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="11" Attno="2" ColName="year" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="3" ColName="region" TypeMdid="0.25.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:ExternalScan>
+            </dxl:Append>
+          </dxl:Sequence>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/ExternalPartitionTableSelectOnPartKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExternalPartitionTableSelectOnPartKey.mdp
@@ -1,0 +1,679 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+  DROP EXTERNAL TABLE IF EXISTS my_sales_ext;
+  DROP TABLE IF EXISTS sales;
+
+  \set loc1 'file://' `hostname` '/tmp/sales0.csv'
+  \set loc2 'file://' `hostname` '/tmp/sales1.csv'
+  \set loc3 'file://' `hostname` '/tmp/sales2.csv'
+
+  CREATE TABLE sales (id int, year int, region text)
+    DISTRIBUTED BY (id) 
+    PARTITION BY RANGE (year) 
+    ( PARTITION yr START (2010) END (2013) EVERY (1) ) ;
+
+  CREATE EXTERNAL TABLE my_sales_ext (id int, year int, region text)
+   LOCATION ( :'loc1', :'loc2', :'loc3')
+   FORMAT 'csv' (HEADER);
+
+  ALTER TABLE sales ALTER PARTITION yr_2 
+     EXCHANGE PARTITION yr_2 
+     WITH TABLE my_sales_ext WITHOUT VALIDATION;
+
+  ALTER TABLE sales RENAME PARTITION yr_2 TO  yr_2_ext ;
+
+  EXPLAIN SELECT * FROM sales WHERE year = 2010;
+
+	TODO: Implement static partition selection with select.
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,103001,103014,103022,103027,103029,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.523.1.0" Name="&lt;=" ComparisonType="LEq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.149.1.0"/>
+        <dxl:Commutator Mdid="0.525.1.0"/>
+        <dxl:InverseOp Mdid="0.521.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.150.1.0"/>
+        <dxl:Commutator Mdid="0.523.1.0"/>
+        <dxl:InverseOp Mdid="0.97.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.8" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.1" Name="year" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.0" Name="id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.3" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="1000000.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.2" Name="region" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.65602.1.0" Name="sales" Rows="1000000.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.65602.1.0" Name="sales" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="r" ConvertHashToRandom="true" NumberLeafPartitions="3">
+        <dxl:Columns>
+          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="year" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="region" Attno="3" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint DefaultPartition="" Unbounded="false">
+          <dxl:And>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="year" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="year" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2013"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+        <dxl:ExternalPartitions>
+          <dxl:ExternalPartition Mdid="0.65630.1.0"/>
+        </dxl:ExternalPartitions>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.5" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.4" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ExternalRelation Mdid="0.65630.1.0" Name="sales_1_prt_yr_2_ext" DistributionPolicy="Random" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="year" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="region" Attno="3" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints>
+          <dxl:CheckConstraint Mdid="0.65633.1.0"/>
+        </dxl:CheckConstraints>
+        <dxl:PartConstraint DefaultPartition="" Unbounded="false">
+          <dxl:And>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="year" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2011"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="year" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:ExternalRelation>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.7" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.65602.1.0.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="id" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="year" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="region" TypeMdid="0.25.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="2" ColName="year" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.65602.1.0" TableName="sales">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="year" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="region" TypeMdid="0.25.1.0" ColWidth="8"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="898.546970" Rows="160000.000000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="id">
+            <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="year">
+            <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="region">
+            <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="889.006703" Rows="160000.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="id">
+              <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="year">
+              <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="region">
+              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:OneTimeFilter/>
+          <dxl:Sequence>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="882.486703" Rows="400000.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="id">
+                <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="year">
+                <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="region">
+                <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:PartitionSelector RelationMdid="0.65602.1.0" PartitionLevels="1" ScanId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:PartEqFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:PartEqFilters>
+              <dxl:PartFilters>
+                <dxl:Or>
+                  <dxl:And>
+                    <dxl:Or>
+                      <dxl:And>
+                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
+                        </dxl:Comparison>
+                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                      </dxl:And>
+                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
+                      </dxl:Comparison>
+                    </dxl:Or>
+                    <dxl:Or>
+                      <dxl:And>
+                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
+                        </dxl:Comparison>
+                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                      </dxl:And>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
+                      </dxl:Comparison>
+                    </dxl:Or>
+                  </dxl:And>
+                  <dxl:Or>
+                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                  </dxl:Or>
+                </dxl:Or>
+              </dxl:PartFilters>
+              <dxl:ResidualFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:ResidualFilter>
+              <dxl:PropagationExpression>
+                <dxl:If TypeMdid="0.23.1.0">
+                  <dxl:And>
+                    <dxl:Not>
+                      <dxl:DefaultPart Level="0"/>
+                    </dxl:Not>
+                    <dxl:Or>
+                      <dxl:And>
+                        <dxl:Or>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                            </dxl:Comparison>
+                            <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                          </dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                          </dxl:Comparison>
+                        </dxl:Or>
+                        <dxl:Or>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2011"/>
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                            </dxl:Comparison>
+                            <dxl:Not>
+                              <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                            </dxl:Not>
+                          </dxl:And>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2011"/>
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                          </dxl:Comparison>
+                        </dxl:Or>
+                      </dxl:And>
+                      <dxl:And>
+                        <dxl:Or>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                            </dxl:Comparison>
+                            <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                          </dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                          </dxl:Comparison>
+                        </dxl:Or>
+                        <dxl:Or>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2013"/>
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                            </dxl:Comparison>
+                            <dxl:Not>
+                              <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                            </dxl:Not>
+                          </dxl:And>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2013"/>
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                          </dxl:Comparison>
+                        </dxl:Or>
+                      </dxl:And>
+                    </dxl:Or>
+                  </dxl:And>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  <dxl:If TypeMdid="0.23.1.0">
+                    <dxl:And>
+                      <dxl:Not>
+                        <dxl:DefaultPart Level="0"/>
+                      </dxl:Not>
+                      <dxl:And>
+                        <dxl:Or>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2011"/>
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                            </dxl:Comparison>
+                            <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
+                          </dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2011"/>
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                          </dxl:Comparison>
+                        </dxl:Or>
+                        <dxl:Or>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+                              <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                            </dxl:Comparison>
+                            <dxl:Not>
+                              <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                            </dxl:Not>
+                          </dxl:And>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
+                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                          </dxl:Comparison>
+                        </dxl:Or>
+                      </dxl:And>
+                    </dxl:And>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                  </dxl:If>
+                </dxl:If>
+              </dxl:PropagationExpression>
+              <dxl:PrintableFilter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
+                </dxl:Comparison>
+              </dxl:PrintableFilter>
+            </dxl:PartitionSelector>
+            <dxl:Append IsTarget="false" IsZapped="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="882.486703" Rows="400000.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="id">
+                  <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="year">
+                  <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="region">
+                  <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:DynamicTableScan PartIndexId="2" PrintablePartIndexId="1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="2.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="id">
+                    <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="year">
+                    <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="region">
+                    <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.65602.1.0" TableName="sales">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="year" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="2" Attno="3" ColName="region" TypeMdid="0.25.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:DynamicTableScan>
+              <dxl:ExternalScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="439.433333" Rows="1000000.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="id">
+                    <dxl:Ident ColId="10" ColName="id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="11" Alias="year">
+                    <dxl:Ident ColId="11" ColName="year" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="12" Alias="region">
+                    <dxl:Ident ColId="12" ColName="region" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.65630.1.0" TableName="sales_1_prt_yr_2_ext">
+                  <dxl:Columns>
+                    <dxl:Column ColId="10" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="11" Attno="2" ColName="year" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="3" ColName="region" TypeMdid="0.25.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:ExternalScan>
+            </dxl:Append>
+          </dxl:Sequence>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-2.mdp
@@ -3400,7 +3400,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.2284492.1.1.11" Name="reason" Width="54.000000" NullFreq="0.785317" NdvRemain="36.000000" FreqRemain="0.789844">

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-vcpart-txt.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-vcpart-txt.mdp
@@ -535,7 +535,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true"/>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true"/>
       </dxl:Relation>
       <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
         <dxl:EqualityOp Mdid="0.98.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned-SortDisabled.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned-SortDisabled.mdp
@@ -177,7 +177,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.24587.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned.mdp
@@ -177,7 +177,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.24587.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -3274,7 +3274,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.353643.1.1.13" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>

--- a/src/backend/gporca/data/dxl/minidump/ListPartLossyCastNEq.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ListPartLossyCastNEq.mdp
@@ -195,10 +195,10 @@ Optimizer: Pivotal Optimizer (GPORCA)
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="false" ExprAbsent="true"/>
         <dxl:DistrOpfamilies>
           <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
         </dxl:DistrOpfamilies>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="false"/>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.77262.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.77262.1.0.0" Name="a" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-1.mdp
@@ -568,7 +568,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17364111.1.1.25" Name="productid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -690,7 +690,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:GPDBScalarOp Mdid="0.1098.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true">
@@ -832,7 +832,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17463072.1.1.31" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -978,7 +978,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.17463072.1.1" Name="mr_star1_voldrip_col_part" Rows="0.000000" EmptyRelation="true"/>
@@ -1100,7 +1100,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.17446437.1.1" Name="mr_star1_skew_col_part" Rows="0.000000" EmptyRelation="true"/>
@@ -1207,7 +1207,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:Relation Mdid="0.17392806.1.1" Name="mr_star1_gammas_col_part" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Column-oriented" DistributionPolicy="Hash" DistributionColumns="9,18,19" Keys="30,31,29" PartitionColumns="2" PartitionTypes="r">
@@ -1312,7 +1312,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17471384.1.1.27" Name="valuationmodelid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -1458,7 +1458,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17421490.1.1.29" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -1589,7 +1589,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:Relation Mdid="0.17384494.1.1" Name="mr_star1_fxdeltas_col_part" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Column-oriented" DistributionPolicy="Hash" DistributionColumns="9,18,19" Keys="30,31,29" PartitionColumns="2" PartitionTypes="r">
@@ -1694,7 +1694,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.17429813.1.1" Name="mr_star1_position_col_part" Rows="0.000000" EmptyRelation="true"/>
@@ -1800,7 +1800,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.17421490.1.1" Name="mr_star1_netexposure_col_part" Rows="0.000000" EmptyRelation="true"/>
@@ -1906,7 +1906,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17463072.1.1.29" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -2052,7 +2052,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
     </dxl:Metadata>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-2.mdp
@@ -568,7 +568,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17364111.1.1.25" Name="productid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -690,7 +690,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:GPDBScalarOp Mdid="0.1098.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true">
@@ -832,7 +832,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17463072.1.1.31" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -978,7 +978,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.17463072.1.1" Name="mr_star1_voldrip_col_part" Rows="0.000000" EmptyRelation="true"/>
@@ -1100,7 +1100,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.17446437.1.1" Name="mr_star1_skew_col_part" Rows="0.000000" EmptyRelation="true"/>
@@ -1207,7 +1207,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:Relation Mdid="0.17392806.1.1" Name="mr_star1_gammas_col_part" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Column-oriented" DistributionPolicy="Hash" DistributionColumns="9,18,19" Keys="30,31,29" PartitionColumns="2" PartitionTypes="r">
@@ -1312,7 +1312,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17471384.1.1.27" Name="valuationmodelid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -1458,7 +1458,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17421490.1.1.29" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -1589,7 +1589,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:Relation Mdid="0.17384494.1.1" Name="mr_star1_fxdeltas_col_part" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Column-oriented" DistributionPolicy="Hash" DistributionColumns="9,18,19" Keys="30,31,29" PartitionColumns="2" PartitionTypes="r">
@@ -1694,7 +1694,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.17429813.1.1" Name="mr_star1_position_col_part" Rows="0.000000" EmptyRelation="true"/>
@@ -1800,7 +1800,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.17421490.1.1" Name="mr_star1_netexposure_col_part" Rows="0.000000" EmptyRelation="true"/>
@@ -1906,7 +1906,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17463072.1.1.29" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -2052,7 +2052,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
     </dxl:Metadata>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-4.mdp
@@ -530,7 +530,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17364111.1.1.25" Name="productid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -652,7 +652,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17421490.1.1.31" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -782,7 +782,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17463072.1.1.31" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -928,7 +928,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.17463072.1.1" Name="mr_star1_voldrip_col_part" Rows="0.000000" EmptyRelation="true"/>
@@ -1034,7 +1034,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.17446437.1.1" Name="mr_star1_skew_col_part" Rows="0.000000" EmptyRelation="true"/>
@@ -1141,7 +1141,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:Relation Mdid="0.17392806.1.1" Name="mr_star1_gammas_col_part" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Column-oriented" DistributionPolicy="Hash" DistributionColumns="9,18,19" Keys="30,31,29" PartitionColumns="2" PartitionTypes="r" NumberLeafPartitions="0">
@@ -1246,7 +1246,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17471384.1.1.27" Name="valuationmodelid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -1392,7 +1392,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17421490.1.1.29" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -1523,7 +1523,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:Relation Mdid="0.17384494.1.1" Name="mr_star1_fxdeltas_col_part" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Column-oriented" DistributionPolicy="Hash" DistributionColumns="9,18,19" Keys="30,31,29" PartitionColumns="2" PartitionTypes="r" NumberLeafPartitions="0">
@@ -1628,7 +1628,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.17429813.1.1" Name="mr_star1_position_col_part" Rows="0.000000" EmptyRelation="true"/>
@@ -1734,7 +1734,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.17421490.1.1" Name="mr_star1_netexposure_col_part" Rows="0.000000" EmptyRelation="true"/>
@@ -1840,7 +1840,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17463072.1.1.29" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -1986,7 +1986,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
     </dxl:Metadata>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-5.mdp
@@ -283,7 +283,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17327104.1.1.27" Name="valuationmodelid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -439,7 +439,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:GPDBScalarOp Mdid="0.1093.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
@@ -590,7 +590,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17327104.1.1.31" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-6.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-6.mdp
@@ -283,7 +283,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17327104.1.1.27" Name="valuationmodelid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -439,7 +439,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:GPDBScalarOp Mdid="0.1093.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
@@ -590,7 +590,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17327104.1.1.31" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-7.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-7.mdp
@@ -283,7 +283,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17327104.1.1.27" Name="valuationmodelid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
@@ -439,7 +439,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:GPDBScalarOp Mdid="0.1093.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
@@ -590,7 +590,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.17327104.1.1.31" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevelPartLossyCastNEq.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevelPartLossyCastNEq.mdp
@@ -224,7 +224,7 @@ default subpartition other2
         <dxl:DistrOpfamilies>
           <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
         </dxl:DistrOpfamilies>
-        <dxl:PartConstraint DefaultPartition="1" Unbounded="false"/>
+        <dxl:PartConstraint DefaultPartition="1" Unbounded="false" ExprAbsent="true"/>
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>

--- a/src/backend/gporca/data/dxl/minidump/PartConstraint-WithOnlyDefaultPartInfo.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartConstraint-WithOnlyDefaultPartInfo.mdp
@@ -82,7 +82,7 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0,1,2" Unbounded="true"/>
+        <dxl:PartConstraint DefaultPartition="0,1,2" Unbounded="true" ExprAbsent="true"/>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.3730374.1.0.9" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.3730374.1.0.8" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
@@ -88,7 +88,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true"/>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true"/>
       </dxl:Relation>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:EqualityOp Mdid="0.91.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide2.mdp
@@ -198,7 +198,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true"/>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true"/>
       </dxl:Relation>
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
       <dxl:ColumnStatistics Mdid="1.90360.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
@@ -710,7 +710,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true"/>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true"/>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.90360.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.010052" DistinctValues="1.000000">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayCoerce.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayCoerce.mdp
@@ -91,7 +91,7 @@ select * from pt where gender in ( 'F', 'FM');
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
@@ -298,7 +298,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.290415.1.1" Name="t" Rows="0.000000"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Limit.mdp
@@ -261,7 +261,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.290415.1.1" Name="t" Rows="0.000000"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-WindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-WindowFunction.mdp
@@ -566,7 +566,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.71822.1.1" Name="jpat" Rows="10000.000000"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IDFList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IDFList.mdp
@@ -192,7 +192,7 @@ EXPLAIN SELECT * FROM listfoo WHERE b IS DISTINCT FROM 2;
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true"/>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true"/>
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IDFNull.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IDFNull.mdp
@@ -168,7 +168,7 @@ EXPLAIN SELECT * FROM listfoo WHERE b IS DISTINCT FROM NULL;
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true"/>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true"/>
       </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IsNullPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IsNullPredicate.mdp
@@ -181,7 +181,7 @@ explain select * from dd_part_singlecol where a is null and b is null;
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
     </dxl:Metadata>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Int-Predicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Int-Predicates.mdp
@@ -166,7 +166,7 @@ select * from foo where b is not null;
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.322247.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Varchar-Predicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Varchar-Predicates.mdp
@@ -213,7 +213,7 @@ select * from pt where gender is null;
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.321479.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-RangeJoinPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-RangeJoinPred.mdp
@@ -645,7 +645,7 @@ where d.msisdn=f.subscriberaddress and f.sessioncreationtimestamp >= d.start_dtm
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoDisjunctPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoDisjunctPredPushDown.mdp
@@ -72,7 +72,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true"/>
+        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true" ExprAbsent="true"/>
       </dxl:Relation>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:EqualityOp Mdid="0.91.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoPredPushDown.mdp
@@ -198,7 +198,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true"/>
+        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true" ExprAbsent="true"/>
       </dxl:Relation>
       <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="false" Length="-1" PassByValue="false">
         <dxl:EqualityOp Mdid="0.1752.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPartialPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPartialPredPushDown.mdp
@@ -198,7 +198,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true"/>
+        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true" ExprAbsent="true"/>
       </dxl:Relation>
       <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="false" Length="-1" PassByValue="false">
         <dxl:EqualityOp Mdid="0.1752.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
@@ -211,7 +211,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true"/>
+        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true" ExprAbsent="true"/>
       </dxl:Relation>
       <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="false" Length="-1" PassByValue="false">
         <dxl:EqualityOp Mdid="0.1752.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncSinglePredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncSinglePredPushDown.mdp
@@ -72,7 +72,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true"/>
+        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true" ExprAbsent="true"/>
       </dxl:Relation>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:EqualityOp Mdid="0.91.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
@@ -566,7 +566,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.71822.1.1" Name="jpat" Rows="10000.000000"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
@@ -188,7 +188,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.224805.1.1.3" Name="ctid" Width="6.000000"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdatePartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdatePartTable.mdp
@@ -188,7 +188,7 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.224805.1.1.3" Name="ctid" Width="6.000000"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-Default.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-Default.mdp
@@ -193,7 +193,7 @@ select * from PT where j < 5 and k = 4;
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level1-Default.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level1-Default.mdp
@@ -169,7 +169,7 @@ select * from PT where k < 4;
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-Default.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-Default.mdp
@@ -193,7 +193,7 @@ select * from PT where j = 5;
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
-        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true">
+        <dxl:PartConstraint DefaultPartition="0,1" Unbounded="true" ExprAbsent="true">
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
@@ -42,6 +42,7 @@ const CCostModelGPDB::SCostMapping CCostModelGPDB::m_rgcm[] = {
 	{COperator::EopPhysicalTableScan, CostScan},
 	{COperator::EopPhysicalDynamicTableScan, CostScan},
 	{COperator::EopPhysicalExternalScan, CostScan},
+	{COperator::EopPhysicalMultiExternalScan, CostScan},
 
 	{COperator::EopPhysicalFilter, CostFilter},
 
@@ -1876,7 +1877,8 @@ CCostModelGPDB::CostScan(CMemoryPool *,	 // mp
 	COperator::EOperatorId op_id = pop->Eopid();
 	GPOS_ASSERT(COperator::EopPhysicalTableScan == op_id ||
 				COperator::EopPhysicalDynamicTableScan == op_id ||
-				COperator::EopPhysicalExternalScan == op_id);
+				COperator::EopPhysicalExternalScan == op_id ||
+				COperator::EopPhysicalMultiExternalScan == op_id);
 
 	const CDouble dInitScan =
 		pcmgpdb->GetCostModelParams()
@@ -1897,6 +1899,7 @@ CCostModelGPDB::CostScan(CMemoryPool *,	 // mp
 		case COperator::EopPhysicalTableScan:
 		case COperator::EopPhysicalDynamicTableScan:
 		case COperator::EopPhysicalExternalScan:
+		case COperator::EopPhysicalMultiExternalScan:
 			// table scan cost considers only retrieving tuple cost,
 			// since we scan the entire table here, the cost is correlated with table rows and table width,
 			// since Scan's parent operator may be a filter that will be pushed into Scan node in GPDB plan,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
@@ -87,7 +87,8 @@ public:
 						   CPartConstraint *ppartcnstrRel);
 
 	CLogicalDynamicGetBase(CMemoryPool *mp, const CName *pnameAlias,
-						   CTableDescriptor *ptabdesc, ULONG scan_id);
+						   CTableDescriptor *ptabdesc, ULONG scan_id,
+						   CColRefArray *pdrgpcrOutput);
 
 	// dtor
 	virtual ~CLogicalDynamicGetBase();

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalGet.h
@@ -224,7 +224,8 @@ public:
 	{
 		GPOS_ASSERT(NULL != pop);
 		GPOS_ASSERT(EopLogicalGet == pop->Eopid() ||
-					EopLogicalExternalGet == pop->Eopid());
+					EopLogicalExternalGet == pop->Eopid() ||
+					EopLogicalMultiExternalGet == pop->Eopid());
 
 		return dynamic_cast<CLogicalGet *>(pop);
 	}

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalMultiExternalGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalMultiExternalGet.h
@@ -1,0 +1,137 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2013 Pivotal, Inc.
+//
+//	@filename:
+//		CLogicalMultiExternalGet.h
+//
+//	@doc:
+//  	Logical external get operator for multiple tables sharing a common
+//  	column layout
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CLogicalMultiExternalGet_H
+#define GPOPT_CLogicalMultiExternalGet_H
+
+#include "gpos/base.h"
+#include "gpopt/operators/CLogicalDynamicGetBase.h"
+
+namespace gpopt
+{
+// fwd declarations
+class CTableDescriptor;
+class CName;
+class CColRefSet;
+
+// Logical external get operator for multiple tables sharing a common column layout
+// Currently only used for external leaf partitions in a partitioned table.
+class CLogicalMultiExternalGet : public CLogicalDynamicGetBase
+{
+private:
+	// private copy ctor
+	CLogicalMultiExternalGet(const CLogicalMultiExternalGet &);
+
+	// partition mdids to scan
+	IMdIdArray *m_part_mdids;
+
+public:
+	// ctors
+	explicit CLogicalMultiExternalGet(CMemoryPool *mp);
+
+	CLogicalMultiExternalGet(CMemoryPool *mp, IMdIdArray *part_mdids,
+							 const CName *pnameAlias,
+							 CTableDescriptor *ptabdesc, ULONG scan_id,
+							 CColRefArray *pdrgpcrOutput);
+
+	~CLogicalMultiExternalGet();
+
+	// ident accessors
+
+	IMdIdArray *
+	GetScanPartitionMdids() const
+	{
+		return m_part_mdids;
+	}
+
+	virtual EOperatorId
+	Eopid() const
+	{
+		return EopLogicalMultiExternalGet;
+	}
+
+	// return a string for operator name
+	virtual const CHAR *
+	SzId() const
+	{
+		return "CLogicalMultiExternalGet";
+	}
+
+	// match function
+	virtual BOOL Matches(COperator *pop) const;
+
+	// return a copy of the operator with remapped columns
+	virtual COperator *PopCopyWithRemappedColumns(
+		CMemoryPool *mp, UlongToColRefMap *colref_mapping, BOOL must_exist);
+
+	//-------------------------------------------------------------------------------------
+	// Required Relational Properties
+	//-------------------------------------------------------------------------------------
+
+	// compute required stat columns of the n-th child
+	virtual CColRefSet *
+	PcrsStat(CMemoryPool *,		   // mp,
+			 CExpressionHandle &,  // exprhdl
+			 CColRefSet *,		   // pcrsInput
+			 ULONG				   // child_index
+	) const
+	{
+		GPOS_ASSERT(!"CLogicalMultiExternalGet has no children");
+		return NULL;
+	}
+
+	// sensitivity to order of inputs
+	virtual BOOL
+	FInputOrderSensitive() const
+	{
+		GPOS_ASSERT(!"Unexpected function call of FInputOrderSensitive");
+		return false;
+	}
+
+	// derive statistics
+	virtual IStatistics *PstatsDerive(CMemoryPool *mp,
+									  CExpressionHandle &exprhdl,
+									  IStatisticsArray *stats_ctxt) const;
+
+	// stat promise
+	virtual EStatPromise
+	Esp(CExpressionHandle &) const
+	{
+		return CLogical::EspHigh;
+	}
+
+	//-------------------------------------------------------------------------------------
+	// Transformations
+	//-------------------------------------------------------------------------------------
+
+	// candidate set of xforms
+	virtual CXformSet *PxfsCandidates(CMemoryPool *mp) const;
+
+	//-------------------------------------------------------------------------------------
+	//-------------------------------------------------------------------------------------
+	//-------------------------------------------------------------------------------------
+
+	// conversion function
+	static CLogicalMultiExternalGet *
+	PopConvert(COperator *pop)
+	{
+		GPOS_ASSERT(NULL != pop);
+		GPOS_ASSERT(EopLogicalMultiExternalGet == pop->Eopid());
+
+		return dynamic_cast<CLogicalMultiExternalGet *>(pop);
+	}
+
+};	// class CLogicalMultiExternalGet
+}  // namespace gpopt
+
+#endif	// !GPOPT_CLogicalMultiExternalGet_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
@@ -142,6 +142,7 @@ public:
 		EopLogicalPartitionSelector,
 		EopLogicalAssert,
 		EopLogicalMaxOneRow,
+		EopLogicalMultiExternalGet,
 
 		EopScalarCmp,
 		EopScalarIsDistinctFrom,
@@ -259,6 +260,7 @@ public:
 
 		EopLogicalDynamicBitmapTableGet,
 		EopPhysicalDynamicBitmapTableScan,
+		EopPhysicalMultiExternalScan,
 
 		EopSentinel
 	};

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalMultiExternalScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalMultiExternalScan.h
@@ -1,0 +1,124 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2013 Pivotal, Inc.
+//
+//	@filename:
+//		CPhysicalMultiExternalScan.h
+//
+//	@doc:
+//  	External scan operator for multiple tables sharing a common
+//  	column layout
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CPhysicalMultiExternalScan_H
+#define GPOPT_CPhysicalMultiExternalScan_H
+
+#include "gpos/base.h"
+#include "gpopt/operators/CPhysicalDynamicScan.h"
+
+namespace gpopt
+{
+// External scan operator for multiple tables sharing a common column layout.
+// Currently only used for external leaf partitions in a partitioned table.
+class CPhysicalMultiExternalScan : public CPhysicalDynamicScan
+{
+private:
+	// private copy ctor
+	CPhysicalMultiExternalScan(const CPhysicalMultiExternalScan &);
+
+	// partition mdids to scan
+	IMdIdArray *m_part_mdids;
+
+public:
+	// ctor
+	CPhysicalMultiExternalScan(CMemoryPool *mp, IMdIdArray *part_mdids,
+							   BOOL is_partial, CTableDescriptor *ptabdesc,
+							   ULONG ulOriginOpId, const CName *pnameAlias,
+							   ULONG scan_id, CColRefArray *pdrgpcrOutput,
+							   CColRef2dArray *pdrgpdrgpcrParts,
+							   ULONG ulSecondaryScanId,
+							   CPartConstraint *ppartcnstr,
+							   CPartConstraint *ppartcnstrRel);
+
+	~CPhysicalMultiExternalScan();
+
+	// ident accessors
+	IMdIdArray *
+	GetScanPartitionMdids() const
+	{
+		return m_part_mdids;
+	}
+
+	virtual EOperatorId
+	Eopid() const
+	{
+		return EopPhysicalMultiExternalScan;
+	}
+
+	// return a string for operator name
+	virtual const CHAR *
+	SzId() const
+	{
+		return "CPhysicalMultiExternalScan";
+	}
+
+	// match function
+	virtual BOOL Matches(COperator *) const;
+
+	// statistics derivation during costing
+	virtual IStatistics *
+	PstatsDerive(CMemoryPool *,		   // mp
+				 CExpressionHandle &,  // exprhdl
+				 CReqdPropPlan *,	   // prpplan
+				 IStatisticsArray *	   //stats_ctxt
+	) const
+	{
+		GPOS_ASSERT(
+			!"stats derivation during costing for table scan is invalid");
+
+		return NULL;
+	}
+
+	//-------------------------------------------------------------------------------------
+	// Derived Plan Properties
+	//-------------------------------------------------------------------------------------
+
+	// derive rewindability
+	virtual CRewindabilitySpec *
+	PrsDerive(CMemoryPool *mp,
+			  CExpressionHandle &  // exprhdl
+	) const
+	{
+		// external tables are neither rewindable nor rescannable
+		return GPOS_NEW(mp) CRewindabilitySpec(
+			CRewindabilitySpec::ErtNone, CRewindabilitySpec::EmhtNoMotion);
+	}
+
+	//-------------------------------------------------------------------------------------
+	// Enforced Properties
+	//-------------------------------------------------------------------------------------
+
+	// return rewindability property enforcing type for this operator
+	virtual CEnfdProp::EPropEnforcingType EpetRewindability(
+		CExpressionHandle &exprhdl, const CEnfdRewindability *per) const;
+
+	//-------------------------------------------------------------------------------------
+	//-------------------------------------------------------------------------------------
+	//-------------------------------------------------------------------------------------
+
+	// conversion function
+	static CPhysicalMultiExternalScan *
+	PopConvert(COperator *pop)
+	{
+		GPOS_ASSERT(NULL != pop);
+		GPOS_ASSERT(EopPhysicalMultiExternalScan == pop->Eopid());
+
+		return reinterpret_cast<CPhysicalMultiExternalScan *>(pop);
+	}
+
+};	// class CPhysicalMultiExternalScan
+
+}  // namespace gpopt
+
+#endif	// !GPOPT_CPhysicalMultiExternalScan_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalTableScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalTableScan.h
@@ -80,7 +80,8 @@ public:
 	{
 		GPOS_ASSERT(NULL != pop);
 		GPOS_ASSERT(EopPhysicalTableScan == pop->Eopid() ||
-					EopPhysicalExternalScan == pop->Eopid());
+					EopPhysicalExternalScan == pop->Eopid() ||
+					EopPhysicalMultiExternalScan == pop->Eopid());
 
 		return reinterpret_cast<CPhysicalTableScan *>(pop);
 	}

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/ops.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/ops.h
@@ -66,6 +66,7 @@
 #include "gpopt/operators/CLogicalIntersectAll.h"
 #include "gpopt/operators/CLogicalGet.h"
 #include "gpopt/operators/CLogicalExternalGet.h"
+#include "gpopt/operators/CLogicalMultiExternalGet.h"
 #include "gpopt/operators/CLogicalIndexGet.h"
 #include "gpopt/operators/CLogicalDynamicIndexGet.h"
 #include "gpopt/operators/CLogicalBitmapTableGet.h"
@@ -118,6 +119,7 @@
 // physical ops
 #include "gpopt/operators/CPhysicalTableScan.h"
 #include "gpopt/operators/CPhysicalExternalScan.h"
+#include "gpopt/operators/CPhysicalMultiExternalScan.h"
 #include "gpopt/operators/CPhysicalIndexScan.h"
 #include "gpopt/operators/CPhysicalBitmapTableScan.h"
 #include "gpopt/operators/CPhysicalFilter.h"

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -393,6 +393,14 @@ private:
 									CDistributionSpecArray *pdrgpdsBaseTables,
 									ULONG *pulNonGatherMotions, BOOL *pfDML);
 
+	// translate a multi external scan to multiple external scans
+	CDXLNode *PdxlnMultiExternalScan(CExpression *pexprTblScan,
+									 CColRefSet *pcrsOutput,
+									 CColRefArray *colref_array,
+									 CDistributionSpecArray *pdrgpdsBaseTables,
+									 CExpression *pexprScalarCond,
+									 CDXLPhysicalProperties *dxl_properties);
+
 	// translate a const table get into a result node
 	CDXLNode *PdxlnResultFromConstTableGet(
 		CExpression *pexprCTG, CColRefArray *colref_array,

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
@@ -222,6 +222,8 @@ public:
 		ExfIndexGet2IndexOnlyScan,
 		ExfJoin2BitmapIndexGetApply,
 		ExfJoin2IndexGetApply,
+		ExfMultiExternalGet2MultiExternalScan,
+		ExfExpandDynamicGetWithExternalPartitions,
 		ExfInvalid,
 		ExfSentinel = ExfInvalid
 	};

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformExpandDynamicGetWithExternalPartitions.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformExpandDynamicGetWithExternalPartitions.h
@@ -1,0 +1,106 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2012 EMC Corp.
+//
+//	@filename:
+//		CXformExpandDynamicGetWithExternalPartitions.h
+//
+//	@doc:
+//  	Transform DynamicGet to a UNION ALL of a DynamicGet without External
+//  	partitions and a MultiExternalGet that encapsulates all the external
+//  	partitions.
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CXformExpandDynamicGetWithExternalPartitions_H
+#define GPOPT_CXformExpandDynamicGetWithExternalPartitions_H
+
+#include "gpos/base.h"
+#include "gpopt/xforms/CXformExploration.h"
+#include "gpopt/operators/CLogicalDynamicGet.h"
+#include "gpopt/operators/CExpressionHandle.h"
+
+namespace gpopt
+{
+using namespace gpos;
+
+//---------------------------------------------------------------------------
+//	@class:
+//		CXformExpandDynamicGetWithExternalPartitions
+//
+//	@doc:
+//  	Transform DynamicGet to a UNION ALL of a DynamicGet without External
+//  	partitions and a MultiExternalGet that encapsulates all the external
+//  	partitions.
+//---------------------------------------------------------------------------
+class CXformExpandDynamicGetWithExternalPartitions : public CXformExploration
+{
+private:
+	// private copy ctor
+	CXformExpandDynamicGetWithExternalPartitions(
+		const CXformExpandDynamicGetWithExternalPartitions &);
+
+public:
+	// ctor
+	explicit CXformExpandDynamicGetWithExternalPartitions(CMemoryPool *mp);
+
+	// dtor
+	virtual ~CXformExpandDynamicGetWithExternalPartitions()
+	{
+	}
+
+	// ident accessors
+	virtual EXformId
+	Exfid() const
+	{
+		return ExfExpandDynamicGetWithExternalPartitions;
+	}
+
+	// return a string for xform name
+	virtual const CHAR *
+	SzId() const
+	{
+		return "CXformExpandDynamicGetWithExternalPartitions";
+	}
+
+	// compute xform promise for a given expression handle
+	virtual EXformPromise
+	Exfp(CExpressionHandle &exprhdl) const
+	{
+		CLogicalDynamicGet *popGet =
+			CLogicalDynamicGet::PopConvert(exprhdl.Pop());
+		CTableDescriptor *ptabdesc = popGet->Ptabdesc();
+		CMDAccessor *mda = COptCtxt::PoctxtFromTLS()->Pmda();
+
+		const IMDRelation *relation = mda->RetrieveRel(ptabdesc->MDId());
+		if (relation->HasExternalPartitions())
+		{
+			if (popGet->IsPartial())
+			{
+				// Prevent unneccesary re-execution of this xform once a
+				// DynamicGet has already been split. In such a case, a
+				// Partitial DynamicGet is produced, and any indexes or external
+				// partitions are handled separately.
+				return CXform::ExfpNone;
+			}
+
+			// Run the xform only on a non-partial DynamicGet with external
+			// partitions
+			return CXform::ExfpHigh;
+		}
+
+		// No need to run this xform if the relation being scanned does not
+		// contain external partitions
+		return CXform::ExfpNone;
+	}
+
+	// actual transform
+	void Transform(CXformContext *pxfctxt, CXformResult *pxfres,
+				   CExpression *pexpr) const;
+
+};	// class CXformExpandDynamicGetWithExternalPartitions
+
+}  // namespace gpopt
+
+
+#endif	// !GPOPT_CXformExpandDynamicGetWithExternalPartitions_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformMultiExternalGet2MultiExternalScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformMultiExternalGet2MultiExternalScan.h
@@ -1,0 +1,72 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2013 Pivotal, Inc.
+//
+//	@filename:
+//		CXformMultiExternalGet2MultiExternalScan.h
+//
+//	@doc:
+//		Transform MultiExternalGet to MultiExternalScan
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CXformMultiExternalGet2MultiExternalScan_H
+#define GPOPT_CXformMultiExternalGet2MultiExternalScan_H
+
+#include "gpos/base.h"
+#include "gpopt/xforms/CXformImplementation.h"
+
+namespace gpopt
+{
+using namespace gpos;
+
+//---------------------------------------------------------------------------
+//	@class:
+//		CXformMultiExternalGet2MultiExternalScan
+//
+//	@doc:
+//		Transform MultiExternalGet to MultiExternalScan
+//
+//---------------------------------------------------------------------------
+class CXformMultiExternalGet2MultiExternalScan : public CXformImplementation
+{
+private:
+	// private copy ctor
+	CXformMultiExternalGet2MultiExternalScan(
+		const CXformMultiExternalGet2MultiExternalScan &);
+
+public:
+	// ctor
+	explicit CXformMultiExternalGet2MultiExternalScan(CMemoryPool *);
+
+	// dtor
+	virtual ~CXformMultiExternalGet2MultiExternalScan()
+	{
+	}
+
+	// ident accessors
+	virtual EXformId
+	Exfid() const
+	{
+		return ExfMultiExternalGet2MultiExternalScan;
+	}
+
+	// return a string for xform name
+	virtual const CHAR *
+	SzId() const
+	{
+		return "CXformMultiExternalGet2MultiExternalScan";
+	}
+
+	// compute xform promise for a given expression handle
+	virtual EXformPromise Exfp(CExpressionHandle &exprhdl) const;
+
+	// actual transform
+	virtual void Transform(CXformContext *pxfctxt, CXformResult *pxfres,
+						   CExpression *pexpr) const;
+
+};	// class CXformMultiExternalGet2MultiExternalScan
+
+}  // namespace gpopt
+
+#endif	// !GPOPT_CXformMultiExternalGet2MultiExternalScan_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -335,11 +335,6 @@ private:
 		CMemoryPool *mp, BOOL fConjunction, CExpression *pexprOriginalPred,
 		CExpression **ppexprResidual, CExpressionArray *pdrgpexprResidualNew);
 
-	// compute a disjunction of two part constraints
-	static CPartConstraint *PpartcnstrDisjunction(
-		CMemoryPool *mp, CPartConstraint *ppartcnstrOld,
-		CPartConstraint *ppartcnstrNew);
-
 	// construct a bitmap index path expression for the given predicate coming
 	// from a condition without outer references
 	static CExpression *PexprBitmapSelectBestIndex(
@@ -643,6 +638,11 @@ public:
 	// over bitmap bool op
 	static CExpression *PexprSelect2BitmapBoolOp(CMemoryPool *mp,
 												 CExpression *pexpr);
+
+	// compute a disjunction of two part constraints
+	static CPartConstraint *PpartcnstrDisjunction(
+		CMemoryPool *mp, CPartConstraint *ppartcnstrOld,
+		CPartConstraint *ppartcnstrNew);
 
 	// find a set of partial index combinations
 	static SPartDynamicIndexGetInfoArrays *PdrgpdrgppartdigCandidates(

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
@@ -19,6 +19,7 @@
 
 #include "gpopt/xforms/CXformGet2TableScan.h"
 #include "gpopt/xforms/CXformExternalGet2ExternalScan.h"
+#include "gpopt/xforms/CXformMultiExternalGet2MultiExternalScan.h"
 #include "gpopt/xforms/CXformDynamicGet2DynamicTableScan.h"
 #include "gpopt/xforms/CXformDynamicIndexGet2DynamicIndexScan.h"
 #include "gpopt/xforms/CXformSelect2DynamicIndexGet.h"
@@ -165,6 +166,8 @@
 #include "gpopt/xforms/CXformGbAggWithMDQA2Join.h"
 #include "gpopt/xforms/CXformMaxOneRow2Assert.h"
 #include "gpopt/xforms/CXformRemoveSubqDistinct.h"
+
+#include "gpopt/xforms/CXformExpandDynamicGetWithExternalPartitions.h"
 
 #endif	// !GPOPT_xforms_H
 

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecExternal.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecExternal.cpp
@@ -57,7 +57,7 @@ CDistributionSpecExternal::FSatisfies(const CDistributionSpec *pds) const
 		return true;
 	}
 
-	return EdtAny == pds->Edt();
+	return EdtAny == pds->Edt() || EdtNonSingleton == pds->Edt();
 }
 
 void

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGet.cpp
@@ -74,7 +74,8 @@ CLogicalDynamicGet::CLogicalDynamicGet(
 CLogicalDynamicGet::CLogicalDynamicGet(CMemoryPool *mp, const CName *pnameAlias,
 									   CTableDescriptor *ptabdesc,
 									   ULONG ulPartIndex)
-	: CLogicalDynamicGetBase(mp, pnameAlias, ptabdesc, ulPartIndex)
+	: CLogicalDynamicGetBase(mp, pnameAlias, ptabdesc, ulPartIndex,
+							 NULL /* pdrgpcrOutput*/)
 {
 }
 
@@ -194,6 +195,8 @@ CLogicalDynamicGet::PxfsCandidates(CMemoryPool *mp) const
 {
 	CXformSet *xform_set = GPOS_NEW(mp) CXformSet(mp);
 	(void) xform_set->ExchangeSet(CXform::ExfDynamicGet2DynamicTableScan);
+	(void) xform_set->ExchangeSet(
+		CXform::ExfExpandDynamicGetWithExternalPartitions);
 	return xform_set;
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGetBase.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGetBase.cpp
@@ -95,7 +95,6 @@ CLogicalDynamicGetBase::CLogicalDynamicGetBase(
 	m_pcrsDist = CLogical::PcrsDist(mp, m_ptabdesc, m_pdrgpcrOutput);
 }
 
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CLogicalDynamicGetBase::CLogicalDynamicGetBase
@@ -107,12 +106,13 @@ CLogicalDynamicGetBase::CLogicalDynamicGetBase(
 CLogicalDynamicGetBase::CLogicalDynamicGetBase(CMemoryPool *mp,
 											   const CName *pnameAlias,
 											   CTableDescriptor *ptabdesc,
-											   ULONG scan_id)
+											   ULONG scan_id,
+											   CColRefArray *pdrgpcrOutput)
 	: CLogical(mp),
 	  m_pnameAlias(pnameAlias),
 	  m_ptabdesc(ptabdesc),
 	  m_scan_id(scan_id),
-	  m_pdrgpcrOutput(NULL),
+	  m_pdrgpcrOutput(pdrgpcrOutput),
 	  m_ulSecondaryScanId(scan_id),
 	  m_is_partial(false),
 	  m_part_constraint(NULL),
@@ -122,9 +122,12 @@ CLogicalDynamicGetBase::CLogicalDynamicGetBase(CMemoryPool *mp,
 	GPOS_ASSERT(NULL != ptabdesc);
 	GPOS_ASSERT(NULL != pnameAlias);
 
-	// generate a default column set for the table descriptor
-	m_pdrgpcrOutput = PdrgpcrCreateMapping(mp, m_ptabdesc->Pdrgpcoldesc(),
-										   UlOpId(), m_ptabdesc->MDId());
+	// generate a default column set for the table descriptor if not passed in
+	if (NULL == m_pdrgpcrOutput)
+	{
+		m_pdrgpcrOutput = PdrgpcrCreateMapping(mp, m_ptabdesc->Pdrgpcoldesc(),
+											   UlOpId(), m_ptabdesc->MDId());
+	}
 	m_pdrgpdrgpcrPart = PdrgpdrgpcrCreatePartCols(mp, m_pdrgpcrOutput,
 												  m_ptabdesc->PdrgpulPart());
 

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalMultiExternalGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalMultiExternalGet.cpp
@@ -1,0 +1,156 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2013 Pivotal, Inc.
+//
+//	@filename:
+//		CLogicalMultiExternalGet.cpp
+//
+//	@doc:
+//		Implementation of external get
+//---------------------------------------------------------------------------
+
+#include "gpos/base.h"
+
+#include "gpopt/base/CUtils.h"
+#include "gpopt/base/CColRefSet.h"
+#include "gpopt/base/CColRefSetIter.h"
+#include "gpopt/base/CColRefTable.h"
+#include "gpopt/base/COptCtxt.h"
+
+#include "gpopt/operators/CLogicalMultiExternalGet.h"
+#include "gpopt/metadata/CTableDescriptor.h"
+#include "gpopt/metadata/CName.h"
+
+#include "naucrates/statistics/CStatistics.h"
+
+using namespace gpopt;
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CLogicalMultiExternalGet::CLogicalMultiExternalGet
+//
+//	@doc:
+//		Ctor - for pattern
+//
+//---------------------------------------------------------------------------
+CLogicalMultiExternalGet::CLogicalMultiExternalGet(CMemoryPool *mp)
+	: CLogicalDynamicGetBase(mp), m_part_mdids(NULL)
+{
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CLogicalMultiExternalGet::CLogicalMultiExternalGet
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CLogicalMultiExternalGet::CLogicalMultiExternalGet(
+	CMemoryPool *mp, IMdIdArray *part_mdids, const CName *pnameAlias,
+	CTableDescriptor *ptabdesc, ULONG scan_id, CColRefArray *pdrgpcrOutput)
+	: CLogicalDynamicGetBase(mp, pnameAlias, ptabdesc, scan_id, pdrgpcrOutput),
+	  m_part_mdids(part_mdids)
+{
+	GPOS_ASSERT(NULL != m_part_mdids && m_part_mdids->Size() > 0);
+}
+
+CLogicalMultiExternalGet::~CLogicalMultiExternalGet()
+{
+	CRefCount::SafeRelease(m_part_mdids);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CLogicalMultiExternalGet::Matches
+//
+//	@doc:
+//		Match function on operator level
+//
+//---------------------------------------------------------------------------
+BOOL
+CLogicalMultiExternalGet::Matches(COperator *pop) const
+{
+	if (pop->Eopid() != Eopid())
+	{
+		return false;
+	}
+	CLogicalMultiExternalGet *popGet =
+		CLogicalMultiExternalGet::PopConvert(pop);
+
+	return Ptabdesc() == popGet->Ptabdesc() &&
+		   PdrgpcrOutput()->Equals(popGet->PdrgpcrOutput());
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CLogicalMultiExternalGet::PopCopyWithRemappedColumns
+//
+//	@doc:
+//		Return a copy of the operator with remapped columns
+//
+//---------------------------------------------------------------------------
+COperator *
+CLogicalMultiExternalGet::PopCopyWithRemappedColumns(
+	CMemoryPool *mp, UlongToColRefMap *colref_mapping, BOOL must_exist)
+{
+	CColRefArray *pdrgpcrOutput = NULL;
+	if (must_exist)
+	{
+		pdrgpcrOutput =
+			CUtils::PdrgpcrRemapAndCreate(mp, PdrgpcrOutput(), colref_mapping);
+	}
+	else
+	{
+		pdrgpcrOutput = CUtils::PdrgpcrRemap(mp, PdrgpcrOutput(),
+											 colref_mapping, must_exist);
+	}
+	CName *pnameAlias = GPOS_NEW(mp) CName(mp, Name());
+
+	CTableDescriptor *ptabdesc = Ptabdesc();
+	ptabdesc->AddRef();
+
+	m_part_mdids->AddRef();
+
+	return GPOS_NEW(mp) CLogicalMultiExternalGet(
+		mp, m_part_mdids, pnameAlias, ptabdesc, ScanId(), pdrgpcrOutput);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CLogicalMultiExternalGet::PxfsCandidates
+//
+//	@doc:
+//		Get candidate xforms
+//
+//---------------------------------------------------------------------------
+CXformSet *
+CLogicalMultiExternalGet::PxfsCandidates(CMemoryPool *mp) const
+{
+	CXformSet *xform_set = GPOS_NEW(mp) CXformSet(mp);
+	(void) xform_set->ExchangeSet(
+		CXform::ExfMultiExternalGet2MultiExternalScan);
+
+	return xform_set;
+}
+
+IStatistics *
+CLogicalMultiExternalGet::PstatsDerive(CMemoryPool *mp,
+									   CExpressionHandle &exprhdl,
+									   IStatisticsArray *  // not used
+) const
+{
+	// requesting stats on distribution columns to estimate data skew
+	IStatistics *pstatsTable =
+		PstatsBaseTable(mp, exprhdl, m_ptabdesc, m_pcrsDist);
+
+	CColRefSet *pcrs = GPOS_NEW(mp) CColRefSet(mp, m_pdrgpcrOutput);
+	CUpperBoundNDVs *upper_bound_NDVs =
+		GPOS_NEW(mp) CUpperBoundNDVs(pcrs, pstatsTable->Rows());
+	CStatistics::CastStats(pstatsTable)->AddCardUpperBound(upper_bound_NDVs);
+
+	return pstatsTable;
+}
+
+// EOF

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalMultiExternalScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalMultiExternalScan.cpp
@@ -1,0 +1,107 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2013 Pivotal, Inc.
+//
+//	@filename:
+//		CPhysicalMultiExternalScan.cpp
+//
+//	@doc:
+//		Implementation of external scan operator
+//---------------------------------------------------------------------------
+
+#include "gpos/base.h"
+#include "gpopt/base/CDistributionSpecExternal.h"
+
+#include "gpopt/operators/CExpressionHandle.h"
+#include "gpopt/operators/CPhysicalMultiExternalScan.h"
+#include "gpopt/metadata/CTableDescriptor.h"
+#include "gpopt/metadata/CName.h"
+
+using namespace gpopt;
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalMultiExternalScan::CPhysicalMultiExternalScan
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CPhysicalMultiExternalScan::CPhysicalMultiExternalScan(
+	CMemoryPool *mp, IMdIdArray *part_mdids, BOOL is_partial,
+	CTableDescriptor *ptabdesc, ULONG ulOriginOpId, const CName *pnameAlias,
+	ULONG scan_id, CColRefArray *pdrgpcrOutput,
+	CColRef2dArray *pdrgpdrgpcrParts, ULONG ulSecondaryScanId,
+	CPartConstraint *ppartcnstr, CPartConstraint *ppartcnstrRel)
+	: CPhysicalDynamicScan(mp, is_partial, ptabdesc, ulOriginOpId, pnameAlias,
+						   scan_id, pdrgpcrOutput, pdrgpdrgpcrParts,
+						   ulSecondaryScanId, ppartcnstr, ppartcnstrRel),
+	  m_part_mdids(part_mdids)
+{
+	// if this table is master only, then keep the original distribution spec.
+	if (IMDRelation::EreldistrMasterOnly == ptabdesc->GetRelDistribution())
+	{
+		return;
+	}
+
+	// otherwise, override the distribution spec for external table
+	if (m_pds)
+	{
+		m_pds->Release();
+	}
+
+	m_pds = GPOS_NEW(mp) CDistributionSpecExternal();
+
+	GPOS_ASSERT(NULL != m_part_mdids && m_part_mdids->Size() > 0);
+}
+
+CPhysicalMultiExternalScan::~CPhysicalMultiExternalScan()
+{
+	CRefCount::SafeRelease(m_part_mdids);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalMultiExternalScan::Matches
+//
+//	@doc:
+//		match operator
+//
+//---------------------------------------------------------------------------
+BOOL
+CPhysicalMultiExternalScan::Matches(COperator *pop) const
+{
+	if (Eopid() != pop->Eopid())
+	{
+		return false;
+	}
+
+	CPhysicalMultiExternalScan *popExternalScan =
+		CPhysicalMultiExternalScan::PopConvert(pop);
+	return m_ptabdesc == popExternalScan->Ptabdesc() &&
+		   m_pdrgpcrOutput->Equals(popExternalScan->PdrgpcrOutput());
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CPhysicalMultiExternalScan::EpetRewindability
+//
+//	@doc:
+//		Return the enforcing type for rewindability property based on this operator
+//
+//---------------------------------------------------------------------------
+CEnfdProp::EPropEnforcingType
+CPhysicalMultiExternalScan::EpetRewindability(
+	CExpressionHandle &exprhdl, const CEnfdRewindability *per) const
+{
+	CRewindabilitySpec *prs = CDrvdPropPlan::Pdpplan(exprhdl.Pdp())->Prs();
+	if (per->FCompatible(prs))
+	{
+		return CEnfdProp::EpetUnnecessary;
+	}
+
+	return CEnfdProp::EpetRequired;
+}
+
+// EOF

--- a/src/backend/gporca/libgpopt/src/operators/Makefile
+++ b/src/backend/gporca/libgpopt/src/operators/Makefile
@@ -33,6 +33,7 @@ OBJS        = CExpression.o \
               CLogicalDynamicGetBase.o \
               CLogicalDynamicIndexGet.o \
               CLogicalExternalGet.o \
+              CLogicalMultiExternalGet.o \
               CLogicalFullOuterJoin.o \
               CLogicalGbAgg.o \
               CLogicalGbAggDeduplicate.o \
@@ -93,6 +94,7 @@ OBJS        = CExpression.o \
               CPhysicalDynamicScan.o \
               CPhysicalDynamicTableScan.o \
               CPhysicalExternalScan.o \
+              CPhysicalMultiExternalScan.o \
               CPhysicalFilter.o \
               CPhysicalFullMergeJoin.o \
               CPhysicalHashAgg.o \

--- a/src/backend/gporca/libgpopt/src/xforms/CXformExpandDynamicGetWithExternalPartitions.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformExpandDynamicGetWithExternalPartitions.cpp
@@ -1,0 +1,178 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2012 EMC Corp.
+//
+//	@filename:
+//		CXformExpandDynamicGetWithExternalPartitions.cpp
+//
+//	@doc:
+//		Implementation of transform
+//---------------------------------------------------------------------------
+
+#include "gpos/base.h"
+#include "gpopt/xforms/CXformExpandDynamicGetWithExternalPartitions.h"
+
+#include "gpopt/operators/CLogicalUnionAll.h"
+#include "gpopt/operators/CLogicalMultiExternalGet.h"
+#include "gpopt/metadata/CTableDescriptor.h"
+#include "gpopt/xforms/CXformUtils.h"
+
+#include "gpopt/exception.h"
+
+using namespace gpopt;
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformExpandDynamicGetWithExternalPartitions::CXformExpandDynamicGetWithExternalPartitions
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CXformExpandDynamicGetWithExternalPartitions::
+	CXformExpandDynamicGetWithExternalPartitions(CMemoryPool *mp)
+	: CXformExploration(
+		  // pattern
+		  GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CLogicalDynamicGet(mp)))
+{
+}
+
+
+// Converts a CLogicalDynamicGet on a partitioned table containing external partitions
+// into a UNION ALL over two partial scans:
+// - Partial CLogicalDynamicGet with part constraints of non-external partitions
+// - Partial CLogicalMultiExternalGet with part constraints for all external partitions
+void
+CXformExpandDynamicGetWithExternalPartitions::Transform(
+	CXformContext *pxfctxt, CXformResult *pxfres, CExpression *pexpr) const
+{
+	GPOS_ASSERT(NULL != pxfctxt);
+	GPOS_ASSERT(FPromising(pxfctxt->Pmp(), this, pexpr));
+	GPOS_ASSERT(FCheckPattern(pexpr));
+
+	CMDAccessor *mda = COptCtxt::PoctxtFromTLS()->Pmda();
+
+	CLogicalDynamicGet *popGet = CLogicalDynamicGet::PopConvert(pexpr->Pop());
+	CTableDescriptor *ptabdesc = popGet->Ptabdesc();
+	const IMDRelation *relation = mda->RetrieveRel(ptabdesc->MDId());
+
+	if (!relation->HasExternalPartitions() || popGet->IsPartial())
+	{
+		// no external partitions or already a partial dynamic get;
+		// do not try to split further
+		return;
+	}
+
+	CMemoryPool *mp = pxfctxt->Pmp();
+
+	// Iterate over all the External Scans to determine partial scan contraints
+	CColRef2dArray *pdrgpdrgpcrPartKeys = popGet->PdrgpdrgpcrPart();
+
+	// capture constraints of all external and remaining (non-external) scans in
+	// ppartcnstrCovered & ppartcnstrRest respectively
+	CPartConstraint *ppartcnstrCovered = NULL;
+	CPartConstraint *ppartcnstrRest = NULL;
+
+	IMdIdArray *external_part_mdids = relation->GetExternalPartitions();
+	GPOS_ASSERT(external_part_mdids->Size() > 0);
+	for (ULONG ul = 0; ul < external_part_mdids->Size(); ul++)
+	{
+		IMDId *extpart_mdid = (*external_part_mdids)[ul];
+		const IMDRelation *extpart = mda->RetrieveRel(extpart_mdid);
+		GPOS_ASSERT(NULL != extpart->MDPartConstraint());
+
+		CPartConstraint *ppartcnstr = CUtils::PpartcnstrFromMDPartCnstr(
+			mp, mda, pdrgpdrgpcrPartKeys, extpart->MDPartConstraint(),
+			popGet->PdrgpcrOutput());
+		GPOS_ASSERT(NULL != ppartcnstr);
+
+		CPartConstraint *ppartcnstrNewlyCovered =
+			CXformUtils::PpartcnstrDisjunction(mp, ppartcnstrCovered,
+											   ppartcnstr);
+
+		if (NULL == ppartcnstrNewlyCovered)
+		{
+			// FIXME: Can this happen here?
+			CRefCount::SafeRelease(ppartcnstr);
+			continue;
+		}
+		CRefCount::SafeRelease(ppartcnstrCovered);
+		CRefCount::SafeRelease(ppartcnstr);
+		ppartcnstrCovered = ppartcnstrNewlyCovered;
+	}
+	CPartConstraint *ppartcnstrRel = CUtils::PpartcnstrFromMDPartCnstr(
+		mp, mda, popGet->PdrgpdrgpcrPart(), relation->MDPartConstraint(),
+		popGet->PdrgpcrOutput());
+	ppartcnstrRest = ppartcnstrRel->PpartcnstrRemaining(mp, ppartcnstrCovered);
+
+	// PpartcnstrRemaining() returns NULL if ppartcnstrCovered has no constraint
+	// on the first level and contraints on higher levels are bounded (see
+	// CPartConstraint::FCanNegate()), which is the case for external partitions
+	// on multi-level partitioned tables,
+	// FIXME: Support multi-level external partitions
+	if (ppartcnstrRest == NULL)
+	{
+		// FIXME: Just return here instead? OR fall back earlier in the translator?
+		GPOS_RAISE(
+			gpopt::ExmaGPOPT, gpopt::ExmiUnsupportedOp,
+			GPOS_WSZ_LIT(
+				"Query over external partitions in multi-level partitioned table"));
+	}
+
+	// Create new partial DynamicGet node with part constraints from ppartcnstrRest
+	CName *pnameDG = GPOS_NEW(mp) CName(mp, popGet->Name());
+	ptabdesc->AddRef();
+	popGet->PdrgpcrOutput()->AddRef();
+	popGet->PdrgpdrgpcrPart()->AddRef();
+	CLogicalDynamicGet *popPartialDynamicGet = GPOS_NEW(mp) CLogicalDynamicGet(
+		mp, pnameDG, ptabdesc, popGet->ScanId(), popGet->PdrgpcrOutput(),
+		popGet->PdrgpdrgpcrPart(),
+		COptCtxt::PoctxtFromTLS()->UlPartIndexNextVal(), true, /* is_partial */
+		ppartcnstrRest, ppartcnstrRel);
+
+	CExpression *pexprPartialDynamicGet =
+		GPOS_NEW(mp) CExpression(mp, popPartialDynamicGet);
+
+	// Create new MultiExternalGet node capturing all the external scans with part constraints
+	// from ppartcnstrCovered
+	CName *pnameMEG = GPOS_NEW(mp) CName(mp, popGet->Name());
+	CColRefArray *pdrgpcrNew = CUtils::PdrgpcrCopy(mp, popGet->PdrgpcrOutput());
+	ptabdesc->AddRef();
+	external_part_mdids->AddRef();
+
+	CLogicalMultiExternalGet *popMultiExternalGet = GPOS_NEW(mp)
+		CLogicalMultiExternalGet(mp, external_part_mdids, pnameMEG, ptabdesc,
+								 popGet->ScanId(), pdrgpcrNew);
+	popMultiExternalGet->SetSecondaryScanId(
+		COptCtxt::PoctxtFromTLS()->UlPartIndexNextVal());
+	popMultiExternalGet->SetPartial();
+	popMultiExternalGet->SetPartConstraint(ppartcnstrCovered);
+	CExpression *pexprMultiExternalGet =
+		GPOS_NEW(mp) CExpression(mp, popMultiExternalGet);
+
+	// Create a UNION ALL node above the two Gets
+	CColRef2dArray *pdrgpdrgpcrInput = GPOS_NEW(mp) CColRef2dArray(mp);
+
+	popPartialDynamicGet->PdrgpcrOutput()->AddRef();
+	pdrgpdrgpcrInput->Append(popPartialDynamicGet->PdrgpcrOutput());
+	popMultiExternalGet->PdrgpcrOutput()->AddRef();
+	pdrgpdrgpcrInput->Append(popMultiExternalGet->PdrgpcrOutput());
+
+	CExpressionArray *pdrgpexprInput = GPOS_NEW(mp) CExpressionArray(mp);
+	pdrgpexprInput->Append(pexprPartialDynamicGet);
+	pdrgpexprInput->Append(pexprMultiExternalGet);
+
+	popGet->PdrgpcrOutput()->AddRef();
+	CExpression *pexprResult = GPOS_NEW(mp) CExpression(
+		mp,
+		GPOS_NEW(mp) CLogicalUnionAll(mp, popGet->PdrgpcrOutput(),
+									  pdrgpdrgpcrInput, popGet->ScanId()),
+		pdrgpexprInput);
+
+	// add alternative to transformation result
+	pxfres->Add(pexprResult);
+}
+
+
+// EOF

--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -290,6 +290,8 @@ CXformFactory::Instantiate()
 	Add(GPOS_NEW(m_mp) CXformIndexGet2IndexOnlyScan(m_mp));
 	Add(GPOS_NEW(m_mp) CXformJoin2BitmapIndexGetApply(m_mp));
 	Add(GPOS_NEW(m_mp) CXformJoin2IndexGetApply(m_mp));
+	Add(GPOS_NEW(m_mp) CXformMultiExternalGet2MultiExternalScan(m_mp));
+	Add(GPOS_NEW(m_mp) CXformExpandDynamicGetWithExternalPartitions(m_mp));
 
 	GPOS_ASSERT(NULL != m_rgpxf[CXform::ExfSentinel - 1] &&
 				"Not all xforms have been instantiated");

--- a/src/backend/gporca/libgpopt/src/xforms/CXformMultiExternalGet2MultiExternalScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformMultiExternalGet2MultiExternalScan.cpp
@@ -1,0 +1,101 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2013 Pivotal, Inc.
+//
+//	@filename:
+//		CXformMultiExternalGet2MultiExternalScan.cpp
+//
+//	@doc:
+//		Implementation of transform
+//---------------------------------------------------------------------------
+
+#include "gpos/base.h"
+#include "gpopt/xforms/CXformMultiExternalGet2MultiExternalScan.h"
+
+#include "gpopt/operators/CLogicalMultiExternalGet.h"
+#include "gpopt/operators/CPhysicalMultiExternalScan.h"
+#include "gpopt/metadata/CTableDescriptor.h"
+
+using namespace gpopt;
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformMultiExternalGet2MultiExternalScan::CXformMultiExternalGet2MultiExternalScan
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CXformMultiExternalGet2MultiExternalScan::
+	CXformMultiExternalGet2MultiExternalScan(CMemoryPool *mp)
+	: CXformImplementation(
+		  // pattern
+		  GPOS_NEW(mp)
+			  CExpression(mp, GPOS_NEW(mp) CLogicalMultiExternalGet(mp)))
+{
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformMultiExternalGet2MultiExternalScan::Exfp
+//
+//	@doc:
+//		Compute promise of xform
+//
+//---------------------------------------------------------------------------
+CXform::EXformPromise
+CXformMultiExternalGet2MultiExternalScan::Exfp(CExpressionHandle &	//exprhdl
+) const
+{
+	return CXform::ExfpHigh;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformMultiExternalGet2MultiExternalScan::Transform
+//
+//	@doc:
+//		Actual transformation
+//
+//---------------------------------------------------------------------------
+void
+CXformMultiExternalGet2MultiExternalScan::Transform(CXformContext *pxfctxt,
+													CXformResult *pxfres,
+													CExpression *pexpr) const
+{
+	GPOS_ASSERT(NULL != pxfctxt);
+	GPOS_ASSERT(FPromising(pxfctxt->Pmp(), this, pexpr));
+	GPOS_ASSERT(FCheckPattern(pexpr));
+
+	CLogicalMultiExternalGet *popGet =
+		CLogicalMultiExternalGet::PopConvert(pexpr->Pop());
+	CMemoryPool *mp = pxfctxt->Pmp();
+
+	// extract components for alternative
+	CName *pname = GPOS_NEW(mp) CName(mp, popGet->Name());
+
+	CColRefArray *pdrgpcrOutput = popGet->PdrgpcrOutput();
+	GPOS_ASSERT(NULL != pdrgpcrOutput);
+
+	popGet->GetScanPartitionMdids()->AddRef();
+	popGet->Ptabdesc()->AddRef();
+	popGet->PdrgpdrgpcrPart()->AddRef();
+	popGet->Ppartcnstr()->AddRef();
+	popGet->PpartcnstrRel()->AddRef();
+	pdrgpcrOutput->AddRef();
+
+	// create alternative expression
+	CExpression *pexprAlt = GPOS_NEW(mp) CExpression(
+		mp, GPOS_NEW(mp) CPhysicalMultiExternalScan(
+				mp, popGet->GetScanPartitionMdids(), popGet->IsPartial(),
+				popGet->Ptabdesc(), popGet->UlOpId(), pname, popGet->ScanId(),
+				pdrgpcrOutput, popGet->PdrgpdrgpcrPart(),
+				popGet->UlSecondaryScanId(), popGet->Ppartcnstr(),
+				popGet->PpartcnstrRel()));
+
+	// add alternative to transformation result
+	pxfres->Add(pexprAlt);
+}
+
+// EOF

--- a/src/backend/gporca/libgpopt/src/xforms/Makefile
+++ b/src/backend/gporca/libgpopt/src/xforms/Makefile
@@ -25,6 +25,7 @@ OBJS        = CDecorrelator.o \
               CXformDelete2DML.o \
               CXformDifference2LeftAntiSemiJoin.o \
               CXformDifferenceAll2LeftAntiSemiJoin.o \
+              CXformExpandDynamicGetWithExternalPartitions.o \
               CXformDynamicGet2DynamicTableScan.o \
               CXformDynamicIndexGet2DynamicIndexScan.o \
               CXformEagerAgg.o \
@@ -36,6 +37,7 @@ OBJS        = CDecorrelator.o \
               CXformExpandNAryJoinMinCard.o \
               CXformExploration.o \
               CXformExternalGet2ExternalScan.o \
+              CXformMultiExternalGet2MultiExternalScan.o \
               CXformFactory.o \
               CXformGbAgg2Apply.o \
               CXformGbAgg2HashAgg.o \

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperator.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLOperator.h
@@ -131,6 +131,7 @@ enum Edxlopid
 	EdxlopPhysicalBitmapTableScan,
 	EdxlopPhysicalDynamicBitmapTableScan,
 	EdxlopPhysicalExternalScan,
+	EdxlopPhysicalMultiExternalScan,
 	EdxlopPhysicalIndexScan,
 	EdxlopPhysicalIndexOnlyScan,
 	EdxlopScalarBitmapIndexProbe,

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDRelation.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDRelation.h
@@ -82,11 +82,17 @@ protected:
 	// distribution opfamilies parse handler
 	CParseHandlerBase *m_opfamilies_parse_handler;
 
+	// distribution opfamilies parse handler
+	CParseHandlerBase *m_external_partitions_parse_handler;
+
 	// levels that include default partitions
 	ULongPtrArray *m_level_with_default_part_array;
 
 	// is part constraint unbounded
 	BOOL m_part_constraint_unbounded;
+
+	// is part constraint complete with part constraint expr
+	BOOL m_part_constraint_contains_expr;
 
 	// helper function to parse main relation attributes: name, id,
 	// distribution policy and keys

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDRelationExternal.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDRelationExternal.h
@@ -47,6 +47,15 @@ private:
 	// distribution opfamilies parse handler
 	CParseHandlerBase *m_opfamilies_parse_handler;
 
+	// part constraint
+	CMDPartConstraintGPDB *m_part_constraint;
+
+	// levels that include default partitions
+	ULongPtrArray *m_level_with_default_part_array;
+
+	// is part constraint unbounded
+	BOOL m_part_constraint_unbounded;
+
 	// private copy ctor
 	CParseHandlerMDRelationExternal(const CParseHandlerMDRelationExternal &);
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -87,6 +87,7 @@ enum Edxltoken
 	EdxltokenPhysicalBitmapTableScan,
 	EdxltokenPhysicalDynamicBitmapTableScan,
 	EdxltokenPhysicalExternalScan,
+	EdxltokenPhysicalMultiExternalScan,
 	EdxltokenPhysicalIndexScan,
 	EdxltokenPhysicalIndexOnlyScan,
 	EdxltokenPhysicalHashJoin,
@@ -480,6 +481,9 @@ enum Edxltoken
 	EdxltokenRelDistrOpclasses,
 	EdxltokenRelDistrOpclass,
 
+	EdxltokenRelExternalPartitions,
+	EdxltokenRelExternalPartition,
+
 	EdxltokenExtRelRejLimit,
 	EdxltokenExtRelRejLimitInRows,
 	EdxltokenExtRelFmtErrRel,
@@ -523,6 +527,7 @@ enum Edxltoken
 	EdxltokenCheckConstraints,
 	EdxltokenCheckConstraint,
 	EdxltokenPartConstraint,
+	EdxltokenPartConstraintExprAbsent,
 	EdxltokenDefaultPartition,
 	EdxltokenPartConstraintUnbounded,
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDRelationExternalGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDRelationExternalGPDB.h
@@ -83,6 +83,9 @@ private:
 	// array of check constraint mdids
 	IMdIdArray *m_mdid_check_constraint_array;
 
+	// partition constraint
+	IMDPartConstraint *m_mdpart_constraint;
+
 	// reject limit
 	INT m_reject_limit;
 
@@ -122,7 +125,8 @@ public:
 		ULongPtrArray *distr_col_array, IMdIdArray *distr_opfamilies,
 		BOOL convert_hash_to_random, ULongPtr2dArray *keyset_array,
 		CMDIndexInfoArray *md_index_info_array, IMdIdArray *mdid_triggers_array,
-		IMdIdArray *mdid_check_constraint_array, INT reject_limit,
+		IMdIdArray *mdid_check_constraint_array,
+		IMDPartConstraint *mdpart_constraint, INT reject_limit,
 		BOOL is_reject_limit_in_rows, IMDId *mdid_fmt_err_table);
 
 	// dtor
@@ -217,6 +221,9 @@ public:
 
 	// retrieve the id of the check constraint cache at the given position
 	virtual IMDId *CheckConstraintMDidAt(ULONG pos) const;
+
+	// Return the part constraint
+	virtual IMDPartConstraint *MDPartConstraint() const;
 
 #ifdef GPOS_DEBUG
 	// debug print of the metadata relation

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDRelationGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDRelationGPDB.h
@@ -123,6 +123,9 @@ private:
 	// array of column widths including dropped columns
 	CDoubleArray *m_col_width_array;
 
+	// oids of any external partitions (for partitioned tables only)
+	IMdIdArray *m_external_partitions;
+
 	// private copy ctor
 	CMDRelationGPDB(const CMDRelationGPDB &);
 
@@ -139,7 +142,8 @@ public:
 					CMDIndexInfoArray *md_index_info_array,
 					IMdIdArray *mdid_triggers_array,
 					IMdIdArray *mdid_check_constraint_array,
-					IMDPartConstraint *mdpart_constraint, BOOL has_oids);
+					IMDPartConstraint *mdpart_constraint, BOOL has_oids,
+					IMdIdArray *external_partitions);
 
 	// dtor
 	virtual ~CMDRelationGPDB();
@@ -257,6 +261,9 @@ public:
 
 	// part constraint
 	virtual IMDPartConstraint *MDPartConstraint() const;
+
+	// external partitions (for partitioned tables)
+	virtual IMdIdArray *GetExternalPartitions() const;
 
 #ifdef GPOS_DEBUG
 	// debug print of the metadata relation

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelation.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelation.h
@@ -187,6 +187,21 @@ public:
 	// part constraint
 	virtual IMDPartConstraint *MDPartConstraint() const = 0;
 
+	// external partitions (for partitioned tables)
+	virtual IMdIdArray *
+	GetExternalPartitions() const
+	{
+		return NULL;
+	}
+
+	// contains any external partitions (for partitioned tables only)
+	BOOL
+	HasExternalPartitions() const
+	{
+		return (NULL != GetExternalPartitions() &&
+				GetExternalPartitions()->Size() > 0);
+	}
+
 	// relation distribution policy as a string value
 	static const CWStringConst *GetDistrPolicyStr(
 		Ereldistrpolicy rel_distr_policy);

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelationExternal.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelationExternal.h
@@ -98,13 +98,6 @@ public:
 		return (CHAR) 0;
 	}
 
-	// part constraint
-	virtual IMDPartConstraint *
-	MDPartConstraint() const
-	{
-		return NULL;
-	}
-
 	// reject limit
 	virtual INT RejectLimit() const = 0;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -213,6 +213,9 @@ enum EOptTraceFlag
 	// Use legacy (cdbhash) opfamilies for compatibility
 	EopttraceUseLegacyOpfamilies = 103039,
 
+	// Enable handling external partitioned tables
+	EopttraceEnableExternalPartitionedTables = 103040,
+
 	///////////////////////////////////////////////////////
 	///////////////////// statistics flags ////////////////
 	//////////////////////////////////////////////////////

--- a/src/backend/gporca/libnaucrates/src/md/CMDPartConstraintGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDPartConstraintGPDB.cpp
@@ -131,7 +131,15 @@ CMDPartConstraintGPDB::Serialize(CXMLSerializer *xml_serializer) const
 
 	// serialize the scalar expression
 	if (NULL != m_dxl_node)
+	{
 		m_dxl_node->SerializeToDXL(xml_serializer);
+	}
+	else
+	{
+		xml_serializer->AddAttribute(
+			CDXLTokens::GetDXLTokenStr(EdxltokenPartConstraintExprAbsent),
+			true);
+	}
 
 	xml_serializer->CloseElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),

--- a/src/backend/gporca/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
@@ -30,7 +30,8 @@ CMDRelationExternalGPDB::CMDRelationExternalGPDB(
 	ULongPtrArray *distr_col_array, IMdIdArray *distr_opfamilies,
 	BOOL convert_hash_to_random, ULongPtr2dArray *keyset_array,
 	CMDIndexInfoArray *md_index_info_array, IMdIdArray *mdid_triggers_array,
-	IMdIdArray *mdid_check_constraint_array, INT reject_limit,
+	IMdIdArray *mdid_check_constraint_array,
+	IMDPartConstraint *mdpart_constraint, INT reject_limit,
 	BOOL is_reject_limit_in_rows, IMDId *mdid_fmt_err_table)
 	: m_mp(mp),
 	  m_mdid(mdid),
@@ -45,6 +46,7 @@ CMDRelationExternalGPDB::CMDRelationExternalGPDB(
 	  m_mdindex_info_array(md_index_info_array),
 	  m_mdid_trigger_array(mdid_triggers_array),
 	  m_mdid_check_constraint_array(mdid_check_constraint_array),
+	  m_mdpart_constraint(mdpart_constraint),
 	  m_reject_limit(reject_limit),
 	  m_is_rej_limit_in_rows(is_reject_limit_in_rows),
 	  m_mdid_fmt_err_table(mdid_fmt_err_table),
@@ -130,6 +132,7 @@ CMDRelationExternalGPDB::~CMDRelationExternalGPDB()
 	m_mdid_check_constraint_array->Release();
 	CRefCount::SafeRelease(m_mdid_fmt_err_table);
 
+	CRefCount::SafeRelease(m_mdpart_constraint);
 	CRefCount::SafeRelease(m_colpos_nondrop_colpos_map);
 	CRefCount::SafeRelease(m_attrno_nondrop_col_pos_map);
 	CRefCount::SafeRelease(m_nondrop_col_pos_array);
@@ -528,6 +531,12 @@ CMDRelationExternalGPDB::CheckConstraintMDidAt(ULONG pos) const
 	return (*m_mdid_check_constraint_array)[pos];
 }
 
+IMDPartConstraint *
+CMDRelationExternalGPDB::MDPartConstraint() const
+{
+	return m_mdpart_constraint;
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CMDRelationExternalGPDB::Serialize
@@ -645,6 +654,12 @@ CMDRelationExternalGPDB::Serialize(CXMLSerializer *xml_serializer) const
 			xml_serializer, m_distr_opfamilies,
 			CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpfamilies),
 			CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpfamily));
+	}
+
+	// serialize part constraint
+	if (NULL != m_mdpart_constraint)
+	{
+		m_mdpart_constraint->Serialize(xml_serializer);
 	}
 
 	xml_serializer->CloseElement(

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationExternal.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationExternal.cpp
@@ -42,7 +42,11 @@ CParseHandlerMDRelationExternal::CParseHandlerMDRelationExternal(
 	: CParseHandlerMDRelation(mp, parse_handler_mgr, parse_handler_root),
 	  m_reject_limit(GPDXL_DEFAULT_REJLIMIT),
 	  m_is_rej_limit_in_rows(false),
-	  m_mdid_fmt_err_table(NULL)
+	  m_mdid_fmt_err_table(NULL),
+	  m_opfamilies_parse_handler(NULL),
+	  m_part_constraint(NULL),
+	  m_level_with_default_part_array(NULL),
+	  m_part_constraint_unbounded(false)
 {
 	m_rel_storage_type = IMDRelation::ErelstorageExternal;
 }
@@ -60,6 +64,43 @@ CParseHandlerMDRelationExternal::StartElement(
 	const XMLCh *const element_uri, const XMLCh *const element_local_name,
 	const XMLCh *const element_qname, const Attributes &attrs)
 {
+	if (0 == XMLString::compareString(
+				 CDXLTokens::XmlstrToken(EdxltokenPartConstraint),
+				 element_local_name))
+	{
+		GPOS_ASSERT(NULL == m_part_constraint);
+
+		const XMLCh *xmlszDefParts =
+			attrs.getValue(CDXLTokens::XmlstrToken(EdxltokenDefaultPartition));
+		if (NULL != xmlszDefParts)
+		{
+			m_level_with_default_part_array =
+				CDXLOperatorFactory::ExtractIntsToUlongArray(
+					m_parse_handler_mgr->GetDXLMemoryManager(), xmlszDefParts,
+					EdxltokenDefaultPartition, EdxltokenRelation);
+		}
+		else
+		{
+			// construct an empty keyset
+			m_level_with_default_part_array =
+				GPOS_NEW(m_mp) ULongPtrArray(m_mp);
+		}
+		m_part_constraint_unbounded =
+			CDXLOperatorFactory::ExtractConvertAttrValueToBool(
+				m_parse_handler_mgr->GetDXLMemoryManager(), attrs,
+				EdxltokenPartConstraintUnbounded, EdxltokenRelation);
+
+		// parse handler for part constraints
+		CParseHandlerBase *pphPartConstraint =
+			CParseHandlerFactory::GetParseHandler(
+				m_mp, CDXLTokens::XmlstrToken(EdxltokenScalar),
+				m_parse_handler_mgr, this);
+		m_parse_handler_mgr->ActivateParseHandler(pphPartConstraint);
+		this->Append(pphPartConstraint);
+
+		return;
+	}
+
 	if (0 == XMLString::compareString(
 				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamilies),
 				 element_local_name))
@@ -143,6 +184,30 @@ CParseHandlerMDRelationExternal::EndElement(
 	const XMLCh *const	// element_qname
 )
 {
+	// CParseHandlerMDIndexInfoList *pphMdlIndexInfo = dynamic_cast<CParseHandlerMDIndexInfoList*>((*this)[1]);
+	if (0 == XMLString::compareString(
+				 CDXLTokens::XmlstrToken(EdxltokenPartConstraint),
+				 element_local_name))
+	{
+		// relcache translator will send partition constraint expression only when a partitioned relation has indices
+		//		if (pphMdlIndexInfo->GetMdIndexInfoArray()->Size() > 0)
+		//		{
+		CParseHandlerScalarOp *pphPartCnstr =
+			dynamic_cast<CParseHandlerScalarOp *>((*this)[Length() - 1]);
+		CDXLNode *pdxlnPartConstraint = pphPartCnstr->CreateDXLNode();
+		pdxlnPartConstraint->AddRef();
+		m_part_constraint = GPOS_NEW(m_mp) CMDPartConstraintGPDB(
+			m_mp, m_level_with_default_part_array, m_part_constraint_unbounded,
+			pdxlnPartConstraint);
+		//		}
+		//		else
+		//		{
+		//			// no partition constraint expression
+		//			m_part_constraint = GPOS_NEW(m_mp) CMDPartConstraintGPDB(m_mp, m_level_with_default_part_array, m_part_constraint_unbounded, NULL);
+		//		}
+		return;
+	}
+
 	if (0 != XMLString::compareString(
 				 CDXLTokens::XmlstrToken(EdxltokenRelationExternal),
 				 element_local_name))
@@ -195,8 +260,8 @@ CParseHandlerMDRelationExternal::EndElement(
 		m_mp, m_mdid, m_mdname, m_rel_distr_policy, md_col_array,
 		m_distr_col_array, distr_opfamilies, m_convert_hash_to_random,
 		m_key_sets_arrays, md_index_info_array, mdid_triggers_array,
-		mdid_check_constraint_array, m_reject_limit, m_is_rej_limit_in_rows,
-		m_mdid_fmt_err_table);
+		mdid_check_constraint_array, m_part_constraint, m_reject_limit,
+		m_is_rej_limit_in_rows, m_mdid_fmt_err_table);
 
 	// deactivate handler
 	m_parse_handler_mgr->DeactivateHandler();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMetadataIdList.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMetadataIdList.cpp
@@ -158,6 +158,18 @@ CParseHandlerMetadataIdList::StartElement(const XMLCh *const,  // element_uri,
 			EdxltokenRelDistrOpclass);
 		m_mdid_array->Append(mdid);
 	}
+	else if (0 == XMLString::compareString(
+					  CDXLTokens::XmlstrToken(EdxltokenRelExternalPartition),
+					  element_local_name))
+	{
+		// partition metadata id: array must be initialized already
+		GPOS_ASSERT(NULL != m_mdid_array);
+
+		IMDId *mdid = CDXLOperatorFactory::ExtractConvertAttrValueToMdId(
+			m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenMdid,
+			EdxltokenRelExternalPartition);
+		m_mdid_array->Append(mdid);
+	}
 	else
 	{
 		CWStringDynamic *str = CDXLUtils::CreateDynamicStringFromXMLChArray(
@@ -198,6 +210,9 @@ CParseHandlerMetadataIdList::EndElement(const XMLCh *const,	 // element_uri,
 				 element_local_name) ||
 		0 == XMLString::compareString(
 				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpclasses),
+				 element_local_name) ||
+		0 == XMLString::compareString(
+				 CDXLTokens::XmlstrToken(EdxltokenRelExternalPartitions),
 				 element_local_name))
 	{
 		// end the index or partition metadata id list
@@ -240,7 +255,10 @@ CParseHandlerMetadataIdList::FSupportedElem(const XMLCh *const xml_str)
 		0 == XMLString::compareString(
 				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamily), xml_str) ||
 		0 == XMLString::compareString(
-				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpclass), xml_str));
+				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpclass), xml_str) ||
+		0 == XMLString::compareString(
+				 CDXLTokens::XmlstrToken(EdxltokenRelExternalPartition),
+				 xml_str));
 }
 
 //---------------------------------------------------------------------------
@@ -267,7 +285,10 @@ CParseHandlerMetadataIdList::FSupportedListType(const XMLCh *const xml_str)
 				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamilies),
 				 xml_str) ||
 		0 == XMLString::compareString(
-				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpclasses), xml_str));
+				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpclasses), xml_str) ||
+		0 == XMLString::compareString(
+				 CDXLTokens::XmlstrToken(EdxltokenRelExternalPartitions),
+				 xml_str));
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -569,6 +569,9 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenOpfamily, GPOS_WSZ_LIT("Opfamily")},
 		{EdxltokenOpfamilies, GPOS_WSZ_LIT("Opfamilies")},
 
+		{EdxltokenRelExternalPartitions, GPOS_WSZ_LIT("ExternalPartitions")},
+		{EdxltokenRelExternalPartition, GPOS_WSZ_LIT("ExternalPartition")},
+
 		{EdxltokenPartitions, GPOS_WSZ_LIT("Partitions")},
 		{EdxltokenPartition, GPOS_WSZ_LIT("Partition")},
 
@@ -579,6 +582,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenCheckConstraint, GPOS_WSZ_LIT("CheckConstraint")},
 
 		{EdxltokenPartConstraint, GPOS_WSZ_LIT("PartConstraint")},
+		{EdxltokenPartConstraintExprAbsent, GPOS_WSZ_LIT("ExprAbsent")},
 		{EdxltokenDefaultPartition, GPOS_WSZ_LIT("DefaultPartition")},
 		{EdxltokenPartConstraintUnbounded, GPOS_WSZ_LIT("Unbounded")},
 

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CExternalTableTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CExternalTableTest.cpp
@@ -41,7 +41,10 @@ const CHAR *rgszExternalTableFileNames[] = {
 	"../data/dxl/minidump/ExternalTableWithFilter.mdp",
 	"../data/dxl/minidump/CTAS-with-randomly-distributed-external-table.mdp",
 	"../data/dxl/minidump/CTAS-with-hashed-distributed-external-table.mdp",
-	"../data/dxl/minidump/AggonExternalTableNoMotion.mdp"};
+	"../data/dxl/minidump/AggonExternalTableNoMotion.mdp",
+	"../data/dxl/minidump/ExternalPartitionTableNoPredicate.mdp",
+	"../data/dxl/minidump/ExternalPartitionTableSelectOnPartKey.mdp",
+};
 
 
 //---------------------------------------------------------------------------

--- a/src/include/cdb/cdbpartition.h
+++ b/src/include/cdb/cdbpartition.h
@@ -76,6 +76,8 @@ extern void rel_partition_keys_kinds_ordered(Oid relid, List **pkeys, List **pki
 
 extern bool rel_has_external_partition(Oid relid);
 
+extern List *rel_get_external_partitions(Oid relid);
+
 extern bool rel_has_appendonly_partition(Oid relid);
 
 extern bool rel_is_child_partition(Oid relid);
@@ -119,6 +121,9 @@ all_partition_relids(PartitionNode *pn);
 
 extern Node *
 get_relation_part_constraints(Oid rootOid, List **defaultLevels);
+
+extern Node *
+get_leaf_part_constraints(Oid partoid, List **defaultLevels);
 
 extern List *
 all_prule_relids(PartitionRule *prule);

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -249,6 +249,9 @@ List *GetCheckConstraintOids(Oid rel_oid);
 // part constraint expression tree
 Node *GetRelationPartContraints(Oid rel_oid, List **default_levels);
 
+// part constraint expression tree for a leaf partition
+Node *GetLeafPartContraints(Oid rel_oid, List **default_levels);
+
 // get the cast function for the specified source and destination types
 bool GetCastFunc(Oid src_oid, Oid dest_oid, bool *is_binary_coercible,
 				 Oid *cast_fn_oid, CoercionPathType *pathtype);
@@ -300,6 +303,8 @@ bool IsLeafPartition(Oid oid);
 
 // partition table has an external partition
 bool HasExternalPartition(Oid oid);
+
+List *GetExternalPartitions(Oid oid);
 
 // find the oid of the root partition given partition oid belongs to
 Oid GetRootPartition(Oid oid);

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -280,7 +280,7 @@ private:
 	// retrieve part constraint for relation
 	static CMDPartConstraintGPDB *RetrievePartConstraintForRel(
 		CMemoryPool *mp, CMDAccessor *md_accessor, OID rel_oid,
-		CMDColumnArray *mdcol_array, BOOL has_index);
+		CMDColumnArray *mdcol_array, BOOL construct_full_expr);
 
 	// retrieve part constraint from a GPDB node
 	static CMDPartConstraintGPDB *RetrievePartConstraintFromNode(
@@ -346,6 +346,9 @@ private:
 
 	static IMdIdArray *RetrieveRelDistributionOpFamilies(CMemoryPool *mp,
 														 GpPolicy *policy);
+
+	static IMdIdArray *RetrieveRelExternalPartitions(CMemoryPool *mp,
+													 OID rel_oid);
 
 	// for non-leaf partition tables return the number of child partitions
 	// else return 1

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -23,6 +23,9 @@
 -- m/DETAIL:  Found \d+ URLs and \d+ primary segments./
 -- s/Found.+//
 --
+-- m/NOTICE:\s+found \d+ data formatting errors \(\d+ or more input rows\)/
+-- s/found.+//
+--
 -- end_matchsubs
 CREATE TABLE REG_REGION (R_REGIONKEY INT, R_NAME CHAR(25), R_COMMENT VARCHAR(152)) DISTRIBUTED BY (R_REGIONKEY);
 

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -23,6 +23,9 @@
 -- m/DETAIL:  Found \d+ URLs and \d+ primary segments./
 -- s/Found.+//
 --
+-- m/NOTICE:\s+found \d+ data formatting errors \(\d+ or more input rows\)/
+-- s/found.+//
+--
 -- end_matchsubs
 CREATE TABLE REG_REGION (R_REGIONKEY INT, R_NAME CHAR(25), R_COMMENT VARCHAR(152)) DISTRIBUTED BY (R_REGIONKEY);
 -- --------------------------------------


### PR DESCRIPTION
In GPDB, one can create a partitioned table and then exchange one of its leaf 
partitions with an external table. There are some restrictions on when this is possible, detailed in https://gpdb.docs.pivotal.io/500/admin_guide/ddl/ddl-partition.html#topic_yhz_gpn_qs.

This PR extends ORCA's support for querying tables that contain external partitioned tables.

Setup and plans:
```sql
CREATE TABLE sales (id int, year int, region text)
  DISTRIBUTED BY (id) 
  PARTITION BY RANGE (year) 
  ( PARTITION yr START (2010) END (2013) EVERY (1),  DEFAULT PARTITION extra ) ;

CREATE EXTERNAL TABLE my_sales_ext1 (id int, year int, region text)
 LOCATION ( 'file://sylkas/Users/shardikar/sales10.csv',
            'file://sylkas/Users/shardikar/sales11.csv',
            'file://sylkas/Users/shardikar/sales12.csv' )
 FORMAT 'csv' (HEADER);

CREATE EXTERNAL TABLE my_sales_ext2 (id int, year int, region text)
 LOCATION ( 'file://sylkas/Users/shardikar/sales20.csv',
            'file://sylkas/Users/shardikar/sales21.csv',
            'file://sylkas/Users/shardikar/sales22.csv' )
 FORMAT 'csv' (HEADER);

ALTER TABLE sales ALTER PARTITION yr_1 
   EXCHANGE PARTITION yr_1 
   WITH TABLE my_sales_ext1 WITHOUT VALIDATION;

ALTER TABLE sales ALTER PARTITION yr_2 
   EXCHANGE PARTITION yr_2 
   WITH TABLE my_sales_ext2 WITHOUT VALIDATION;

shardikar=# explain select * from sales;
                                                 QUERY PLAN
------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1053.98 rows=2000000 width=16)
   ->  Sequence  (cost=0.00..924.06 rows=666667 width=16)
         ->  Partition Selector for sales (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
               Partitions selected: 4 (out of 4)
         ->  Append  (cost=0.00..924.06 rows=666667 width=16)
               ->  Dynamic Seq Scan on sales (dynamic scan id: 1)  (cost=0.00..437.75 rows=266667 width=16)
               ->  Append  (cost=0.00..447.87 rows=666667 width=16)
                     ->  External Scan on sales_1_prt_yr_1  (cost=0.00..447.87 rows=666667 width=16)
                     ->  External Scan on sales_1_prt_yr_2  (cost=0.00..447.87 rows=666667 width=16)
 Optimizer: Pivotal Optimizer (GPORCA)
(10 rows)

shardikar=# select * from sales;
 id | year | region
----+------+--------
  1 | 2011 | CA
  6 | 2011 | WI
 10 | 2010 | NY
 10 | 2011 | MA
  3 | 2010 | NY
  3 | 2011 | CA
(6 rows)
```

*Note that this PR is not feature-complete!* It only works for simple SELECT queries only. Any predicate in the SELECT is used
for static partition elimination of non-external partitions, but all external partitions are scanned at the moment.

Future work is needed to support:
1. Static partition elimination using the xform `CXformSelect2PartialDynamicIndexGet`.
2. Support dynamic partition elimination using the xform `CXformInnerJoin2PartialDynamicIndexGetApply`.
3. Support for external tables in multi-level partitioned tables. According to the documentation, it should not be possible
    exchange partitions for external partitions if there is a SUBPARTITION clause. However, in practice it is possible. See 
    comments in CXformExpandDynamicGetWithExternalPartitions for details.

Please review the PR commit by commit. There are some refactor/fixup commits that should go in independent of this PR.

TODOs
- [ ] Add ICG tests