### PR TITLE
Fix Orca CTAS for tables created with legacy hashops

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5149,7 +5149,7 @@ CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToDistrPolicy
 			Oid typeoid = gpdb::ExprType((Node *) tle->expr);
 
 			distr_policy->attrs[ul] = col_pos_idx + 1;
-			distr_policy->opclasses[ul] = m_dxl_to_plstmt_context->GetDistributionHashOpclassForType(typeoid);
+			distr_policy->opclasses[ul] = gpdb::GetColumnDefOpclassForType(NIL, typeoid);
 		}
 	}
 	return distr_policy;

--- a/src/test/regress/expected/gpdist_legacy_opclasses.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses.out
@@ -418,3 +418,39 @@ select dp.localoid::regclass::name as name, oc.opcname
  ctastest_on  | cdbhash_int4_ops
 (2 rows)
 
+-- CTAS should use value of gp_use_legacy_hashops when setting the distribution policy based on an existing table
+set gp_use_legacy_hashops=on;
+create table ctas_base_legacy as select unnest(array[1,2,3]) as col distributed by (col);
+set gp_use_legacy_hashops=off;
+create table ctas_from_legacy as select * from ctas_base_legacy distributed by (col);
+create table ctas_base_nonlegacy as select unnest(array[1,2,3]) as col distributed by (col);
+set gp_use_legacy_hashops=on;
+create table ctas_from_nonlegacy as select * from ctas_base_nonlegacy distributed by (col);
+select dp.localoid::regclass::name as name, oc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass oc
+    on oc.oid::text = dp.distclass::text
+ where dp.localoid in ('ctas_base_legacy'::regclass::oid,
+                       'ctas_from_legacy'::regclass::oid,
+                       'ctas_base_nonlegacy'::regclass::oid,
+                       'ctas_from_nonlegacy'::regclass::oid);
+        name         |     opcname      
+---------------------+------------------
+ ctas_base_nonlegacy | int4_ops
+ ctas_from_legacy    | int4_ops
+ ctas_from_nonlegacy | cdbhash_int4_ops
+ ctas_base_legacy    | cdbhash_int4_ops
+(4 rows)
+
+select * from ctas_from_legacy where col=1;
+ col 
+-----
+   1
+(1 row)
+
+select * from ctas_from_nonlegacy where col=1;
+ col 
+-----
+   1
+(1 row)
+

--- a/src/test/regress/expected/gpdist_legacy_opclasses.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses.out
@@ -426,14 +426,14 @@ create table ctas_from_legacy as select * from ctas_base_legacy distributed by (
 create table ctas_base_nonlegacy as select unnest(array[1,2,3]) as col distributed by (col);
 set gp_use_legacy_hashops=on;
 create table ctas_from_nonlegacy as select * from ctas_base_nonlegacy distributed by (col);
-select dp.localoid::regclass::name as name, oc.opcname
+select dp.localoid::regclass as name, opc.opcname
   from gp_distribution_policy dp
-  join pg_opclass oc
-    on oc.oid::text = dp.distclass::text
- where dp.localoid in ('ctas_base_legacy'::regclass::oid,
-                       'ctas_from_legacy'::regclass::oid,
-                       'ctas_base_nonlegacy'::regclass::oid,
-                       'ctas_from_nonlegacy'::regclass::oid);
+  join pg_opclass opc
+    on ARRAY[opc.oid]::oidvector = dp.distclass
+ where dp.localoid in ('ctas_base_legacy'::regclass,
+                       'ctas_from_legacy'::regclass,
+                       'ctas_base_nonlegacy'::regclass,
+                       'ctas_from_nonlegacy'::regclass);
         name         |     opcname      
 ---------------------+------------------
  ctas_base_nonlegacy | int4_ops

--- a/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
@@ -425,14 +425,14 @@ create table ctas_from_legacy as select * from ctas_base_legacy distributed by (
 create table ctas_base_nonlegacy as select unnest(array[1,2,3]) as col distributed by (col);
 set gp_use_legacy_hashops=on;
 create table ctas_from_nonlegacy as select * from ctas_base_nonlegacy distributed by (col);
-select dp.localoid::regclass::name as name, oc.opcname
+select dp.localoid::regclass as name, opc.opcname
   from gp_distribution_policy dp
-  join pg_opclass oc
-    on oc.oid::text = dp.distclass::text
- where dp.localoid in ('ctas_base_legacy'::regclass::oid,
-                       'ctas_from_legacy'::regclass::oid,
-                       'ctas_base_nonlegacy'::regclass::oid,
-                       'ctas_from_nonlegacy'::regclass::oid);
+  join pg_opclass opc
+    on ARRAY[opc.oid]::oidvector = dp.distclass
+ where dp.localoid in ('ctas_base_legacy'::regclass,
+                       'ctas_from_legacy'::regclass,
+                       'ctas_base_nonlegacy'::regclass,
+                       'ctas_from_nonlegacy'::regclass);
         name         |     opcname      
 ---------------------+------------------
  ctas_base_nonlegacy | int4_ops

--- a/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
@@ -417,3 +417,39 @@ select dp.localoid::regclass::name as name, oc.opcname
  ctastest_on  | cdbhash_int4_ops
 (2 rows)
 
+-- CTAS should use value of gp_use_legacy_hashops when setting the distribution policy based on an existing table
+set gp_use_legacy_hashops=on;
+create table ctas_base_legacy as select unnest(array[1,2,3]) as col distributed by (col);
+set gp_use_legacy_hashops=off;
+create table ctas_from_legacy as select * from ctas_base_legacy distributed by (col);
+create table ctas_base_nonlegacy as select unnest(array[1,2,3]) as col distributed by (col);
+set gp_use_legacy_hashops=on;
+create table ctas_from_nonlegacy as select * from ctas_base_nonlegacy distributed by (col);
+select dp.localoid::regclass::name as name, oc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass oc
+    on oc.oid::text = dp.distclass::text
+ where dp.localoid in ('ctas_base_legacy'::regclass::oid,
+                       'ctas_from_legacy'::regclass::oid,
+                       'ctas_base_nonlegacy'::regclass::oid,
+                       'ctas_from_nonlegacy'::regclass::oid);
+        name         |     opcname      
+---------------------+------------------
+ ctas_base_nonlegacy | int4_ops
+ ctas_from_legacy    | int4_ops
+ ctas_from_nonlegacy | cdbhash_int4_ops
+ ctas_base_legacy    | cdbhash_int4_ops
+(4 rows)
+
+select * from ctas_from_legacy where col=1;
+ col 
+-----
+   1
+(1 row)
+
+select * from ctas_from_nonlegacy where col=1;
+ col 
+-----
+   1
+(1 row)
+

--- a/src/test/regress/sql/gpdist_legacy_opclasses.sql
+++ b/src/test/regress/sql/gpdist_legacy_opclasses.sql
@@ -247,13 +247,13 @@ create table ctas_base_nonlegacy as select unnest(array[1,2,3]) as col distribut
 set gp_use_legacy_hashops=on;
 create table ctas_from_nonlegacy as select * from ctas_base_nonlegacy distributed by (col);
 
-select dp.localoid::regclass::name as name, oc.opcname
+select dp.localoid::regclass as name, opc.opcname
   from gp_distribution_policy dp
-  join pg_opclass oc
-    on oc.oid::text = dp.distclass::text
- where dp.localoid in ('ctas_base_legacy'::regclass::oid,
-                       'ctas_from_legacy'::regclass::oid,
-                       'ctas_base_nonlegacy'::regclass::oid,
-                       'ctas_from_nonlegacy'::regclass::oid);
+  join pg_opclass opc
+    on ARRAY[opc.oid]::oidvector = dp.distclass
+ where dp.localoid in ('ctas_base_legacy'::regclass,
+                       'ctas_from_legacy'::regclass,
+                       'ctas_base_nonlegacy'::regclass,
+                       'ctas_from_nonlegacy'::regclass);
 select * from ctas_from_legacy where col=1;
 select * from ctas_from_nonlegacy where col=1;


### PR DESCRIPTION
For CTAS creating tables with non-legacy hashop distribution from tables
with legacy hashops, CTAS with Orca would distribute the data according
to the value of gp_use_legacy_hashops; however, it would set the table's
distribution policy hashop to the value of the original table. This
caused queries to give incorrect results as the distribution policy
mismatched the data distribution.

Now, we also set the new table's distribution policy according to
gp_use_legacy_hashops, irrespective of whether the original table was
created with a legacy or non-legacy hashop. This is aligned with 
the table's actual distribution and planner's behavior.