### PR TITLE
GPHOME is determined dynamically when sourcing greenplum_path

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -9,7 +9,7 @@ $(recurse)
 generate_greenplum_path_file:
 	mkdir -p $(DESTDIR)$(prefix)
 	unset LIBPATH; \
-	bin/generate-greenplum-path.sh $(prefix) > $(DESTDIR)$(prefix)/greenplum_path.sh
+	bin/generate-greenplum-path.sh > $(DESTDIR)$(prefix)/greenplum_path.sh
 
 install: generate_greenplum_path_file
 	mkdir -p $(DESTDIR)$(prefix)/lib/python

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 
-if [ -z "$1" ]; then
-  printf "Must specify a value for GPHOME"
-  exit 1
+cat <<"EOF"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+if [ ! -L "${SCRIPT_DIR}" ]; then
+	GPDB_DIR=$(basename "${SCRIPT_DIR}")
+else
+	GPDB_DIR=$(basename "$(readlink "${SCRIPT_DIR}")")
 fi
-
-GPHOME_PATH="$1"
-cat <<EOF
-GPHOME="${GPHOME_PATH}"
-
+GPHOME=$(dirname "${SCRIPT_DIR}")/"${GPDB_DIR}"
 EOF
 
 cat <<"EOF"

--- a/gpMgmt/bin/gpload
+++ b/gpMgmt/bin/gpload
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 if [ ! -z "$GPHOME" ]; then
     . $GPHOME/greenplum_path.sh
 fi


### PR DESCRIPTION
Update greenplum_path.sh to use BASH_SOURCE for determining GPHOME

Update gpload test script to use bash instead of sh

discussion mail list: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/AgEGOsoAAlQ/m/a2VIBZgMCQAJ

dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-173785163-gphome-gp7