### PR TITLE
[gpopt] Remove dead variables from translator

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2360,11 +2360,9 @@ CTranslatorRelcacheToDXL::RetrieveColStats
 
 	// null frequency and NDV
 	CDouble null_freq(0.0);
-	int null_ndv = 0;
 	if (CStatistics::Epsilon < form_pg_stats->stanullfrac)
 	{
 		null_freq = form_pg_stats->stanullfrac;
-		null_ndv = 1;
 	}
 
 	// column width
@@ -2684,7 +2682,6 @@ CTranslatorRelcacheToDXL::RetrieveCast
 	CMDIdCast *mdid_cast = CMDIdCast::CastMdid(mdid);
 	IMDId *mdid_src = mdid_cast->MdidSrc();
 	IMDId *mdid_dest = mdid_cast->MdidDest();
-	IMDCast::EmdCoercepathType coercePathType;
 
 	OID src_oid = CMDIdGPDB::CastMdid(mdid_src)->Oid();
 	OID dest_oid = CMDIdGPDB::CastMdid(mdid_dest)->Oid();
@@ -2725,7 +2722,6 @@ CTranslatorRelcacheToDXL::RetrieveCast
 	switch (pathtype) {
 		case COERCION_PATH_ARRAYCOERCE:
 		{
-			coercePathType = IMDCast::EmdtArrayCoerce;
 			return GPOS_NEW(mp) CMDArrayCoerceCastGPDB(mp, mdid, mdname, mdid_src, mdid_dest, is_binary_coercible, GPOS_NEW(mp) CMDIdGPDB(cast_fn_oid), IMDCast::EmdtArrayCoerce, default_type_modifier, false, EdxlcfImplicitCast, -1);
 		}
 			break;


### PR DESCRIPTION
With this patch, the whole translator compiles warning free.

null_ndv was orphaned in commit 25479cf1500b ("Fix num_distinct
calculation in relcache translator").

coercePathType was dead on arrival in commit cc799db46933 ("Fix Relcache
Translator to send CoercePath info (#2842)").

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
