### PR TITLE
[backport 5X]GPHOME is determined dynamically when sourcing greenplum_path

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -1059,9 +1059,9 @@ greenplum_path:
 	mkdir -p $(INSTLOC)
 ifeq ($(BLD_ARCH),$(filter $(BLD_ARCH),ubuntu1604_amd64))
 	# python is not vendored in the enterpise builds of Ubuntu 16.04
-	$(BUILDDIR)/gpMgmt/bin/generate-greenplum-path.sh $(INSTLOC) no > $(INSTLOC)/greenplum_path.sh
+	$(BUILDDIR)/gpMgmt/bin/generate-greenplum-path.sh no > $(INSTLOC)/greenplum_path.sh
 else
-	$(BUILDDIR)/gpMgmt/bin/generate-greenplum-path.sh $(INSTLOC) yes > $(INSTLOC)/greenplum_path.sh
+	$(BUILDDIR)/gpMgmt/bin/generate-greenplum-path.sh yes > $(INSTLOC)/greenplum_path.sh
 endif
 
 copylicense:

--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -61,7 +61,7 @@ set_scripts_version :
 generate_greenplum_path_file:
 	mkdir -p $(DESTDIR)$(prefix)
 	unset LIBPATH; \
-	bin/generate-greenplum-path.sh $(prefix) > $(DESTDIR)$(prefix)/greenplum_path.sh
+	bin/generate-greenplum-path.sh > $(DESTDIR)$(prefix)/greenplum_path.sh
 
 install: generate_greenplum_path_file
 	# Generate some python libraries

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -58,7 +58,7 @@ PYGRESQL_DIR=PyGreSQL-$(PYGRESQL_VERSION)
 
 pygresql:
 	@echo "--- PyGreSQL"
-	. $(prefix)/greenplum_path.sh && unset PYTHONHOME && \
+	PATH=$(bindir):$$PATH && \
 	if [ `uname -s` = 'HP-UX' ]; then \
 	    cd $(PYLIB_SRC)/$(PYGRESQL_DIR) && DESTDIR="$(DESTDIR)" CC="$(CC)" LDFLAGS="-L../../../../gpAux/ext/hpux_ia64/python-2.5.6/lib" python setup.py build; \
 	elif [ "$(BLD_ARCH)" = 'aix7_ppc_64' ]; then \

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 
-if [ -z "$1" ]; then
-  printf "Must specify a value for GPHOME"
-  exit 1
+SET_PYTHONHOME="${1:-no}"
+
+cat <<"EOF"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+if [ ! -L "${SCRIPT_DIR}" ]; then
+	GPDB_DIR=$(basename "${SCRIPT_DIR}")
+else
+	GPDB_DIR=$(basename "$(readlink "${SCRIPT_DIR}")")
 fi
-
-SET_PYTHONHOME="${2:-no}"
-
-GPHOME_PATH="$1"
-cat <<EOF
-GPHOME="${GPHOME_PATH}"
-
+GPHOME=$(dirname "${SCRIPT_DIR}")/"${GPDB_DIR}"
 EOF
 
 if [ "${SET_PYTHONHOME}" = "yes" ]; then

--- a/gpMgmt/bin/gpload
+++ b/gpMgmt/bin/gpload
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 if [ ! -z "$GPHOME" ]; then
     . $GPHOME/greenplum_path.sh
 fi

--- a/gpMgmt/bin/test-generate-greenplum-path.bash
+++ b/gpMgmt/bin/test-generate-greenplum-path.bash
@@ -2,23 +2,13 @@
 
 set -e
 
-echo "set GPHOME with first argument"
-./generate-greenplum-path.sh /foo | grep -q 'GPHOME="/foo"'
+echo "set PYTHONHOME if first argument is 'yes'"
+./generate-greenplum-path.sh yes | grep -q 'PYTHONHOME="${GPHOME}/ext/python"'
 
-echo "set PYTHONHOME if second argument is 'yes'"
-./generate-greenplum-path.sh /foo yes | grep -q 'PYTHONHOME="${GPHOME}/ext/python"'
+echo "do not set PYTHONHOME if first argument is not 'yes'"
+[ $(./generate-greenplum-path.sh no | grep -c PYTHONHOME) -eq 0 ]
 
-echo "do not set PYTHONHOME if second argument is not 'yes'"
-[ $(./generate-greenplum-path.sh /foo no | grep -c PYTHONHOME) -eq 0 ]
-
-echo "do not set PYTHONHOME if second argument is missing"
-[ $(./generate-greenplum-path.sh /foo | grep -c PYTHONHOME) -eq 0 ]
-
-echo "error out if no argument is given"
-if ./generate-greenplum-path.sh; then
-  echo "should not have passed"
-  exit 1
-fi
-./generate-greenplum-path.sh | grep -q "Must specify a value for GPHOME"
+echo "do not set PYTHONHOME if first argument is missing"
+[ $(./generate-greenplum-path.sh | grep -c PYTHONHOME) -eq 0 ]
 
 echo "ALL TEST PASSED"


### PR DESCRIPTION
Update greenplum_path.sh to use BASH_SOURCE for determining GPHOME

Update gpload test script to use bash instead of sh

Update Makefile target for pygresql to not source greenplum_path.sh, since BASH_SOURCE is only defined in bash, in ubuntu platform, it only has dash, which will make source greenplum_path.sh failed, build pygresql only need pg_config, so set PATH in order to find pg_config.

discussion mail list: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/AgEGOsoAAlQ/m/a2VIBZgMCQAJ

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-sbai