### PR TITLE
Fix pulling up pathkeys from a CTE plan.

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -2869,7 +2869,6 @@ create_ctescan_path(PlannerInfo *root, RelOptInfo *rel,
 		pathnode->rows = clamp_row_est(rel->rows / numsegments);
 		pathnode->startup_cost = subpath->startup_cost;
 		pathnode->total_cost = subpath->total_cost;
-		pathnode->pathkeys = subpath->pathkeys;
 
 		ctepath->subpath = subpath;
 	}

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -122,6 +122,23 @@ select sum(total) from (select sum(value) as total from with_test1 group by i) m
 
 --end_equivalent
 -- pathkeys
+explain (costs off)
+with my_order as (select * from with_test1 order by i)
+select i, count(*)
+from my_order
+group by i order by i;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: with_test1.i
+   ->  GroupAggregate
+         Group Key: with_test1.i
+         ->  Sort
+               Sort Key: with_test1.i
+               ->  Seq Scan on with_test1
+ Optimizer: Postgres query optimizer
+(8 rows)
+
 with my_order as (select * from with_test1 order by i)
 select i, count(*)
 from my_order

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -122,6 +122,25 @@ select sum(total) from (select sum(value) as total from with_test1 group by i) m
 
 --end_equivalent
 -- pathkeys
+explain (costs off)
+with my_order as (select * from with_test1 order by i)
+select i, count(*)
+from my_order
+group by i order by i;
+                   QUERY PLAN                   
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: i
+   ->  Sort
+         Sort Key: i
+         ->  GroupAggregate
+               Group Key: i
+               ->  Sort
+                     Sort Key: i
+                     ->  Seq Scan on with_test1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
 with my_order as (select * from with_test1 order by i)
 select i, count(*)
 from my_order

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -62,10 +62,17 @@ select sum(total) from (select sum(value) as total from with_test1 group by i) m
 --end_equivalent
 
 -- pathkeys
+explain (costs off)
 with my_order as (select * from with_test1 order by i)
 select i, count(*)
 from my_order
 group by i order by i;
+
+with my_order as (select * from with_test1 order by i)
+select i, count(*)
+from my_order
+group by i order by i;
+
 
 -- WITH query used in InitPlan
 --begin_equivalent


### PR DESCRIPTION
A CteScan's pathkeys were incorrectly taken from the subpath. That's wrong
because a CteScan's subpath belongs to the subquery, which has its own
equivalence classes, range table and everything. The subpath's pathkeys
are nonsensical in the outer query. The caller of create_ctescan_path()
correctly converted the subpath's pathkeys to the outer query's context,
but create_ctescan_path() didn't use the passed-in pathkeys correctly.

As a result, queries involving CTEs would sometimes sort, even though the
input was already sorted. For example:

    postgres=# explain (costs off) with my_order as
               (select * from with_test1 order by i)
               select i, count(*)
               from my_order
               group by i order by i;
                          QUERY PLAN
    ------------------------------------------------------
     Gather Motion 3:1  (slice1; segments: 3)
       Merge Key: my_order.i
       ->  GroupAggregate
             Group Key: my_order.i
             ->  Sort
                   Sort Key: my_order.i
                   ->  Subquery Scan on my_order
                         ->  Sort
                               Sort Key: with_test1.i
                               ->  Seq Scan on with_test1
     Optimizer: Postgres query optimizer
    (11 rows)

This bug was introduced in the 9.6 merge. I first bumped into this while
hacking on https://github.com/greenplum-db/gpdb/pull/10727. That PR
exposed this bug in one of the complicated queries in the 'qp_with_clause'
test, where it caused an "ERROR:  could not find pathkey item to sort".
I was not able to craft a query that would reproduce that error without
the changes in that PR, but I'm pretty sure it could happen with the right
query.
