### PR TITLE
[WIP]Handle JSON ill-formed escapes

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -427,6 +427,10 @@ bool		gp_enable_mk_sort = true;
 /* Enable GDD */
 bool		gp_enable_global_deadlock_detector = false;
 
+/* Handling JSON ill-formed escape sequence*/
+bool		gp_json_preserve_ill_formed = false;
+char		*gp_json_preserve_ill_formed_prefix = NULL;
+
 static const struct config_enum_entry gp_log_format_options[] = {
 	{"text", 0},
 	{"csv", 1},
@@ -2893,6 +2897,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		false,
 		NULL, NULL, NULL
 	},
+
+	{
+		{"gp_json_preserve_ill_formed", PGC_USERSET, CUSTOM_OPTIONS,
+			gettext_noop("Preserve ill-formed escape sequence as the original sequence string in JSON with a specified prefix."),
+			NULL,
+		},
+		&gp_json_preserve_ill_formed,
+		false,
+		NULL, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL
@@ -4382,6 +4397,16 @@ struct config_string ConfigureNamesString_gp[] =
 		NULL, NULL, NULL
 	},
 #endif  /* ENABLE_IC_PROXY */
+
+	{
+		{"gp_json_preserve_ill_formed_prefix", PGC_USERSET, CUSTOM_OPTIONS,
+			gettext_noop("Sets prefix string for preserved ill-formed JSON escape sequences."),
+			NULL
+		},
+		&gp_json_preserve_ill_formed_prefix,
+		"",
+		NULL, NULL, NULL
+	},
 
 	/* End-of-list marker */
 	{

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -116,3 +116,5 @@
 		"verify_gpfdists_cert",
 		"vmem_process_interrupt",
 		"work_mem",
+		"gp_json_preserve_ill_formed",
+		"gp_json_preserve_ill_formed_prefix",

--- a/src/test/regress/expected/json_ill_formed_escapes.out
+++ b/src/test/regress/expected/json_ill_formed_escapes.out
@@ -1,0 +1,411 @@
+-- GUC preserve_json_illegal_escape and bad escapes with \u tests for json and jsonb
+-- Set GUC value
+SET gp_json_preserve_ill_formed = true;
+SET gp_json_preserve_ill_formed_prefix = "##";
+-- first json
+-- basic unicode input, the GUC doesn't handle those errors as well.
+SELECT '"\u"'::json;			-- ERROR, incomplete escape
+ERROR:  invalid input syntax for type json
+LINE 1: SELECT '"\u"'::json;
+               ^
+DETAIL:  "\u" must be followed by four hexadecimal digits.
+CONTEXT:  JSON data, line 1: "\u"
+SELECT '"\u00"'::json;			-- ERROR, incomplete escape
+ERROR:  invalid input syntax for type json
+LINE 1: SELECT '"\u00"'::json;
+               ^
+DETAIL:  "\u" must be followed by four hexadecimal digits.
+CONTEXT:  JSON data, line 1: "\u00"
+SELECT '"\u000g"'::json;		-- ERROR, g is not a hex digit
+ERROR:  invalid input syntax for type json
+LINE 1: SELECT '"\u000g"'::json;
+               ^
+DETAIL:  "\u" must be followed by four hexadecimal digits.
+CONTEXT:  JSON data, line 1: "\u000g...
+SELECT '"\u0000"'::json;		-- OK, legal escape
+   json   
+----------
+ "\u0000"
+(1 row)
+
+SELECT '"\uaBcD"'::json;		-- OK, uppercase and lower case both OK
+   json   
+----------
+ "\uaBcD"
+(1 row)
+
+-- handling of unicode surrogate pairs
+select json '{ "a":  "\ud83d\ude04\ud83d\udc36" }' -> 'a' as correct_in_utf8;
+      correct_in_utf8       
+----------------------------
+ "\ud83d\ude04\ud83d\udc36"
+(1 row)
+
+select json '{ "a":  "\ud83d\ud83d" }' -> 'a'; -- 2 high surrogates in a row
+    ?column?    
+----------------
+ "\ud83d\ud83d"
+(1 row)
+
+select json '{ "a":  "\ude04\ud83d" }' -> 'a'; -- surrogates in wrong order
+    ?column?    
+----------------
+ "\ude04\ud83d"
+(1 row)
+
+select json '{ "a":  "\ud83dX" }' -> 'a'; -- orphan high surrogate
+ ?column?  
+-----------
+ "\ud83dX"
+(1 row)
+
+select json '{ "a":  "\ude04X" }' -> 'a'; -- orphan low surrogate
+ ?column?  
+-----------
+ "\ude04X"
+(1 row)
+
+-- handling of simple unicode escapes
+select json '{ "a":  "the Copyright \u00a9 sign" }' as correct_in_utf8;
+            correct_in_utf8            
+---------------------------------------
+ { "a":  "the Copyright \u00a9 sign" }
+(1 row)
+
+select json '{ "a":  "dollar \u0024 character" }' as correct_everywhere;
+         correct_everywhere          
+-------------------------------------
+ { "a":  "dollar \u0024 character" }
+(1 row)
+
+select json '{ "a":  "dollar \\u0024 character" }' as not_an_escape;
+            not_an_escape             
+--------------------------------------
+ { "a":  "dollar \\u0024 character" }
+(1 row)
+
+select json '{ "a":  "null \u0000 escape" }' as not_unescaped;
+         not_unescaped          
+--------------------------------
+ { "a":  "null \u0000 escape" }
+(1 row)
+
+select json '{ "a":  "null \\u0000 escape" }' as not_an_escape;
+          not_an_escape          
+---------------------------------
+ { "a":  "null \\u0000 escape" }
+(1 row)
+
+select json '{ "a":  "the Copyright \u00a9 sign" }' ->> 'a' as correct_in_utf8;
+   correct_in_utf8    
+----------------------
+ the Copyright © sign
+(1 row)
+
+select json '{ "a":  "dollar \u0024 character" }' ->> 'a' as correct_everywhere;
+ correct_everywhere 
+--------------------
+ dollar $ character
+(1 row)
+
+select json '{ "a":  "dollar \\u0024 character" }' ->> 'a' as not_an_escape;
+      not_an_escape      
+-------------------------
+ dollar \u0024 character
+(1 row)
+
+select json '{ "a":  "null \u0000 escape" }' ->> 'a' as fails;
+        fails         
+----------------------
+ null ##\u0000 escape
+(1 row)
+
+select json '{ "a":  "null \\u0000 escape" }' ->> 'a' as not_an_escape;
+   not_an_escape    
+--------------------
+ null \u0000 escape
+(1 row)
+
+-- ill-formed escaped sequences in key
+select json '{ "\u0000": "abc" }' -> '##\u0000'; -- \u0000
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+select json '{ "\u0000X": "abc" }' -> '##\u0000X'; -- \u0000 followed by a ASCII char
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+select json '{ "Y\u0000": "abc" }' -> 'Y##\u0000'; -- \u0000 following a ASCII char
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+select json '{ "Y\u0000X": "abc" }' -> 'Y##\u0000X'; -- \u0000 in between two ASCII chars
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+select json '{ "\ud83dX": "abc" }' -> '##\ud83dX'; -- orphan high surrogate
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+select json '{ "\ude04X": "abc" }' -> '##\ude04X'; -- orphan low surrogate
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+select json '{ "\uDe04X": "abc" }' -> '##\uDe04X'; -- orphan low surrogate, the uppercase should be preserved
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+-- then jsonb
+-- basic unicode input
+SELECT '"\u"'::jsonb;			-- ERROR, incomplete escape
+ERROR:  invalid input syntax for type json
+LINE 1: SELECT '"\u"'::jsonb;
+               ^
+DETAIL:  "\u" must be followed by four hexadecimal digits.
+CONTEXT:  JSON data, line 1: "\u"
+SELECT '"\u00"'::jsonb;			-- ERROR, incomplete escape
+ERROR:  invalid input syntax for type json
+LINE 1: SELECT '"\u00"'::jsonb;
+               ^
+DETAIL:  "\u" must be followed by four hexadecimal digits.
+CONTEXT:  JSON data, line 1: "\u00"
+SELECT '"\u000g"'::jsonb;		-- ERROR, g is not a hex digit
+ERROR:  invalid input syntax for type json
+LINE 1: SELECT '"\u000g"'::jsonb;
+               ^
+DETAIL:  "\u" must be followed by four hexadecimal digits.
+CONTEXT:  JSON data, line 1: "\u000g...
+SELECT '"\u0045"'::jsonb;		-- OK, legal escape
+ jsonb 
+-------
+ "E"
+(1 row)
+
+SELECT '"\u0000"'::jsonb;		-- ERROR, we don't support U+0000
+    jsonb    
+-------------
+ "##\\u0000"
+(1 row)
+
+-- use octet_length here so we don't get an odd unicode char in the
+-- output
+SELECT octet_length('"\uaBcD"'::jsonb::text); -- OK, uppercase and lower case both OK
+ octet_length 
+--------------
+            5
+(1 row)
+
+-- since "\u0000" will be represented as the original escaped form string, it will has
+-- the same length as "\\u0000"
+SELECT octet_length('"\u0000"'::jsonb::text); -- OK, represented as "\u0000"
+ octet_length 
+--------------
+           11
+(1 row)
+
+SELECT octet_length('"\u0000"'::jsonb::text); -- OK, totoally legal, represented as the same as the above one
+ octet_length 
+--------------
+           11
+(1 row)
+
+-- handling of unicode surrogate pairs
+SELECT octet_length((jsonb '{ "a":  "\ud83d\ude04\ud83d\udc36" }' -> 'a')::text) AS correct_in_utf8;
+ correct_in_utf8 
+-----------------
+              10
+(1 row)
+
+SELECT jsonb '{ "a":  "\ud83d\ud83d" }' -> 'a'; -- 2 high surrogates in a row
+       ?column?       
+----------------------
+ "##\\ud83d##\\ud83d"
+(1 row)
+
+SELECT jsonb '{ "a":  "\ude04\ud83d" }' -> 'a'; -- surrogates in wrong order
+       ?column?       
+----------------------
+ "##\\ude04##\\ud83d"
+(1 row)
+
+SELECT jsonb '{ "a":  "\ud83dX" }' -> 'a'; -- orphan high surrogate
+   ?column?   
+--------------
+ "##\\ud83dX"
+(1 row)
+
+SELECT jsonb '{ "a":  "\ude04X" }' -> 'a'; -- orphan low surrogate
+   ?column?   
+--------------
+ "##\\ude04X"
+(1 row)
+
+-- handling of simple unicode escapes
+SELECT jsonb '{ "a":  "the Copyright \u00a9 sign" }' as correct_in_utf8;
+        correct_in_utf8        
+-------------------------------
+ {"a": "the Copyright © sign"}
+(1 row)
+
+SELECT jsonb '{ "a":  "dollar \u0024 character" }' as correct_everywhere;
+     correct_everywhere      
+-----------------------------
+ {"a": "dollar $ character"}
+(1 row)
+
+SELECT jsonb '{ "a":  "dollar \\u0024 character" }' as not_an_escape;
+           not_an_escape           
+-----------------------------------
+ {"a": "dollar \\u0024 character"}
+(1 row)
+
+SELECT jsonb '{ "a":  "null \u0000 escape" }' as fails;
+             fails              
+--------------------------------
+ {"a": "null ##\\u0000 escape"}
+(1 row)
+
+SELECT jsonb '{ "a":  "null \\u0000 escape" }' as not_an_escape;
+        not_an_escape         
+------------------------------
+ {"a": "null \\u0000 escape"}
+(1 row)
+
+SELECT jsonb '{ "a":  "the Copyright \u00a9 sign" }' ->> 'a' as correct_in_utf8;
+   correct_in_utf8    
+----------------------
+ the Copyright © sign
+(1 row)
+
+SELECT jsonb '{ "a":  "dollar \u0024 character" }' ->> 'a' as correct_everywhere;
+ correct_everywhere 
+--------------------
+ dollar $ character
+(1 row)
+
+SELECT jsonb '{ "a":  "dollar \\u0024 character" }' ->> 'a' as not_an_escape;
+      not_an_escape      
+-------------------------
+ dollar \u0024 character
+(1 row)
+
+SELECT jsonb '{ "a":  "null \u0000 escape" }' ->> 'a' as fails;
+        fails         
+----------------------
+ null ##\u0000 escape
+(1 row)
+
+SELECT jsonb '{ "a":  "null \\u0000 escape" }' ->> 'a' as not_an_escape;
+   not_an_escape    
+--------------------
+ null \u0000 escape
+(1 row)
+
+-- ill-formed escaped sequences in key
+SELECT jsonb '{ "\u0000": "abc" }' -> '##\u0000'; -- \u0000
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+SELECT jsonb '{ "\u0000X": "abc" }' -> '##\u0000X'; -- \u0000 followed by a ASCII char
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+SELECT jsonb '{ "Y\u0000": "abc" }' -> 'Y##\u0000'; -- \u0000 following a ASCII char
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+SELECT jsonb '{ "Y\u0000X": "abc" }' -> 'Y##\u0000X'; -- \u0000 in between two ASCII chars
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+SELECT jsonb '{ "\ud83dX": "abc" }' -> '##\ud83dX'; -- orphan high surrogate
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+SELECT jsonb '{ "\ude04X": "abc" }' -> '##\ude04X'; -- orphan low surrogate
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+SELECT jsonb '{ "\uDe04X": "abc" }' -> '##\uDe04X'; -- orphan low surrogate, the uppercase should be preserved
+ ?column? 
+----------
+ "abc"
+(1 row)
+
+-- Inconsistencies
+select json '{ "a":  "null \u0000 escape" }' -> 'a' as it_is;
+        it_is         
+----------------------
+ "null \u0000 escape"
+(1 row)
+
+select json '{ "a":  "null \u0000 escape" }' ->> 'a' as preserved_with_prefix;
+ preserved_with_prefix 
+-----------------------
+ null ##\u0000 escape
+(1 row)
+
+SELECT jsonb '{ "a":  "null \u0000 escape" }' -> 'a' as preserved_with_prefix;
+  preserved_with_prefix  
+-------------------------
+ "null ##\\u0000 escape"
+(1 row)
+
+SELECT jsonb '{ "a":  "null \u0000 escape" }' ->> 'a' as preserved_with_prefix;
+ preserved_with_prefix 
+-----------------------
+ null ##\u0000 escape
+(1 row)
+
+select '{ "a":  "dollar \u0000 character" }'::jsonb::json->'a' as preserved_with_prefix;
+    preserved_with_prefix     
+------------------------------
+ "dollar ##\\u0000 character"
+(1 row)
+
+SELECT '{ "a":  "dollar \u0000 character" }'::json::jsonb->'a' as preserved_with_prefix;
+    preserved_with_prefix     
+------------------------------
+ "dollar ##\\u0000 character"
+(1 row)
+
+-- empty prefix
+SET gp_json_preserve_ill_formed_prefix = '';
+SELECT jsonb '{ "a":  "null \u0000 escape" }' ->> 'a' as no_prefix;
+     no_prefix      
+--------------------
+ null \u0000 escape
+(1 row)
+
+SELECT jsonb '{ "a":  "\ude04\ud83d" }' -> 'a' as no_prefix; -- surrogates in wrong order
+    no_prefix     
+------------------
+ "\\ude04\\ud83d"
+(1 row)
+

--- a/src/test/regress/sql/json_ill_formed_escapes.sql
+++ b/src/test/regress/sql/json_ill_formed_escapes.sql
@@ -1,0 +1,107 @@
+
+-- GUC preserve_json_illegal_escape and bad escapes with \u tests for json and jsonb
+
+-- Set GUC value
+SET gp_json_preserve_ill_formed = true;
+SET gp_json_preserve_ill_formed_prefix = "##";
+
+-- first json
+
+-- basic unicode input, the GUC doesn't handle those errors as well.
+SELECT '"\u"'::json;			-- ERROR, incomplete escape
+SELECT '"\u00"'::json;			-- ERROR, incomplete escape
+SELECT '"\u000g"'::json;		-- ERROR, g is not a hex digit
+SELECT '"\u0000"'::json;		-- OK, legal escape
+SELECT '"\uaBcD"'::json;		-- OK, uppercase and lower case both OK
+
+-- handling of unicode surrogate pairs
+
+select json '{ "a":  "\ud83d\ude04\ud83d\udc36" }' -> 'a' as correct_in_utf8;
+select json '{ "a":  "\ud83d\ud83d" }' -> 'a'; -- 2 high surrogates in a row
+select json '{ "a":  "\ude04\ud83d" }' -> 'a'; -- surrogates in wrong order
+select json '{ "a":  "\ud83dX" }' -> 'a'; -- orphan high surrogate
+select json '{ "a":  "\ude04X" }' -> 'a'; -- orphan low surrogate
+
+-- handling of simple unicode escapes
+
+select json '{ "a":  "the Copyright \u00a9 sign" }' as correct_in_utf8;
+select json '{ "a":  "dollar \u0024 character" }' as correct_everywhere;
+select json '{ "a":  "dollar \\u0024 character" }' as not_an_escape;
+select json '{ "a":  "null \u0000 escape" }' as not_unescaped;
+select json '{ "a":  "null \\u0000 escape" }' as not_an_escape;
+
+select json '{ "a":  "the Copyright \u00a9 sign" }' ->> 'a' as correct_in_utf8;
+select json '{ "a":  "dollar \u0024 character" }' ->> 'a' as correct_everywhere;
+select json '{ "a":  "dollar \\u0024 character" }' ->> 'a' as not_an_escape;
+select json '{ "a":  "null \u0000 escape" }' ->> 'a' as fails;
+select json '{ "a":  "null \\u0000 escape" }' ->> 'a' as not_an_escape;
+
+-- ill-formed escaped sequences in key
+select json '{ "\u0000": "abc" }' -> '##\u0000'; -- \u0000
+select json '{ "\u0000X": "abc" }' -> '##\u0000X'; -- \u0000 followed by a ASCII char
+select json '{ "Y\u0000": "abc" }' -> 'Y##\u0000'; -- \u0000 following a ASCII char
+select json '{ "Y\u0000X": "abc" }' -> 'Y##\u0000X'; -- \u0000 in between two ASCII chars
+select json '{ "\ud83dX": "abc" }' -> '##\ud83dX'; -- orphan high surrogate
+select json '{ "\ude04X": "abc" }' -> '##\ude04X'; -- orphan low surrogate
+select json '{ "\uDe04X": "abc" }' -> '##\uDe04X'; -- orphan low surrogate, the uppercase should be preserved
+
+
+-- then jsonb
+
+-- basic unicode input
+SELECT '"\u"'::jsonb;			-- ERROR, incomplete escape
+SELECT '"\u00"'::jsonb;			-- ERROR, incomplete escape
+SELECT '"\u000g"'::jsonb;		-- ERROR, g is not a hex digit
+SELECT '"\u0045"'::jsonb;		-- OK, legal escape
+SELECT '"\u0000"'::jsonb;		-- ERROR, we don't support U+0000
+-- use octet_length here so we don't get an odd unicode char in the
+-- output
+SELECT octet_length('"\uaBcD"'::jsonb::text); -- OK, uppercase and lower case both OK
+-- since "\u0000" will be represented as the original escaped form string, it will has
+-- the same length as "\\u0000"
+SELECT octet_length('"\u0000"'::jsonb::text); -- OK, represented as "\u0000"
+SELECT octet_length('"\u0000"'::jsonb::text); -- OK, totoally legal, represented as the same as the above one
+
+-- handling of unicode surrogate pairs
+
+SELECT octet_length((jsonb '{ "a":  "\ud83d\ude04\ud83d\udc36" }' -> 'a')::text) AS correct_in_utf8;
+SELECT jsonb '{ "a":  "\ud83d\ud83d" }' -> 'a'; -- 2 high surrogates in a row
+SELECT jsonb '{ "a":  "\ude04\ud83d" }' -> 'a'; -- surrogates in wrong order
+SELECT jsonb '{ "a":  "\ud83dX" }' -> 'a'; -- orphan high surrogate
+SELECT jsonb '{ "a":  "\ude04X" }' -> 'a'; -- orphan low surrogate
+
+-- handling of simple unicode escapes
+
+SELECT jsonb '{ "a":  "the Copyright \u00a9 sign" }' as correct_in_utf8;
+SELECT jsonb '{ "a":  "dollar \u0024 character" }' as correct_everywhere;
+SELECT jsonb '{ "a":  "dollar \\u0024 character" }' as not_an_escape;
+SELECT jsonb '{ "a":  "null \u0000 escape" }' as fails;
+SELECT jsonb '{ "a":  "null \\u0000 escape" }' as not_an_escape;
+
+SELECT jsonb '{ "a":  "the Copyright \u00a9 sign" }' ->> 'a' as correct_in_utf8;
+SELECT jsonb '{ "a":  "dollar \u0024 character" }' ->> 'a' as correct_everywhere;
+SELECT jsonb '{ "a":  "dollar \\u0024 character" }' ->> 'a' as not_an_escape;
+SELECT jsonb '{ "a":  "null \u0000 escape" }' ->> 'a' as fails;
+SELECT jsonb '{ "a":  "null \\u0000 escape" }' ->> 'a' as not_an_escape;
+
+-- ill-formed escaped sequences in key
+SELECT jsonb '{ "\u0000": "abc" }' -> '##\u0000'; -- \u0000
+SELECT jsonb '{ "\u0000X": "abc" }' -> '##\u0000X'; -- \u0000 followed by a ASCII char
+SELECT jsonb '{ "Y\u0000": "abc" }' -> 'Y##\u0000'; -- \u0000 following a ASCII char
+SELECT jsonb '{ "Y\u0000X": "abc" }' -> 'Y##\u0000X'; -- \u0000 in between two ASCII chars
+SELECT jsonb '{ "\ud83dX": "abc" }' -> '##\ud83dX'; -- orphan high surrogate
+SELECT jsonb '{ "\ude04X": "abc" }' -> '##\ude04X'; -- orphan low surrogate
+SELECT jsonb '{ "\uDe04X": "abc" }' -> '##\uDe04X'; -- orphan low surrogate, the uppercase should be preserved
+
+-- Inconsistencies
+select json '{ "a":  "null \u0000 escape" }' -> 'a' as it_is;
+select json '{ "a":  "null \u0000 escape" }' ->> 'a' as preserved_with_prefix;
+SELECT jsonb '{ "a":  "null \u0000 escape" }' -> 'a' as preserved_with_prefix;
+SELECT jsonb '{ "a":  "null \u0000 escape" }' ->> 'a' as preserved_with_prefix;
+select '{ "a":  "dollar \u0000 character" }'::jsonb::json->'a' as preserved_with_prefix;
+SELECT '{ "a":  "dollar \u0000 character" }'::json::jsonb->'a' as preserved_with_prefix;
+
+-- empty prefix
+SET gp_json_preserve_ill_formed_prefix = '';
+SELECT jsonb '{ "a":  "null \u0000 escape" }' ->> 'a' as no_prefix;
+SELECT jsonb '{ "a":  "\ude04\ud83d" }' -> 'a' as no_prefix; -- surrogates in wrong order


### PR DESCRIPTION
When deal with '\u' escape sequences in the JSON string, PG/GP throws an
error if the sequences cannot be de-escaped or represented as text type.
e.g.:
- Incomplete escape sequence like '\u0fe' (One digit is missing)
- Incorrect surrogate pairs
- '\u0000' which is a valid JSON encode but it cannot be represented
  with text type correctly.

PG tried to suppport '\u0000' case but failed and the '\u0000' was
disallowed by 451d280815 since the workaround introduced some
correctness issues which cannot be easily solved.

This commit tries to solve the issue by let user preserve the ill-formed
escape sequence or '\u0000' as it is in the JSON string field.
Two GUCs is introduced by this commit.

gp_json_preserve_ill_formed is a boolean value to enable the ill-formed
escape sequence handling. When it is true, the ill-formed sequence won't
cause a error while parsing JSON. Instead, the ill-formed sequence will
be used as the de-escaped text. For example:

```
postgres=# select json '{ "a":  "\u0000" }' ->> 'a' as it_is;
 it_is
--------
 \u0000
(1 row)
```

But in this way, the parsed JSON text cannot be distinguished from
source "\\u0000" (totally illegal one) and "\u0000" (the problematic one).
This is also one reason for commit 451d280815 .

gp_json_preserve_ill_formed_prefix is added to solve the above issue by
giving user control to decide what prefix to be added to the ill-formed
sequence string. e.g.:

```
postgres=# SET gp_json_preserve_ill_formed_prefix = "##";
postgres=# select json '{ "a":  "\u0000" }' ->> 'a' as it_is;
  it_is
----------
 ##\u0000
(1 row)
```

When gp_json_preserve_ill_formed is false, the behaviour is just like
before, an error will be reported when a escape sequence cannot be
handled.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
