### PR TITLE
[gpopt] Safer, and more succinct relation cleanup

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2522,7 +2522,7 @@ gpdb::GetLogicalIndexInfo
 	return NULL;
 }
 
-Relation
+gpdb::RelationWrapper
 gpdb::GetRelation
 	(
 	Oid rel_oid
@@ -2531,10 +2531,9 @@ gpdb::GetRelation
 	GP_WRAP_START;
 	{
 		/* catalog tables: relcache */
-		return RelationIdGetRelation(rel_oid);
+		return RelationWrapper{RelationIdGetRelation(rel_oid)};
 	}
 	GP_WRAP_END;
-	return NULL;
 }
 
 ExtTableEntry *

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3166,13 +3166,12 @@ CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses
 	// ones, for all hashing within the query.
 	if (rte->rtekind == RTE_RELATION)
 	{
-		Relation rel = gpdb::GetRelation(rte->relid);
+		auto rel = gpdb::GetRelation(rte->relid);
 		GpPolicy *policy = rel->rd_cdbpolicy;
 
 		// master-only tables
 		if (NULL == policy)
 		{
-			gpdb::CloseRelation(rel);
 			return;
 		}
 
@@ -3207,7 +3206,6 @@ CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses
 					contains_nondefault_hashops = true;
 			}
 		}
-		gpdb::CloseRelation(rel);
 
 		if (contains_nondefault_hashops)
 		{

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -287,7 +287,7 @@ CTranslatorRelcacheToDXL::RetrieveRelIndexInfoForPartTable
 		OID index_oid = logicalIndexInfo->logicalIndexOid;
 
 		// only add supported indexes
-		Relation index_rel = gpdb::GetRelation(index_oid);
+		auto index_rel = gpdb::GetRelation(index_oid);
 
 		if (!index_rel)
 		{
@@ -300,24 +300,13 @@ CTranslatorRelcacheToDXL::RetrieveRelIndexInfoForPartTable
 
 		GPOS_ASSERT(NULL != index_rel->rd_indextuple);
 
-		GPOS_TRY
+		if (IsIndexSupported(index_rel))
 		{
-			if (IsIndexSupported(index_rel))
-			{
-				CMDIdGPDB *mdid_index = GPOS_NEW(mp) CMDIdGPDB(index_oid);
-				BOOL is_partial = (NULL != logicalIndexInfo->partCons) || (NIL != logicalIndexInfo->defaultLevels);
-				CMDIndexInfo *md_index_info = GPOS_NEW(mp) CMDIndexInfo(mdid_index, is_partial);
-				md_index_info_array->Append(md_index_info);
-			}
-
-			gpdb::CloseRelation(index_rel);
+			CMDIdGPDB *mdid_index = GPOS_NEW(mp) CMDIdGPDB(index_oid);
+			BOOL is_partial = (NULL != logicalIndexInfo->partCons) || (NIL != logicalIndexInfo->defaultLevels);
+			CMDIndexInfo *md_index_info = GPOS_NEW(mp) CMDIndexInfo(mdid_index, is_partial);
+			md_index_info_array->Append(md_index_info);
 		}
-		GPOS_CATCH_EX(ex)
-		{
-			gpdb::CloseRelation(index_rel);
-			GPOS_RETHROW(ex);
-		}
-		GPOS_CATCH_END;
 	}
 	return md_index_info_array;
 }
@@ -342,7 +331,7 @@ CTranslatorRelcacheToDXL::RetrieveRelIndexInfoForNonPartTable
 		OID index_oid = lfirst_oid(lc);
 
 		// only add supported indexes
-		Relation index_rel = gpdb::GetRelation(index_oid);
+		auto index_rel = gpdb::GetRelation(index_oid);
 
 		if (!index_rel)
 		{
@@ -355,24 +344,13 @@ CTranslatorRelcacheToDXL::RetrieveRelIndexInfoForNonPartTable
 
 		GPOS_ASSERT(NULL != index_rel->rd_indextuple);
 
-		GPOS_TRY
+		if (IsIndexSupported(index_rel))
 		{
-			if (IsIndexSupported(index_rel))
-			{
-				CMDIdGPDB *mdid_index = GPOS_NEW(mp) CMDIdGPDB(index_oid);
-				// for a regular table, external table or leaf partition, an index is always complete
-				CMDIndexInfo *md_index_info = GPOS_NEW(mp) CMDIndexInfo(mdid_index, false /* is_partial */);
-				md_index_info_array->Append(md_index_info);
-			}
-
-			gpdb::CloseRelation(index_rel);
+			CMDIdGPDB *mdid_index = GPOS_NEW(mp) CMDIdGPDB(index_oid);
+			// for a regular table, external table or leaf partition, an index is always complete
+			CMDIndexInfo *md_index_info = GPOS_NEW(mp) CMDIndexInfo(mdid_index, false /* is_partial */);
+			md_index_info_array->Append(md_index_info);
 		}
-		GPOS_CATCH_EX(ex)
-		{
-			gpdb::CloseRelation(index_rel);
-			GPOS_RETHROW(ex);
-		}
-		GPOS_CATCH_END;
 	}
 
 	return md_index_info_array;
@@ -507,7 +485,7 @@ CTranslatorRelcacheToDXL::RetrieveRel
 
 	CheckUnsupportedRelation(oid);
 
-	Relation rel = gpdb::GetRelation(oid);
+	auto rel = gpdb::GetRelation(oid);
 
 	if (!rel)
 	{
@@ -519,7 +497,6 @@ CTranslatorRelcacheToDXL::RetrieveRel
 		gpdb::GetGPSegmentCount() != rel->rd_cdbpolicy->numsegments)
 	{
 		// GPORCA does not support partially distributed tables yet
-		gpdb::CloseRelation(rel);
 		GPOS_RAISE(gpdxl::ExmaMD,
 				   gpdxl::ExmiDXLInvalidAttributeValue,
 				   GPOS_WSZ_LIT("Partially Distributed Data"));
@@ -549,67 +526,57 @@ CTranslatorRelcacheToDXL::RetrieveRel
 	 */
 	IMdIdArray *mdid_triggers_array = GPOS_NEW(mp) IMdIdArray(mp);
 
-	GPOS_TRY
+	// get rel name
+	mdname = GetRelName(mp, rel);
+
+	// get storage type
+	rel_storage_type = RetrieveRelStorageType(rel);
+
+	// get relation columns
+	mdcol_array = RetrieveRelColumns(mp, md_accessor, rel, rel_storage_type);
+	const ULONG max_cols = GPDXL_SYSTEM_COLUMNS + (ULONG) rel->rd_att->natts + 1;
+	ULONG *attno_mapping = ConstructAttnoMapping(mp, mdcol_array, max_cols);
+
+	// get distribution policy
+	GpPolicy *gp_policy = gpdb::GetDistributionPolicy(rel);
+	dist = GetRelDistribution(gp_policy);
+
+	// get distribution columns
+	if (IMDRelation::EreldistrHash == dist)
 	{
-		// get rel name
-		mdname = GetRelName(mp, rel);
-
-		// get storage type
-		rel_storage_type = RetrieveRelStorageType(rel);
-
-		// get relation columns
-		mdcol_array = RetrieveRelColumns(mp, md_accessor, rel, rel_storage_type);
-		const ULONG max_cols = GPDXL_SYSTEM_COLUMNS + (ULONG) rel->rd_att->natts + 1;
-		ULONG *attno_mapping = ConstructAttnoMapping(mp, mdcol_array, max_cols);
-
-		// get distribution policy
-		GpPolicy *gp_policy = gpdb::GetDistributionPolicy(rel);
-		dist = GetRelDistribution(gp_policy);
-
-		// get distribution columns
-		if (IMDRelation::EreldistrHash == dist)
-		{
-			distr_cols = RetrieveRelDistributionCols(mp, gp_policy, mdcol_array, max_cols);
-			distr_op_families = RetrieveRelDistributionOpFamilies(mp, gp_policy);
-		}
-
-		convert_hash_to_random = gpdb::IsChildPartDistributionMismatched(rel);
-
-		// collect relation indexes
-		md_index_info_array = RetrieveRelIndexInfo(mp, rel);
-
-		// get partition keys
-		if (IMDRelation::ErelstorageExternal != rel_storage_type)
-		{
-			RetrievePartKeysAndTypes(mp, rel, oid, &part_keys, &part_types);
-		}
-		is_partitioned = (NULL != part_keys && 0 < part_keys->Size());
-
-		// get number of leaf partitions
-		if (gpdb::RelPartIsRoot(oid))
-		{
-			num_leaf_partitions = gpdb::CountLeafPartTables(oid);
-		}
-
-		// get key sets
-		BOOL should_add_default_keys = RelHasSystemColumns(rel->rd_rel->relkind);
-		keyset_array = RetrieveRelKeysets(mp, oid, should_add_default_keys, is_partitioned, attno_mapping);
-
-		// collect all check constraints
-		check_constraint_mdids = RetrieveRelCheckConstraints(mp, oid);
-
-		is_temporary = (rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP);
-		has_oids = rel->rd_rel->relhasoids;
-	
-		GPOS_DELETE_ARRAY(attno_mapping);
-		gpdb::CloseRelation(rel);
+		distr_cols = RetrieveRelDistributionCols(mp, gp_policy, mdcol_array, max_cols);
+		distr_op_families = RetrieveRelDistributionOpFamilies(mp, gp_policy);
 	}
-	GPOS_CATCH_EX(ex)
+
+	convert_hash_to_random = gpdb::IsChildPartDistributionMismatched(rel);
+
+	// collect relation indexes
+	md_index_info_array = RetrieveRelIndexInfo(mp, rel);
+
+	// get partition keys
+	if (IMDRelation::ErelstorageExternal != rel_storage_type)
 	{
-		gpdb::CloseRelation(rel);
-		GPOS_RETHROW(ex);
+		RetrievePartKeysAndTypes(mp, rel, oid, &part_keys, &part_types);
 	}
-	GPOS_CATCH_END;
+	is_partitioned = (NULL != part_keys && 0 < part_keys->Size());
+
+	// get number of leaf partitions
+	if (gpdb::RelPartIsRoot(oid))
+	{
+		num_leaf_partitions = gpdb::CountLeafPartTables(oid);
+	}
+
+	// get key sets
+	BOOL should_add_default_keys = RelHasSystemColumns(rel->rd_rel->relkind);
+	keyset_array = RetrieveRelKeysets(mp, oid, should_add_default_keys, is_partitioned, attno_mapping);
+
+	// collect all check constraints
+	check_constraint_mdids = RetrieveRelCheckConstraints(mp, oid);
+
+	is_temporary = (rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP);
+	has_oids = rel->rd_rel->relhasoids;
+
+	GPOS_DELETE_ARRAY(attno_mapping);
 
 	GPOS_ASSERT(IMDRelation::ErelstorageSentinel != rel_storage_type);
 	GPOS_ASSERT(IMDRelation::EreldistrSentinel != dist);
@@ -1031,7 +998,7 @@ CTranslatorRelcacheToDXL::RetrieveIndex
 {
 	OID index_oid = CMDIdGPDB::CastMdid(mdid_index)->Oid();
 	GPOS_ASSERT(0 != index_oid);
-	Relation index_rel = gpdb::GetRelation(index_oid);
+	auto index_rel = gpdb::GetRelation(index_oid);
 
 	if (!index_rel)
 	{
@@ -1047,93 +1014,80 @@ CTranslatorRelcacheToDXL::RetrieveIndex
 	ULongPtrArray *index_key_cols_array = NULL;
 	ULONG *attno_mapping = NULL;
 
-	GPOS_TRY
+	if (!IsIndexSupported(index_rel))
 	{
-		if (!IsIndexSupported(index_rel))
-		{
-			GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Index type"));
-		}
-
-		form_pg_index = index_rel->rd_index;
-		GPOS_ASSERT (NULL != form_pg_index);
-		index_clustered = form_pg_index->indisclustered;
-
-		OID rel_oid = form_pg_index->indrelid;
-
-		if (gpdb::IsLeafPartition(rel_oid))
-		{
-			rel_oid = gpdb::GetRootPartition(rel_oid);
-		}
-
-		CMDIdGPDB *mdid_rel = GPOS_NEW(mp) CMDIdGPDB(rel_oid);
-
-		md_rel = md_accessor->RetrieveRel(mdid_rel);
-	
-		if (md_rel->IsPartitioned())
-		{
-			LogicalIndexes *logical_indexes = gpdb::GetLogicalPartIndexes(rel_oid);
-			GPOS_ASSERT(NULL != logical_indexes);
-
-			IMDIndex *index = RetrievePartTableIndex(mp, md_accessor, mdid_index, md_rel, logical_indexes);
-
-			// cleanup
-			gpdb::GPDBFree(logical_indexes);
-
-			if (NULL != index)
-			{
-				mdid_rel->Release();
-				gpdb::CloseRelation(index_rel);
-				return index;
-			}
-		}
-	
-		index_type = IMDIndex::EmdindBtree;
-		mdid_item_type = GPOS_NEW(mp) CMDIdGPDB(GPDB_ANY);
-		if (GIN_AM_OID == index_rel->rd_rel->relam)
-		{
-				index_type = IMDIndex::EmdindGin;
-		}
-		else if (GIST_AM_OID == index_rel->rd_rel->relam)
-		{
-			index_type = IMDIndex::EmdindGist;
-		}
-		else if (BITMAP_AM_OID == index_rel->rd_rel->relam)
-		{
-			index_type = IMDIndex::EmdindBitmap;
-		}
-
-		// get the index name
-		CHAR *index_name = NameStr(index_rel->rd_rel->relname);
-		CWStringDynamic *str_name = CDXLUtils::CreateDynamicStringFromCharArray(mp, index_name);
-		mdname = GPOS_NEW(mp) CMDName(mp, str_name);
-		GPOS_DELETE(str_name);
-
-		auto table_oid = CMDIdGPDB::CastMdid(md_rel->MDId())->Oid();
-		Relation table = gpdb::GetRelation(table_oid);
-		ULONG size = GPDXL_SYSTEM_COLUMNS + (ULONG) table->rd_att->natts + 1;
-		gpdb::CloseRelation(table); // close relation as early as possible
-
-		attno_mapping = PopulateAttnoPositionMap(mp, md_rel, size);
-
-		// extract the position of the key columns
-		index_key_cols_array = GPOS_NEW(mp) ULongPtrArray(mp);
-
-		for (int i = 0; i < form_pg_index->indnatts; i++)
-		{
-			INT attno = form_pg_index->indkey.values[i];
-			GPOS_ASSERT(0 != attno && "Index expressions not supported");
-
-			index_key_cols_array->Append(GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
-		}
-		mdid_rel->Release();
-		gpdb::CloseRelation(index_rel);
+		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Index type"));
 	}
-	GPOS_CATCH_EX(ex)
+
+	form_pg_index = index_rel->rd_index;
+	GPOS_ASSERT (NULL != form_pg_index);
+	index_clustered = form_pg_index->indisclustered;
+
+	OID rel_oid = form_pg_index->indrelid;
+
+	if (gpdb::IsLeafPartition(rel_oid))
 	{
-		gpdb::CloseRelation(index_rel);
-		GPOS_RETHROW(ex);
+		rel_oid = gpdb::GetRootPartition(rel_oid);
 	}
-	GPOS_CATCH_END;
+
+	CMDIdGPDB *mdid_rel = GPOS_NEW(mp) CMDIdGPDB(rel_oid);
+
+	md_rel = md_accessor->RetrieveRel(mdid_rel);
+
+	if (md_rel->IsPartitioned())
+	{
+		LogicalIndexes *logical_indexes = gpdb::GetLogicalPartIndexes(rel_oid);
+		GPOS_ASSERT(NULL != logical_indexes);
+
+		IMDIndex *index = RetrievePartTableIndex(mp, md_accessor, mdid_index, md_rel, logical_indexes);
+
+		// cleanup
+		gpdb::GPDBFree(logical_indexes);
+
+		if (NULL != index)
+		{
+			mdid_rel->Release();
+			return index;
+		}
+	}
+
+	index_type = IMDIndex::EmdindBtree;
+	mdid_item_type = GPOS_NEW(mp) CMDIdGPDB(GPDB_ANY);
+	if (GIN_AM_OID == index_rel->rd_rel->relam)
+	{
+			index_type = IMDIndex::EmdindGin;
+	}
+	else if (GIST_AM_OID == index_rel->rd_rel->relam)
+	{
+		index_type = IMDIndex::EmdindGist;
+	}
+	else if (BITMAP_AM_OID == index_rel->rd_rel->relam)
+	{
+		index_type = IMDIndex::EmdindBitmap;
+	}
+
+	// get the index name
+	CHAR *index_name = NameStr(index_rel->rd_rel->relname);
+	CWStringDynamic *str_name = CDXLUtils::CreateDynamicStringFromCharArray(mp, index_name);
+	mdname = GPOS_NEW(mp) CMDName(mp, str_name);
+	GPOS_DELETE(str_name);
+
+	auto table_oid = CMDIdGPDB::CastMdid(md_rel->MDId())->Oid();
+	ULONG size = GPDXL_SYSTEM_COLUMNS + (ULONG) gpdb::GetRelation(table_oid)->rd_att->natts + 1;
+
+	attno_mapping = PopulateAttnoPositionMap(mp, md_rel, size);
+
+	// extract the position of the key columns
+	index_key_cols_array = GPOS_NEW(mp) ULongPtrArray(mp);
+
+	for (int i = 0; i < form_pg_index->indnatts; i++)
+	{
+		INT attno = form_pg_index->indkey.values[i];
+		GPOS_ASSERT(0 != attno && "Index expressions not supported");
+
+		index_key_cols_array->Append(GPOS_NEW(mp) ULONG(GetAttributePosition(attno, attno_mapping)));
+	}
+	mdid_rel->Release();
 
 	ULongPtrArray *included_cols = ComputeIncludedCols(mp, md_rel);
 	mdid_index->AddRef();
@@ -1242,7 +1196,7 @@ CTranslatorRelcacheToDXL::RetrievePartTableIndex
 {
 	OID index_oid = index_info->logicalIndexOid;
 	
-	Relation index_rel = gpdb::GetRelation(index_oid);
+	auto index_rel = gpdb::GetRelation(index_oid);
 
 	if (!index_rel)
 	{
@@ -1251,7 +1205,6 @@ CTranslatorRelcacheToDXL::RetrievePartTableIndex
 
 	if (!IsIndexSupported(index_rel))
 	{
-		gpdb::CloseRelation(index_rel);
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported, GPOS_WSZ_LIT("Index type"));
 	}
 	
@@ -1261,12 +1214,10 @@ CTranslatorRelcacheToDXL::RetrievePartTableIndex
 	
 	CHAR *index_name = NameStr(index_rel->rd_rel->relname);
 	CMDName *mdname = CDXLUtils::CreateMDNameFromCharArray(mp, index_name);
-	gpdb::CloseRelation(index_rel);
+	index_rel.Close();
 
 	OID rel_oid = CMDIdGPDB::CastMdid(md_rel->MDId())->Oid();
-	Relation table = gpdb::GetRelation(rel_oid);
-	ULONG size = GPDXL_SYSTEM_COLUMNS + (ULONG) table->rd_att->natts + 1;
-	gpdb::CloseRelation(table);
+	ULONG size = GPDXL_SYSTEM_COLUMNS + (ULONG) gpdb::GetRelation(rel_oid)->rd_att->natts + 1;
 
 	ULONG *attno_mapping = PopulateAttnoPositionMap(mp, md_rel, size);
 
@@ -2225,7 +2176,7 @@ CTranslatorRelcacheToDXL::RetrieveRelStats
 	IMDId *mdid_rel = m_rel_stats_mdid->GetRelMdId();
 	OID rel_oid = CMDIdGPDB::CastMdid(mdid_rel)->Oid();
 
-	Relation rel = gpdb::GetRelation(rel_oid);
+	auto rel = gpdb::GetRelation(rel_oid);
 	if (!rel)
 	{
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
@@ -2234,26 +2185,16 @@ CTranslatorRelcacheToDXL::RetrieveRelStats
 	double num_rows = 0.0;
 	CMDName *mdname = NULL;
 
-	GPOS_TRY
-	{
-		// get rel name
-		CHAR *relname = NameStr(rel->rd_rel->relname);
-		CWStringDynamic *relname_str = CDXLUtils::CreateDynamicStringFromCharArray(mp, relname);
-		mdname = GPOS_NEW(mp) CMDName(mp, relname_str);
-		// CMDName ctor created a copy of the string
-		GPOS_DELETE(relname_str);
+	// get rel name
+	CHAR *relname = NameStr(rel->rd_rel->relname);
+	CWStringDynamic *relname_str = CDXLUtils::CreateDynamicStringFromCharArray(mp, relname);
+	mdname = GPOS_NEW(mp) CMDName(mp, relname_str);
+	// CMDName ctor created a copy of the string
+	GPOS_DELETE(relname_str);
 
-		num_rows = gpdb::CdbEstimatePartitionedNumTuples(rel);
+	num_rows = gpdb::CdbEstimatePartitionedNumTuples(rel);
 
-		m_rel_stats_mdid->AddRef();
-		gpdb::CloseRelation(rel);
-	}
-	GPOS_CATCH_EX(ex)
-	{
-		gpdb::CloseRelation(rel);
-		GPOS_RETHROW(ex);
-	}
-	GPOS_CATCH_END;
+	m_rel_stats_mdid->AddRef();
 
 	/*
 	 * relation_empty should be set to true only if the total row
@@ -2296,8 +2237,6 @@ CTranslatorRelcacheToDXL::RetrieveColStats
 	ULONG pos = mdid_col_stats->Position();
 	OID rel_oid = CMDIdGPDB::CastMdid(mdid_rel)->Oid();
 
-	Relation rel = gpdb::GetRelation(rel_oid);
-
 	const IMDRelation *md_rel = md_accessor->RetrieveRel(mdid_rel);
 	const IMDColumn *md_col = md_rel->GetMdCol(pos);
 	AttrNumber attno = (AttrNumber) md_col->AttrNum();
@@ -2305,12 +2244,11 @@ CTranslatorRelcacheToDXL::RetrieveColStats
 	// number of rows from pg_class
 	double num_rows;
 
-	num_rows = gpdb::CdbEstimatePartitionedNumTuples(rel);
+	num_rows = gpdb::CdbEstimatePartitionedNumTuples(gpdb::GetRelation(rel_oid));
 
 	// extract column name and type
 	CMDName *md_colname = GPOS_NEW(mp) CMDName(mp, md_col->Mdname().GetMDName());
 	OID att_type = CMDIdGPDB::CastMdid(md_col->MdidType())->Oid();
-	gpdb::CloseRelation(rel);
 
 	CDXLBucketArray *dxl_stats_bucket_array = GPOS_NEW(mp) CDXLBucketArray(mp);
 

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -289,7 +289,7 @@ CTranslatorRelcacheToDXL::RetrieveRelIndexInfoForPartTable
 		// only add supported indexes
 		Relation index_rel = gpdb::GetRelation(index_oid);
 
-		if (NULL == index_rel)
+		if (!index_rel)
 		{
 			WCHAR wstr[1024];
 			CWStringStatic str(wstr, 1024);
@@ -344,7 +344,7 @@ CTranslatorRelcacheToDXL::RetrieveRelIndexInfoForNonPartTable
 		// only add supported indexes
 		Relation index_rel = gpdb::GetRelation(index_oid);
 
-		if (NULL == index_rel)
+		if (!index_rel)
 		{
 			WCHAR wstr[1024];
 			CWStringStatic str(wstr, 1024);
@@ -509,7 +509,7 @@ CTranslatorRelcacheToDXL::RetrieveRel
 
 	Relation rel = gpdb::GetRelation(oid);
 
-	if (NULL == rel)
+	if (!rel)
 	{
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
@@ -1033,7 +1033,7 @@ CTranslatorRelcacheToDXL::RetrieveIndex
 	GPOS_ASSERT(0 != index_oid);
 	Relation index_rel = gpdb::GetRelation(index_oid);
 
-	if (NULL == index_rel)
+	if (!index_rel)
 	{
 		 GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid_index->GetBuffer());
 	}
@@ -1108,7 +1108,8 @@ CTranslatorRelcacheToDXL::RetrieveIndex
 		mdname = GPOS_NEW(mp) CMDName(mp, str_name);
 		GPOS_DELETE(str_name);
 
-		Relation table = gpdb::GetRelation(CMDIdGPDB::CastMdid(md_rel->MDId())->Oid());
+		auto table_oid = CMDIdGPDB::CastMdid(md_rel->MDId())->Oid();
+		Relation table = gpdb::GetRelation(table_oid);
 		ULONG size = GPDXL_SYSTEM_COLUMNS + (ULONG) table->rd_att->natts + 1;
 		gpdb::CloseRelation(table); // close relation as early as possible
 
@@ -1243,7 +1244,7 @@ CTranslatorRelcacheToDXL::RetrievePartTableIndex
 	
 	Relation index_rel = gpdb::GetRelation(index_oid);
 
-	if (NULL == index_rel)
+	if (!index_rel)
 	{
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid_index->GetBuffer());
 	}
@@ -2225,7 +2226,7 @@ CTranslatorRelcacheToDXL::RetrieveRelStats
 	OID rel_oid = CMDIdGPDB::CastMdid(mdid_rel)->Oid();
 
 	Relation rel = gpdb::GetRelation(rel_oid);
-	if (NULL == rel)
+	if (!rel)
 	{
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
@@ -2296,10 +2297,6 @@ CTranslatorRelcacheToDXL::RetrieveColStats
 	OID rel_oid = CMDIdGPDB::CastMdid(mdid_rel)->Oid();
 
 	Relation rel = gpdb::GetRelation(rel_oid);
-	if (NULL == rel)
-	{
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
-	}
 
 	const IMDRelation *md_rel = md_accessor->RetrieveRel(mdid_rel);
 	const IMDColumn *md_col = md_rel->GetMdCol(pos);

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1036,7 +1036,7 @@ CTranslatorUtils::GetOpFamilyForIndexQual
 	)
 {
 	Relation rel = gpdb::GetRelation(index_oid);
-	GPOS_ASSERT(NULL != rel);
+	GPOS_ASSERT(rel);
 	GPOS_ASSERT(attno <= rel->rd_index->indnatts);
 	
 	OID op_family_oid = rel->rd_opfamily[attno - 1];

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1035,13 +1035,12 @@ CTranslatorUtils::GetOpFamilyForIndexQual
 	OID index_oid
 	)
 {
-	Relation rel = gpdb::GetRelation(index_oid);
+	auto rel = gpdb::GetRelation(index_oid);
 	GPOS_ASSERT(rel);
 	GPOS_ASSERT(attno <= rel->rd_index->indnatts);
 	
 	OID op_family_oid = rel->rd_opfamily[attno - 1];
-	gpdb::CloseRelation(rel);
-	
+
 	return op_family_oid;
 }
 

--- a/src/backend/gpopt/utils/Makefile
+++ b/src/backend/gpopt/utils/Makefile
@@ -11,6 +11,6 @@ include $(top_builddir)/src/Makefile.global
 
 include $(top_srcdir)/src/backend/gpopt/gpopt.mk
 
-OBJS = COptTasks.o CConstExprEvaluatorProxy.o CMemoryPoolPalloc.o CMemoryPoolPallocManager.o funcs.o
+OBJS = COptTasks.o CConstExprEvaluatorProxy.o CMemoryPoolPalloc.o CMemoryPoolPallocManager.o funcs.o RelationWrapper.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/gpopt/utils/RelationWrapper.cpp
+++ b/src/backend/gpopt/utils/RelationWrapper.cpp
@@ -1,0 +1,26 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//---------------------------------------------------------------------------
+#include "gpopt/utils/RelationWrapper.h"
+
+#include "gpopt/gpdbwrappers.h"	 // for CloseRelation
+
+namespace gpdb
+{
+RelationWrapper::~RelationWrapper() noexcept(false)
+{
+	if (m_relation)
+		CloseRelation(m_relation);
+}
+
+void
+RelationWrapper::Close()
+{
+	if (m_relation)
+	{
+		CloseRelation(m_relation);
+		m_relation = nullptr;
+	}
+}
+}  // namespace gpdb

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -21,6 +21,8 @@
 #include "parser/parse_coerce.h"
 #include "utils/lsyscache.h"
 
+#include "gpos/types.h"
+
 // fwd declarations
 typedef struct SysScanDescData *SysScanDesc;
 typedef int LOCKMODE;

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -58,6 +58,8 @@ struct Var;
 struct Const;
 struct ArrayExpr;
 
+#include "gpopt/utils/RelationWrapper.h"
+
 namespace gpdb {
 
 	// convert datum to bool
@@ -548,6 +550,18 @@ namespace gpdb {
 
 	// close the given relation
 	void CloseRelation(Relation rel);
+	/// Passing the transparent wrapper (which is implicitly convertible to a
+	/// Relation pointer) to CloseRelation is almost definitely a double-close.
+	/// Defensively mark this radioactive. Now an accidental
+	///
+	/// \code
+	/// RelationWrapper rel = GetRelation(...);
+	/// CloseRelation(rel);
+	/// \endcode
+	///
+	/// will result in a compiler error.
+	/// FIXME: remove this once we remove the implicit cast to Relation
+	void CloseRelation(RelationWrapper rel) = delete;
 
 	// return the logical indexes for a partitioned table
 	LogicalIndexes *GetLogicalPartIndexes(Oid oid);
@@ -562,7 +576,7 @@ namespace gpdb {
 	void BuildRelationTriggers(Relation rel);
 
 	// get relation with given oid
-	Relation GetRelation(Oid rel_oid);
+	RelationWrapper GetRelation(Oid rel_oid);
 
 	// get external table entry with given oid
 	ExtTableEntry *GetExternalTableEntry(Oid rel_oid);

--- a/src/include/gpopt/utils/RelationWrapper.h
+++ b/src/include/gpopt/utils/RelationWrapper.h
@@ -1,0 +1,113 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//---------------------------------------------------------------------------
+#ifndef GPDB_RelationWrapper_H
+#define GPDB_RelationWrapper_H
+
+#include <cstddef>
+
+typedef struct RelationData *Relation;
+
+namespace gpdb
+{
+/// \class
+/// A transparent RAII wrapper for a pointer to a Postgres RelationData.
+/// "Transparent" means that an object of this type can be used in most contexts
+/// that expect a Relation. The main advantage of using this wrapper is that it
+/// automatically closes the wrapper relation when exiting scope. So you no
+/// longer have to write code like this:
+/// \code
+/// void RetrieveRel(Oid reloid) {
+///     Relation rel = GetRelation(reloid);
+///     if (IsPartialDist(rel)) {
+///         CloseRelation(rel);
+///         GPOS_RAISE(...);
+///     }
+///     try {
+///         do_stuff();
+///         CloseRelation(rel);
+///     catch (...) {
+///         CloseRelation(rel);
+///         GPOS_RETHROW(...);
+///     }
+/// }
+/// \endcode
+/// and instead you can write this:
+/// \code
+/// void RetrieveRel(Oid reloid) {
+///     auto rel = GetRelation(reloid);
+///     if (IsPartialDist(rel)) {
+///         GPOS_RAISE(...);
+///     }
+///     do_stuff();
+/// }
+/// \endcode
+class RelationWrapper
+{
+public:
+	RelationWrapper(RelationWrapper const &) = delete;
+	RelationWrapper(RelationWrapper &&r) : m_relation(r.m_relation)
+	{
+		r.m_relation = nullptr;
+	};
+
+	explicit RelationWrapper(Relation relation) : m_relation(relation)
+	{
+	}
+
+	/// the following two operators allow use in typical conditionals of the
+	/// form.
+	///
+	/// \code if (rel == nullptr) return; \endcode or
+	/// \code if (rel != nullptr) do_stuff(rel); \endcode
+	///
+	/// They are currently unused because the preferred form is
+	///
+	/// \code if (rel) ... \endcode or
+	/// \code if (!rel) ... \endcode
+	bool operator==(std::nullptr_t) const
+	{
+		return m_relation == nullptr;
+	}
+
+	bool operator!=(std::nullptr_t) const
+	{
+		return m_relation != nullptr;
+	}
+
+	/// allows use in typical conditionals of the form
+	///
+	/// \code if (rel) { do_stuff(rel); } \endcode or
+	/// \code if (!rel) return; \endcode
+	explicit operator bool() const
+	{
+		return m_relation != nullptr;
+	}
+
+	// behave like a raw pointer on arrow
+	Relation
+	operator->() const
+	{
+		return m_relation;
+	}
+
+	// FIXME: this eases the transition, but an implicit cast is an antipattern
+	// once we're done migrating, replace with something like get()
+	operator Relation() const
+	{
+		return m_relation;
+	}
+
+	/// Explicitly close the underlying relation early. This is not usually
+	/// necessary unless there is significant amount of time between the point
+	/// of close and the end-of-scope
+	void Close();
+
+	~RelationWrapper() noexcept(false);
+
+private:
+	Relation m_relation = nullptr;
+};
+}  // namespace gpdb
+#endif	// GPDB_RelationWrapper_H


### PR DESCRIPTION
## TL;DR: Would you like to read and write code like this:

```c++
auto rel = GetRelation(...);
if (!RelIsSupported(rel)) {
	return -1;
}
do_stuff(rel);
```

Instead of code like this:

```c++
Relation rel = GetRelation(...);

if (!RelIsSupported(rel)) {
	CloseRelation(rel);
	return -1;
}

GPOS_TRY {
	do_stuff(rel);
	CloseRelation(rel);
} GPOS_CATCH_EX(ex) {
	CloseRelation(rel);
	GPOS_RETHROW(ex);
} GPOS_CATCH_END;
```
?

## Description
The two snippets above will have the same outcome, but the former is less cluttered and more readable. As a bonus, it's also safer. This patch set introduces a thin wrapper type that encapsulates the resource-safety logic of closing the Postgres Relation object, makes `GetRelation()` return such a type, and cleans up the usages of `GetRelation()`.

### To review
You can either look at the whole diff (but I'd recommend a differ that can strip indentation / whitespace changes), or go through them one by one:
1. first commit cleans up the callers a bit, changing Yoda conditions
1. next commit introduced the wrapper with minimal code to ease the transition
1. Actually transition `GetRleation()` to return the wrapper. Clean up usages.

### Tips for reviewer
1. If you're using GitHub, make sure you teach the UI to ignore whitespace changes like this: 
![image](https://user-images.githubusercontent.com/440892/91595814-fceb7e00-e918-11ea-8e2f-926e39484dc5.png)


## Feedback I'm seeking:
1. Where should the wrapper class be? I've settled on `gpopt/utils` but I'm not 100% sure it fits there. It just seems to fit there slightly better than all other options I had.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [x] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
