### PR TITLE
Fix interconnect hung issue

### DIFF
--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1140,6 +1140,18 @@ PG_TRY();
 		prm->isnull = false;
 	}
 
+	/* Clean up the interconnect. */
+	if (shouldTeardownInterconnect)
+	{
+		shouldTeardownInterconnect = false;
+
+		TeardownInterconnect(queryDesc->estate->interconnect_context,
+							 queryDesc->estate->motionlayer_context,
+							 false, false); /* following success on QD */
+		queryDesc->estate->interconnect_context = NULL;
+		queryDesc->estate->es_interconnect_is_setup = false;
+	}
+
 	/*
 	 * If we dispatched to QEs, wait for completion and check for errors.
 	 */
@@ -1173,17 +1185,6 @@ PG_TRY();
 
 	/* teardown the sequence server */
 	TeardownSequenceServer();
-
-	/* Clean up the interconnect. */
-	if (shouldTeardownInterconnect)
-	{
-		shouldTeardownInterconnect = false;
-
-		TeardownInterconnect(queryDesc->estate->interconnect_context,
-							 queryDesc->estate->motionlayer_context,
-							 false, false); /* following success on QD */
-		queryDesc->estate->interconnect_context = NULL;
-	}
 }
 PG_CATCH();
 {
@@ -1212,17 +1213,6 @@ PG_CATCH();
 	MemoryContextSetPeakSpace(planstate->state->es_query_cxt, savepeakspace);
 
 	/*
-	 * Request any commands still executing on qExecs to stop.
-	 * Wait for them to finish and clean up the dispatching structures.
-	 * Replace current error info with QE error info if more interesting.
-	 */
-	if (shouldDispatch && queryDesc && queryDesc->estate && queryDesc->estate->dispatcherState && queryDesc->estate->dispatcherState->primaryResults)
-		CdbDispatchHandleError(queryDesc->estate->dispatcherState);
-		
-	/* teardown the sequence server */
-	TeardownSequenceServer();
-		
-	/*
 	 * Clean up the interconnect.
 	 * CDB TODO: Is this needed following failure on QD?
 	 */
@@ -1232,7 +1222,20 @@ PG_CATCH();
 							 queryDesc->estate->motionlayer_context,
 							 true, false);
 		queryDesc->estate->interconnect_context = NULL;
+		queryDesc->estate->es_interconnect_is_setup = false;
 	}
+
+	/*
+	 * Request any commands still executing on qExecs to stop.
+	 * Wait for them to finish and clean up the dispatching structures.
+	 * Replace current error info with QE error info if more interesting.
+	 */
+	if (shouldDispatch && queryDesc && queryDesc->estate && queryDesc->estate->dispatcherState && queryDesc->estate->dispatcherState->primaryResults)
+		CdbDispatchHandleError(queryDesc->estate->dispatcherState);
+		
+	/* teardown the sequence server */
+	TeardownSequenceServer();
+
 	PG_RE_THROW();
 }
 PG_END_TRY();


### PR DESCRIPTION
We hit interconnect hung issue many times in many cases, all have
the same pattern: the downstream interconnect motion senders keep
sending the tuples and they are blind to the fact that upstream
nodes have finished and quitted the execution earlier, the QD
then get enough tuples and wait all QEs to quit which cause a
deadlock.

Many nodes may quit execution earlier, eg, LIMIT, HashJoin, Nest
Loop, to resolve the hung issue, they need to stop the interconnect
stream explicitly by calling ExecSquelchNode(), however, we cannot
do that for rescan cases in which data might lose, eg, commit
2c011ce. For rescan cases, we tried using QueryFinishPending to
stop the senders in commit 02213a731 and let senders check this
flag and quit, that commit has its own problem, firstly, QueryFini
shPending can only set by QD, it doesn't work for INSERT or UPDATE
cases, secondly, that commit only let the senders detect the flag
and quit the loop in a rude way (without sending the EOS to its
receiver), the receiver may still be stuck inreceiving tuples.

This commit revert the QueryFinishPending method firstly.

To resolve the hung issue, we move TeardownInterconnect to the
ahead of cdbdisp_checkDispatchResult so it guarantees to stop
the interconnect stream before waiting and checking the status
of QEs.

For UDPIFC, TeardownInterconnect() remove the ic entries, any
packets for this interconnect context will be treated as 'past'
packets and be acked with STOP flag.

For TCP, TeardownInterconnect() close all connection with its
children, the children will treat any readable data in the
connection as a STOP message include the closure operation.

this commit backport from master ec1d9a7063f9c46280d1b4bae2e7de7db6aa5321

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
