### PR TITLE
Fix crash when planner chose an Index Only Scan on a bitmap index.

### DIFF
--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -317,6 +317,9 @@ bmbeginscan(Relation rel, int nkeys, int norderbys)
 	so->bm_markPos = NULL;
 	so->cur_pos_valid = false;
 	so->mark_pos_valid = false;
+
+	scan->xs_itupdesc = RelationGetDescr(rel);
+
 	scan->opaque = so;
 
 	return scan;

--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -597,6 +597,56 @@ insert into oversize_test values (array_to_string(array(select generate_series(1
 CREATE INDEX oversize_test_idx ON oversize_test USING BITMAP (c1);
 ERROR:  row is too big: size 33256, maximum size 32736  (seg2 172.17.0.2:25434 pid=390371)
 --
+-- Test Index Only Scans.
+--
+-- Bitmap indexes don't really support index only scans at the moment. But the
+-- planner can still choose an Index Only Scan, if the query doesn't need any
+-- of the attributes from the index.
+create table bm_indexonly_test (i int, t text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into bm_indexonly_test select g, 'foo' || g from generate_series(1, 5) g;
+create index on bm_indexonly_test using bitmap (i, t);
+set enable_seqscan=off;
+set enable_bitmapscan=off;
+set enable_indexscan=on;
+set enable_indexonlyscan=on;
+-- if bitmap indexes supported Index Only Scans, properly, this could use one.
+explain (costs off) select i, t from bm_indexonly_test where i = 1;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Index Scan using bm_indexonly_test_i_t_idx on bm_indexonly_test
+         Index Cond: (i = 1)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select i, t from bm_indexonly_test where i = 1;
+ i |  t   
+---+------
+ 1 | foo1
+(1 row)
+
+-- even without proper support, the planner chooses an Index Only Scan for this.
+explain (costs off) select 'foobar' from bm_indexonly_test;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Index Only Scan using bm_indexonly_test_i_t_idx on bm_indexonly_test
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select 'foobar' from bm_indexonly_test;
+ ?column? 
+----------
+ foobar
+ foobar
+ foobar
+ foobar
+ foobar
+(5 rows)
+
+--
 -- Test unlogged table
 --
 set enable_seqscan=off;

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -597,6 +597,57 @@ insert into oversize_test values (array_to_string(array(select generate_series(1
 CREATE INDEX oversize_test_idx ON oversize_test USING BITMAP (c1);
 ERROR:  row is too big: size 33256, maximum size 32736  (seg2 172.17.0.2:25434 pid=391078)
 --
+-- Test Index Only Scans.
+--
+-- Bitmap indexes don't really support index only scans at the moment. But the
+-- planner can still choose an Index Only Scan, if the query doesn't need any
+-- of the attributes from the index.
+create table bm_indexonly_test (i int, t text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into bm_indexonly_test select g, 'foo' || g from generate_series(1, 5) g;
+create index on bm_indexonly_test using bitmap (i, t);
+set enable_seqscan=off;
+set enable_bitmapscan=off;
+set enable_indexscan=on;
+set enable_indexonlyscan=on;
+-- if bitmap indexes supported Index Only Scans, properly, this could use one.
+explain (costs off) select i, t from bm_indexonly_test where i = 1;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on bm_indexonly_test
+         Filter: (i = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select i, t from bm_indexonly_test where i = 1;
+ i |  t   
+---+------
+ 1 | foo1
+(1 row)
+
+-- even without proper support, the planner chooses an Index Only Scan for this.
+explain (costs off) select 'foobar' from bm_indexonly_test;
+                   QUERY PLAN                   
+------------------------------------------------
+ Result
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on bm_indexonly_test
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select 'foobar' from bm_indexonly_test;
+ ?column? 
+----------
+ foobar
+ foobar
+ foobar
+ foobar
+ foobar
+(5 rows)
+
+--
 -- Test unlogged table
 --
 set enable_seqscan=off;


### PR DESCRIPTION
Index Only Scans have not been implemented on Bitmap Indexes, but in
certain circumstances, when the query doesn't need any of the attributes
from the index, like in "SELECT count(*) from table", the planner may
still choose an Index Only Scan. It's debatable if that's actually a
planner bug, but we can easily support that limited case.
