### PR TITLE
Don't try to generate generic plans with GPORCA.

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -323,6 +323,9 @@ CTranslatorScalarToDXL::TranslateScalarToDXL
 		// give a better message.
 		if (tag == T_Param)
 		{
+			// Note: The choose_custom_plan() function in plancache.c
+			// knows that GPORCA doesn't support Params. If you lift this
+			// limitation, adjust choose_custom_plan() accordingly!
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiPlStmt2DXLConversion, GPOS_WSZ_LIT("Query Parameter"));
 		}
 		else


### PR DESCRIPTION
If you have plan_cache_mode=auto, which is the default, never try to
generate "generic" plans. GPORCA doesn't support Param nodes, so it will
always fall back to the Postgres planner. What happened without this patch
was that the backend code would compare the cost of the custom plan
generated with GPORCA with the cost of a generic plan generated with the
Postgres planner, and that doesn't make much sense because the GPORCA has
a very different cost model from the Postgres planner.

No test, because it would be quite tedious and fragile to write one, and
the code change seems simple enough.

I bumped into this while hacking on PR #10676, which changes the Postgres
planner's cost model. There's a test in 'direct_dispatch' for the generic
plan generation, and it started to fail because with the planner cost
model changes, the Postgres planner's generic plan started to look cheaper
than the custom plan generated with GPORCA. So we do have some test
coverage for this, although accidental.
