### PR TITLE
[ORCA] Simplify assert-only variables

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -443,9 +443,7 @@ CConfigParamMapping::PackConfigParamInBitset
 
 		if (value)
 		{
-#ifdef GPOS_DEBUG
-			BOOL is_traceflag_set =
-#endif // GPOS_DEBUG
+			BOOL is_traceflag_set GPOS_ASSERTS_ONLY =
 				traceflag_bitset->ExchangeSet((ULONG) elem.m_trace_flag);
 			GPOS_ASSERT(!is_traceflag_set);
 		}
@@ -459,9 +457,7 @@ CConfigParamMapping::PackConfigParamInBitset
 
 		if (optimizer_xforms[ul])
 		{
-#ifdef GPOS_DEBUG
-			BOOL is_traceflag_set =
-#endif // GPOS_DEBUG
+			BOOL is_traceflag_set GPOS_ASSERTS_ONLY =
 				traceflag_bitset->ExchangeSet(EopttraceDisableXformBase + ul);
 			GPOS_ASSERT(!is_traceflag_set);
 		}

--- a/src/backend/gpopt/translate/CCTEListEntry.cpp
+++ b/src/backend/gpopt/translate/CCTEListEntry.cpp
@@ -47,9 +47,7 @@ CCTEListEntry::CCTEListEntry
 	m_cte_info = GPOS_NEW(mp) HMSzCTEInfo(mp);
 	Query *cte_query = (Query*) cte->ctequery;
 		
-#ifdef GPOS_DEBUG
-		BOOL result =
-#endif
+		BOOL result GPOS_ASSERTS_ONLY =
 	m_cte_info->Insert(cte->ctename, GPOS_NEW(mp) SCTEProducerInfo(cte_producer, cte_query->targetList));
 		
 	GPOS_ASSERT(result);
@@ -87,9 +85,7 @@ CCTEListEntry::CCTEListEntry
 
 		Query *cte_query = (Query*) cte->ctequery;
 		
-#ifdef GPOS_DEBUG
-		BOOL result =
-#endif
+		BOOL result GPOS_ASSERTS_ONLY =
 		m_cte_info->Insert(cte->ctename, GPOS_NEW(mp) SCTEProducerInfo(cte_producer, cte_query->targetList));
 		
 		GPOS_ASSERT(result);
@@ -164,9 +160,7 @@ CCTEListEntry::AddCTEProducer
 	GPOS_ASSERT(NULL == m_cte_info->Find(cte->ctename) && "CTE entry already exists");
 	Query *cte_query = (Query*) cte->ctequery;
 	
-#ifdef GPOS_DEBUG
-	BOOL result =
-#endif
+	BOOL result GPOS_ASSERTS_ONLY =
 	m_cte_info->Insert(cte->ctename, GPOS_NEW(mp) SCTEProducerInfo(cte_producer, cte_query->targetList));
 	
 	GPOS_ASSERT(result);

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -176,9 +176,7 @@ CContextDXLToPlStmt::AddCTEConsumerInfo
 	List *cte_plan = ListMake1(share_input_scan);
 
 	ULONG *key = GPOS_NEW(m_mp) ULONG(cte_id);
-#ifdef GPOS_DEBUG
-	BOOL result =
-#endif
+	BOOL result GPOS_ASSERTS_ONLY =
 			m_cte_consumer_info->Insert(key, GPOS_NEW(m_mp) SCTEConsumerInfo(cte_plan));
 
 	GPOS_ASSERT(result);

--- a/src/backend/gpopt/translate/CMappingVarColId.cpp
+++ b/src/backend/gpopt/translate/CMappingVarColId.cpp
@@ -167,9 +167,7 @@ CMappingVarColId::Insert
 	gpdb_att_info->AddRef();
 	CGPDBAttOptCol *gpdb_att_opt_col_info = GPOS_NEW(m_mp) CGPDBAttOptCol(gpdb_att_info, opt_col_info);
 
-#ifdef GPOS_DEBUG
-	BOOL result =
-#endif // GPOS_DEBUG
+	BOOL result GPOS_ASSERTS_ONLY =
 			m_gpdb_att_opt_col_mapping->Insert(gpdb_att_info, gpdb_att_opt_col_info);
 
 	GPOS_ASSERT(result);
@@ -484,9 +482,7 @@ CMappingVarColId::CopyMapColId
 			CGPDBAttOptCol *gpdb_att_opt_col_new = GPOS_NEW(m_mp) CGPDBAttOptCol(gpdb_att_info_new, opt_col_info_new);
 
 			// insert into hashmap
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 					var_colid_mapping->m_gpdb_att_opt_col_mapping->Insert(gpdb_att_info_new, gpdb_att_opt_col_new);
 			GPOS_ASSERT(result);
 		}
@@ -526,9 +522,7 @@ CMappingVarColId::CopyMapColId
 		CGPDBAttOptCol *gpdb_att_opt_col_new = GPOS_NEW(mp) CGPDBAttOptCol(gpdb_att_info_new, opt_col_info_new);
 
 		// insert into hashmap
-#ifdef GPOS_DEBUG
-	BOOL result =
-#endif // GPOS_DEBUG
+	BOOL result GPOS_ASSERTS_ONLY =
 		var_colid_mapping->m_gpdb_att_opt_col_mapping->Insert(gpdb_att_info_new, gpdb_att_opt_col_new);
 		GPOS_ASSERT(result);
 	}
@@ -581,9 +575,7 @@ CMappingVarColId::CopyRemapColId
 		gpdb_att_info_new->AddRef();
 		CGPDBAttOptCol *gpdb_att_opt_col_new = GPOS_NEW(mp) CGPDBAttOptCol(gpdb_att_info_new, opt_col_info_new);
 
-#ifdef GPOS_DEBUG
-		BOOL result =
-#endif // GPOS_DEBUG
+		BOOL result GPOS_ASSERTS_ONLY =
 		var_colid_mapping->m_gpdb_att_opt_col_mapping->Insert(gpdb_att_info_new, gpdb_att_opt_col_new);
 		GPOS_ASSERT(result);
 	}

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1612,9 +1612,7 @@ CTranslatorDXLToPlStmt::TranslateDXLNLJoin
 			if (NULL == right_dxl_translate_ctxt.GetParamIdMappingElement(ulColid))
 			{
 				CMappingElementColIdParamId *pmecolidparamid = GPOS_NEW(m_mp) CMappingElementColIdParamId(ulColid, m_dxl_to_plstmt_context->GetNextParamId(), pmdid, iTypeModifier);
-#ifdef GPOS_DEBUG
-					BOOL fInserted =
-#endif
+					BOOL fInserted GPOS_ASSERTS_ONLY =
 						right_dxl_translate_ctxt.FInsertParamMapping(ulColid, pmecolidparamid);
 					GPOS_ASSERT(fInserted);
 			}

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -685,9 +685,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar
 			// keep outer reference mapping to the original column for subsequent subplans
 			CMappingElementColIdParamId *colid_to_param_id_map = GPOS_NEW(m_mp) CMappingElementColIdParamId(colid, dxl_to_plstmt_ctxt->GetNextParamId(), mdid, type_modifier);
 
-#ifdef GPOS_DEBUG
-			BOOL is_inserted =
-#endif
+			BOOL is_inserted GPOS_ASSERTS_ONLY =
 			subplan_translate_ctxt.FInsertParamMapping(colid, colid_to_param_id_map);
 			GPOS_ASSERT(is_inserted);
 		}

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -212,9 +212,7 @@ CTranslatorQueryToDXL::CTranslatorQueryToDXL
 			if (cte_query_level < query_level && NULL != cte_list_entry)
 			{
 				cte_list_entry->AddRef();
-#ifdef GPOS_DEBUG
-				BOOL is_res =
-#endif
+				BOOL is_res GPOS_ASSERTS_ONLY =
 				m_query_level_to_cte_map->Insert(GPOS_NEW(m_mp) ULONG(cte_query_level), cte_list_entry);
 				GPOS_ASSERT(is_res);
 			}
@@ -2014,9 +2012,7 @@ CTranslatorQueryToDXL::AddSortingGroupingColumn
 		ULONG *value = GPOS_NEW(m_mp) ULONG(colid);
 
 		// insert idx-colid mapping in the hash map
-#ifdef GPOS_DEBUG
-		BOOL is_res =
-#endif // GPOS_DEBUG
+		BOOL is_res GPOS_ASSERTS_ONLY =
 				sort_grpref_to_colid_mapping->Insert(key, value);
 
 		GPOS_ASSERT(is_res);
@@ -4275,9 +4271,7 @@ CTranslatorQueryToDXL::ConstructCTEProducerList
 		CDXLNode *cte_producer_dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, lg_cte_prod_dxlop, cte_child_dxlnode);
 		
 		m_dxl_cte_producers->Append(cte_producer_dxlnode);
-#ifdef GPOS_DEBUG
-		BOOL result =
-#endif
+		BOOL result GPOS_ASSERTS_ONLY =
 		m_cteid_at_current_query_level_map->Insert(GPOS_NEW(m_mp) ULONG(lg_cte_prod_dxlop->Id()), GPOS_NEW(m_mp) BOOL(true));
 		GPOS_ASSERT(result);
 		
@@ -4286,9 +4280,7 @@ CTranslatorQueryToDXL::ConstructCTEProducerList
 		if (NULL == cte_list_entry)
 		{
 			cte_list_entry = GPOS_NEW(m_mp) CCTEListEntry (m_mp, cte_query_level, cte, cte_producer_dxlnode);
-#ifdef GPOS_DEBUG
-		BOOL is_res =
-#endif
+		BOOL is_res GPOS_ASSERTS_ONLY =
 			m_query_level_to_cte_map->Insert(GPOS_NEW(m_mp) ULONG(cte_query_level), cte_list_entry);
 			GPOS_ASSERT(is_res);
 		}
@@ -4444,9 +4436,7 @@ CTranslatorQueryToDXL::RemapColIds
 	const ULONG size = from_list_colids->Size();
 	for (ULONG ul = 0; ul < size; ul++)
 	{
-#ifdef GPOS_DEBUG
-		BOOL result =
-#endif // GPOS_DEBUG
+		BOOL result GPOS_ASSERTS_ONLY =
 		old_new_col_mapping->Insert(GPOS_NEW(mp) ULONG(*((*from_list_colids)[ul])), GPOS_NEW(mp) ULONG(*((*to_list_colids)[ul])));
 		GPOS_ASSERT(result);
 	}

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -32,6 +32,7 @@
 #define GPDB_SETVAL 1576
 
 #include "gpos/base.h"
+#include "gpos/attributes.h"
 #include "gpos/common/CAutoTimer.h"
 #include "gpos/common/CBitSetIter.h"
 #include "gpos/string/CWStringDynamic.h"
@@ -2325,7 +2326,7 @@ CTranslatorUtils::MapDXLSubplanToSublinkType
 
         const ULONG arity = GPOS_ARRAY_SIZE(mapping);
         SubLinkType slink = EXPR_SUBLINK;
-		BOOL found = false;
+		BOOL found GPOS_ASSERTS_ONLY = false;
         for (ULONG ul = 0; ul < arity; ul++)
         {
                 ULONG *elem = mapping[ul];
@@ -2368,7 +2369,7 @@ CTranslatorUtils::MapSublinkTypeToDXLSubplan
 
         const ULONG arity = GPOS_ARRAY_SIZE(mapping);
         EdxlSubPlanType dxl_subplan_type = EdxlSubPlanTypeScalar;
-		BOOL found = false;
+		BOOL found GPOS_ASSERTS_ONLY = false;
         for (ULONG ul = 0; ul < arity; ul++)
         {
                 ULONG *elem = mapping[ul];

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobStateMachine.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobStateMachine.h
@@ -173,9 +173,7 @@ namespace gpopt
 
                     // use the event to transition state machine
                     estNext = estCurrent;
-#ifdef GPOS_DEBUG
-                    BOOL fSucceeded =
-#endif // GPOS_DEBUG
+                    BOOL fSucceeded GPOS_ASSERTS_ONLY =
                     m_sm.FTransition(eev, estNext);
 
                     GPOS_ASSERT(fSucceeded);

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CTreeMap.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CTreeMap.h
@@ -512,9 +512,7 @@ namespace gpopt
                 ++m_ulCountLinks;
 
                 // add created link to links map
-#ifdef GPOS_DEBUG
-                BOOL fInserted =
-#endif // GPOS_DEBUG
+                BOOL fInserted GPOS_ASSERTS_ONLY =
                 m_plinkmap->Insert(ptlink, GPOS_NEW(m_mp) BOOL(true));
                 GPOS_ASSERT(fInserted);		
             }

--- a/src/backend/gporca/libgpopt/src/base/CCTEInfo.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCTEInfo.cpp
@@ -112,9 +112,7 @@ CCTEInfo::CCTEInfoEntry::AddConsumerCols
 		CColRef *colref = (*colref_array)[ul];
 		if (NULL == m_phmcrulConsumers->Find(colref))
 		{
-#ifdef GPOS_DEBUG
-			BOOL fSuccess =
-#endif // GPOS_DEBUG
+			BOOL fSuccess GPOS_ASSERTS_ONLY =
 				m_phmcrulConsumers->Insert(colref, GPOS_NEW(m_mp) ULONG(ul));
 			GPOS_ASSERT(fSuccess);
 		}
@@ -261,9 +259,7 @@ CCTEInfo::AddCTEProducer
 	COperator *pop = pexprCTEProducer->Pop();
 	ULONG ulCTEId = CLogicalCTEProducer::PopConvert(pop)->UlCTEId();
 
-#ifdef GPOS_DEBUG
-	BOOL fInserted =
-#endif
+	BOOL fInserted GPOS_ASSERTS_ONLY =
 	m_phmulcteinfoentry->Insert(GPOS_NEW(m_mp) ULONG(ulCTEId), GPOS_NEW(m_mp) CCTEInfoEntry(m_mp, pexprProducerToAdd));
 	GPOS_ASSERT(fInserted);
 }
@@ -297,9 +293,7 @@ CCTEInfo::ReplaceCTEProducer
 
 	CExpression *pexprCTEProducerNew = PexprPreprocessCTEProducer(pexprCTEProducer);
 
-#ifdef GPOS_DEBUG
-	BOOL fReplaced =
-#endif
+	BOOL fReplaced GPOS_ASSERTS_ONLY =
 		m_phmulcteinfoentry->Replace(&ulCTEId, GPOS_NEW(m_mp) CCTEInfoEntry(m_mp, pexprCTEProducerNew, pcteinfoentry->FUsed()));
 	GPOS_ASSERT(fReplaced);
 }
@@ -494,9 +488,7 @@ CCTEInfo::IncrementConsumers
 	if (NULL == phmulconsumermap)
 	{
 		phmulconsumermap = GPOS_NEW(m_mp) UlongToConsumerCounterMap(m_mp);
-#ifdef GPOS_DEBUG
-		BOOL fInserted =
-#endif
+		BOOL fInserted GPOS_ASSERTS_ONLY =
 		m_phmulprodconsmap->Insert(GPOS_NEW(m_mp) ULONG(ulParentCTEId), phmulconsumermap);
 		GPOS_ASSERT(fInserted);
 	}
@@ -506,9 +498,7 @@ CCTEInfo::IncrementConsumers
 	if (NULL == pconsumercounter)
 	{
 		// no existing counter - start a new one
-#ifdef GPOS_DEBUG
-		BOOL fInserted =
-#endif
+		BOOL fInserted GPOS_ASSERTS_ONLY =
 		phmulconsumermap->Insert(GPOS_NEW(m_mp) ULONG(ulConsumerId), GPOS_NEW(m_mp) SConsumerCounter(ulConsumerId));
 		GPOS_ASSERT(fInserted);
 	}
@@ -768,9 +758,7 @@ CCTEInfo::PhmulcrConsumerToProducer
 			GPOS_ASSERT(ulPos < pdrgpcrProducer->Size());
 
 			CColRef *pcrProducer = (*pdrgpcrProducer)[ulPos];
-#ifdef GPOS_DEBUG
-			BOOL fSuccess =
-#endif // GPOS_DEBUG
+			BOOL fSuccess GPOS_ASSERTS_ONLY =
 				colref_mapping->Insert(GPOS_NEW(mp) ULONG(colref->Id()), pcrProducer);
 			GPOS_ASSERT(fSuccess);
 		}

--- a/src/backend/gporca/libgpopt/src/base/CCTEMap.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCTEMap.cpp
@@ -74,9 +74,7 @@ CCTEMap::Insert
 	}
 
 	CCTEMapEntry *pcme = GPOS_NEW(m_mp) CCTEMapEntry(ulCteId, ect, pdpplan);
-#ifdef GPOS_DEBUG
-	BOOL fSuccess =
-#endif // GPOS_DEBUG
+	BOOL fSuccess GPOS_ASSERTS_ONLY =
 	m_phmcm->Insert(GPOS_NEW(m_mp) ULONG(ulCteId), pcme);
 	GPOS_ASSERT(fSuccess);
 }

--- a/src/backend/gporca/libgpopt/src/base/CCTEReq.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCTEReq.cpp
@@ -194,9 +194,7 @@ CCTEReq::Insert
 {
 	GPOS_ASSERT(CCTEMap::EctSentinel > ect);
 	CCTEReqEntry *pcre = GPOS_NEW(m_mp) CCTEReqEntry(ulCteId, ect, fRequired, pdpplan);
-#ifdef GPOS_DEBUG
-	BOOL fSuccess =
-#endif // GPOS_DEBUG
+	BOOL fSuccess GPOS_ASSERTS_ONLY =
 	m_phmcter->Insert(GPOS_NEW(m_mp) ULONG(ulCteId), pcre);
 	GPOS_ASSERT(fSuccess);
 	if (fRequired)

--- a/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
@@ -430,9 +430,7 @@ CColumnFactory::AddComputedToUsedColsMap
 	CColRefSet *pcrsUsed = pexpr->DeriveUsedColumns();
 	if (NULL != pcrsUsed && 0 < pcrsUsed->Size())
 	{
-#ifdef GPOS_DEBUG
-		BOOL fres =
-#endif // GPOS_DEBUG
+		BOOL fres GPOS_ASSERTS_ONLY =
 			m_phmcrcrs->Insert(pcrComputedCol, GPOS_NEW(m_mp) CColRefSet(m_mp, *pcrsUsed));
 		GPOS_ASSERT(fres);
 	}

--- a/src/backend/gporca/libgpopt/src/base/CConstraint.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CConstraint.cpp
@@ -877,9 +877,7 @@ CConstraint::Phmcolconstr
 		CColRef *colref = crsi.Pcr();
 		CConstraintArray *pdrgpcnstrCol = PdrgpcnstrOnColumn(mp, pdrgpcnstr, colref, false /*fExclusive*/);
 
-#ifdef GPOS_DEBUG
-		BOOL fres =
-#endif //GPOS_DEBUG
+		BOOL fres GPOS_ASSERTS_ONLY =
 		phmcolconstr->Insert(colref, pdrgpcnstrCol);
 		GPOS_ASSERT(fres);
 	}
@@ -987,9 +985,7 @@ CConstraint::Contains
 	}
 
 	// insert containment query into the local map
-#ifdef GPOS_DEBUG
-	BOOL fSuccess =
-#endif // GPOS_DEBUG
+	BOOL fSuccess GPOS_ASSERTS_ONLY =
 		m_phmcontain->Insert(pcnstr, PfVal(fContains));
 	GPOS_ASSERT(fSuccess);
 

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecRouted.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecRouted.cpp
@@ -109,9 +109,7 @@ CDistributionSpecRouted::PdsCopyWithRemappedColumns
 			CColumnFactory *col_factory = COptCtxt::PoctxtFromTLS()->Pcf();
 			pcrSegmentId = col_factory->PcrCopy(m_pcrSegmentId);
 
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 			colref_mapping->Insert(GPOS_NEW(mp) ULONG(id), pcrSegmentId);
 			GPOS_ASSERT(result);
 		}

--- a/src/backend/gporca/libgpopt/src/base/CDrvdPropCtxtPlan.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDrvdPropCtxtPlan.cpp
@@ -126,9 +126,7 @@ CDrvdPropCtxtPlan::AddProps
 	if (m_fUpdateCTEMap)
 	{
 		pdpplanProducer->AddRef();
-#ifdef GPOS_DEBUG
-		BOOL fInserted =
-#endif // GPOS_DEBUG
+		BOOL fInserted GPOS_ASSERTS_ONLY =
 				m_phmulpdpCTEs->Insert(GPOS_NEW(m_mp) ULONG(ulProducerId), pdpplanProducer);
 		GPOS_ASSERT(fInserted);
 	}
@@ -203,9 +201,7 @@ CDrvdPropCtxtPlan::CopyCTEProducerProps
 	GPOS_ASSERT(NULL != pdpplan);
 
 	pdpplan->AddRef();
-#ifdef GPOS_DEBUG
-	BOOL fInserted =
-#endif // GPOS_DEBUG
+	BOOL fInserted GPOS_ASSERTS_ONLY =
 		m_phmulpdpCTEs->Insert(GPOS_NEW(m_mp) ULONG(ulCTEId), pdpplan);
 	GPOS_ASSERT(fInserted);
 }

--- a/src/backend/gporca/libgpopt/src/base/COrderSpec.cpp
+++ b/src/backend/gporca/libgpopt/src/base/COrderSpec.cpp
@@ -328,9 +328,7 @@ COrderSpec::PosCopyWithRemappedColumns
 				// not found in hashmap, so create a new colref and add to hashmap
 				pcrMapped = col_factory->PcrCopy(colref);
 
-#ifdef GPOS_DEBUG
-				BOOL result =
-#endif // GPOS_DEBUG
+				BOOL result GPOS_ASSERTS_ONLY =
 				colref_mapping->Insert(GPOS_NEW(mp) ULONG(id), pcrMapped);
 				GPOS_ASSERT(result);
 			}

--- a/src/backend/gporca/libgpopt/src/base/CPartFilterMap.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CPartFilterMap.cpp
@@ -282,9 +282,7 @@ CPartFilterMap::AddPartFilter
 
 	ppf = GPOS_NEW(mp) CPartFilter(scan_id, pexpr, stats);
 
-#ifdef GPOS_DEBUG
-	BOOL fSuccess =
-#endif // GPOS_DEBUG
+	BOOL fSuccess GPOS_ASSERTS_ONLY =
 	m_phmulpf->Insert(GPOS_NEW(mp) ULONG(scan_id), ppf);
 
 	GPOS_ASSERT(fSuccess);
@@ -395,9 +393,7 @@ CPartFilterMap::CopyPartFilterMap
 
 		ppf->AddRef();
 
-#ifdef GPOS_DEBUG
-		BOOL fSuccess =
-#endif // GPOS_DEBUG
+		BOOL fSuccess GPOS_ASSERTS_ONLY =
 		m_phmulpf->Insert(GPOS_NEW(mp) ULONG(scan_id), ppf);
 
 		GPOS_ASSERT(fSuccess);

--- a/src/backend/gporca/libgpopt/src/base/CPartIndexMap.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CPartIndexMap.cpp
@@ -100,9 +100,7 @@ CPartIndexMap::CPartTableInfo::AddPartConstraint
 	)
 {
 	GPOS_ASSERT(NULL != m_ppartcnstrmap);
-#ifdef GPOS_DEBUG
-	BOOL result =
-#endif // GPOS_DEBUG
+	BOOL result GPOS_ASSERTS_ONLY =
 	m_ppartcnstrmap->Insert(GPOS_NEW(mp) ULONG(scan_id), ppartcnstr);
 
 	GPOS_ASSERT(result && "Part constraint already exists in map");
@@ -275,9 +273,7 @@ CPartIndexMap::Insert
 	{
 		// no entry is found, create a new entry
 		ppti = GPOS_NEW(m_mp) CPartTableInfo(scan_id, ppartcnstrmap, epim, mdid, pdrgppartkeys, ppartcnstrRel, ulExpectedPropagators);
-#ifdef GPOS_DEBUG
-		BOOL fSuccess =
-#endif // GPOS_DEBUG
+		BOOL fSuccess GPOS_ASSERTS_ONLY =
 		m_pim->Insert(GPOS_NEW(m_mp) ULONG(scan_id), ppti);
 		GPOS_ASSERT(fSuccess && "failed to insert partition index map entry");
 		

--- a/src/backend/gporca/libgpopt/src/base/CPartitionPropagationSpec.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CPartitionPropagationSpec.cpp
@@ -359,9 +359,7 @@ CPartitionPropagationSpec::SplitPartPredicates
 			CPredicateUtils::ExtractComponents((*pdrgpexprKey)[0], colref, &pexprPartKey, &pexprOther, &cmp_type);
 			GPOS_ASSERT(NULL != pexprOther);
 			pexprOther->AddRef();
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 			phmulexprEqFilter->Insert(GPOS_NEW(mp) ULONG(ul), pexprOther);
 			GPOS_ASSERT(result);
 			pdrgpexprKey->Release();
@@ -370,9 +368,7 @@ CPartitionPropagationSpec::SplitPartPredicates
 		{
 			// Filters
 			// more than one predicate on this key or one non-simple-equality predicate
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 			phmulexprFilter->Insert(GPOS_NEW(mp) ULONG(ul), CPredicateUtils::PexprConjunction(mp, pdrgpexprKey));
 			GPOS_ASSERT(result);
 			continue;

--- a/src/backend/gporca/libgpopt/src/base/CPropConstraint.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CPropConstraint.cpp
@@ -86,9 +86,7 @@ CPropConstraint::InitHashMap
 		while (crsi.Advance())
 		{
 			pcrs->AddRef();
-#ifdef GPOS_DEBUG
-			BOOL fres =
-#endif //GPOS_DEBUG
+			BOOL fres GPOS_ASSERTS_ONLY =
 			m_phmcrcrs->Insert(crsi.Pcr(), pcrs);
 			GPOS_ASSERT(fres);
 		}

--- a/src/backend/gporca/libgpopt/src/base/CReqdPropPlan.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CReqdPropPlan.cpp
@@ -302,9 +302,7 @@ CReqdPropPlan::PpfmCombineDerived
 		BOOL fCopied = ppfmDerived->FCopyPartFilter(mp, scan_id, prppInput->Pepp()->PpfmDerived(), NULL);
 		if (fCopied)
 		{
-#ifdef GPOS_DEBUG
-			BOOL fSet =
-#endif // GPOS_DEBUG
+			BOOL fSet GPOS_ASSERTS_ONLY =
 				pbs->ExchangeSet(scan_id);
 			GPOS_ASSERT(!fSet);
 		}
@@ -325,9 +323,7 @@ CReqdPropPlan::PpfmCombineDerived
 				BOOL fCopied = ppfmDerived->FCopyPartFilter(mp, scan_id, pdpplan->Ppfm(), NULL);
 				if (fCopied)
 				{
-#ifdef GPOS_DEBUG
-					BOOL fSet =
-#endif // GPOS_DEBUG
+					BOOL fSet GPOS_ASSERTS_ONLY =
 						pbs->ExchangeSet(scan_id);
 					GPOS_ASSERT(!fSet);
 				}

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -2450,9 +2450,7 @@ CUtils::PexprScalarProjListConst
 		CColRef *new_colref = col_factory->PcrCreate(colref->RetrieveType(), colref->TypeModifier(), colref->Name());
 		if (NULL != colref_mapping)
 		{
-#ifdef GPOS_DEBUG
-			BOOL fInserted =
-#endif
+			BOOL fInserted GPOS_ASSERTS_ONLY =
 			colref_mapping->Insert(GPOS_NEW(mp) ULONG(colref->Id()), new_colref);
 			GPOS_ASSERT(fInserted);
 		}
@@ -3618,9 +3616,7 @@ CUtils::GenerateFileName
 
 	// get local time
 	syslib::GetTimeOfDay(&tv, NULL/*timezone*/);
-#ifdef GPOS_DEBUG
-	TIME *ptm =
-#endif // GPOS_DEBUG
+	TIME *ptm GPOS_ASSERTS_ONLY =
 	clib::Localtime_r(&tv.tv_sec, &tm);
 
 	GPOS_ASSERT(NULL != ptm && "Failed to get local time");
@@ -3760,9 +3756,7 @@ CUtils::PdrgpcrRemapAndCreate
 			// not found in hashmap, so create a new colref and add to hashmap
 			pcrMapped = col_factory->PcrCopy(colref);
 
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 			colref_mapping->Insert(GPOS_NEW(mp) ULONG(id), pcrMapped);
 			GPOS_ASSERT(result);
 		}
@@ -3942,9 +3936,7 @@ CUtils::PdrgpcrCopy
 		pdrgpcrNew->Append(new_colref);
 		if (NULL != colref_mapping)
 		{
-#ifdef GPOS_DEBUG
-			BOOL fInserted =
-#endif
+			BOOL fInserted GPOS_ASSERTS_ONLY =
 			colref_mapping->Insert(GPOS_NEW(mp) ULONG(colref->Id()), new_colref);
 			GPOS_ASSERT(fInserted);
 		}
@@ -4277,9 +4269,7 @@ CUtils::PhmulcnstrBoolConstOnPartKeys
 
 		if (NULL != pcnstr)
 		{
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 			phmulcnstr->Insert(GPOS_NEW(mp) ULONG(ul), pcnstr);
 			GPOS_ASSERT(result);
 		}
@@ -4377,9 +4367,7 @@ CUtils::PpartcnstrFromMDPartCnstr
 
 			if (NULL != pcnstrLevel)
 			{
-#ifdef GPOS_DEBUG
-				BOOL result =
-#endif // GPOS_DEBUG
+				BOOL result GPOS_ASSERTS_ONLY =
 				phmulcnstr->Insert(GPOS_NEW(mp) ULONG(ul), pcnstrLevel);
 				GPOS_ASSERT(result);
 			}

--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
@@ -636,9 +636,7 @@ CMDAccessor::GetImdObj
 				// object gets pinned independent of whether insertion succeeded or
 				// failed because object was already in cache
 
-#ifdef GPOS_DEBUG
-				IMDCacheObject *pmdobjInserted =
-#endif
+				IMDCacheObject *pmdobjInserted GPOS_ASSERTS_ONLY =
 				a_pmdcacc->Insert(a_pmdkeyCache.Value(), pmdobjNew);
 
 				GPOS_ASSERT(NULL != pmdobjInserted);

--- a/src/backend/gporca/libgpopt/src/metadata/CPartConstraint.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CPartConstraint.cpp
@@ -77,9 +77,7 @@ CPartConstraint::CPartConstraint
 	GPOS_ASSERT_IMP(is_unbounded, fDefaultPartition);
 
 	m_phmulcnstr = GPOS_NEW(mp) UlongToConstraintMap(mp);
-#ifdef GPOS_DEBUG
-	BOOL result =
-#endif // GPOS_DEBUG
+	BOOL result GPOS_ASSERTS_ONLY =
 	m_phmulcnstr->Insert(GPOS_NEW(mp) ULONG(0 /*ulLevel*/), pcnstr);
 	GPOS_ASSERT(result);
 
@@ -484,9 +482,7 @@ CPartConstraint::PpartcnstrRemaining
 
 	CConstraint *pcnstrRemaining = PcnstrRemaining(mp, pcnstrCurrent, pcnstrOther);
 
-#ifdef GPOS_DEBUG
-	BOOL result =
-#endif // GPOS_DEBUG
+	BOOL result GPOS_ASSERTS_ONLY =
 	phmulcnstr->Insert(GPOS_NEW(mp) ULONG(0), pcnstrRemaining);
 	GPOS_ASSERT(result);
 
@@ -502,9 +498,7 @@ CPartConstraint::PpartcnstrRemaining
 		if (NULL != pcnstrLevel)
 		{
 			pcnstrLevel->AddRef();
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 			phmulcnstr->Insert(GPOS_NEW(mp) ULONG(ul), pcnstrLevel);
 			GPOS_ASSERT(result);
 		}
@@ -588,9 +582,7 @@ CPartConstraint::PpartcnstrCopyWithRemappedColumns
 		if (NULL != pcnstr)
 		{
 			CConstraint *pcnstrRemapped = pcnstr->PcnstrCopyWithRemappedColumns(mp, colref_mapping, must_exist);
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 			phmulcnstr->Insert(GPOS_NEW(mp) ULONG(ul), pcnstrRemapped);
 			GPOS_ASSERT(result);
 		}
@@ -733,9 +725,7 @@ CPartConstraint::PpartcnstrDisjunction
 		CConstraint *pcnstrFst = ppartcnstrFst->Pcnstr(ul);
 
 		pcnstrFst->AddRef();
-#ifdef GPOS_DEBUG
-		BOOL result =
-#endif // GPOS_DEBUG
+		BOOL result GPOS_ASSERTS_ONLY =
 		phmulcnstr->Insert(GPOS_NEW(mp) ULONG(ul), pcnstrFst);
 		GPOS_ASSERT(result);
 
@@ -758,9 +748,7 @@ CPartConstraint::PpartcnstrDisjunction
 
 	CConstraint *pcnstrDisj = CConstraint::PcnstrDisjunction(mp, pdrgpcnstrCombined);
 	GPOS_ASSERT(NULL != pcnstrDisj);
-#ifdef GPOS_DEBUG
-	BOOL result =
-#endif // GPOS_DEBUG
+	BOOL result GPOS_ASSERTS_ONLY =
 	phmulcnstr->Insert(GPOS_NEW(mp) ULONG(ulLevels - 1), pcnstrDisj);
 	GPOS_ASSERT(result);
 
@@ -807,9 +795,7 @@ CPartConstraint::CopyPartConstraints
 		{
 			ppartcnstrSource->AddRef();
 
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 				ppartcnstrmapDest->Insert(GPOS_NEW(mp) ULONG(ulKey), ppartcnstrSource);
 
 			GPOS_ASSERT(result && "Duplicate part constraints");

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -1959,9 +1959,7 @@ CExpressionPreprocessor::CollectCTEPredicates
 			if (NULL == pdrgpexpr)
 			{
 				pdrgpexpr = GPOS_NEW(mp) CExpressionArray(mp);
-#ifdef GPOS_DEBUG
-				BOOL fInserted =
-#endif // GPOS_DEBUG
+				BOOL fInserted GPOS_ASSERTS_ONLY =
 					phm->Insert(GPOS_NEW(mp) ULONG(ulCTEId), pdrgpexpr);
 				GPOS_ASSERT(fInserted);
 			}

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalProject.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalProject.cpp
@@ -389,9 +389,7 @@ CLogicalProject::PstatsDerive
 			if (datum->StatsMappable())
 			{
 				datum->AddRef();
-#ifdef GPOS_DEBUG
-				BOOL fInserted =
-#endif
+				BOOL fInserted GPOS_ASSERTS_ONLY =
 						phmuldatum->Insert(GPOS_NEW(mp) ULONG(colref->Id()), datum);
 				GPOS_ASSERT(fInserted);
 			}

--- a/src/backend/gporca/libgpopt/src/operators/CPhysical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysical.cpp
@@ -607,9 +607,7 @@ CPhysical::PcrsChildReqd
 
 	// insert request in map
 	pcrs->AddRef();
-#ifdef GPOS_DEBUG
-	BOOL fSuccess =
-#endif // GPOS_DEBUG
+	BOOL fSuccess GPOS_ASSERTS_ONLY =
 	m_phmrcr->Insert(prcr, pcrs);
 	GPOS_ASSERT(fSuccess);
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
@@ -1229,9 +1229,7 @@ CPhysicalJoin::PppsRequiredJoinChild
 	if (NULL == ppps)
 	{
 		ppps = PppsRequiredCompute(mp, exprhdl, pppsRequired, child_index, fNLJoin);
-#ifdef GPOS_DEBUG
-		BOOL fSuccess =
-#endif // GPOS_DEBUG
+		BOOL fSuccess GPOS_ASSERTS_ONLY =
 			m_phmpp->Insert(pppr, ppps);
 		GPOS_ASSERT(fSuccess);
 	}

--- a/src/backend/gporca/libgpopt/src/operators/CScalarIdent.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarIdent.cpp
@@ -105,9 +105,7 @@ CScalarIdent::PopCopyWithRemappedColumns
 
 			colref = col_factory->PcrCopy(m_pcr);
 
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 			colref_mapping->Insert(GPOS_NEW(mp) ULONG(id), colref);
 			GPOS_ASSERT(result);
 		}

--- a/src/backend/gporca/libgpopt/src/operators/CScalarProjectElement.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarProjectElement.cpp
@@ -101,9 +101,7 @@ CScalarProjectElement::PopCopyWithRemappedColumns
 			CName name(m_pcr->Name());
 			colref = col_factory->PcrCreate(m_pcr->RetrieveType(), m_pcr->TypeModifier(), name);
 
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 			colref_mapping->Insert(GPOS_NEW(mp) ULONG(id), colref);
 			GPOS_ASSERT(result);
 		}

--- a/src/backend/gporca/libgpopt/src/search/CGroup.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroup.cpp
@@ -1336,9 +1336,7 @@ CGroup::BuildTreeMap
 	}
 
 	// remember processed links to avoid re-processing them later
-#ifdef GPOS_DEBUG
-	BOOL fInserted =
-#endif  // GPOS_DEBUG
+	BOOL fInserted GPOS_ASSERTS_ONLY =
 		m_plinkmap->Insert(pclink, GPOS_NEW(m_mp) BOOL(true));
 	GPOS_ASSERT(fInserted);
 }
@@ -2095,9 +2093,7 @@ CGroup::PstatsCompute
 
 	// add computed stats to local map
 	poc->AddRef();
-#ifdef GPOS_DEBUG
-	BOOL fSuccess =
-#endif  // GPOS_DEBUG
+	BOOL fSuccess GPOS_ASSERTS_ONLY =
 	m_pstatsmap->Insert(poc, stats);
 	GPOS_ASSERT(fSuccess);
 
@@ -2214,9 +2210,7 @@ CGroup::CostLowerBound
 
 
 	prppInput->AddRef();
-#ifdef GPOS_DEBUG
-	BOOL fSuccess =
-#endif // GPOS_DEBUG
+	BOOL fSuccess GPOS_ASSERTS_ONLY =
 		m_pcostmap->Insert(prppInput, GPOS_NEW(mp) CCost(costLowerBound.Get()));
 	GPOS_ASSERT(fSuccess);
 

--- a/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
@@ -554,9 +554,7 @@ CGroupExpression::CostLowerBound
 	// compute partial plan cost
 	CCost cost = ppp->CostCompute(mp);
 
-#ifdef GPOS_DEBUG
-	BOOL fSuccess =
-#endif // GPOS_DEBUG
+	BOOL fSuccess GPOS_ASSERTS_ONLY =
 		m_ppartialplancostmap->Insert(ppp, GPOS_NEW(mp) CCost(cost.Get()));
 	GPOS_ASSERT(fSuccess);
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -238,9 +238,7 @@ CTranslatorDXLToExpr::Pexpr
 		CDXLLogicalCTEProducer *pdxlopCTEProducer = CDXLLogicalCTEProducer::Cast(pdxlnCTE->GetOperator());
 
 		pdxlnCTE->AddRef();
-#ifdef GPOS_DEBUG
-		BOOL fres =
-#endif // GPOS_DEBUG
+		BOOL fres GPOS_ASSERTS_ONLY =
 				m_phmulpdxlnCTEProducer->Insert(GPOS_NEW(m_mp) ULONG(pdxlopCTEProducer->Id()), pdxlnCTE);
 		GPOS_ASSERT(fres);
 	}
@@ -1046,9 +1044,7 @@ CTranslatorDXLToExpr::PcrCreate
 
 	if (fStoreMapping)
 	{
-#ifdef GPOS_DEBUG
-		BOOL result =
-#endif // GPOS_DEBUG
+		BOOL result GPOS_ASSERTS_ONLY =
 				m_phmulcr->Insert(GPOS_NEW(m_mp) ULONG(colid), new_colref);
 
 		GPOS_ASSERT(result);
@@ -1121,9 +1117,7 @@ CTranslatorDXLToExpr::ConstructDXLColId2ColRefMapping
 
 		// copy key
 		ULONG *pulKey = GPOS_NEW(m_mp) ULONG(pdxlcd->Id());
-#ifdef GPOS_DEBUG
-		BOOL result =
-#endif // GPOS_DEBUG
+		BOOL result GPOS_ASSERTS_ONLY =
 		m_phmulcr->Insert(pulKey, colref);
 
 		GPOS_ASSERT(result);
@@ -1366,9 +1360,7 @@ CTranslatorDXLToExpr::PexprLogicalCTEConsumer
 		ULONG *pulColId = GPOS_NEW(m_mp) ULONG(*(*pdrgpulCols)[ul]);
 		CColRef *colref = (*pdrgpcrConsumer)[ul];
 
-#ifdef GPOS_DEBUG
-		BOOL result =
-#endif // GPOS_DEBUG
+		BOOL result GPOS_ASSERTS_ONLY =
 		m_phmulcr->Insert(pulColId, colref);
 		GPOS_ASSERT(result);
 	}
@@ -1397,9 +1389,7 @@ CTranslatorDXLToExpr::UlMapCTEId
 	{
 		pulNewId = GPOS_NEW(m_mp) ULONG(COptCtxt::PoctxtFromTLS()->Pcteinfo()->next_id());
 
-#ifdef GPOS_DEBUG
-		BOOL fInserted =
-#endif
+		BOOL fInserted GPOS_ASSERTS_ONLY =
 		m_phmululCTE->Insert(GPOS_NEW(m_mp) ULONG(ulIdOld), pulNewId);
 		GPOS_ASSERT(fInserted);
 	}
@@ -1753,9 +1743,7 @@ CTranslatorDXLToExpr::PexprLogicalSeqPr
 			CScalarProjectElement *popScPrEl = GPOS_NEW(m_mp) CScalarProjectElement(m_mp, colref);
 
 			// store colid -> colref mapping
-#ifdef GPOS_DEBUG
-		BOOL fInserted =
-#endif
+		BOOL fInserted GPOS_ASSERTS_ONLY =
 			m_phmulcr->Insert(GPOS_NEW(m_mp) ULONG(pdxlopPrEl->Id()), colref);
 			GPOS_ASSERT(fInserted);
 
@@ -1769,9 +1757,7 @@ CTranslatorDXLToExpr::PexprLogicalSeqPr
 			{
 				CExpressionArray *pdrgpexprNew = GPOS_NEW(m_mp) CExpressionArray(m_mp);
 				pdrgpexprNew->Append(pexprProjElem);
-#ifdef GPOS_DEBUG
-			BOOL fInsert =
-#endif
+			BOOL fInsert GPOS_ASSERTS_ONLY =
 				phmulpdrgpexpr->Insert(GPOS_NEW(m_mp) ULONG(ulSpecPos), pdrgpexprNew);
 				GPOS_ASSERT(fInsert);
 			}
@@ -3923,9 +3909,7 @@ CTranslatorDXLToExpr::PexprScalarProjElem
 	CColRef *colref = m_pcf->PcrCreate(pmdtype, popScalar->TypeModifier(), name);
 	
 	// store colid -> colref mapping
-#ifdef GPOS_DEBUG
-	BOOL fInserted =
-#endif
+	BOOL fInserted GPOS_ASSERTS_ONLY =
 	m_phmulcr->Insert(GPOS_NEW(m_mp) ULONG(pdxlopPrEl->Id()), colref);
 	
 	GPOS_ASSERT(fInserted);

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -2655,9 +2655,7 @@ CTranslatorExprToDXL::PdxlnAggregate
 
 		if (NULL == phmululPL->Find(&colid))
 		{
-#ifdef GPOS_DEBUG
-			BOOL fRes =
-#endif
+			BOOL fRes GPOS_ASSERTS_ONLY =
 			phmululPL->Insert(GPOS_NEW(m_mp) ULONG(colid), GPOS_NEW(m_mp) ULONG(colid));
 			GPOS_ASSERT(fRes);
 		}
@@ -2686,9 +2684,7 @@ CTranslatorExprToDXL::PdxlnAggregate
 		{
 			CDXLNode *pdxlnProjElem = CTranslatorExprToDXLUtils::PdxlnProjElem(m_mp, m_phmcrdxln, pcrGroupingCol);
 			proj_list_dxlnode->AddChild(pdxlnProjElem);
-#ifdef GPOS_DEBUG
-		BOOL fRes =
-#endif
+		BOOL fRes GPOS_ASSERTS_ONLY =
 				phmululPL->Insert(GPOS_NEW(m_mp) ULONG(colid), GPOS_NEW(m_mp) ULONG(colid));
 			GPOS_ASSERT(fRes);
 		}
@@ -3119,9 +3115,7 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan
 	pdxlnSubPlan->AddChild(inner_dxlnode);
 
 	// add to hashmap
-#ifdef GPOS_DEBUG
-	BOOL fRes =
-#endif // GPOS_DEBUG
+	BOOL fRes GPOS_ASSERTS_ONLY =
 		m_phmcrdxln->Insert(const_cast<CColRef *>((*pdrgpcrInner)[0]), pdxlnSubPlan);
 	GPOS_ASSERT(fRes);
 
@@ -3323,9 +3317,7 @@ CTranslatorExprToDXL::PdxlnExistentialSubplan
 	pdxlnSubPlan->AddChild(inner_dxlnode);
 
 	// add to hashmap
-#ifdef GPOS_DEBUG
-	BOOL fRes =
-#endif // GPOS_DEBUG
+	BOOL fRes GPOS_ASSERTS_ONLY =
 		m_phmcrdxln->Insert(const_cast<CColRef *>((*pdrgpcrInner)[0]), pdxlnSubPlan);
 	GPOS_ASSERT(fRes);
 
@@ -3541,9 +3533,7 @@ CTranslatorExprToDXL::BuildDxlnSubPlan
 	pdxlnSubPlan->AddChild(pdxlnRelChild);
 
 	// add to hashmap
-#ifdef GPOS_DEBUG
-	BOOL fRes =
-#endif // GPOS_DEBUG
+	BOOL fRes GPOS_ASSERTS_ONLY =
 	m_phmcrdxln->Insert(const_cast<CColRef *>(colref), pdxlnSubPlan);
 	GPOS_ASSERT(fRes);
 }
@@ -7728,9 +7718,7 @@ CTranslatorExprToDXL::PdxlnProjList
 				CScalarProjectElement::PopConvert(pexprProjElem->Pop());
 
 		ULONG *pulKey = GPOS_NEW(m_mp) ULONG(popScPrEl->Pcr()->Id());
-#ifdef GPOS_DEBUG
-		BOOL fInserted =
-#endif // GPOS_DEBUG
+		BOOL fInserted GPOS_ASSERTS_ONLY =
 		phmComputedColumns->Insert(pulKey, pdxlnProjElem);
 
 		GPOS_ASSERT(fInserted);

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
@@ -1560,9 +1560,7 @@ CTranslatorExprToDXLUtils::ReplaceSubplan
 	CDXLColRef *dxl_colref = GPOS_NEW(mp) CDXLColRef(mp, mdname, pdxlopPrEl->Id(), mdid_type, colref->TypeModifier());
 	CDXLScalarIdent *pdxlnScId = GPOS_NEW(mp) CDXLScalarIdent(mp, dxl_colref);
 	CDXLNode *dxlnode = GPOS_NEW(mp) CDXLNode(mp, pdxlnScId);
-#ifdef GPOS_DEBUG
-	BOOL fReplaced =
-#endif // GPOS_DEBUG
+	BOOL fReplaced GPOS_ASSERTS_ONLY =
 		phmcrdxlnSubplans->Replace(colref, dxlnode);
 	GPOS_ASSERT(fReplaced);
 }

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDP.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDP.cpp
@@ -324,9 +324,7 @@ CJoinOrderDP::PexprPred
 	}
 
 	// store predicate in link map
-#ifdef GPOS_DEBUG
-	BOOL fInserted =
-#endif // GPOS_DEBUG
+	BOOL fInserted GPOS_ASSERTS_ONLY =
 		m_phmcomplink->Insert(pcomppair, pexprPred);
 	GPOS_ASSERT(fInserted);
 
@@ -429,9 +427,7 @@ CJoinOrderDP::InsertExpressionCost
 	}
 
 	pexpr->AddRef();
-#ifdef GPOS_DEBUG
-	BOOL fInserted =
-#endif // GPOS_DEBUG
+	BOOL fInserted GPOS_ASSERTS_ONLY =
 		m_phmexprcost->Insert(pexpr, GPOS_NEW(m_mp) CDouble(dCost));
 	GPOS_ASSERT(fInserted);
 }
@@ -484,9 +480,7 @@ CJoinOrderDP::PexprJoin
 	DeriveStats(pexprJoin);
 	// store solution in DP table
 	pbs->AddRef();
-#ifdef GPOS_DEBUG
-	BOOL fInserted =
-#endif // GPOS_DEBUG
+	BOOL fInserted GPOS_ASSERTS_ONLY =
 		m_phmbsexpr->Insert(pbs, pexprJoin);
 	GPOS_ASSERT(fInserted);
 
@@ -573,9 +567,7 @@ CJoinOrderDP::PexprBestJoinOrderDP
 
 	DeriveStats(pexprResult);
 	pbs->AddRef();
-#ifdef GPOS_DEBUG
-	BOOL fInserted =
-#endif // GPOS_DEBUG
+	BOOL fInserted GPOS_ASSERTS_ONLY =
 		m_phmbsexpr->Insert(pbs, pexprResult);
 	GPOS_ASSERT(fInserted);
 
@@ -620,9 +612,7 @@ CJoinOrderDP::GenerateSubsets
 	}
 
 	CBitSet *pbsCopy = GPOS_NEW(mp) CBitSet(mp, *pbsCurrent);
-#ifdef GPOS_DEBUG
-	BOOL fSet =
-#endif // GPOS_DEBUG
+	BOOL fSet GPOS_ASSERTS_ONLY =
 		pbsCopy->ExchangeSet(pulElems[ulIndex]);
 	GPOS_ASSERT(!fSet);
 
@@ -784,9 +774,7 @@ CJoinOrderDP::PexprCross
 	}
 
 	pbs->AddRef();
-#ifdef GPOS_DEBUG
-		BOOL fInserted =
-#endif // GPOS_DEBUG
+		BOOL fInserted GPOS_ASSERTS_ONLY =
 			m_phmbsexpr->Insert(pbs, pexprCross);
 		GPOS_ASSERT(fInserted);
 
@@ -832,9 +820,7 @@ CJoinOrderDP::PexprJoinCoveredSubsetWithUncoveredSubset
 	pexprCross->AddRef();
 	CExpression *pexprResult = CUtils::PexprLogicalJoin<CLogicalInnerJoin>(m_mp, pexprJoin, pexprCross, CPredicateUtils::PexprConjunction(m_mp, NULL));
 	pbs->AddRef();
-#ifdef GPOS_DEBUG
-	BOOL fInserted =
-#endif // GPOS_DEBUG
+	BOOL fInserted GPOS_ASSERTS_ONLY =
 		m_phmbsexpr->Insert(pbs, pexprResult);
 	GPOS_ASSERT(fInserted);
 
@@ -947,9 +933,7 @@ CJoinOrderDP::PexprBuildPred
 			!pbsSnd->IsDisjoint(pedge->m_pbs)
 			)
 		{
-#ifdef GPOS_DEBUG
-		BOOL fSet =
-#endif // GPOS_DEBUG
+		BOOL fSet GPOS_ASSERTS_ONLY =
 			pbsEdges->ExchangeSet(ul);
 			GPOS_ASSERT(!fSet);
 		}

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
@@ -241,9 +241,7 @@ CJoinOrderDPv2::PexprBuildInnerJoinPred
 			!pbsSnd->IsDisjoint(pedge->m_pbs)
 			)
 		{
-#ifdef GPOS_DEBUG
-		BOOL fSet =
-#endif // GPOS_DEBUG
+		BOOL fSet GPOS_ASSERTS_ONLY =
 			pbsEdges->ExchangeSet(ul);
 			GPOS_ASSERT(!fSet);
 		}

--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -111,9 +111,7 @@ CXformFactory::Add
 	CHAR *szXformName = GPOS_NEW_ARRAY(m_mp, CHAR, length + 1);
 	clib::Strncpy(szXformName, pxform->SzId(), length + 1);
 
-#ifdef GPOS_DEBUG
-		BOOL fInserted =
-#endif
+		BOOL fInserted GPOS_ASSERTS_ONLY =
 		m_phmszxform->Insert(szXformName, pxform);
 	GPOS_ASSERT(fInserted);
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformImplementPartitionSelector.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformImplementPartitionSelector.cpp
@@ -85,9 +85,7 @@ CXformImplementPartitionSelector::Transform
 		CExpression *pexprFilter = popSelector->PexprPartFilter(ul);
 		GPOS_ASSERT(NULL != pexprFilter);
 		pexprFilter->AddRef();
-#ifdef GPOS_DEBUG
-		BOOL fInserted =
-#endif
+		BOOL fInserted GPOS_ASSERTS_ONLY =
 		phmulexprFilter->Insert(GPOS_NEW(mp) ULONG(ul), pexprFilter);
 		GPOS_ASSERT(fInserted);
 	}

--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
@@ -758,9 +758,7 @@ CXformJoin2IndexApply::PexprJoinOverCTEConsumer
 	{
 		CColRef *pcrOld = (*pdrgpcrOuter)[ul];
 		CColRef *new_colref = (*pdrgpcrOuterNew)[ul];
-#ifdef GPOS_DEBUG
-		BOOL fInserted =
-#endif
+		BOOL fInserted GPOS_ASSERTS_ONLY =
 		colref_mapping->Insert(GPOS_NEW(mp) ULONG(pcrOld->Id()), new_colref);
 		GPOS_ASSERT(fInserted);
 	}

--- a/src/backend/gporca/libgpopt/src/xforms/CXformLeftOuter2InnerUnionAllLeftAntiSemiJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformLeftOuter2InnerUnionAllLeftAntiSemiJoin.cpp
@@ -470,9 +470,7 @@ CXformLeftOuter2InnerUnionAllLeftAntiSemiJoin::PexprProjectOverLeftAntiSemiJoin
 	{
 		ULONG ulOrigIndex = *(*pdrgpulIndexesOfOuter)[ul];
 		CColRef *pcrOriginal = (*pdrgpcrJoinOutput)[ulOrigIndex];
-#ifdef GPOS_DEBUG
-		BOOL fInserted =
-#endif
+		BOOL fInserted GPOS_ASSERTS_ONLY =
 		colref_mapping->Insert(GPOS_NEW(mp) ULONG(pcrOriginal->Id()), (*pdrgpcrOuterCopy)[ul]);
 		GPOS_ASSERT(fInserted);
 	}

--- a/src/backend/gporca/libgpopt/src/xforms/CXformSplitDQA.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformSplitDQA.cpp
@@ -907,9 +907,7 @@ CXformSplitDQA::ExtractDistinctCols
 				// insert into the map between the expression representing the DQA argument 
 				// and its column reference
 				pexprArg->AddRef();
-#ifdef GPOS_DEBUG
-				BOOL fInserted =
-#endif
+				BOOL fInserted GPOS_ASSERTS_ONLY =
 						phmexprcr->Insert(pexprArg, pcrDistinctCol);
 				GPOS_ASSERT(fInserted);
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -2025,9 +2025,7 @@ CXformUtils::AddMinAggs
 											);
 
 			pdrgpexpr->Append(pexprProjElemMin);
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 			phmcrcr->Insert(colref, new_colref);
 			GPOS_ASSERT(result);
 		}
@@ -4399,9 +4397,7 @@ CXformUtils::PexprPartialDynamicIndexGet
 			{
 				CColRef *pcrOld = (*pdrgpcrOuter)[ul];
 				CColRef *new_colref = (*pdrgpcrNewOuter)[ul];
-#ifdef GPOS_DEBUG
-				BOOL fInserted =
-#endif
+				BOOL fInserted GPOS_ASSERTS_ONLY =
 				colref_mapping->Insert(GPOS_NEW(mp) ULONG(pcrOld->Id()), new_colref);
 				GPOS_ASSERT(fInserted);
 			}

--- a/src/backend/gporca/libgpos/include/gpos/attributes.h
+++ b/src/backend/gporca/libgpos/include/gpos/attributes.h
@@ -10,4 +10,16 @@
 
 #define GPOS_ATTRIBUTE_PRINTF(f, a) __attribute__((format(GPOS_FORMAT_ARCHETYPE, f, a)))
 
+#ifdef __GNUC__
+#define GPOS_UNUSED __attribute__((unused))
+#else
+#define GPOS_UNUSED
+#endif
+
+#ifndef GPOS_DEBUG
+#define GPOS_ASSERTS_ONLY GPOS_UNUSED
+#else
+#define GPOS_ASSERTS_ONLY
+#endif
+
 #endif // !GPOS_attributes_H

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashMapTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashMapTest.cpp
@@ -67,9 +67,7 @@ CHashMapTest::EresUnittest_Basic()
 	UlongPtrToCharMap *phm = GPOS_NEW(mp) UlongPtrToCharMap(mp, 128);
 	for (ULONG i = 0; i < ulCnt; ++i)
 	{
-#ifdef GPOS_DEBUG
-		BOOL fSuccess =
-#endif // GPOS_DEBUG
+		BOOL fSuccess GPOS_ASSERTS_ONLY =
 			phm->Insert(&rgul[i], (CHAR*)rgsz[i]);
 		GPOS_ASSERT(fSuccess);
 		
@@ -84,9 +82,7 @@ CHashMapTest::EresUnittest_Basic()
 	CHAR rgszNew[][10] = {"abc_", "def_", "ghi_", "qwe_", "wer_", "wert_", "dfg_", "xcv_", "zxc_"};
 	for (ULONG i = 0; i < ulCnt; ++i)
 	{
-#ifdef GPOS_DEBUG
-		BOOL fSuccess =
-#endif // GPOS_DEBUG
+		BOOL fSuccess GPOS_ASSERTS_ONLY =
 			phm->Replace(&rgul[i], rgszNew[i]);
 		GPOS_ASSERT(fSuccess);
 
@@ -100,9 +96,7 @@ CHashMapTest::EresUnittest_Basic()
 
 	// test replacing entry value of a non-existing key
 	ULONG_PTR ulp = 0;
-#ifdef GPOS_DEBUG
-	BOOL fSuccess =
-#endif // GPOS_DEBUG
+	BOOL fSuccess GPOS_ASSERTS_ONLY =
 		phm->Replace(&ulp, rgsz[0]);
 	GPOS_ASSERT(!fSuccess);
 
@@ -169,9 +163,7 @@ CHashMapTest::EresUnittest_Ownership()
 		ULONG_PTR *pulp = GPOS_NEW(mp) ULONG_PTR(i);
 		CHAR *sz = GPOS_NEW_ARRAY(mp, CHAR, 3);
 	
-#ifdef GPOS_DEBUG
-		BOOL fSuccess =
-#endif // GPOS_DEBUG
+		BOOL fSuccess GPOS_ASSERTS_ONLY =
 			phm->Insert(pulp, sz);
 
 		GPOS_ASSERT(fSuccess);

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashSetTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashSetTest.cpp
@@ -71,9 +71,7 @@ CHashSetTest::EresUnittest_Basic()
 	UlongPtrHashSet *phs = GPOS_NEW(mp) UlongPtrHashSet(mp, 128);
 	for (ULONG ul = 0; ul < ulCnt; ul++)
 	{
-#ifdef GPOS_DEBUG
-		BOOL fSuccess =
-#endif // GPOS_DEBUG
+		BOOL fSuccess GPOS_ASSERTS_ONLY =
 			phs->Insert(&rgul[ul]);
 		GPOS_ASSERT(fSuccess);
 	}
@@ -114,9 +112,7 @@ CHashSetTest::EresUnittest_Ownership()
 	{
 		ULONG_PTR *pulp = GPOS_NEW(mp) ULONG_PTR(ul);
 
-#ifdef GPOS_DEBUG
-		BOOL fSuccess =
-#endif // GPOS_DEBUG
+		BOOL fSuccess GPOS_ASSERTS_ONLY =
 			phs->Insert(pulp);
 
 		GPOS_ASSERT(fSuccess);

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CSyncHashtableTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CSyncHashtableTest.cpp
@@ -380,9 +380,7 @@ CSyncHashtableTest::EresUnittest_NonConcurrentIteration()
 	{
 		SElemHashtableIterAccessor htitacc(shtit);
 
-#ifdef GPOS_DEBUG
-		SElem *pelem =
-#endif	// GPOS_DEBUG
+		SElem *pelem GPOS_ASSERTS_ONLY =
 			htitacc.Value();
 
 		GPOS_ASSERT(NULL != pelem);

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CSyncListTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CSyncListTest.cpp
@@ -83,9 +83,7 @@ CSyncListTest::EresUnittest_Basics()
 	// pop elements until empty
 	for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgelem); i++)
 	{
-#ifdef GPOS_DEBUG
-		SElem *pe =
-#endif // GPOS_DEBUG
+		SElem *pe GPOS_ASSERTS_ONLY =
 			list.Pop();
 
 		GPOS_ASSERT(pe == &rgelem[GPOS_ARRAY_SIZE(rgelem) - i - 1]);
@@ -103,9 +101,7 @@ CSyncListTest::EresUnittest_Basics()
 	// pop elements until empty
 	for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgelem); i++)
 	{
-#ifdef GPOS_DEBUG
-		SElem *pe =
-#endif // GPOS_DEBUG
+		SElem *pe GPOS_ASSERTS_ONLY =
 			list.Pop();
 
 		GPOS_ASSERT(pe == &rgelem[i]);

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/io/CFileTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/io/CFileTest.cpp
@@ -466,9 +466,7 @@ CFileTest::Unittest_ReadInconsistentSize
 	GPOS_ASSERT(ulExpectSize == ulpRdSize);
 	GPOS_ASSERT(ulExpectSize == rd.FileReadSize());
 
-#ifdef GPOS_DEBUG
-	BOOL fEqual =
-#endif // GPOS_DEBUG
+	BOOL fEqual GPOS_ASSERTS_ONLY =
 	strRdData.Equals(szExpectData);
 
 	GPOS_ASSERT(fEqual);

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/io/COstreamFileTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/io/COstreamFileTest.cpp
@@ -150,9 +150,7 @@ COstreamFileTest::Unittest_CheckOutputFile
 	const ULONG ulReadBufferSize = 1024;
 	WCHAR wszReadBuffer[ulReadBufferSize];
 
-#ifdef GPOS_DEBUG
-	ULONG_PTR ulpRead =
-#endif // GPOS_DEBUG
+	ULONG_PTR ulpRead GPOS_ASSERTS_ONLY =
 	fr.ReadBytesToBuffer((BYTE *) wszReadBuffer, GPOS_ARRAY_SIZE(wszReadBuffer));
 
 	CWStringConst strExpected(GPOS_WSZ_LIT("WC102-10some regular stringdeadbeef"));

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/memory/CCacheTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/memory/CCacheTest.cpp
@@ -231,9 +231,7 @@ CCacheTest::EresUnittest_Basic()
 
 		SSimpleObject *pso = GPOS_NEW(ca.Pmp()) SSimpleObject(1, 2);
 
-#ifdef GPOS_DEBUG
-		SSimpleObject *psoReturned =
-#endif // GPOS_DEBUG
+		SSimpleObject *psoReturned GPOS_ASSERTS_ONLY =
 			ca.Insert(&(pso->m_ulKey), pso);
 
 		//release the ownership from pso, but ccacheentry still has the ownership
@@ -249,9 +247,7 @@ CCacheTest::EresUnittest_Basic()
 			CSimpleObjectCacheAccessor ca(pcache);
 			SSimpleObject *psoDuplicate = GPOS_NEW(ca.Pmp()) SSimpleObject(1, 5);
 
-#ifdef GPOS_DEBUG
-			SSimpleObject *psoReturned =
-#endif // GPOS_DEBUG
+			SSimpleObject *psoReturned GPOS_ASSERTS_ONLY =
 				ca.Insert(&(psoDuplicate->m_ulKey), psoDuplicate);
 
 			GPOS_ASSERT(psoReturned == pso &&
@@ -454,9 +450,7 @@ CCacheTest::ULFillCacheWithoutEviction(CCache<SSimpleObject*, ULONG*> *pCache, U
 		GPOS_CHECK_ABORT;
 	}
 
-#ifdef GPOS_DEBUG
-	ULLONG ullSizeBeforeEviction =
-#endif // GPOS_DEBUG
+	ULLONG ullSizeBeforeEviction GPOS_ASSERTS_ONLY =
 			pCache->TotalAllocatedSize();
 
 	// Check the size of the cache. Nothing should be evicted if the cache was initially empty
@@ -669,9 +663,7 @@ CCacheTest::EresInsertDuplicates
 			CSimpleObjectCacheAccessor ca(pcache);
 			SSimpleObject *pso = GPOS_NEW(ca.Pmp()) SSimpleObject(i, j);
 
-#ifdef GPOS_DEBUG
-			SSimpleObject *psoReturned =
-#endif // GPOS_DEBUG
+			SSimpleObject *psoReturned GPOS_ASSERTS_ONLY =
 					ca.Insert(&(pso->m_ulKey), pso);
 
 			GPOS_ASSERT(NULL != psoReturned);
@@ -784,9 +776,7 @@ CCacheTest::EresUnittest_DeepObject()
 		pdo->AddEntry(mp, 1, 1);
 		pdo->AddEntry(mp, 2, 2);
 
-#ifdef GPOS_DEBUG
-		CDeepObject *pdoReturned =
-#endif // GPOS_DEBUG
+		CDeepObject *pdoReturned GPOS_ASSERTS_ONLY =
 			ca.Insert(pdo->Key(), pdo);
 		pdo->Release();
 
@@ -802,9 +792,7 @@ CCacheTest::EresUnittest_DeepObject()
 			pdoDuplicate->AddEntry(mp, 1, 5);
 			pdoDuplicate->AddEntry(mp, 2, 5);
 
-#ifdef GPOS_DEBUG
-			CDeepObject *pdoReturned  =
-#endif // GPOS_DEBUG
+			CDeepObject *pdoReturned  GPOS_ASSERTS_ONLY =
 				ca.Insert(pdoDuplicate->Key(), pdoDuplicate);
 
 			GPOS_ASSERT(pdoReturned == pdo &&

--- a/src/backend/gporca/libgpos/src/common/clibwrapper.cpp
+++ b/src/backend/gporca/libgpos/src/common/clibwrapper.cpp
@@ -498,9 +498,7 @@ gpos::clib::Strerror_r
 	}
 #else  // !_GNU_SOURCE
 	// POSIX.1-2001 standard strerror_r() returns int.
-#ifdef GPOS_DEBUG
-	INT str_err_code =
-#endif
+	INT str_err_code GPOS_ASSERTS_ONLY =
 			strerror_r(errnum, buf, buf_len);
 	GPOS_ASSERT(0 == str_err_code);
 
@@ -734,9 +732,7 @@ gpos::clib::Dladdr
 	DL_INFO *info
 	)
 {
-#ifdef GPOS_DEBUG
-	INT res =
-#endif
+	INT res GPOS_ASSERTS_ONLY =
 	dladdr(addr, info);
 
 	GPOS_ASSERT(0 != res);

--- a/src/backend/gporca/libgpos/src/common/syslibwrapper.cpp
+++ b/src/backend/gporca/libgpos/src/common/syslibwrapper.cpp
@@ -42,9 +42,7 @@ gpos::syslib::GetTimeOfDay
 {
 	GPOS_ASSERT(NULL != tv);
 
-#ifdef GPOS_DEBUG
-	INT res =
-#endif // GPOS_DEBUG
+	INT res GPOS_ASSERTS_ONLY =
 	gettimeofday(tv, tz);
 
 	GPOS_ASSERT(0 == res);
@@ -67,9 +65,7 @@ gpos::syslib::GetRusage
 {
 	GPOS_ASSERT(NULL != usage);
 
-#ifdef GPOS_DEBUG
-	INT res =
-#endif // GPOS_DEBUG
+	INT res GPOS_ASSERTS_ONLY =
 	getrusage(RUSAGE_SELF, usage);
 
 	GPOS_ASSERT(0 == res);

--- a/src/backend/gporca/libgpos/src/error/CLogger.cpp
+++ b/src/backend/gporca/libgpos/src/error/CLogger.cpp
@@ -188,9 +188,7 @@ CLogger::AppendDate()
 
 	// get local time
 	syslib::GetTimeOfDay(&tv, NULL/*timezone*/);
-#ifdef GPOS_DEBUG
-	TIME *t =
-#endif // GPOS_DEBUG
+	TIME *t GPOS_ASSERTS_ONLY =
 	clib::Localtime_r(&tv.tv_sec, &tm);
 
 	GPOS_ASSERT(NULL != t && "Failed to get local time");

--- a/src/backend/gporca/libgpos/src/string/CWStringDynamic.cpp
+++ b/src/backend/gporca/libgpos/src/string/CWStringDynamic.cpp
@@ -183,9 +183,7 @@ CWStringDynamic::AppendCharArray
 	WCHAR *w_str_buffer = GPOS_NEW_ARRAY(m_mp, WCHAR, length + 1);
 
 	// convert input string to wide character buffer
-#ifdef GPOS_DEBUG
-	ULONG wide_length =
-#endif // GPOS_DEBUG
+	ULONG wide_length GPOS_ASSERTS_ONLY =
 		clib::Mbstowcs(w_str_buffer, sz, length);
 	GPOS_ASSERT(wide_length == length);
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerFactory.cpp
@@ -38,9 +38,7 @@ CParseHandlerFactory::AddMapping
 	const XMLCh *token_identifier_str = CDXLTokens::XmlstrToken(token_type);
 	GPOS_ASSERT(NULL != token_identifier_str);
 	
-#ifdef GPOS_DEBUG
-	BOOL success =
-#endif
+	BOOL success GPOS_ASSERTS_ONLY =
 	m_token_parse_handler_func_map->Insert(token_identifier_str, parse_handler_op_func);
 	
 	GPOS_ASSERT(success);

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerSearchStage.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerSearchStage.cpp
@@ -141,9 +141,7 @@ CParseHandlerSearchStage::EndElement
 	for (ULONG idx = 0; idx < size; idx++)
 	{
 		CParseHandlerXform *xform_set_parse_handler = dynamic_cast<CParseHandlerXform*>((*this)[idx]);
-#ifdef GPOS_DEBUG
-		BOOL fSet =
-#endif // GPOS_DEBUG
+		BOOL fSet GPOS_ASSERTS_ONLY =
 			m_xforms->ExchangeSet(xform_set_parse_handler->GetXform()->Exfid());
 		GPOS_ASSERT(!fSet);
 	}

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
@@ -794,9 +794,7 @@ CStatistics::AddWidthInfoWithRemap
 		{
 			const CDouble *width = col_width_map_iterator.Value();
 			CDouble *width_copy = GPOS_NEW(mp) CDouble(*width);
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 					dest_width->Insert(GPOS_NEW(mp) ULONG(colid), width_copy);
 			GPOS_ASSERT(result);
 		}

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -857,17 +857,13 @@ CStatisticsUtils::AddHistogram
 
 	if (NULL == col_histogram_mapping->Find(&colid))
 	{
-#ifdef GPOS_DEBUG
-		BOOL result =
-#endif
+		BOOL result GPOS_ASSERTS_ONLY =
 		col_histogram_mapping->Insert(GPOS_NEW(mp) ULONG(colid), histogram->CopyHistogram());
 		GPOS_ASSERT(result);
 	}
 	else if (replace_old)
 	{
-#ifdef GPOS_DEBUG
-		BOOL result =
-#endif
+		BOOL result GPOS_ASSERTS_ONLY =
 		col_histogram_mapping->Replace(&colid, histogram->CopyHistogram());
 		GPOS_ASSERT(result);
 	}
@@ -1334,9 +1330,7 @@ CStatisticsUtils::GetGrpColIdToUpperBoundNDVIdxMap
 			{
 				ULongPtrArray *colids_new = GPOS_NEW(mp) ULongPtrArray(mp);
 				colids_new->Append(GPOS_NEW(mp) ULONG(colid));
-#ifdef GPOS_DEBUG
-		BOOL fres =
-#endif // GPOS_DEBUG
+		BOOL fres GPOS_ASSERTS_ONLY =
 					grp_colid_upper_bound_ndv_idx_map->Insert(GPOS_NEW(mp) ULONG(upper_bound_ndv_idx), colids_new);
 				GPOS_ASSERT(fres);
 			}

--- a/src/backend/gporca/libnaucrates/src/traceflags.cpp
+++ b/src/backend/gporca/libnaucrates/src/traceflags.cpp
@@ -52,18 +52,14 @@ void SetTraceflags
 		if (GPOS_FTRACE(ulTraceFlag))
 		{
 			// set trace flag in the enabled set
-#ifdef GPOS_DEBUG
-			BOOL fSet =
-#endif	// GPOS_DEBUG
+			BOOL fSet GPOS_ASSERTS_ONLY =
 				(*ppbsEnabled)->ExchangeSet(ulTraceFlag);
 			GPOS_ASSERT(!fSet);
 		}
 		else
 		{
 			// set trace flag in the disabled set
-#ifdef GPOS_DEBUG
-			BOOL fSet =
-#endif	// GPOS_DEBUG
+			BOOL fSet GPOS_ASSERTS_ONLY =
 				(*ppbsDisabled)->ExchangeSet(ulTraceFlag);
 			GPOS_ASSERT(!fSet);
 		}

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -833,9 +833,7 @@ CDXLTokens::XmlstrFromWsz
 	ULONG length = GPOS_WSZ_LENGTH(wsz);
 	CHAR *sz = GPOS_NEW_ARRAY(m_mp, CHAR, 1 + length);
 
-#ifdef GPOS_DEBUG
-	LINT  iLen =
-#endif
+	LINT  iLen GPOS_ASSERTS_ONLY =
 	clib::Wcstombs(sz, const_cast<WCHAR *>(wsz), 1 + length);
 	
 	GPOS_ASSERT(0 <= iLen);

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -293,9 +293,7 @@ CTestUtils::PtabdescCreate
 	// create a keyset containing the first column
 	CBitSet *pbs = GPOS_NEW(mp) CBitSet(mp, num_cols);
 	pbs->ExchangeSet(0);
-#ifdef GPOS_DEBUG
-	BOOL fSuccess =
-#endif // GPOS_DEBUG
+	BOOL fSuccess GPOS_ASSERTS_ONLY =
 		ptabdesc->FAddKeySet(pbs);
 	GPOS_ASSERT(fSuccess);
 

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
@@ -93,9 +93,7 @@ CJoinCardinalityTest::EresUnittest_JoinNDVRemain()
 		CDouble num_NDV_remain = elem.m_dNDVRemain;
 
 		CHistogram *histogram = CCardinalityTestUtils::PhistInt4Remain(mp, num_of_buckets, dNDVPerBucket, fNullFreq, num_NDV_remain);
-#ifdef GPOS_DEBUG
-			BOOL result =
-#endif // GPOS_DEBUG
+			BOOL result GPOS_ASSERTS_ONLY =
 		col_histogram_mapping->Insert(GPOS_NEW(mp) ULONG(ul1), histogram);
 		GPOS_ASSERT(result);
 	}

--- a/src/backend/gporca/server/src/unittest/gpopt/base/COrderSpecTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/base/COrderSpecTest.cpp
@@ -119,16 +119,12 @@ COrderSpecTest::EresUnittest_Basics()
 	// iterate over the components of the order spec
 	for (ULONG ul = 0; ul < pos1->UlSortColumns(); ul++)
 	{
-#ifdef GPOS_DEBUG
-		const CColRef *colref =
-#endif // GPOS_DEBUG
+		const CColRef *colref GPOS_ASSERTS_ONLY =
 		pos1->Pcr(ul);
 		
 		GPOS_ASSERT(NULL != colref);
 		
-#ifdef GPOS_DEBUG
-		const IMDId *mdid =
-#endif // GPOS_DEBUG
+		const IMDId *mdid GPOS_ASSERTS_ONLY =
 		pos1->GetMdIdSortOp(ul);
 		
 		GPOS_ASSERT(mdid->IsValid());

--- a/src/backend/gporca/server/src/unittest/gpopt/base/CStateMachineTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/base/CStateMachineTest.cpp
@@ -131,9 +131,7 @@ CStateMachineTest::EresUnittest_Basics()
 		// choose random event
 		ULONG ul = rand.Next() % GPOS_ARRAY_SIZE(rgev);
 
-#ifdef GPOS_DEBUG
-		BOOL fCheck =
-#endif // GPOS_DEBUG
+		BOOL fCheck GPOS_ASSERTS_ONLY =
 			ptm->Psm()->FTransition(rgev[ul], es);
 			
 		GPOS_ASSERT_IFF(eeThree != rgev[ul], fCheck);

--- a/src/backend/gporca/server/src/unittest/gpopt/mdcache/CMDAccessorTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/mdcache/CMDAccessorTest.cpp
@@ -154,9 +154,7 @@ CMDAccessorTest::EresUnittest_Basic()
 #endif
 	mda.RetrieveType(mdid_type);
 	
-#ifdef GPOS_DEBUG
-	const IMDScalarOp *md_scalar_op =
-#endif
+	const IMDScalarOp *md_scalar_op GPOS_ASSERTS_ONLY =
 	mda.RetrieveScOp(mdid_op);
 
 	GPOS_ASSERT(IMDType::EcmptL == md_scalar_op->ParseCmpType());
@@ -349,9 +347,7 @@ CMDAccessorTest::EresUnittest_Navigate()
 	// lookup equality operator for function return type
 	IMDId *pmdidEqOp = pimdtype->GetMdidForCmpType(IMDType::EcmptEq);
 
-#ifdef GPOS_DEBUG
-	const IMDScalarOp *md_scalar_op =
-#endif
+	const IMDScalarOp *md_scalar_op GPOS_ASSERTS_ONLY =
 	mda.RetrieveScOp(pmdidEqOp);
 		
 #ifdef GPOS_DEBUG

--- a/src/backend/gporca/server/src/unittest/gpopt/operators/CPredicateUtilsTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/operators/CPredicateUtilsTest.cpp
@@ -183,9 +183,7 @@ CPredicateUtilsTest::EresUnittest_Disjunctions()
 	CColRefSet *pcrs = pexprGet->DeriveOutputColumns();
 	CColRefSetIter crsi(*pcrs);
 
-#ifdef GPOS_DEBUG
-	BOOL fAdvance =
-#endif
+	BOOL fAdvance GPOS_ASSERTS_ONLY =
 	crsi.Advance();
 	GPOS_ASSERT(fAdvance);
 	CColRef *pcr1 = crsi.Pcr();


### PR DESCRIPTION
This patch set has two commits, one introduces the attribute we can adorn variables with, and the second commit applies it in about 100 places. See each commit for detail.

TL;DR: instead of writing code like this:

```C++
#ifdef GPOS_DEBUG
    BOOL result =
#endif // GPOS_DEBUG
            m_cte_consumer_info->Insert(key, GPOS_NEW(m_mp) SCTEConsumerInfo(cte_plan));
```

you can now write it like this:
```C++
    BOOL result GPOS_ASSERTS_ONLY =
            m_cte_consumer_info->Insert(key, GPOS_NEW(m_mp) SCTEConsumerInfo(cte_plan));
```

## Here are some reminders before you submit the pull request
~- [ ] Add tests for the change~
~- [ ] Document changes~
~- [ ] Communicate in the mailing list if needed~
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
