### PR TITLE
Fix bug for ANALYZE inherited tables.

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -709,7 +709,13 @@ do_analyze_rel(Relation onerel, int options, VacuumParams *params,
 		rows = NULL;
 	}
 
-	if (ctx)
+	/*
+	 * When QD acquiring sample rows on QE, the QE should only collects required
+	 * on parent or all inherited tables. Otherwise, the QD may get wrong results
+	 * for parent table since the inherited tables will overwrite the expected
+	 * values.
+	 */
+	if (ctx && (inh == ctx->inherited))
 	{
 		ctx->sample_rows = rows;
 		ctx->num_sample_rows = numrows;

--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -85,6 +85,7 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 	MemoryContext oldcontext;
 	Oid			relOid = PG_GETARG_OID(0);
 	int32		targrows = PG_GETARG_INT32(1);
+	bool        inherited = PG_GETARG_BOOL(2);
 	TupleDesc	relDesc;
 	TupleDesc	outDesc;
 	int			live_natts;
@@ -111,6 +112,7 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		/* Construct the context to keep across calls. */
 		ctx = (gp_acquire_sample_rows_context *) palloc0(sizeof(gp_acquire_sample_rows_context));
 		ctx->targrows = targrows;
+		ctx->inherited = inherited;
 
 		if (!pg_class_ownercheck(relOid, GetUserId()))
 			aclcheck_error(ACLCHECK_NOT_OWNER, ACL_KIND_CLASS,

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -185,6 +185,9 @@ typedef struct
 	Relation	onerel;
 	int32		targrows;
 
+	/* whether acquire inherited sample rows */
+	bool        inherited;
+
 	/* Sampled rows and estimated total number of rows in the table. */
 	HeapTuple  *sample_rows;
 	int			num_sample_rows;

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -952,3 +952,60 @@ drop table testid;
 drop extension citext;
 drop schema test_ns;
 drop role nsuser1;
+set search_path to default;
+--
+-- Test analyze on inherited table.
+-- We used to have a bug for acquiring sample rows on QE. It always return
+-- rows for all inherited tables even the QD only wants samples for parent table's.
+--
+CREATE TABLE ana_parent (aa int);
+CREATE TABLE ana_c1 (bb text) INHERITS (ana_parent);
+CREATE TABLE ana_c2 (cc text) INHERITS (ana_c1);
+INSERT INTO ana_c1 SELECT i, 'bb' FROM generate_series(1, 10) AS i;
+INSERT INTO ana_c2 SELECT i, 'bb', 'cc' FROM generate_series(10, 20) AS i;
+ANALYZE ana_parent;
+ANALYZE ana_c1;
+ANALYZE ana_c2;
+-- Check pg_class entry
+SELECT relpages, reltuples FROM pg_class WHERE relname = 'ana_parent';
+ relpages | reltuples 
+----------+-----------
+        1 |         0
+(1 row)
+
+SELECT relpages, reltuples FROM pg_class WHERE relname = 'ana_c1';
+ relpages | reltuples 
+----------+-----------
+        3 |        10
+(1 row)
+
+SELECT relpages, reltuples FROM pg_class WHERE relname = 'ana_c2';
+ relpages | reltuples 
+----------+-----------
+        3 |        11
+(1 row)
+
+-- Check pg_stats entries
+SELECT * FROM pg_stats WHERE tablename = 'ana_parent';
+ schemaname | tablename  | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs |                 histogram_bounds                  | correlation | most_common_elems | most_common_elem_freqs | elem_count_histogram 
+------------+------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+---------------------------------------------------+-------------+-------------------+------------------------+----------------------
+ public     | ana_parent | aa      | t         |         0 |         4 |  -0.952381 | {10}             | {0.0952381}       | {1,2,3,4,5,6,7,8,9,11,12,13,14,15,16,17,18,19,20} |     0.38961 |                   |                        | 
+(1 row)
+
+SELECT * FROM pg_stats WHERE tablename = 'ana_c1';
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs |                 histogram_bounds                  | correlation | most_common_elems | most_common_elem_freqs | elem_count_histogram 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+---------------------------------------------------+-------------+-------------------+------------------------+----------------------
+ public     | ana_c1    | aa      | f         |         0 |         4 |         -1 |                  |                   | {1,2,3,4,5,6,7,8,9,10}                            |    0.672727 |                   |                        | 
+ public     | ana_c1    | bb      | f         |         0 |         3 |          1 | {bb}             | {1}               |                                                   |           1 |                   |                        | 
+ public     | ana_c1    | aa      | t         |         0 |         4 |  -0.952381 | {10}             | {0.0952381}       | {1,2,3,4,5,6,7,8,9,11,12,13,14,15,16,17,18,19,20} |     0.38961 |                   |                        | 
+ public     | ana_c1    | bb      | t         |         0 |         3 |          1 | {bb}             | {1}               |                                                   |           1 |                   |                        | 
+(4 rows)
+
+SELECT * FROM pg_stats WHERE tablename = 'ana_c2';
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs |          histogram_bounds          | correlation | most_common_elems | most_common_elem_freqs | elem_count_histogram 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------------------------+-------------+-------------------+------------------------+----------------------
+ public     | ana_c2    | aa      | f         |         0 |         4 |         -1 |                  |                   | {10,11,12,13,14,15,16,17,18,19,20} |   -0.327273 |                   |                        | 
+ public     | ana_c2    | bb      | f         |         0 |         3 |          1 | {bb}             | {1}               |                                    |           1 |                   |                        | 
+ public     | ana_c2    | cc      | f         |         0 |         3 |          1 | {cc}             | {1}               |                                    |           1 |                   |                        | 
+(3 rows)
+


### PR DESCRIPTION
When QD acquiring sample rows on QE, the QE should only collects required
on parent or all inherited tables. Otherwise, the QD may get wrong results
for parent table since the inherited tables will overwrite the expected
values. And we'll have incorrect results in pg_class and pg_statistic.

In `gp_acquire_sample_rows`, the function has three inputs, but somehow,
the code loses the last `inherited` argument usage. This is important to
distinguish whether the QD need samples for parent only or all inherited
tables.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
