### PR TITLE
Fix error planning sorted Agg when subpath is more strictly ordered.

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -512,7 +512,6 @@ add_twostage_group_agg_path(PlannerInfo *root,
 	}
 	else if (parse->hasAggs || parse->groupClause)
 	{
-
 		initial_agg_path =
 			(Path *) create_agg_path(root,
 									 output_rel,
@@ -529,7 +528,7 @@ add_twostage_group_agg_path(PlannerInfo *root,
 																	 getgpsegmentCount()),
 									 NULL);
 
-		motion_pathkeys = initial_agg_path->pathkeys;
+		motion_pathkeys = root->group_pathkeys;
 	}
 	else
 	{

--- a/src/test/regress/expected/bfv_olap.out
+++ b/src/test/regress/expected/bfv_olap.out
@@ -686,6 +686,49 @@ select * from cte;
 (3 rows)
 
 reset optimizer_trace_fallback;
+--
+-- Test for github issue #10729.
+-- This failed with:
+--   ERROR:  could not find pathkey item to sort (createplan.c:6326)
+--
+-- In the outermost query, group_pathkeys is NIL, even though there is a
+-- GROUP BY, because the grouping expression is a constant. The subquery scan
+-- comes out sorted by foo.t. We generated a plan with a Gather Motion that
+-- tried to preserve the ordering on foo.t, even though group_pathkeys was NIL,
+-- which failed. It was fixed by changing the code that generates the Motion
+-- path, to only preserve the order based on group_pathkeys, not the sub-path's
+-- pathkeys.
+--
+create temporary table foo (t text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set enable_hashagg=off;
+explain (costs off)
+with cte as
+( select t
+  from foo
+  group by t
+)
+select 'xx'::text
+from cte
+group by 'xx'::text;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Finalize GroupAggregate
+   Group Key: ('xx'::text)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial GroupAggregate
+               Group Key: 'xx'::text
+               ->  Subquery Scan on cte
+                     ->  GroupAggregate
+                           Group Key: foo.t
+                           ->  Sort
+                                 Sort Key: foo.t
+                                 ->  Seq Scan on foo
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+reset enable_hashagg;
 -- CLEANUP
 -- start_ignore
 drop schema bfv_olap cascade;

--- a/src/test/regress/expected/bfv_olap_optimizer.out
+++ b/src/test/regress/expected/bfv_olap_optimizer.out
@@ -687,6 +687,50 @@ select * from cte;
 (3 rows)
 
 reset optimizer_trace_fallback;
+--
+-- Test for github issue #10729.
+-- This failed with:
+--   ERROR:  could not find pathkey item to sort (createplan.c:6326)
+--
+-- In the outermost query, group_pathkeys is NIL, even though there is a
+-- GROUP BY, because the grouping expression is a constant. The subquery scan
+-- comes out sorted by foo.t. We generated a plan with a Gather Motion that
+-- tried to preserve the ordering on foo.t, even though group_pathkeys was NIL,
+-- which failed. It was fixed by changing the code that generates the Motion
+-- path, to only preserve the order based on group_pathkeys, not the sub-path's
+-- pathkeys.
+--
+create temporary table foo (t text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set enable_hashagg=off;
+explain (costs off)
+with cte as
+( select t
+  from foo
+  group by t
+)
+select 'xx'::text
+from cte
+group by 'xx'::text;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: ('xx'::text)
+         ->  Sort
+               Sort Key: ('xx'::text)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: ('xx'::text)
+                     ->  GroupAggregate
+                           Group Key: t
+                           ->  Sort
+                                 Sort Key: t
+                                 ->  Seq Scan on foo
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+reset enable_hashagg;
 -- CLEANUP
 -- start_ignore
 drop schema bfv_olap cascade;


### PR DESCRIPTION
When creating a Gather Motion for input that's already sorted, we mustn't
try to preserve the ordering of columns that are not in
root->group_pathkeys, because they might not be available in the outer
query.

Fixes https://github.com/greenplum-db/gpdb/issues/10729
