### PR TITLE
[6X backport] Fix a 'VACUUM FULL' bug

### DIFF
--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -50,6 +50,7 @@
 #include "storage/predicate.h"
 #include "storage/smgr.h"
 #include "utils/acl.h"
+#include "utils/faultinjector.h"
 #include "utils/fmgroids.h"
 #include "utils/inval.h"
 #include "utils/lsyscache.h"
@@ -1625,18 +1626,16 @@ swap_relation_files(Oid r1, Oid r2, bool target_is_pg_class,
 							mapped_tables);
 	}
 
-	/* swap size statistics too, since new rel has freshly-updated stats */
-	if (swap_stats)
+	/* Send statistics from QE to QD */
+	if (Gp_role == GP_ROLE_EXECUTE && swap_stats && !IsSystemClass(r1, relform1))
 	{
 		rel = relation_open(r1, AccessShareLock);
 
-		vac_update_relstats(rel, relform1->relpages, relform1->reltuples,
-							relform1->relallvisible,
-							relform1->relhaspkey,
-							relform1->relfrozenxid,
-							relform1->relminmxid,
-							false,
-							true /* isvacuum */);
+		vac_send_relstats_to_qd(rel,
+								relform1->relpages,
+								relform1->reltuples,
+								relform1->relallvisible);
+
 		relation_close(rel, AccessShareLock);
 	}
 	/* Clean up. */
@@ -1697,6 +1696,8 @@ finish_heap_swap(Oid OIDOldHeap, Oid OIDNewHeap,
 						swap_stats,
 						is_internal,
 						frozenXid, cutoffMulti, mapped_tables);
+
+	SIMPLE_FAULT_INJECTOR("after_swap_relation_files");
 
 	/*
 	 * If it's a system catalog, queue an sinval message to flush all

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1593,6 +1593,35 @@ vac_update_relstats_from_list(List *updated_stats)
 }
 
 /*
+ * CDB: Build a special message, to send the number of tuples
+ * and the number of pages in pg_class located at QEs through
+ * the dispatcher.
+ */
+void
+vac_send_relstats_to_qd(Relation relation,
+						BlockNumber num_pages,
+						double num_tuples,
+						BlockNumber num_all_visible_pages)
+{
+
+	StringInfoData buf;
+	VPgClassStats stats;
+
+	Oid relid = RelationGetRelid(relation);
+	Assert(relid != InvalidOid);
+
+	pq_beginmessage(&buf, 'y');
+	pq_sendstring(&buf, "VACUUM");
+	stats.relid = relid;
+	stats.rel_pages = num_pages;
+	stats.rel_tuples = num_tuples;
+	stats.relallvisible = num_all_visible_pages;
+	pq_sendint(&buf, sizeof(VPgClassStats), sizeof(int));
+	pq_sendbytes(&buf, (char *) &stats, sizeof(VPgClassStats));
+	pq_endmessage(&buf);
+}
+
+/*
  *	vac_update_relstats() -- update statistics for one relation
  *
  *		Update the whole-relation statistics that are kept in its pg_class
@@ -1668,23 +1697,10 @@ vac_update_relstats(Relation relation,
 		}
 		else if (Gp_role == GP_ROLE_EXECUTE)
 		{
-			/*
-			 * CDB: Build a special message, to send the number of tuples
-			 * and the number of pages in pg_class located at QEs through
-			 * the dispatcher.
-			 */
-			StringInfoData buf;
-			VPgClassStats stats;
-
-			pq_beginmessage(&buf, 'y');
-			pq_sendstring(&buf, "VACUUM");
-			stats.relid = RelationGetRelid(relation);
-			stats.rel_pages = num_pages;
-			stats.rel_tuples = num_tuples;
-			stats.relallvisible = num_all_visible_pages;
-			pq_sendint(&buf, sizeof(VPgClassStats), sizeof(int));
-			pq_sendbytes(&buf, (char *) &stats, sizeof(VPgClassStats));
-			pq_endmessage(&buf);
+			vac_send_relstats_to_qd(relation,
+									num_pages,
+									num_tuples,
+									num_all_visible_pages);
 		}
 	}
 

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -181,6 +181,10 @@ extern double vac_estimate_reltuples(Relation relation, bool is_analyze,
 					   BlockNumber total_pages,
 					   BlockNumber scanned_pages,
 					   double scanned_tuples);
+extern void vac_send_relstats_to_qd(Relation relation,
+						BlockNumber num_pages,
+						double num_tuples,
+						BlockNumber num_all_visible_pages);
 extern void vac_update_relstats(Relation relation,
 					BlockNumber num_pages,
 					double num_tuples,

--- a/src/test/isolation2/expected/vacuum_full_interrupt.out
+++ b/src/test/isolation2/expected/vacuum_full_interrupt.out
@@ -1,0 +1,87 @@
+-- Test the scenario when the VACUUM FULL is interrupted on segment after
+-- 'swap_relation_files' is finished.
+
+-- There was a bug that swap_relation_files inplace update the old entry in the
+-- pg_class and the pg_class entry has incorrect relfrozenxid after the
+-- transaction is aborted.
+
+1: CREATE TABLE vacuum_full_interrupt(a int, b int, c int);
+CREATE
+1: CREATE INDEX vacuum_full_interrupt_idx on vacuum_full_interrupt(b);
+CREATE
+1: INSERT INTO vacuum_full_interrupt SELECT i, i, i from generate_series(1,100)i;
+INSERT 100
+1: ANALYZE vacuum_full_interrupt;
+ANALYZE
+-- the relfrozenxid is the same as xmin when there's concurrent transactions.
+-- the reltuples is 100
+1: SELECT xmin=relfrozenxid relfrozenxid_not_changed, relhasindex, reltuples FROM pg_class WHERE relname='vacuum_full_interrupt';
+ relfrozenxid_not_changed | relhasindex | reltuples 
+--------------------------+-------------+-----------
+ t                        | t           | 100.0     
+(1 row)
+
+-- break on QE after 'swap_relation_files' is finished
+1: SELECT gp_inject_fault('after_swap_relation_files', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2&: VACUUM FULL vacuum_full_interrupt;  <waiting ...>
+1: SELECT gp_wait_until_triggered_fault('after_swap_relation_files', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- cancel VACUUM FULL
+1: SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query = 'VACUUM FULL vacuum_full_interrupt;';
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+1: SELECT gp_inject_fault('after_swap_relation_files', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2<:  <... completed>
+ERROR:  canceling statement due to user request
+
+-- the relfrozenxid should stay unchanged
+2: SELECT xmin=relfrozenxid relfrozenxid_not_changed, relhasindex, reltuples FROM pg_class WHERE relname='vacuum_full_interrupt';
+ relfrozenxid_not_changed | relhasindex | reltuples 
+--------------------------+-------------+-----------
+ t                        | t           | 100.0     
+(1 row)
+0U: SELECT xmin=relfrozenxid relfrozenxid_not_changed, relhasindex, reltuples FROM pg_class WHERE relname='vacuum_full_interrupt';
+ relfrozenxid_not_changed | relhasindex | reltuples 
+--------------------------+-------------+-----------
+ t                        | t           | 0.0       
+(1 row)
+
+-- verify the index is correctly when insert new tuples, in bug also reset 'relhasindex' in pg_class.
+2: INSERT INTO vacuum_full_interrupt SELECT i, i, i from generate_series(1,100)i;
+INSERT 100
+2: SET optimizer=off;
+SET
+2: SET enable_seqscan=off;
+SET
+2: SET enable_bitmapscan=off;
+SET
+2: SET enable_indexscan=on;
+SET
+2: EXPLAIN SELECT * FROM vacuum_full_interrupt WHERE b=2;
+ QUERY PLAN                                                                                                    
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.14..12.18 rows=2 width=12)                                  
+   ->  Index Scan using vacuum_full_interrupt_idx on vacuum_full_interrupt  (cost=0.14..12.14 rows=1 width=12) 
+         Index Cond: (b = 2)                                                                                   
+ Optimizer: Postgres query optimizer                                                                           
+(4 rows)
+2: SELECT * FROM vacuum_full_interrupt WHERE b=2;
+ a | b | c 
+---+---+---
+ 2 | 2 | 2 
+ 2 | 2 | 2 
+(2 rows)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -77,6 +77,7 @@ test: commit_transaction_block_checkpoint
 test: instr_in_shmem_setup
 test: instr_in_shmem_terminate
 test: vacuum_recently_dead_tuple_due_to_distributed_snapshot
+test: vacuum_full_interrupt
 test: invalidated_toast_index
 test: distributed_snapshot
 test: gp_collation

--- a/src/test/isolation2/sql/vacuum_full_interrupt.sql
+++ b/src/test/isolation2/sql/vacuum_full_interrupt.sql
@@ -1,0 +1,37 @@
+-- Test the scenario when the VACUUM FULL is interrupted on segment after
+-- 'swap_relation_files' is finished.
+
+-- There was a bug that swap_relation_files inplace update the old entry in the
+-- pg_class and the pg_class entry has incorrect relfrozenxid after the
+-- transaction is aborted.
+
+1: CREATE TABLE vacuum_full_interrupt(a int, b int, c int);
+1: CREATE INDEX vacuum_full_interrupt_idx on vacuum_full_interrupt(b);
+1: INSERT INTO vacuum_full_interrupt SELECT i, i, i from generate_series(1,100)i;
+1: ANALYZE vacuum_full_interrupt;
+-- the relfrozenxid is the same as xmin when there's concurrent transactions.
+-- the reltuples is 100
+1: SELECT xmin=relfrozenxid relfrozenxid_not_changed, relhasindex, reltuples FROM pg_class WHERE relname='vacuum_full_interrupt';
+
+-- break on QE after 'swap_relation_files' is finished
+1: SELECT gp_inject_fault('after_swap_relation_files', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+2&: VACUUM FULL vacuum_full_interrupt;
+1: SELECT gp_wait_until_triggered_fault('after_swap_relation_files', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+
+-- cancel VACUUM FULL
+1: SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query = 'VACUUM FULL vacuum_full_interrupt;';
+1: SELECT gp_inject_fault('after_swap_relation_files', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+2<:
+
+-- the relfrozenxid should stay unchanged
+2: SELECT xmin=relfrozenxid relfrozenxid_not_changed, relhasindex, reltuples FROM pg_class WHERE relname='vacuum_full_interrupt';
+0U: SELECT xmin=relfrozenxid relfrozenxid_not_changed, relhasindex, reltuples FROM pg_class WHERE relname='vacuum_full_interrupt';
+
+-- verify the index is correctly when insert new tuples, in bug also reset 'relhasindex' in pg_class.
+2: INSERT INTO vacuum_full_interrupt SELECT i, i, i from generate_series(1,100)i;
+2: SET optimizer=off;
+2: SET enable_seqscan=off;
+2: SET enable_bitmapscan=off;
+2: SET enable_indexscan=on;
+2: EXPLAIN SELECT * FROM vacuum_full_interrupt WHERE b=2;
+2: SELECT * FROM vacuum_full_interrupt WHERE b=2;


### PR DESCRIPTION
When doing 'VACUUM FULL', 'swap_relation_files' updates the pg_class entry but
not increase the command counter, so the later 'vac_update_relstats' will
inplace update the 'relfrozenxid' and 'relhasindex' of old tuple, when the
transaction is interrupted and aborted on the QE after this, the old entry is
corrupted.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
