### PR TITLE
Allow setting direct dispatch info if predicate on  gp_segment_id for…

### DIFF
--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -638,6 +638,104 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 drop table test_prepare;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- test direct dispatch via gp_segment_id qual
+create table t_test_dd_via_segid(id int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into t_test_dd_via_segid select * from generate_series(1, 6);
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: (gp_segment_id = 0)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | id 
+---------------+----
+             0 |  2
+             0 |  3
+             0 |  4
+(3 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: (gp_segment_id = 1)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | id 
+---------------+----
+             1 |  1
+(1 row)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: (gp_segment_id = 2)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | id 
+---------------+----
+             2 |  5
+             2 |  6
+(2 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 2
+ gp_segment_id | id 
+---------------+----
+             1 |  1
+             2 |  5
+             2 |  6
+(3 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2 or gp_segment_id=3;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2) OR (gp_segment_id = 3))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2 or gp_segment_id=3;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | id 
+---------------+----
+             1 |  1
+             2 |  5
+             2 |  6
+(3 rows)
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -657,6 +657,103 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 drop table test_prepare;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- test direct dispatch via gp_segment_id qual
+create table t_test_dd_via_segid(id int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into t_test_dd_via_segid select * from generate_series(1, 6);
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: (gp_segment_id = 0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | id 
+---------------+----
+             0 |  2
+             0 |  3
+             0 |  4
+(3 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: (gp_segment_id = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | id 
+---------------+----
+             1 |  1
+(1 row)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: (gp_segment_id = 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | id 
+---------------+----
+             2 |  5
+             2 |  6
+(2 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | id 
+---------------+----
+             1 |  1
+             2 |  5
+             2 |  6
+(3 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2 or gp_segment_id=3;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2) OR (gp_segment_id = 3))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2 or gp_segment_id=3;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | id 
+---------------+----
+             1 |  1
+             2 |  5
+             2 |  6
+(3 rows)
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;

--- a/src/test/regress/sql/direct_dispatch.sql
+++ b/src/test/regress/sql/direct_dispatch.sql
@@ -293,6 +293,25 @@ execute p3(1);
 execute p3(1);
 drop table test_prepare;
 
+-- test direct dispatch via gp_segment_id qual
+create table t_test_dd_via_segid(id int);
+insert into t_test_dd_via_segid select * from generate_series(1, 6);
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2 or gp_segment_id=3;
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2 or gp_segment_id=3;
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 


### PR DESCRIPTION
… planner.

This commit implements the same feature for planner as the PR
https://github.com/greenplum-db/gpdb/pull/10679.

This commit does not implement the group-by feature in PR 10679.
The following commit message is almost the same as PR 10679.

This approach special cases gp_segment_id enough to include the column
as a distributed column constraint. It also updates direct dispatch info
to be aware of gp_segment_id which represents the raw value of the
segment where the data resides. This is different than other columns
which hash the datum value to decide where the data resides.

After this change the following DDL shows Gather Motion from 2 segments
on a 3 segment demo cluster.

```
CREATE TABLE t(a int, b int) DISTRIBUTED BY (a);
EXPLAIN SELECT gp_segment_id, * FROM t WHERE gp_segment_id=1 or gp_segment_id=2;
                                    QUERY PLAN
-----------------------------------------------------------------------------------
 Gather Motion 2:1  (slice1; segments: 2)
   ->  Seq Scan on t
         Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2))
 Optimizer: Postgres query optimizer
(4 rows)
```
