### PR TITLE
Handle the PROCSIG_NOTIFY_INTERRUPT signal

### DIFF
--- a/src/backend/storage/ipc/procsignal.c
+++ b/src/backend/storage/ipc/procsignal.c
@@ -295,6 +295,9 @@ procsignal_sigusr1_handler(SIGNAL_ARGS)
 		if (CheckProcSignal(PROCSIG_CATCHUP_INTERRUPT))
 			HandleCatchupInterrupt();
 
+		if (CheckProcSignal(PROCSIG_NOTIFY_INTERRUPT))
+			HandleNotifyInterrupt();
+
 		if (CheckProcSignal(PROCSIG_QUERY_FINISH))
 			QueryFinishHandler();
 

--- a/src/test/regress/expected/async.out
+++ b/src/test/regress/expected/async.out
@@ -40,3 +40,17 @@ SELECT pg_notification_queue_usage();
                            0
 (1 row)
 
+-- start_matchsubs
+-- m/Asynchronous notification "notify_async3" received from server process with PID.*/
+-- s/Asynchronous notification "notify_async3" received from server process with PID.*/Asynchronous notification "notify_async3" received/
+-- end_matchsubs
+\c postgres
+LISTEN notify_async3;
+\! psql postgres -c "notify notify_async3;"
+NOTIFY
+SELECT;
+--
+(1 row)
+
+Asynchronous notification "notify_async3" received
+\c -

--- a/src/test/regress/sql/async.sql
+++ b/src/test/regress/sql/async.sql
@@ -21,3 +21,13 @@ UNLISTEN *;
 -- Should return zero while there are no pending notifications.
 -- src/test/isolation/specs/async-notify.spec tests for actual usage.
 SELECT pg_notification_queue_usage();
+
+-- start_matchsubs
+-- m/Asynchronous notification "notify_async3" received from server process with PID.*/
+-- s/Asynchronous notification "notify_async3" received from server process with PID.*/Asynchronous notification "notify_async3" received/
+-- end_matchsubs
+\c postgres
+LISTEN notify_async3;
+\! psql postgres -c "notify notify_async3;"
+SELECT;
+\c -


### PR DESCRIPTION
This will make LISTEN and NOTIFY work on the QD node.

It was tested by async.sql, but not working on different sessions.