### PR TITLE
[RFC] Safer relation cleanup (alt ver)

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2522,7 +2522,7 @@ gpdb::GetLogicalIndexInfo
 	return NULL;
 }
 
-Relation
+gpdb::RelationWrapper
 gpdb::GetRelation
 	(
 	Oid rel_oid
@@ -2531,10 +2531,9 @@ gpdb::GetRelation
 	GP_WRAP_START;
 	{
 		/* catalog tables: relcache */
-		return RelationIdGetRelation(rel_oid);
+		return RelationWrapper{RelationIdGetRelation(rel_oid)};
 	}
 	GP_WRAP_END;
-	return NULL;
 }
 
 ExtTableEntry *

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3166,13 +3166,12 @@ CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses
 	// ones, for all hashing within the query.
 	if (rte->rtekind == RTE_RELATION)
 	{
-		Relation rel = gpdb::GetRelation(rte->relid);
+		gpdb::RelationWrapper rel = gpdb::GetRelation(rte->relid);
 		GpPolicy *policy = rel->rd_cdbpolicy;
 
 		// master-only tables
 		if (NULL == policy)
 		{
-			gpdb::CloseRelation(rel);
 			return;
 		}
 
@@ -3207,7 +3206,6 @@ CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses
 					contains_nondefault_hashops = true;
 			}
 		}
-		gpdb::CloseRelation(rel);
 
 		if (contains_nondefault_hashops)
 		{

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -289,7 +289,7 @@ CTranslatorRelcacheToDXL::RetrieveRelIndexInfoForPartTable
 		// only add supported indexes
 		Relation index_rel = gpdb::GetRelation(index_oid);
 
-		if (NULL == index_rel)
+		if (!index_rel)
 		{
 			WCHAR wstr[1024];
 			CWStringStatic str(wstr, 1024);
@@ -344,7 +344,7 @@ CTranslatorRelcacheToDXL::RetrieveRelIndexInfoForNonPartTable
 		// only add supported indexes
 		Relation index_rel = gpdb::GetRelation(index_oid);
 
-		if (NULL == index_rel)
+		if (!index_rel)
 		{
 			WCHAR wstr[1024];
 			CWStringStatic str(wstr, 1024);
@@ -509,7 +509,7 @@ CTranslatorRelcacheToDXL::RetrieveRel
 
 	Relation rel = gpdb::GetRelation(oid);
 
-	if (NULL == rel)
+	if (!rel)
 	{
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
@@ -1033,7 +1033,7 @@ CTranslatorRelcacheToDXL::RetrieveIndex
 	GPOS_ASSERT(0 != index_oid);
 	Relation index_rel = gpdb::GetRelation(index_oid);
 
-	if (NULL == index_rel)
+	if (!index_rel)
 	{
 		 GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid_index->GetBuffer());
 	}
@@ -1108,7 +1108,8 @@ CTranslatorRelcacheToDXL::RetrieveIndex
 		mdname = GPOS_NEW(mp) CMDName(mp, str_name);
 		GPOS_DELETE(str_name);
 
-		Relation table = gpdb::GetRelation(CMDIdGPDB::CastMdid(md_rel->MDId())->Oid());
+		Oid table_oid = CMDIdGPDB::CastMdid(md_rel->MDId())->Oid();
+		Relation table = gpdb::GetRelation(table_oid);
 		ULONG size = GPDXL_SYSTEM_COLUMNS + (ULONG) table->rd_att->natts + 1;
 		gpdb::CloseRelation(table); // close relation as early as possible
 
@@ -1243,7 +1244,7 @@ CTranslatorRelcacheToDXL::RetrievePartTableIndex
 	
 	Relation index_rel = gpdb::GetRelation(index_oid);
 
-	if (NULL == index_rel)
+	if (!index_rel)
 	{
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid_index->GetBuffer());
 	}
@@ -2225,7 +2226,7 @@ CTranslatorRelcacheToDXL::RetrieveRelStats
 	OID rel_oid = CMDIdGPDB::CastMdid(mdid_rel)->Oid();
 
 	Relation rel = gpdb::GetRelation(rel_oid);
-	if (NULL == rel)
+	if (!rel)
 	{
 		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
 	}
@@ -2296,10 +2297,6 @@ CTranslatorRelcacheToDXL::RetrieveColStats
 	OID rel_oid = CMDIdGPDB::CastMdid(mdid_rel)->Oid();
 
 	Relation rel = gpdb::GetRelation(rel_oid);
-	if (NULL == rel)
-	{
-		GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDCacheEntryNotFound, mdid->GetBuffer());
-	}
 
 	const IMDRelation *md_rel = md_accessor->RetrieveRel(mdid_rel);
 	const IMDColumn *md_col = md_rel->GetMdCol(pos);

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1036,7 +1036,7 @@ CTranslatorUtils::GetOpFamilyForIndexQual
 	)
 {
 	Relation rel = gpdb::GetRelation(index_oid);
-	GPOS_ASSERT(NULL != rel);
+	GPOS_ASSERT(rel);
 	GPOS_ASSERT(attno <= rel->rd_index->indnatts);
 	
 	OID op_family_oid = rel->rd_opfamily[attno - 1];

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1035,13 +1035,12 @@ CTranslatorUtils::GetOpFamilyForIndexQual
 	OID index_oid
 	)
 {
-	Relation rel = gpdb::GetRelation(index_oid);
+	gpdb::RelationWrapper rel = gpdb::GetRelation(index_oid);
 	GPOS_ASSERT(rel);
 	GPOS_ASSERT(attno <= rel->rd_index->indnatts);
 	
 	OID op_family_oid = rel->rd_opfamily[attno - 1];
-	gpdb::CloseRelation(rel);
-	
+
 	return op_family_oid;
 }
 

--- a/src/backend/gpopt/utils/Makefile
+++ b/src/backend/gpopt/utils/Makefile
@@ -11,6 +11,6 @@ include $(top_builddir)/src/Makefile.global
 
 include $(top_srcdir)/src/backend/gpopt/gpopt.mk
 
-OBJS = COptTasks.o CConstExprEvaluatorProxy.o CMemoryPoolPalloc.o CMemoryPoolPallocManager.o funcs.o
+OBJS = COptTasks.o CConstExprEvaluatorProxy.o CMemoryPoolPalloc.o CMemoryPoolPallocManager.o funcs.o RelationWrapper.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/gpopt/utils/RelationWrapper.cpp
+++ b/src/backend/gpopt/utils/RelationWrapper.cpp
@@ -1,0 +1,26 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//---------------------------------------------------------------------------
+#include "gpopt/utils/RelationWrapper.h"
+
+#include "gpopt/gpdbwrappers.h"	 // for CloseRelation
+
+namespace gpdb
+{
+RelationWrapper::~RelationWrapper() noexcept(false)
+{
+	if (m_relation)
+		CloseRelation(m_relation);
+}
+
+void
+RelationWrapper::Close()
+{
+	if (m_relation)
+	{
+		CloseRelation(m_relation);
+		m_relation = nullptr;
+	}
+}
+}  // namespace gpdb

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -58,6 +58,8 @@ struct Var;
 struct Const;
 struct ArrayExpr;
 
+#include "gpopt/utils/RelationWrapper.h"
+
 namespace gpdb {
 
 	// convert datum to bool
@@ -562,7 +564,7 @@ namespace gpdb {
 	void BuildRelationTriggers(Relation rel);
 
 	// get relation with given oid
-	Relation GetRelation(Oid rel_oid);
+	RelationWrapper GetRelation(Oid rel_oid);
 
 	// get external table entry with given oid
 	ExtTableEntry *GetExternalTableEntry(Oid rel_oid);

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -21,6 +21,8 @@
 #include "parser/parse_coerce.h"
 #include "utils/lsyscache.h"
 
+#include "gpos/types.h"
+
 // fwd declarations
 typedef struct SysScanDescData *SysScanDesc;
 typedef int LOCKMODE;

--- a/src/include/gpopt/utils/RelationWrapper.h
+++ b/src/include/gpopt/utils/RelationWrapper.h
@@ -1,0 +1,93 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2020 VMware, Inc.
+//---------------------------------------------------------------------------
+#ifndef GPDB_RelationWrapper_H
+#define GPDB_RelationWrapper_H
+
+#include <cstddef>
+
+typedef struct RelationData *Relation;
+
+namespace gpdb
+{
+/// \class
+/// A transparent RAII wrapper for a pointer to a Postgres RelationData.
+/// "Transparent" means that an object of this type can be used in most contexts
+/// that expect a Relation. The main advantage of using this wrapper is that it
+/// automatically closes the wrapper relation when exiting scope. So you no
+/// longer have to write code like this:
+/// \code
+/// void RetrieveRel(Oid reloid) {
+///     Relation rel = GetRelation(reloid);
+///     if (IsPartialDist(rel)) {
+///         CloseRelation(rel);
+///         GPOS_RAISE(...);
+///     }
+///     try {
+///         do_stuff();
+///         CloseRelation(rel);
+///     catch (...) {
+///         CloseRelation(rel);
+///         GPOS_RETHROW(...);
+///     }
+/// }
+/// \endcode
+/// and instead you can write this:
+/// \code
+/// void RetrieveRel(Oid reloid) {
+///     gpdb::RelationWrapper rel = GetRelation(reloid);
+///     if (IsPartialDist(rel.get())) {
+///         GPOS_RAISE(...);
+///     }
+///     do_stuff();
+/// }
+/// \endcode
+class RelationWrapper
+{
+public:
+	RelationWrapper(RelationWrapper const &) = delete;
+	RelationWrapper(RelationWrapper &&r) : m_relation(r.m_relation)
+	{
+		r.m_relation = nullptr;
+	};
+
+	explicit RelationWrapper(Relation relation) : m_relation(relation)
+	{
+	}
+
+	/// allows use in typical conditionals of the form
+	///
+	/// \code if (rel) { do_stuff(rel); } \endcode or
+	/// \code if (!rel) return; \endcode
+	explicit operator bool() const
+	{
+		return m_relation != nullptr;
+	}
+
+	// behave like a raw pointer on arrow
+	Relation
+	operator->() const
+	{
+		return m_relation;
+	}
+
+	// get the raw pointer, behaves like std::unique_ptr::get()
+	Relation
+	get() const
+	{
+		return m_relation;
+	}
+
+	/// Explicitly close the underlying relation early. This is not usually
+	/// necessary unless there is significant amount of time between the point
+	/// of close and the end-of-scope
+	void Close();
+
+	~RelationWrapper() noexcept(false);
+
+private:
+	Relation m_relation = nullptr;
+};
+}  // namespace gpdb
+#endif	// GPDB_RelationWrapper_H


### PR DESCRIPTION
### Context
Over at #10728, it has been suggested that:

1. Don't use `nullptr` until we've ridden the entire ORCA code base of `NULL`
1. `auto` is unreadable. Spell out the new type `RelationWrapper`
1. Don't overload `operator ->` or `operator ==` or `operator !=`
1. Don't overload `operator bool`.
1. Don't allow implicit cast from `RelationWrapper` to `Relation`.

Here's a patch set that follows those suggestions.

### Rationale for having two PR's
1. I'm glad that stylistic preferences came up in code review rather than felt later in the team that a change has been "snuck in".
1. I opened #10728 because I cannot stomach the manual clean up in code like this:

   ```c++
   Relation rel = GetRelation(...);

   if (!RelIsSupported(rel)) {
     CloseRelation(rel);
     return -1;
   }

   GPOS_TRY {
     do_stuff(rel);
     int i = calculate_stuff(rel->rd_att->natts);
     CloseRelation(rel);
   } GPOS_CATCH_EX(ex) {
     CloseRelation(rel);
     GPOS_RETHROW(ex);
   } GPOS_CATCH_END;
   ```

   The patch over at #10728 enables us to write code like:

   ```c++
   auto rel = GetRelation(...);
   if (!RelIsSupported(rel)) {
     return -1;
   }
   do_stuff(rel);
   int i = calculate_stuff(rel->rd_att->natts);
   ```

   However, objections were raised in uses of some of the "more C++" idiomatic patterns, such as

   1. `auto rel = GetRelation(...)` makes it unclear what the type of `rel` is, spell out the new type
   1. `operator bool` for a "transparent pointer wrapper" to be used in a conditional like `if (rel)`
   1. `operator ->` for a transparent wrapper to be used for memeber access like `rel->rd_att->natts`
   1. `operator Relation` implicit casts a pointer wrapper to the wrapped pointer type, allowing the caller to directly pass the wrapper to functions that expects a Relation.

   The suggested alternative alternative, described by the reviewer, and I quote verbatim as "pedestrian", results in code like this:

   ```c++
   RelationWrapper rel = GetRelation(...);
   if (!RelIsSupported(rel.get())) {
     return -1;
   }
   do_stuff(rel.get());
   int i = calculate_stuff(rel.get()->rd_att->natts);
   ```

   To be clear, I agree with removing the automatic implicit cast to `Relation` (last objection above). But I disagree with the other points, here are reasons:

   1. > `auto rel = GetRelation(...)` makes it unclear what the type of `rel` is, spell out the new type

      The function name indicates that it returns a `Relation` already. And the variable `behaves like` a Relation in most of its touch points. In fact, not spelling out the type reduces the cognitive load on the reader of the code.

   1. > `operator bool` for a "transparent pointer wrapper" to be used in a conditional like `if (rel)`

      One of the most common thing we do with a returned pointer, at least in ORCA, seems to be a nullity check. This operator enables that. The alternative suggested would be a ["Yoda conditions"](https://en.wikipedia.org/wiki/Yoda_conditions) combined with an explicit access to the wrapped pointer:

      ```c++
      if (NULL == rel.get())
      ```

   1. > `operator ->` for a transparent wrapper to be used for memeber access like `rel->rd_att->natts`

      This is another common use of (formerly) pointers is for member access with arrows. Without this we'd be writing `rel.get()->rd_att->natts`.


   Ultimately though, I made my case and I leave the judgement to the reviewers.

   I care more about _not having to manually clean up 3+ times_ in the code, i.e. I want to push the automatic resource clean up forward, if the resulting code will be uglier because it's littered with `rel.get()->rd_att->natts`, I can hold my nose.

   To be clear, I appreciate the reviewer who pointed out about the inconsistency introduced by of `nullptr`. That reminds me I should really spend time pushing the discussion forward on #10357, which petered out a little because I'm consumed by other priorities.

### Feedback I'm Seeking

1. I'm trying my best to faithfully follow the suggestion here and present an alternative to #10728. Is this a fair representation of the feedback's suggestion?
1. While working on this I'm pretty grossed out by _not_ having `operator ->`. Not only is the noise from the diff unbearable, the resulting ergonomics just feels sub par to me. I've kept that change as a separate commit so reviewers can see more easily. Reviewers: how do you feel about the change where `rel->rd_att` need to be spelled like `rel.get()->rd_att`? Specifically are you OK with that next time you need to add code using this class in the vicinity of the change?
1. I've also separated out the commit to clearly show what the resulting code is if we don't have `operator bool`.


## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community