### PR TITLE
Fix resource group runaway rounding issue

### DIFF
--- a/src/test/isolation2/input/resgroup/resgroup_memory_runaway.source
+++ b/src/test/isolation2/input/resgroup/resgroup_memory_runaway.source
@@ -132,6 +132,38 @@ CREATE OR REPLACE VIEW memory_result AS SELECT rsgname, memory_usage from gp_too
 0: DROP RESOURCE GROUP rg2_memory_test;
 0q:
 
+--  test for the rounding issue of runaway_detector_activation_percent
+--  when calculating safeChunksThreshold, we used to multiply
+--  runaway_detector_activation_percent and then divide 100. This will
+--  cause the small chunks to be rounded to zero.
+--  set runaway_detector_activation_percent to 99 to enlarge the rounding
+--  issue
+
+-- start_ignore
+! gpconfig -c runaway_detector_activation_percent -v 99;
+! gpstop -ari;
+-- end_ignore
+
+1: CREATE RESOURCE GROUP rg1_memory_test
+    WITH (concurrency=2, cpu_rate_limit=10,
+          memory_limit=60, memory_shared_quota=50);
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+-- trigger small chunks rounding issue by reducing memory limit in small step
+-- while increasing memory limit in big step.
+1: ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 57;
+1: ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 54;
+1: ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 51;
+1: ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 48;
+1: ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 60;
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+1: SELECT hold_memory_by_percent(0.1);
+1: SELECT hold_memory_by_percent(0.1);
+1q:
+
+0: DROP ROLE role1_memory_test;
+0: DROP RESOURCE GROUP rg1_memory_test;
+0q:
 
 -- start_ignore
 ! gpconfig -c runaway_detector_activation_percent -v 100;

--- a/src/test/isolation2/output/resgroup/resgroup_memory_runaway.source
+++ b/src/test/isolation2/output/resgroup/resgroup_memory_runaway.source
@@ -252,4 +252,52 @@ DROP
 DROP
 0q: ... <quitting>
 
+--  test for the rounding issue of runaway_detector_activation_percent
+--  when calculating safeChunksThreshold, we used to multiply
+--  runaway_detector_activation_percent and then divide 100. This will
+--  cause the small chunks to be rounded to zero.
+--  set runaway_detector_activation_percent to 99 to enlarge the rounding
+--  issue
+
+-- start_ignore
+! gpconfig -c runaway_detector_activation_percent -v 99;
+! gpstop -ari;
+-- end_ignore
+
+1: CREATE RESOURCE GROUP rg1_memory_test WITH (concurrency=2, cpu_rate_limit=10, memory_limit=60, memory_shared_quota=50);
+CREATE
+1: CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
+CREATE
+-- trigger small chunks rounding issue by reducing memory limit in small step
+-- while increasing memory limit in big step.
+1: ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 57;
+ALTER
+1: ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 54;
+ALTER
+1: ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 51;
+ALTER
+1: ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 48;
+ALTER
+1: ALTER RESOURCE GROUP rg1_memory_test SET MEMORY_LIMIT 60;
+ALTER
+--	1a) on QD
+1: SET ROLE TO role1_memory_test;
+SET
+1: SELECT hold_memory_by_percent(0.1);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1: SELECT hold_memory_by_percent(0.1);
+ hold_memory_by_percent 
+------------------------
+ 0                      
+(1 row)
+1q: ... <quitting>
+
+0: DROP ROLE role1_memory_test;
+DROP
+0: DROP RESOURCE GROUP rg1_memory_test;
+DROP
+0q: ... <quitting>
 


### PR DESCRIPTION
When calculating safeChunksThreshold of runaway in resource group,
we used to divide by 100 to get the number of safe chunks. This may
lead to small chunk numbers to be rounded to zero. Fix it by storing
safeChunksThreshold100(100 times bigger than the real safe chunk) and
do the computation on the fly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
