### PR TITLE
Fix dblink's libpq issue on gpdb 5X

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -7,7 +7,7 @@
 subdir =
 top_builddir = .
 include $(top_builddir)/src/Makefile.global
-
+OS := $(shell uname -s)
 
 all:
 #	$(MAKE) -C doc all
@@ -21,7 +21,11 @@ all:
 	$(MAKE) -C contrib/fuzzystrmatch all
 	$(MAKE) -C contrib/extprotocol all	
 	$(MAKE) -C contrib/citext all	
+ifeq ($(OS),Darwin)
+	@echo "dblink can't build on Mac"
+else
 	$(MAKE) -C contrib/dblink all
+endif
 	$(MAKE) -C contrib/gp_error_handling all
 	$(MAKE) -C contrib/gp_sparse_vector all
 	$(MAKE) -C contrib/gp_distribution_policy all
@@ -50,7 +54,9 @@ install:
 	$(MAKE) -C contrib/fuzzystrmatch $@
 	$(MAKE) -C contrib/extprotocol $@
 	$(MAKE) -C contrib/citext $@
+ifneq ($(OS),Darwin)
 	$(MAKE) -C contrib/dblink $@
+endif
 	$(MAKE) -C contrib/gp_error_handling $@
 	$(MAKE) -C contrib/gp_sparse_vector $@
 	$(MAKE) -C contrib/gp_distribution_policy $@
@@ -80,7 +86,9 @@ installdirs uninstall:
 	$(MAKE) -C contrib/fuzzystrmatch $@
 	$(MAKE) -C contrib/extprotocol $@
 	$(MAKE) -C contrib/citext $@
+ifneq ($(OS),Darwin)
 	$(MAKE) -C contrib/dblink $@
+endif
 	$(MAKE) -C contrib/gp_error_handling $@
 	$(MAKE) -C contrib/gp_sparse_vector $@
 	$(MAKE) -C contrib/gp_distribution_policy $@
@@ -114,7 +122,9 @@ clean:
 	$(MAKE) -C contrib/fuzzystrmatch $@
 	$(MAKE) -C contrib/extprotocol $@
 	$(MAKE) -C contrib/citext $@
+ifneq ($(OS),Darwin)
 	$(MAKE) -C contrib/dblink $@
+endif
 	$(MAKE) -C contrib/gp_error_handling $@
 	$(MAKE) -C contrib/gp_sparse_vector $@
 	$(MAKE) -C contrib/gp_distribution_policy $@
@@ -166,7 +176,9 @@ installcheck-world:
 	$(MAKE) -C contrib/formatter_fixedwidth installcheck
 	$(MAKE) -C contrib/extprotocol installcheck
 	$(MAKE) -C contrib/citext installcheck
+ifneq ($(OS),Darwin)
 	$(MAKE) -C contrib/dblink installcheck
+endif
 	$(MAKE) -C contrib/indexscan installcheck
 	$(MAKE) -C contrib/hstore installcheck
 	$(MAKE) -C contrib/pgcrypto installcheck

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -22,7 +22,7 @@ all:
 	$(MAKE) -C contrib/extprotocol all	
 	$(MAKE) -C contrib/citext all	
 ifeq ($(OS),Darwin)
-	@echo "dblink can't build on Mac"
+	@echo "dblink can't be built on Mac"
 else
 	$(MAKE) -C contrib/dblink all
 endif

--- a/contrib/dblink/Makefile
+++ b/contrib/dblink/Makefile
@@ -2,7 +2,7 @@
 # disable dblink on MaxOS as --exclude-libs and -Bstatic are not supported
 OS := $(shell uname -s)
 ifeq ($(OS),Darwin)
-$(error "dblink can't build on Mac")
+$(error "dblink can't be built on Mac")
 endif
 
 MODULE_big = dblink

--- a/contrib/dblink/Makefile
+++ b/contrib/dblink/Makefile
@@ -1,11 +1,16 @@
 # $PostgreSQL: pgsql/contrib/dblink/Makefile,v 1.15 2007/11/10 23:59:50 momjian Exp $
+# disable dblink on MaxOS as --exclude-libs and -Bstatic are not supported
+OS := $(shell uname -s)
+ifneq ($(OS),Darwin)
+	MODULE_big = dblink
+	PG_CPPFLAGS = -I$(libpq_srcdir)
+	SHLIB_LINK = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
+	OBJS	= dblink.o
 
-MODULE_big = dblink
-PG_CPPFLAGS = -I$(libpq_srcdir)
-OBJS	= dblink.o
+	DATA_built = dblink.sql
+	DATA = uninstall_dblink.sql
+endif
 
-DATA_built = dblink.sql 
-DATA = uninstall_dblink.sql 
 REGRESS = dblink
 REGRESS_OPTS = --init-file=$(top_builddir)/src/test/regress/init_file --dbname=contrib_regression
 

--- a/contrib/dblink/Makefile
+++ b/contrib/dblink/Makefile
@@ -1,16 +1,17 @@
 # $PostgreSQL: pgsql/contrib/dblink/Makefile,v 1.15 2007/11/10 23:59:50 momjian Exp $
 # disable dblink on MaxOS as --exclude-libs and -Bstatic are not supported
 OS := $(shell uname -s)
-ifneq ($(OS),Darwin)
-	MODULE_big = dblink
-	PG_CPPFLAGS = -I$(libpq_srcdir)
-	SHLIB_LINK = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
-	OBJS	= dblink.o
-
-	DATA_built = dblink.sql
-	DATA = uninstall_dblink.sql
+ifeq ($(OS),Darwin)
+$(error "dblink can't build on Mac")
 endif
 
+MODULE_big = dblink
+PG_CPPFLAGS = -I$(libpq_srcdir)
+SHLIB_LINK = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
+OBJS	= dblink.o
+
+DATA_built = dblink.sql
+DATA = uninstall_dblink.sql
 REGRESS = dblink
 REGRESS_OPTS = --init-file=$(top_builddir)/src/test/regress/init_file --dbname=contrib_regression
 

--- a/contrib/dblink/dblink.c
+++ b/contrib/dblink/dblink.c
@@ -34,7 +34,32 @@
 
 #include <limits.h>
 
+/* dblink is compiled as a backend, it needs the server's
+ * header files. It also needs libpq to connect to a
+ * remote postgres database, so it's statically linked to
+ * libpq.a which is compiled as a frontend using -DFRONTEND.
+ *
+ * But the struct PQconninfoOption's length is different between
+ * backend and frontend, there is no "connofs" field in frontend.
+ * When dblink calls the function "PQconndefaults" implemented
+ * in libpq.a and uses the returned PQconninfoOption variable, it crashs,
+ * because the PQconninfoOption variable returned by libpq.a doesn't contain
+ * the "connofs" value, but the dblink thinks it has, so it crashes.
+ *
+ * We define FRONTEND here to include frontend libpq header files.
+ */
+#ifdef LIBPQ_FE_H
+#error "libpq-fe.h" should not be included before "dblink.c"
+#endif /* LIBPQ_FE_H */
+
+#ifndef FRONTEND
+#define FRONTEND
 #include "libpq-fe.h"
+#undef FRONTEND
+#else
+#include "libpq-fe.h"
+#endif /* FRONTEND */
+
 #include "fmgr.h"
 #include "funcapi.h"
 #include "miscadmin.h"


### PR DESCRIPTION
When using dblink to connect to a postgres database, it reports the
following error:
unsupported frontend protocol 28675.0: server supports 2.0 to 3.0

Even if dblink.so is dynamic linked to libpq.so which is compiled
with the option -DFRONTEND, but when it's loaded in gpdb and run,
it will use the backend libpq which is compiled together with
postgres program and reports the error. So we define FRONTEND
before defining libpq-fe.h.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
