### PR TITLE
Using lwlock to protect resgroup slot in session state

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -399,8 +399,7 @@ ic_proxy_server_on_read_postmaster_pipe(uv_stream_t *stream, ssize_t nread, cons
 	else if (nread < 0)
 		ic_proxy_log(FATAL, "read on postmaster death monitoring pipe failed: %s", uv_strerror(nread));
 	else if (nread > 0)
-		ic_proxy_log(FATAL, "unexpected data in postmaster death monitoring pipe with length: %d", nread);
-}
+		ic_proxy_log(FATAL, "unexpected data in postmaster death monitoring pipe with length: %ld", nread)
 
 /*
  * The main loop of the ic-proxy.

--- a/src/backend/utils/mmgr/redzone_handler.c
+++ b/src/backend/utils/mmgr/redzone_handler.c
@@ -177,6 +177,10 @@ RedZoneHandler_FlagTopConsumer()
 	 * resource group slot being changed during flag top consumer in redzone.
 	 * Note that flag top consumer is a low frequency action, so the
 	 * additional overhead is acceptable.
+	 *
+	 * Note that we also need to acquire SessionStateLock as well, so the lock
+	 * order is important to avoid deadlock. Make sure always acquire
+	 * ResGroupLock ahead.
 	 */
 	if (IsResGroupEnabled())
 		LWLockAcquire(ResGroupLock, LW_SHARED);

--- a/src/backend/utils/mmgr/redzone_handler.c
+++ b/src/backend/utils/mmgr/redzone_handler.c
@@ -174,7 +174,7 @@ RedZoneHandler_FlagTopConsumer()
 
 	/*
 	 * In resource group mode, we should acquire ResGroupLock to avoid
-	 * resource group slot is changed during flag top consumer in redzone.
+	 * resource group slot being changed during flag top consumer in redzone.
 	 * Note that flag top consumer is a low frequency action, so the
 	 * additional overhead is acceptable.
 	 */

--- a/src/backend/utils/mmgr/redzone_handler.c
+++ b/src/backend/utils/mmgr/redzone_handler.c
@@ -173,6 +173,15 @@ RedZoneHandler_FlagTopConsumer()
 	}
 
 	/*
+	 * In resource group mode, we should acquire ResGroupLock to avoid
+	 * resource group slot is changed during flag top consumer in redzone.
+	 * Note that flag top consumer is a low frequency action, so the
+	 * additional overhead is acceptable.
+	 */
+	if (IsResGroupEnabled())
+		LWLockAcquire(ResGroupLock, LW_SHARED);
+
+	/*
 	 * Grabbing a shared lock prevents others to modify the SessionState
 	 * data structure, therefore ensuring that we don't flag someone
 	 * who was already dying. A shared lock is enough as we access the
@@ -189,15 +198,10 @@ RedZoneHandler_FlagTopConsumer()
 
 	/*
 	 * Find the group which used the most of global memory in resgroup mode.
-	 * Since there exists concurrent DDLs to drop resource group and it is
-	 * not safe to acquire resgroup lock in redzone. We access ResGroupData
-	 * in a lock free way, and using SessionStateLock to ensure the groups with
-	 * sessions will not be dropped.
 	 */
 	if (IsResGroupEnabled())
 	{
 		int32	maxGlobalShareMem = 0;
-		Oid		sessionGroupId = InvalidOid;
 		int32	sessionGroupGSMem;
 
 		while (curSessionState != NULL)
@@ -209,10 +213,7 @@ RedZoneHandler_FlagTopConsumer()
 			if (sessionGroupGSMem > maxGlobalShareMem)
 			{
 				maxGlobalShareMem = sessionGroupGSMem;
-				sessionGroupId = SessionGetResGroupId(curSessionState);
-
-				Assert(InvalidOid != sessionGroupId);
-				resGroupId = sessionGroupId;
+				resGroupId = SessionGetResGroupId(curSessionState);
 			}
 
 			curSessionState = curSessionState->next;
@@ -334,6 +335,9 @@ RedZoneHandler_FlagTopConsumer()
 	}
 
 	LWLockRelease(SessionStateLock);
+
+	if (IsResGroupEnabled())
+		LWLockRelease(ResGroupLock);
 }
 
 /*

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -370,6 +370,7 @@ static void resgroupDumpSlots(StringInfo str);
 static void resgroupDumpFreeSlots(StringInfo str);
 
 static void sessionSetSlot(ResGroupSlotData *slot);
+static void sessionResetSlot();
 static ResGroupSlotData *sessionGetSlot(void);
 
 static void bindGroupOperation(ResGroupData *group);
@@ -2733,7 +2734,7 @@ UnassignResGroup(bool releaseSlot)
 		 * could be reset as NULL in shmem_exit() before.
 		 */
 		if (MySessionState != NULL)
-			MySessionState->resGroupSlot = NULL;
+			sessionResetSlot();
 	}
 
 	LWLockRelease(ResGroupLock);
@@ -3133,7 +3134,7 @@ groupWaitCancel(bool isMoveQuery)
 		 * could be reset as NULL in shmem_exit() before.
 		 */
 		if (MySessionState != NULL)
-			MySessionState->resGroupSlot = NULL;
+			sessionResetSlot();
 
 		group->totalExecuted++;
 
@@ -3867,7 +3868,36 @@ sessionSetSlot(ResGroupSlotData *slot)
 	Assert(slot != NULL);
 	Assert(MySessionState->resGroupSlot == NULL);
 
+	/*
+	 * SessionStateLock is required since runaway detector will traverse
+	 * the current session array and check corresponding resGroupSlot with
+	 * shared lock on SessionStateLock.
+	 */
+	LWLockAcquire(SessionStateLock, LW_EXCLUSIVE);
+
 	MySessionState->resGroupSlot = (void *) slot;
+
+	LWLockRelease(SessionStateLock);
+}
+
+/*
+ * Reset resource group slot for current session to NULL.
+ */
+static void
+sessionResetSlot()
+{
+	Assert(MySessionState != NULL);
+
+	/*
+	 * SessionStateLock is required since runaway detector will traverse
+	 * the current session array and check corresponding resGroupSlot with
+	 * shared lock on SessionStateLock.
+	 */
+	LWLockAcquire(SessionStateLock, LW_EXCLUSIVE);
+
+	MySessionState->resGroupSlot = NULL;
+
+	LWLockRelease(SessionStateLock);
 }
 
 /*


### PR DESCRIPTION
Resource group used to access resGroupSlot in SessionState without
lock. This is correct when session only access resGroupSlot by itself.
But as we introduced runaway feature, we need to traverse the current
session array to find the top consumer session when redzone is reached.
This requires:
1. runaway detector should hold shared resgroup lock to avoid resGroupSlot
is detached from a session concurrently when redzone is reached.
2. normal session should hold exclusive lock when modifying resGroupSlot
in SessionState.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
