### PR TITLE
Re-enable upstream optimization to pull up simple UNION ALL subqueries.

### DIFF
--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -633,66 +633,68 @@ explain select count(*) from
 	  union all
 	  select * from t, pt where tid + 2 = ptid
 	  ) foo;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=41.10..41.11 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=41.07..41.10 rows=1 width=8)
-         ->  Partial Aggregate  (cost=41.07..41.08 rows=1 width=8)
-               ->  Append  (cost=1.18..40.62 rows=12 width=50)
-                     ->  Hash Join  (cost=1.18..20.10 rows=6 width=50)
-                           Hash Cond: (pt_1_prt_junk_data.ptid = t.tid)
-                           ->  Append  (cost=0.00..18.54 rows=18 width=31)
-                                 ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                                       One-Time Filter: PartSelected
-                                       ->  Seq Scan on pt_1_prt_junk_data  (cost=0.00..3.09 rows=3 width=31)
-                                 ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                                       One-Time Filter: PartSelected
-                                       ->  Seq Scan on pt_1_prt_2  (cost=0.00..3.09 rows=3 width=31)
-                                 ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                                       One-Time Filter: PartSelected
-                                       ->  Seq Scan on pt_1_prt_3  (cost=0.00..3.09 rows=3 width=31)
-                                 ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                                       One-Time Filter: PartSelected
-                                       ->  Seq Scan on pt_1_prt_4  (cost=0.00..3.09 rows=3 width=31)
-                                 ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                                       One-Time Filter: PartSelected
-                                       ->  Seq Scan on pt_1_prt_5  (cost=0.00..3.09 rows=3 width=31)
-                                 ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                                       One-Time Filter: PartSelected
-                                       ->  Seq Scan on pt_1_prt_6  (cost=0.00..3.09 rows=3 width=31)
-                           ->  Hash  (cost=1.10..1.10 rows=2 width=19)
-                                 ->  Partition Selector for pt (dynamic scan id: 1)  (cost=0.00..1.10 rows=2 width=19)
-                                       Filter: t.tid
-                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.10 rows=2 width=19)
-                                             ->  Seq Scan on t  (cost=0.00..1.02 rows=1 width=19)
-                     ->  Hash Join  (cost=1.18..20.16 rows=6 width=50)
-                           Hash Cond: (pt_1_prt_junk_data_1.ptid = (t_1.tid + 2))
-                           ->  Append  (cost=0.00..18.54 rows=18 width=31)
-                                 ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                                       One-Time Filter: PartSelected
-                                       ->  Seq Scan on pt_1_prt_junk_data pt_1_prt_junk_data_1  (cost=0.00..3.09 rows=3 width=31)
-                                 ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                                       One-Time Filter: PartSelected
-                                       ->  Seq Scan on pt_1_prt_2 pt_1_prt_2_1  (cost=0.00..3.09 rows=3 width=31)
-                                 ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                                       One-Time Filter: PartSelected
-                                       ->  Seq Scan on pt_1_prt_3 pt_1_prt_3_1  (cost=0.00..3.09 rows=3 width=31)
-                                 ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                                       One-Time Filter: PartSelected
-                                       ->  Seq Scan on pt_1_prt_4 pt_1_prt_4_1  (cost=0.00..3.09 rows=3 width=31)
-                                 ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                                       One-Time Filter: PartSelected
-                                       ->  Seq Scan on pt_1_prt_5 pt_1_prt_5_1  (cost=0.00..3.09 rows=3 width=31)
-                                 ->  Result  (cost=0.00..3.09 rows=3 width=31)
-                                       One-Time Filter: PartSelected
-                                       ->  Seq Scan on pt_1_prt_6 pt_1_prt_6_1  (cost=0.00..3.09 rows=3 width=31)
-                           ->  Hash  (cost=1.10..1.10 rows=2 width=19)
-                                 ->  Partition Selector for pt (dynamic scan id: 1)  (cost=0.00..1.10 rows=2 width=19)
-                                       Filter: (t_1.tid + 2)
-                                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.10 rows=2 width=19)
-                                             ->  Seq Scan on t t_1  (cost=0.00..1.02 rows=1 width=19)
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=40.61..40.62 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=40.58..40.61 rows=1 width=8)
+         ->  Partial Aggregate  (cost=40.58..40.59 rows=1 width=8)
+               ->  Append  (cost=1.18..40.49 rows=12 width=0)
+                     ->  Subquery Scan on "*SELECT* 1"  (cost=1.18..20.23 rows=6 width=0)
+                           ->  Hash Join  (cost=1.18..20.05 rows=6 width=176)
+                                 Hash Cond: (pt_1_prt_junk_data.ptid = t.tid)
+                                 ->  Append  (cost=0.00..18.54 rows=18 width=4)
+                                       ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                             One-Time Filter: PartSelected
+                                             ->  Seq Scan on pt_1_prt_junk_data  (cost=0.00..3.09 rows=3 width=4)
+                                       ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                             One-Time Filter: PartSelected
+                                             ->  Seq Scan on pt_1_prt_2  (cost=0.00..3.09 rows=3 width=4)
+                                       ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                             One-Time Filter: PartSelected
+                                             ->  Seq Scan on pt_1_prt_3  (cost=0.00..3.09 rows=3 width=4)
+                                       ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                             One-Time Filter: PartSelected
+                                             ->  Seq Scan on pt_1_prt_4  (cost=0.00..3.09 rows=3 width=4)
+                                       ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                             One-Time Filter: PartSelected
+                                             ->  Seq Scan on pt_1_prt_5  (cost=0.00..3.09 rows=3 width=4)
+                                       ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                             One-Time Filter: PartSelected
+                                             ->  Seq Scan on pt_1_prt_6  (cost=0.00..3.09 rows=3 width=4)
+                                 ->  Hash  (cost=1.10..1.10 rows=2 width=4)
+                                       ->  Partition Selector for pt (dynamic scan id: 1)  (cost=0.00..1.10 rows=2 width=4)
+                                             Filter: t.tid
+                                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.10 rows=2 width=4)
+                                                   ->  Seq Scan on t  (cost=0.00..1.02 rows=1 width=4)
+                     ->  Subquery Scan on "*SELECT* 2"  (cost=1.18..20.26 rows=6 width=0)
+                           ->  Hash Join  (cost=1.18..20.08 rows=6 width=176)
+                                 Hash Cond: (pt_1_prt_junk_data_1.ptid = (t_1.tid + 2))
+                                 ->  Append  (cost=0.00..18.54 rows=18 width=4)
+                                       ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                             One-Time Filter: PartSelected
+                                             ->  Seq Scan on pt_1_prt_junk_data pt_1_prt_junk_data_1  (cost=0.00..3.09 rows=3 width=4)
+                                       ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                             One-Time Filter: PartSelected
+                                             ->  Seq Scan on pt_1_prt_2 pt_1_prt_2_1  (cost=0.00..3.09 rows=3 width=4)
+                                       ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                             One-Time Filter: PartSelected
+                                             ->  Seq Scan on pt_1_prt_3 pt_1_prt_3_1  (cost=0.00..3.09 rows=3 width=4)
+                                       ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                             One-Time Filter: PartSelected
+                                             ->  Seq Scan on pt_1_prt_4 pt_1_prt_4_1  (cost=0.00..3.09 rows=3 width=4)
+                                       ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                             One-Time Filter: PartSelected
+                                             ->  Seq Scan on pt_1_prt_5 pt_1_prt_5_1  (cost=0.00..3.09 rows=3 width=4)
+                                       ->  Result  (cost=0.00..3.09 rows=3 width=4)
+                                             One-Time Filter: PartSelected
+                                             ->  Seq Scan on pt_1_prt_6 pt_1_prt_6_1  (cost=0.00..3.09 rows=3 width=4)
+                                 ->  Hash  (cost=1.10..1.10 rows=2 width=4)
+                                       ->  Partition Selector for pt (dynamic scan id: 1)  (cost=0.00..1.10 rows=2 width=4)
+                                             Filter: (t_1.tid + 2)
+                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.10 rows=2 width=4)
+                                                   ->  Seq Scan on t t_1  (cost=0.00..1.02 rows=1 width=4)
  Optimizer: Postgres query optimizer
-(57 rows)
+(59 rows)
 
 select count(*) from
 	( select * from t, pt where tid = ptid

--- a/src/test/regress/expected/equivclass.out
+++ b/src/test/regress/expected/equivclass.out
@@ -233,23 +233,28 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss1
   where ss1.x = ec1.f1 and ec1.ff = 42::int8;
-                          QUERY PLAN                           
----------------------------------------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
-         Join Filter: (((ss0.ff + 1)) = ec1.f1)
+         ->  Broadcast Motion 1:3  (slice2; segments: 1)
+               ->  Index Scan using ec1_pkey on ec1
+                     Index Cond: (ff = '42'::bigint)
          ->  Append
-               ->  Subquery Scan on ss0
-                     ->  Append
-                           ->  Seq Scan on ec1 ec1_2
-                           ->  Seq Scan on ec1 ec1_3
-               ->  Seq Scan on ec1 ec1_1
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  Index Scan using ec1_pkey on ec1
-                           Index Cond: (ff = '42'::bigint)
+               ->  Bitmap Heap Scan on ec1 ec1_1
+                     Recheck Cond: (((ff + 2) + 1) = ec1.f1)
+                     ->  Bitmap Index Scan on ec1_expr2
+                           Index Cond: (((ff + 2) + 1) = ec1.f1)
+               ->  Bitmap Heap Scan on ec1 ec1_2
+                     Recheck Cond: (((ff + 3) + 1) = ec1.f1)
+                     ->  Bitmap Index Scan on ec1_expr3
+                           Index Cond: (((ff + 3) + 1) = ec1.f1)
+               ->  Bitmap Heap Scan on ec1 ec1_3
+                     Recheck Cond: ((ff + 4) = ec1.f1)
+                     ->  Bitmap Index Scan on ec1_expr4
+                           Index Cond: ((ff + 4) = ec1.f1)
  Optimizer: Postgres query optimizer
-(14 rows)
+(19 rows)
 
 explain (costs off)
   select * from ec1,
@@ -260,33 +265,23 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss1
   where ss1.x = ec1.f1 and ec1.ff = 42::int8 and ec1.ff = ec1.f1;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
-         Join Filter: (((ss0.ff + 1)) = ec1.f1)
          ->  Broadcast Motion 1:3  (slice2; segments: 1)
                ->  Index Scan using ec1_pkey on ec1
                      Index Cond: ((ff = '42'::bigint) AND (ff = '42'::bigint))
                      Filter: (ff = f1)
-         ->  Materialize
-               ->  Append
-                     ->  Subquery Scan on ss0
-                           ->  Append
-                                 ->  Bitmap Heap Scan on ec1 ec1_1
-                                       Recheck Cond: (((ff + 2) + 1) = '42'::bigint)
-                                       ->  Bitmap Index Scan on ec1_expr2
-                                             Index Cond: (((ff + 2) + 1) = '42'::bigint)
-                                 ->  Bitmap Heap Scan on ec1 ec1_2
-                                       Recheck Cond: (((ff + 3) + 1) = '42'::bigint)
-                                       ->  Bitmap Index Scan on ec1_expr3
-                                             Index Cond: (((ff + 3) + 1) = '42'::bigint)
-                     ->  Bitmap Heap Scan on ec1 ec1_3
-                           Recheck Cond: ((ff + 4) = '42'::bigint)
-                           ->  Bitmap Index Scan on ec1_expr4
-                                 Index Cond: ((ff + 4) = '42'::bigint)
+         ->  Append
+               ->  Index Scan using ec1_expr2 on ec1 ec1_1
+                     Index Cond: ((((ff + 2) + 1) = ec1.f1) AND (((ff + 2) + 1) = '42'::bigint))
+               ->  Index Scan using ec1_expr3 on ec1 ec1_2
+                     Index Cond: ((((ff + 3) + 1) = ec1.f1) AND (((ff + 3) + 1) = '42'::bigint))
+               ->  Index Scan using ec1_expr4 on ec1 ec1_3
+                     Index Cond: (((ff + 4) = ec1.f1) AND ((ff + 4) = '42'::bigint))
  Optimizer: Postgres query optimizer
-(24 rows)
+(14 rows)
 
 explain (costs off)
   select * from ec1,
@@ -303,36 +298,31 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss2
   where ss1.x = ec1.f1 and ss1.x = ss2.x and ec1.ff = 42::int8;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Merge Join
-         Merge Cond: (((ss0.ff + 1)) = ((ss0_1.ff + 1)))
-         ->  Sort
-               Sort Key: ec1.f1 USING <
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Nested Loop
-                           Join Filter: (((ss0.ff + 1)) = ec1.f1)
-                           ->  Append
-                                 ->  Subquery Scan on ss0
-                                       ->  Append
-                                             ->  Seq Scan on ec1 ec1_2
-                                             ->  Seq Scan on ec1 ec1_3
-                                 ->  Seq Scan on ec1 ec1_1
-                           ->  Materialize
-                                 ->  Broadcast Motion 1:3  (slice3; segments: 1)
-                                       ->  Index Scan using ec1_pkey on ec1
-                                             Index Cond: (ff = '42'::bigint)
-         ->  Sort
-               Sort Key: ((ss0_1.ff + 1))
-               ->  Append
-                     ->  Subquery Scan on ss0_1
-                           ->  Append
-                                 ->  Seq Scan on ec1 ec1_5
-                                 ->  Seq Scan on ec1 ec1_6
-                     ->  Seq Scan on ec1 ec1_4
+   ->  Nested Loop
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)
+               ->  Nested Loop
+                     Join Filter: ((((ec1_1.ff + 2) + 1)) = ec1.f1)
+                     ->  Merge Append
+                           Sort Key: (((ec1_1.ff + 2) + 1))
+                           ->  Index Scan using ec1_expr2 on ec1 ec1_1
+                           ->  Index Scan using ec1_expr3 on ec1 ec1_2
+                           ->  Index Scan using ec1_expr4 on ec1 ec1_3
+                     ->  Materialize
+                           ->  Broadcast Motion 1:3  (slice3; segments: 1)
+                                 ->  Index Scan using ec1_pkey on ec1
+                                       Index Cond: (ff = '42'::bigint)
+         ->  Append
+               ->  Index Scan using ec1_expr2 on ec1 ec1_4
+                     Index Cond: (((ff + 2) + 1) = (((ec1_1.ff + 2) + 1)))
+               ->  Index Scan using ec1_expr3 on ec1 ec1_5
+                     Index Cond: (((ff + 3) + 1) = (((ec1_1.ff + 2) + 1)))
+               ->  Index Scan using ec1_expr4 on ec1 ec1_6
+                     Index Cond: ((ff + 4) = (((ec1_1.ff + 2) + 1)))
  Optimizer: Postgres query optimizer
-(27 rows)
+(22 rows)
 
 -- let's try that as a mergejoin
 set enable_mergejoin = on;
@@ -352,36 +342,31 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss2
   where ss1.x = ec1.f1 and ss1.x = ss2.x and ec1.ff = 42::int8;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Merge Join
-         Merge Cond: (((ss0.ff + 1)) = ((ss0_1.ff + 1)))
+         Merge Cond: ((((ec1_1.ff + 2) + 1)) = (((ec1_4.ff + 2) + 1)))
+         ->  Nested Loop
+               Join Filter: ((((ec1_1.ff + 2) + 1)) = ec1.f1)
+               ->  Merge Append
+                     Sort Key: (((ec1_1.ff + 2) + 1))
+                     ->  Index Scan using ec1_expr2 on ec1 ec1_1
+                     ->  Index Scan using ec1_expr3 on ec1 ec1_2
+                     ->  Index Scan using ec1_expr4 on ec1 ec1_3
+               ->  Materialize
+                     ->  Broadcast Motion 1:3  (slice2; segments: 1)
+                           ->  Index Scan using ec1_pkey on ec1
+                                 Index Cond: (ff = '42'::bigint)
          ->  Sort
-               Sort Key: ec1.f1 USING <
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Nested Loop
-                           Join Filter: (((ss0.ff + 1)) = ec1.f1)
-                           ->  Append
-                                 ->  Subquery Scan on ss0
-                                       ->  Append
-                                             ->  Seq Scan on ec1 ec1_2
-                                             ->  Seq Scan on ec1 ec1_3
-                                 ->  Seq Scan on ec1 ec1_1
-                           ->  Materialize
-                                 ->  Broadcast Motion 1:3  (slice3; segments: 1)
-                                       ->  Index Scan using ec1_pkey on ec1
-                                             Index Cond: (ff = '42'::bigint)
-         ->  Sort
-               Sort Key: ((ss0_1.ff + 1))
-               ->  Append
-                     ->  Subquery Scan on ss0_1
-                           ->  Append
-                                 ->  Seq Scan on ec1 ec1_5
-                                 ->  Seq Scan on ec1 ec1_6
-                     ->  Seq Scan on ec1 ec1_4
+               Sort Key: (((ec1_4.ff + 2) + 1))
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                     ->  Append
+                           ->  Seq Scan on ec1 ec1_4
+                           ->  Seq Scan on ec1 ec1_5
+                           ->  Seq Scan on ec1 ec1_6
  Optimizer: Postgres query optimizer
-(27 rows)
+(22 rows)
 
 -- check partially indexed scan
 set enable_nestloop = on;
@@ -396,23 +381,26 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss1
   where ss1.x = ec1.f1 and ec1.ff = 42::int8;
-                          QUERY PLAN                           
----------------------------------------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
-         Join Filter: (((ss0.ff + 1)) = ec1.f1)
+         ->  Broadcast Motion 1:3  (slice2; segments: 1)
+               ->  Index Scan using ec1_pkey on ec1
+                     Index Cond: (ff = '42'::bigint)
          ->  Append
-               ->  Subquery Scan on ss0
-                     ->  Append
-                           ->  Seq Scan on ec1 ec1_2
-                           ->  Seq Scan on ec1 ec1_3
-               ->  Seq Scan on ec1 ec1_1
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  Index Scan using ec1_pkey on ec1
-                           Index Cond: (ff = '42'::bigint)
+               ->  Bitmap Heap Scan on ec1 ec1_1
+                     Recheck Cond: (((ff + 2) + 1) = ec1.f1)
+                     ->  Bitmap Index Scan on ec1_expr2
+                           Index Cond: (((ff + 2) + 1) = ec1.f1)
+               ->  Seq Scan on ec1 ec1_2
+                     Filter: (((ff + 3) + 1) = ec1.f1)
+               ->  Bitmap Heap Scan on ec1 ec1_3
+                     Recheck Cond: ((ff + 4) = ec1.f1)
+                     ->  Bitmap Index Scan on ec1_expr4
+                           Index Cond: ((ff + 4) = ec1.f1)
  Optimizer: Postgres query optimizer
-(14 rows)
+(17 rows)
 
 -- let's try that as a mergejoin
 set enable_mergejoin = on;
@@ -426,21 +414,24 @@ explain (costs off)
      union all
      select ff + 4 as x from ec1) as ss1
   where ss1.x = ec1.f1 and ec1.ff = 42::int8;
-                          QUERY PLAN                           
----------------------------------------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
-         Join Filter: (((ss0.ff + 1)) = ec1.f1)
+         ->  Broadcast Motion 1:3  (slice2; segments: 1)
+               ->  Index Scan using ec1_pkey on ec1
+                     Index Cond: (ff = '42'::bigint)
          ->  Append
-               ->  Subquery Scan on ss0
-                     ->  Append
-                           ->  Seq Scan on ec1 ec1_2
-                           ->  Seq Scan on ec1 ec1_3
-               ->  Seq Scan on ec1 ec1_1
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  Index Scan using ec1_pkey on ec1
-                           Index Cond: (ff = '42'::bigint)
+               ->  Bitmap Heap Scan on ec1 ec1_1
+                     Recheck Cond: (((ff + 2) + 1) = ec1.f1)
+                     ->  Bitmap Index Scan on ec1_expr2
+                           Index Cond: (((ff + 2) + 1) = ec1.f1)
+               ->  Seq Scan on ec1 ec1_2
+                     Filter: (((ff + 3) + 1) = ec1.f1)
+               ->  Bitmap Heap Scan on ec1 ec1_3
+                     Recheck Cond: ((ff + 4) = ec1.f1)
+                     ->  Bitmap Index Scan on ec1_expr4
+                           Index Cond: ((ff + 4) = ec1.f1)
  Optimizer: Postgres query optimizer
-(14 rows)
+(17 rows)
 

--- a/src/test/regress/expected/inherit.out
+++ b/src/test/regress/expected/inherit.out
@@ -1598,39 +1598,47 @@ ORDER BY thousand, tenthous;
 (9 rows)
 
 -- Check min/max aggregate optimization
--- GPDB: simple union all pull up is disabled in pull_up_subqueries(), so the
--- min/max optimization doesn't kick in.
 explain (costs off)
 SELECT min(x) FROM
   (SELECT unique1 AS x FROM tenk1 a
    UNION ALL
    SELECT unique2 AS x FROM tenk1 b) s;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Append
-                     ->  Index Only Scan using tenk1_unique1 on tenk1 a
-                     ->  Index Only Scan using tenk1_unique2 on tenk1 b
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: a.unique1
+                 ->  Merge Append
+                       Sort Key: a.unique1
+                       ->  Index Only Scan using tenk1_unique1 on tenk1 a
+                             Index Cond: (unique1 IS NOT NULL)
+                       ->  Index Only Scan using tenk1_unique2 on tenk1 b
+                             Index Cond: (unique2 IS NOT NULL)
  Optimizer: Postgres query optimizer
-(7 rows)
+(12 rows)
 
 explain (costs off)
 SELECT min(y) FROM
   (SELECT unique1 AS x, unique1 AS y FROM tenk1 a
    UNION ALL
    SELECT unique2 AS x, unique2 AS y FROM tenk1 b) s;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Append
-                     ->  Index Only Scan using tenk1_unique1 on tenk1 a
-                     ->  Index Only Scan using tenk1_unique2 on tenk1 b
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Limit
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Merge Key: a.unique1
+                 ->  Merge Append
+                       Sort Key: a.unique1
+                       ->  Index Only Scan using tenk1_unique1 on tenk1 a
+                             Index Cond: (unique1 IS NOT NULL)
+                       ->  Index Only Scan using tenk1_unique2 on tenk1 b
+                             Index Cond: (unique2 IS NOT NULL)
  Optimizer: Postgres query optimizer
-(7 rows)
+(12 rows)
 
 -- XXX planner doesn't recognize that index on unique2 is sufficiently sorted
 explain (costs off)
@@ -1639,17 +1647,18 @@ SELECT x, y FROM
    UNION ALL
    SELECT unique2 AS x, unique2 AS y FROM tenk1 b) s
 ORDER BY x, y;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: a.thousand, a.tenthous
-   ->  Sort
+   ->  Merge Append
          Sort Key: a.thousand, a.tenthous
-         ->  Append
-               ->  Index Only Scan using tenk1_thous_tenthous on tenk1 a
+         ->  Index Only Scan using tenk1_thous_tenthous on tenk1 a
+         ->  Sort
+               Sort Key: b.unique2, b.unique2
                ->  Index Only Scan using tenk1_unique2 on tenk1 b
  Optimizer: Postgres query optimizer
-(8 rows)
+(9 rows)
 
 -- exercise rescan code path via a repeatedly-evaluated subquery
 explain (costs off)
@@ -1661,22 +1670,21 @@ SELECT
     ) f(i)
     ORDER BY f.i LIMIT 10)
 FROM generate_series(1, 3) g(i);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Function Scan on generate_series g
    SubPlan 1
      ->  Limit
-           ->  Sort
+           ->  Merge Append
                  Sort Key: ((d.d + g.i))
-                 ->  Append
-                       ->  Sort
-                             Sort Key: ((d.d + g.i))
-                             ->  Function Scan on generate_series d
-                       ->  Sort
-                             Sort Key: ((d_1.d + g.i))
-                             ->  Function Scan on generate_series d_1
+                 ->  Sort
+                       Sort Key: ((d.d + g.i))
+                       ->  Function Scan on generate_series d
+                 ->  Sort
+                       Sort Key: ((d_1.d + g.i))
+                       ->  Function Scan on generate_series d_1
  Optimizer: Postgres query optimizer
-(13 rows)
+(12 rows)
 
 SELECT
     ARRAY(SELECT f.i FROM (

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -1608,8 +1608,6 @@ ORDER BY thousand, tenthous;
 (8 rows)
 
 -- Check min/max aggregate optimization
--- GPDB: simple union all pull up is disabled in pull_up_subqueries(), so the
--- min/max optimization doesn't kick in.
 explain (costs off)
 SELECT min(x) FROM
   (SELECT unique1 AS x FROM tenk1 a
@@ -1671,22 +1669,21 @@ SELECT
     ) f(i)
     ORDER BY f.i LIMIT 10)
 FROM generate_series(1, 3) g(i);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Function Scan on generate_series g
    SubPlan 1
      ->  Limit
-           ->  Sort
+           ->  Merge Append
                  Sort Key: ((d.d + g.i))
-                 ->  Append
-                       ->  Sort
-                             Sort Key: ((d.d + g.i))
-                             ->  Function Scan on generate_series d
-                       ->  Sort
-                             Sort Key: ((d_1.d + g.i))
-                             ->  Function Scan on generate_series d_1
+                 ->  Sort
+                       Sort Key: ((d.d + g.i))
+                       ->  Function Scan on generate_series d
+                 ->  Sort
+                       Sort Key: ((d_1.d + g.i))
+                       ->  Function Scan on generate_series d_1
  Optimizer: Postgres query optimizer
-(13 rows)
+(12 rows)
 
 SELECT
     ARRAY(SELECT f.i FROM (

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1156,11 +1156,11 @@ select * from (
 join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=65.00..11735.25 rows=192600 width=8)
-   ->  Hash Join  (cost=65.00..9167.25 rows=64200 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=45.00..11715.25 rows=192600 width=8)
+   ->  Hash Join  (cost=45.00..9147.25 rows=64200 width=8)
          Hash Cond: (t_randomly_dist_table.c = a.a)
          ->  Seq Scan on t_randomly_dist_table  (cost=0.00..355.00 rows=32100 width=4)
-         ->  Hash  (cost=40.00..40.00 rows=2000 width=4)
+         ->  Hash  (cost=20.00..20.00 rows=2000 width=4)
                ->  Append  (cost=0.00..20.00 rows=2000 width=4)
                      ->  Function Scan on generate_series a  (cost=0.00..10.00 rows=1000 width=4)
                      ->  Function Scan on generate_series a_1  (cost=0.00..10.00 rows=1000 width=4)

--- a/src/test/regress/expected/olap_window_seq.out
+++ b/src/test/regress/expected/olap_window_seq.out
@@ -8188,17 +8188,19 @@ insert into window_preds values(6,7,8);
 explain select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Subquery Scan on t  (cost=0.00..2.09 rows=1 width=8)
-   Filter: t.k = 3
-   ->  Append  (cost=0.00..2.07 rows=2 width=8)
-         ->  WindowAgg  (cost=0.00..1.02 rows=1 width=0)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=0)
+ Append  (cost=0.00..2.11 rows=2 width=8)
+   ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..1.06 rows=1 width=8)
+         Filter: ("*SELECT* 1".k = 3)
+         ->  WindowAgg  (cost=0.00..1.04 rows=1 width=8)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
                      ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=0)
-         ->  WindowAgg  (cost=0.00..1.02 rows=1 width=0)
-               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=0)
+   ->  Subquery Scan on "*SELECT* 2"  (cost=0.00..1.06 rows=1 width=8)
+         Filter: ("*SELECT* 2".k = 3)
+         ->  WindowAgg  (cost=0.00..1.04 rows=1 width=8)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
                      ->  Seq Scan on window_preds window_preds_1  (cost=0.00..1.01 rows=1 width=0)
  Optimizer: Postgres query optimizer
-(10 rows)
+(12 rows)
 
 select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
  k 
@@ -8208,47 +8210,52 @@ select k from ( select row_number() over()+2 as k from window_preds union all se
 (2 rows)
 
 explain insert into window_preds select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Insert on window_preds  (cost=0.00..2.10 rows=1 width=8)
-   ->  Redistribute Motion 1:3  (slice3; segments: 1)  (cost=0.00..2.10 rows=1 width=8)
-         Hash Key: (t.k::integer)
-         ->  Subquery Scan on t  (cost=0.00..2.10 rows=1 width=8)
-               Filter: t.k = 3
-               ->  Append  (cost=0.00..2.07 rows=2 width=8)
-                     ->  WindowAgg  (cost=0.00..1.02 rows=1 width=0)
-                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=0)
-                                 ->  Seq Scan on window_preds window_preds_1  (cost=0.00..1.01 rows=1 width=0)
-                     ->  WindowAgg  (cost=0.00..1.02 rows=1 width=0)
-                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=0)
-                                 ->  Seq Scan on window_preds window_preds_2  (cost=0.00..1.01 rows=1 width=0)
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Insert on window_preds  (cost=0.00..2.18 rows=1 width=12)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..2.18 rows=2 width=12)
+         Hash Key: (("*SELECT* 1".k)::integer)
+         ->  Result  (cost=0.00..2.14 rows=2 width=12)
+               ->  Append  (cost=0.00..2.11 rows=2 width=8)
+                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..1.06 rows=1 width=8)
+                           Filter: ("*SELECT* 1".k = 3)
+                           ->  WindowAgg  (cost=0.00..1.04 rows=1 width=8)
+                                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                                       ->  Seq Scan on window_preds window_preds_1  (cost=0.00..1.01 rows=1 width=0)
+                     ->  Subquery Scan on "*SELECT* 2"  (cost=0.00..1.06 rows=1 width=8)
+                           Filter: ("*SELECT* 2".k = 3)
+                           ->  WindowAgg  (cost=0.00..1.04 rows=1 width=8)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                                       ->  Seq Scan on window_preds window_preds_2  (cost=0.00..1.01 rows=1 width=0)
  Optimizer: Postgres query optimizer
-(13 rows)
+(16 rows)
 
 insert into window_preds select k from ( select row_number() over()+2 as k from window_preds union all select row_number() over()+2 as k from window_preds) as t where k = 3;
 explain SELECT t.k FROM window_preds p1, window_preds p2, (SELECT ROW_NUMBER() OVER() AS k FROM window_preds union all SELECT ROW_NUMBER() OVER() AS k FROM window_preds) AS t WHERE t.k = 1 limit 1;
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
- Limit  (cost=20000000000.00..20000000001.30 rows=1 width=8)
-   ->  Nested Loop  (cost=20000000000.00..20000000004.31 rows=4 width=8)
-         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000000002.17 rows=4 width=0)
+ Limit  (cost=20000000000.00..20000000000.66 rows=1 width=8)
+   ->  Nested Loop  (cost=20000000000.00..20000000004.37 rows=7 width=8)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000002.17 rows=4 width=0)
                ->  Nested Loop  (cost=10000000000.00..10000000002.10 rows=2 width=0)
                      ->  Seq Scan on window_preds p1  (cost=0.00..1.01 rows=1 width=0)
                      ->  Materialize  (cost=0.00..1.06 rows=1 width=0)
-                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.05 rows=1 width=0)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.05 rows=1 width=0)
                                  ->  Seq Scan on window_preds p2  (cost=0.00..1.01 rows=1 width=0)
-         ->  Materialize  (cost=0.00..2.09 rows=1 width=8)
-               ->  Subquery Scan on t  (cost=0.00..2.09 rows=1 width=8)
-                     Filter: t.k = 1
-                     ->  Append  (cost=0.00..2.06 rows=2 width=8)
-                           ->  WindowAgg  (cost=0.00..1.02 rows=1 width=0)
-                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1.01 rows=1 width=0)
+         ->  Materialize  (cost=0.00..2.12 rows=2 width=8)
+               ->  Append  (cost=0.00..2.11 rows=2 width=8)
+                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..1.05 rows=1 width=8)
+                           Filter: ("*SELECT* 1".k = 1)
+                           ->  WindowAgg  (cost=0.00..1.04 rows=1 width=8)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
                                        ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=0)
-                           ->  WindowAgg  (cost=0.00..1.02 rows=1 width=0)
-                                 ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1.01 rows=1 width=0)
+                     ->  Subquery Scan on "*SELECT* 2"  (cost=0.00..1.05 rows=1 width=8)
+                           Filter: ("*SELECT* 2".k = 1)
+                           ->  WindowAgg  (cost=0.00..1.04 rows=1 width=8)
+                                 ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
                                        ->  Seq Scan on window_preds window_preds_1  (cost=0.00..1.01 rows=1 width=0)
  Optimizer: Postgres query optimizer
-(19 rows)
+(21 rows)
 
 SELECT t.k FROM window_preds p1, window_preds p2, (SELECT ROW_NUMBER() OVER() AS k FROM window_preds union all SELECT ROW_NUMBER() OVER() AS k FROM window_preds) AS t WHERE t.k = 1 limit 1;
  k 
@@ -8285,16 +8292,16 @@ explain with CTE as (select i, row_number() over (partition by j) j from window_
 insert into window_preds with CTE as (select i, row_number() over (partition by j) j from window_preds union all select i, row_number() over (partition by j) from window_preds) select * from cte where j = 1;
 -- qual k = 1 should be pushed down
 explain select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
- Append  (cost=0.00..2.08 rows=2 width=8)
-   ->  Subquery Scan on f  (cost=0.00..1.03 rows=1 width=8)
-         Filter: f.k = 1
-         ->  WindowAgg  (cost=0.00..1.02 rows=1 width=0)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=0)
-                     ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=0)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.04 rows=1 width=8)
-         ->  Seq Scan on window_preds window_preds_1  (cost=0.00..1.01 rows=1 width=0)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Append  (cost=0.00..2.06 rows=2 width=8)
+   ->  Subquery Scan on f  (cost=0.00..1.05 rows=1 width=8)
+         Filter: (f.k = 1)
+         ->  WindowAgg  (cost=0.00..1.04 rows=1 width=8)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                     ->  Seq Scan on window_preds window_preds_1  (cost=0.00..1.01 rows=1 width=0)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
+         ->  Seq Scan on window_preds  (cost=0.00..1.01 rows=1 width=8)
  Optimizer: Postgres query optimizer
 (9 rows)
 
@@ -8329,18 +8336,18 @@ select k from ( select k from (select row_number() over() as k from window_preds
 explain insert into window_preds select k from ( select k from (select row_number() over() as k from window_preds) f union all select 1::bigint as k from window_preds) as t where k = 1;
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
- Insert on window_preds  (cost=0.00..2.11 rows=1 width=8)
-   ->  Redistribute Motion 1:3  (slice3; segments: 1)  (cost=0.00..2.11 rows=2 width=8)
-         Hash Key: (t.k::integer)
-         ->  Subquery Scan on t  (cost=0.00..2.11 rows=2 width=8)
-               ->  Append  (cost=0.00..2.08 rows=2 width=8)
-                     ->  Subquery Scan on f  (cost=0.00..1.03 rows=1 width=8)
-                           Filter: f.k = 1
-                           ->  WindowAgg  (cost=0.00..1.02 rows=1 width=0)
-                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=0)
-                                       ->  Seq Scan on window_preds window_preds_1  (cost=0.00..1.01 rows=1 width=0)
-                     ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.04 rows=1 width=8)
-                           ->  Seq Scan on window_preds window_preds_2  (cost=0.00..1.01 rows=1 width=0)
+ Insert on window_preds  (cost=0.00..2.13 rows=1 width=12)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..2.13 rows=2 width=12)
+         Hash Key: ((f.k)::integer)
+         ->  Result  (cost=0.00..2.09 rows=2 width=12)
+               ->  Append  (cost=0.00..2.06 rows=2 width=8)
+                     ->  Subquery Scan on f  (cost=0.00..1.05 rows=1 width=8)
+                           Filter: (f.k = 1)
+                           ->  WindowAgg  (cost=0.00..1.04 rows=1 width=8)
+                                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=0)
+                                       ->  Seq Scan on window_preds window_preds_2  (cost=0.00..1.01 rows=1 width=0)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
+                           ->  Seq Scan on window_preds window_preds_1  (cost=0.00..1.01 rows=1 width=8)
  Optimizer: Postgres query optimizer
 (13 rows)
 

--- a/src/test/regress/expected/union.out
+++ b/src/test/regress/expected/union.out
@@ -520,29 +520,28 @@ INSERT INTO t2c VALUES ('vw'), ('cd'), ('mn'), ('ef');
 CREATE INDEX t1c_ab_idx on t1c ((a || b));
 set enable_seqscan = on;
 set enable_indexonlyscan = off;
--- NOTE: GPDB planner chooses a seqscan rather than indexscan for t1.
--- This is a side-effect of disabling pull-up for simple union all in GPDB.
+-- Coerce GPDB to produce same plan as in upstream
+set enable_sort=off;
 explain (costs off)
   SELECT * FROM
   (SELECT a || b AS ab FROM t1
    UNION ALL
    SELECT ab FROM t2) t
   ORDER BY 1 LIMIT 8;
-                   QUERY PLAN                   
-------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Limit
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Merge Key: ((t1.a || t1.b))
          ->  Limit
-               ->  Sort
+               ->  Merge Append
                      Sort Key: ((t1.a || t1.b))
-                     ->  Append
-                           ->  Seq Scan on t1
-                           ->  Seq Scan on t1c
-                           ->  Seq Scan on t2
-                           ->  Seq Scan on t2c
+                     ->  Index Scan using t1_ab_idx on t1
+                     ->  Index Scan using t1c_ab_idx on t1c
+                     ->  Index Scan using t2_pkey on t2
+                     ->  Index Scan using t2c_pkey on t2c
  Optimizer: Postgres query optimizer
-(12 rows)
+(11 rows)
 
   SELECT * FROM
   (SELECT a || b AS ab FROM t1
@@ -564,7 +563,10 @@ explain (costs off)
 reset enable_seqscan;
 reset enable_indexscan;
 reset enable_bitmapscan;
+reset enable_sort;
 -- This simpler variant of the above test has been observed to fail differently
+-- Coerce GPDB to produce same plan as in upstream
+set enable_seqscan=off;
 create table events (event_id int primary key);
 create table other_events (event_id int primary key);
 create table events_child () inherits (events);
@@ -574,19 +576,21 @@ select event_id
        union all
        select event_id from other_events) ss
  order by event_id;
-                 QUERY PLAN                 
---------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: events.event_id
-   ->  Sort
+   ->  Merge Append
          Sort Key: events.event_id
-         ->  Append
-               ->  Seq Scan on events
+         ->  Index Scan using events_pkey on events
+         ->  Sort
+               Sort Key: events_child.event_id
                ->  Seq Scan on events_child
-               ->  Seq Scan on other_events
+         ->  Index Scan using other_events_pkey on other_events
  Optimizer: Postgres query optimizer
-(9 rows)
+(10 rows)
 
+reset enable_seqscan;
 drop table events_child, events, other_events;
 reset enable_indexonlyscan;
 -- Test constraint exclusion of UNION ALL subqueries

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -526,29 +526,28 @@ INSERT INTO t2c VALUES ('vw'), ('cd'), ('mn'), ('ef');
 CREATE INDEX t1c_ab_idx on t1c ((a || b));
 set enable_seqscan = on;
 set enable_indexonlyscan = off;
--- NOTE: GPDB planner chooses a seqscan rather than indexscan for t1.
--- This is a side-effect of disabling pull-up for simple union all in GPDB.
+-- Coerce GPDB to produce same plan as in upstream
+set enable_sort=off;
 explain (costs off)
   SELECT * FROM
   (SELECT a || b AS ab FROM t1
    UNION ALL
    SELECT ab FROM t2) t
   ORDER BY 1 LIMIT 8;
-                   QUERY PLAN                   
-------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Limit
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Merge Key: ((t1.a || t1.b))
          ->  Limit
-               ->  Sort
+               ->  Merge Append
                      Sort Key: ((t1.a || t1.b))
-                     ->  Append
-                           ->  Seq Scan on t1
-                           ->  Seq Scan on t1c
-                           ->  Seq Scan on t2
-                           ->  Seq Scan on t2c
+                     ->  Index Scan using t1_ab_idx on t1
+                     ->  Index Scan using t1c_ab_idx on t1c
+                     ->  Index Scan using t2_pkey on t2
+                     ->  Index Scan using t2c_pkey on t2c
  Optimizer: Postgres query optimizer
-(12 rows)
+(11 rows)
 
   SELECT * FROM
   (SELECT a || b AS ab FROM t1
@@ -570,7 +569,10 @@ explain (costs off)
 reset enable_seqscan;
 reset enable_indexscan;
 reset enable_bitmapscan;
+reset enable_sort;
 -- This simpler variant of the above test has been observed to fail differently
+-- Coerce GPDB to produce same plan as in upstream
+set enable_seqscan=off;
 create table events (event_id int primary key);
 create table other_events (event_id int primary key);
 create table events_child () inherits (events);
@@ -581,19 +583,21 @@ select event_id
        union all
        select event_id from other_events) ss
  order by event_id;
-                 QUERY PLAN                 
---------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: events.event_id
-   ->  Sort
+   ->  Merge Append
          Sort Key: events.event_id
-         ->  Append
-               ->  Seq Scan on events
+         ->  Index Scan using events_pkey on events
+         ->  Sort
+               Sort Key: events_child.event_id
                ->  Seq Scan on events_child
-               ->  Seq Scan on other_events
+         ->  Index Scan using other_events_pkey on other_events
  Optimizer: Postgres query optimizer
-(9 rows)
+(10 rows)
 
+reset enable_seqscan;
 drop table events_child, events, other_events;
 reset enable_indexonlyscan;
 -- Test constraint exclusion of UNION ALL subqueries

--- a/src/test/regress/sql/equivclass.sql
+++ b/src/test/regress/sql/equivclass.sql
@@ -176,7 +176,6 @@ explain (costs off)
 -- let's try that as a mergejoin
 set enable_mergejoin = on;
 set enable_nestloop = off;
-
 explain (costs off)
   select * from ec1,
     (select ff + 1 as x from

--- a/src/test/regress/sql/inherit.sql
+++ b/src/test/regress/sql/inherit.sql
@@ -546,8 +546,6 @@ SELECT thousand, random()::integer FROM tenk1
 ORDER BY thousand, tenthous;
 
 -- Check min/max aggregate optimization
--- GPDB: simple union all pull up is disabled in pull_up_subqueries(), so the
--- min/max optimization doesn't kick in.
 explain (costs off)
 SELECT min(x) FROM
   (SELECT unique1 AS x FROM tenk1 a

--- a/src/test/regress/sql/union.sql
+++ b/src/test/regress/sql/union.sql
@@ -212,9 +212,9 @@ CREATE INDEX t1c_ab_idx on t1c ((a || b));
 
 set enable_seqscan = on;
 set enable_indexonlyscan = off;
+-- Coerce GPDB to produce same plan as in upstream
+set enable_sort=off;
 
--- NOTE: GPDB planner chooses a seqscan rather than indexscan for t1.
--- This is a side-effect of disabling pull-up for simple union all in GPDB.
 explain (costs off)
   SELECT * FROM
   (SELECT a || b AS ab FROM t1
@@ -231,8 +231,12 @@ explain (costs off)
 reset enable_seqscan;
 reset enable_indexscan;
 reset enable_bitmapscan;
+reset enable_sort;
 
 -- This simpler variant of the above test has been observed to fail differently
+
+-- Coerce GPDB to produce same plan as in upstream
+set enable_seqscan=off;
 
 create table events (event_id int primary key);
 create table other_events (event_id int primary key);
@@ -244,6 +248,8 @@ select event_id
        union all
        select event_id from other_events) ss
  order by event_id;
+
+reset enable_seqscan;
 
 drop table events_child, events, other_events;
 


### PR DESCRIPTION
There's no good reason to not do it anymore. It was disabled back in 2008,
when this test query was failing:

postgres=# create table tab as select generate_series(1,10) as a;
SELECT 10
postgres=# select * from tab where a in (select a from tab where a = 2 union all values (4));
ERROR:  Cannot append paths with incompatible distribution

But that's been fixed a long time ago, there's now code that adds Motions
as needed to the branches of an append relation, and there are test cases
for that in the 'union_gp' test. That query works fine now with the
optimization.

Some changes were required in examine_simple_variable(), because the code
that was added there for the 'gp_statistics_pullup_from_child_partition'
GUC assumed that all range table entries with 'inh==true' must be of
kind RTE_RELATION, but that's not true for the pulled up subqueries. Fix
that assumption.
