### PR TITLE
[5X Backport]Error out when changing datatype of column with constraint.

### DIFF
--- a/src/test/regress/expected/alter_table_gp.out
+++ b/src/test/regress/expected/alter_table_gp.out
@@ -43,6 +43,22 @@ ERROR:  constraint "test" for relation "dupconstr" already exists
 -- cleanup
 drop table dupconstr;
 --
+-- Alter datatype of column with constraint should raise meaningful error
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/10561
+--
+create table contype (i int4 primary key, j int check (j < 100));
+NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "contype_pkey" for table "contype"
+alter table contype alter i type numeric; --error
+ERROR:  cannot alter column with primary key or unique constraint
+HINT:  DROP the constraint first, and recreate it after the ALTER
+insert into contype values (1, 1), (2, 2), (3, 3);
+-- after insert data, alter primary key/unique column's type will go through a special check logic
+alter table contype alter i type numeric; --error
+ERROR:  Changing the type of a column that is used in a UNIQUE or PRIMARY KEY constraint is not allowed
+alter table contype alter j type numeric;
+-- cleanup
+drop table contype;
+--
 -- Test ALTER COLUMN TYPE after dropped column with text datatype (see MPP-19146)
 --
 create domain mytype as text;

--- a/src/test/regress/sql/alter_table_gp.sql
+++ b/src/test/regress/sql/alter_table_gp.sql
@@ -38,6 +38,20 @@ alter table dupconstr add constraint test primary key (i);
 -- cleanup
 drop table dupconstr;
 
+--
+-- Alter datatype of column with constraint should raise meaningful error
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/10561
+--
+create table contype (i int4 primary key, j int check (j < 100));
+alter table contype alter i type numeric; --error
+
+insert into contype values (1, 1), (2, 2), (3, 3);
+-- after insert data, alter primary key/unique column's type will go through a special check logic
+alter table contype alter i type numeric; --error
+
+alter table contype alter j type numeric;
+-- cleanup
+drop table contype;
 
 --
 -- Test ALTER COLUMN TYPE after dropped column with text datatype (see MPP-19146)


### PR DESCRIPTION
Raise a meaningful error message for this case.
GPDB doesn't support alter type on primary key and unique
constraint column. Because it requires to drop - recreate logic.
The drop currently only performs on master which lead error when
recreating index (since recreate index will dispatch to segments and
there still an old constraint index exists).

This fixes the issue https://github.com/greenplum-db/gpdb/issues/10561.

Reviewed-by: Hubert Zhang <hzhang@pivotal.io>
(cherry picked from commit 32446a321d492226d3f26d91f3b0deeabce90fd4)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
