### PR TITLE
Increase default value of guc gp_snapshotadd_timeout

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3516,7 +3516,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_UNIT_S
 		},
 		&gp_snapshotadd_timeout,
-		10, 0, INT_MAX,
+		30, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
This is used to avoid "writer segworker group shared snapshot collision on id
153871" kind of error.  Pengzhou and I saw this in a real product environment
on gpdb 5. Pengzhou suspected that writer gang exits due to
gp_vmem_idle_resource_timeout but it exits slowly because of ProcArrayLock
contention so the collision happens when a new gang is created. The theory was
roughly verified with process core dump when that issue happens - ProcArrayLock
contention was found in those core files.

Increasing the default gp_snapshotadd_timeout value to tolerate more with the
case. We have been optimizing the ProcArrayLock but we can not 100% avoid the
contention.
