### PR TITLE
[backport 6X]GPHOME is determined dynamically when sourcing greenplum_path

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -695,7 +695,7 @@ copylibs : thirdparty-dist
 
 greenplum_path:
 	mkdir -p $(INSTLOC)
-	$(BUILDDIR)/gpMgmt/bin/generate-greenplum-path.sh $(INSTLOC) yes > $(INSTLOC)/greenplum_path.sh
+	$(BUILDDIR)/gpMgmt/bin/generate-greenplum-path.sh yes > $(INSTLOC)/greenplum_path.sh
 
 copylicense:
 	for proddir in $(INSTLOC) $(CLIENTSINSTLOC); do \

--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -9,7 +9,7 @@ $(recurse)
 generate_greenplum_path_file:
 	mkdir -p $(DESTDIR)$(prefix)
 	unset LIBPATH; \
-	bin/generate-greenplum-path.sh $(prefix) > $(DESTDIR)$(prefix)/greenplum_path.sh
+	bin/generate-greenplum-path.sh > $(DESTDIR)$(prefix)/greenplum_path.sh
 
 install: generate_greenplum_path_file
 	mkdir -p $(DESTDIR)$(prefix)/lib/python

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -78,7 +78,7 @@ pygresql:
 	@echo "--- PyGreSQL"
 	if [ ! -f $(DESTDIR)$(prefix)/greenplum_path.sh ]; then \
 		unset LIBPATH; \
-		./generate-greenplum-path.sh $(prefix) > $(DESTDIR)$(prefix)/greenplum_path.sh ; \
+		./generate-greenplum-path.sh > $(DESTDIR)$(prefix)/greenplum_path.sh ; \
 	fi
 	. $(DESTDIR)$(prefix)/greenplum_path.sh && unset PYTHONHOME && \
 	if [ "$(BLD_ARCH)" = 'aix7_ppc_64' ]; then \

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -80,7 +80,7 @@ pygresql:
 		unset LIBPATH; \
 		./generate-greenplum-path.sh > $(DESTDIR)$(prefix)/greenplum_path.sh ; \
 	fi
-	. $(DESTDIR)$(prefix)/greenplum_path.sh && unset PYTHONHOME && \
+	PATH=$(bindir):$$PATH && \
 	if [ "$(BLD_ARCH)" = 'aix7_ppc_64' ]; then \
 	    unset PYTHONPATH && cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" python_64 setup.py build; \
 	elif [ `uname -s` = 'OpenBSD' ]; then \

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 
-if [ -z "$1" ]; then
-  printf "Must specify a value for GPHOME"
-  exit 1
+SET_PYTHONHOME="${1:-no}"
+
+cat <<"EOF"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+if [ ! -L "${SCRIPT_DIR}" ]; then
+	GPDB_DIR=$(basename "${SCRIPT_DIR}")
+else
+	GPDB_DIR=$(basename "$(readlink "${SCRIPT_DIR}")")
 fi
-
-SET_PYTHONHOME="${2:-no}"
-
-GPHOME_PATH="$1"
-cat <<EOF
-GPHOME="${GPHOME_PATH}"
-
+GPHOME=$(dirname "${SCRIPT_DIR}")/"${GPDB_DIR}"
 EOF
 
 if [ "${SET_PYTHONHOME}" = "yes" ]; then

--- a/gpMgmt/bin/gpload
+++ b/gpMgmt/bin/gpload
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 if [ ! -z "$GPHOME" ]; then
     . $GPHOME/greenplum_path.sh
 fi

--- a/gpMgmt/bin/test-generate-greenplum-path.bash
+++ b/gpMgmt/bin/test-generate-greenplum-path.bash
@@ -2,23 +2,13 @@
 
 set -e
 
-echo "set GPHOME with first argument"
-./generate-greenplum-path.sh /foo | grep -q 'GPHOME="/foo"'
+echo "set PYTHONHOME if first argument is 'yes'"
+./generate-greenplum-path.sh yes | grep -q 'PYTHONHOME="${GPHOME}/ext/python"'
 
-echo "set PYTHONHOME if second argument is 'yes'"
-./generate-greenplum-path.sh /foo yes | grep -q 'PYTHONHOME="${GPHOME}/ext/python"'
+echo "do not set PYTHONHOME if first argument is not 'yes'"
+[ $(./generate-greenplum-path.sh no | grep -c PYTHONHOME) -eq 0 ]
 
-echo "do not set PYTHONHOME if second argument is not 'yes'"
-[ $(./generate-greenplum-path.sh /foo no | grep -c PYTHONHOME) -eq 0 ]
-
-echo "do not set PYTHONHOME if second argument is missing"
-[ $(./generate-greenplum-path.sh /foo | grep -c PYTHONHOME) -eq 0 ]
-
-echo "error out if no argument is given"
-if ./generate-greenplum-path.sh; then
-  echo "should not have passed"
-  exit 1
-fi
-./generate-greenplum-path.sh | grep -q "Must specify a value for GPHOME"
+echo "do not set PYTHONHOME if first argument is missing"
+[ $(./generate-greenplum-path.sh | grep -c PYTHONHOME) -eq 0 ]
 
 echo "ALL TEST PASSED"


### PR DESCRIPTION
Update greenplum_path.sh to use BASH_SOURCE for determining GPHOME

Update gpload test script to use bash instead of sh

Update Makefile target for pygresql to not source greenplum_path.sh, since BASH_SOURCE is only defined in bash, in ubuntu platform, it only has dash, which will make source greenplum_path.sh failed, build pygresql only need pg_config, so set PATH in order to find pg_config.

discussion mail list: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/AgEGOsoAAlQ/m/a2VIBZgMCQAJ

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-173785163-gphome-gp6