### PR TITLE
Wrap all SIGUSR1 handlers for InSIGUSR1Handler mechanism

### DIFF
--- a/src/backend/storage/ipc/procsignal.c
+++ b/src/backend/storage/ipc/procsignal.c
@@ -301,46 +301,46 @@ procsignal_sigusr1_handler(SIGNAL_ARGS)
 		if (CheckProcSignal(PROCSIG_QUERY_FINISH))
 			QueryFinishHandler();
 
+		if (CheckProcSignal(PROCSIG_WALSND_INIT_STOPPING))
+			HandleWalSndInitStopping();
+
+		if (CheckProcSignal(PROCSIG_PARALLEL_MESSAGE))
+			HandleParallelMessageInterrupt();
+
+		if (CheckProcSignal(PROCSIG_RECOVERY_CONFLICT_DATABASE))
+			RecoveryConflictInterrupt(PROCSIG_RECOVERY_CONFLICT_DATABASE);
+
+		if (CheckProcSignal(PROCSIG_RECOVERY_CONFLICT_TABLESPACE))
+			RecoveryConflictInterrupt(PROCSIG_RECOVERY_CONFLICT_TABLESPACE);
+
+		if (CheckProcSignal(PROCSIG_RECOVERY_CONFLICT_LOCK))
+			RecoveryConflictInterrupt(PROCSIG_RECOVERY_CONFLICT_LOCK);
+
+		if (CheckProcSignal(PROCSIG_RECOVERY_CONFLICT_SNAPSHOT))
+			RecoveryConflictInterrupt(PROCSIG_RECOVERY_CONFLICT_SNAPSHOT);
+
+		if (CheckProcSignal(PROCSIG_RECOVERY_CONFLICT_STARTUP_DEADLOCK))
+			RecoveryConflictInterrupt(PROCSIG_RECOVERY_CONFLICT_STARTUP_DEADLOCK);
+
+		if (CheckProcSignal(PROCSIG_RECOVERY_CONFLICT_BUFFERPIN))
+			RecoveryConflictInterrupt(PROCSIG_RECOVERY_CONFLICT_BUFFERPIN);
+
+		if (CheckProcSignal(PROCSIG_RESOURCE_GROUP_MOVE_QUERY))
+			HandleMoveResourceGroup();
+
+		SetLatch(MyLatch);
+
 		latch_sigusr1_handler();
+
 		InSIGUSR1Handler = false;
 	}
 	PG_CATCH();
 	{
 		InSIGUSR1Handler = false;
+
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
-
-	if (CheckProcSignal(PROCSIG_WALSND_INIT_STOPPING))
-		HandleWalSndInitStopping();
-
-	if (CheckProcSignal(PROCSIG_PARALLEL_MESSAGE))
-		HandleParallelMessageInterrupt();
-
-	if (CheckProcSignal(PROCSIG_RECOVERY_CONFLICT_DATABASE))
-		RecoveryConflictInterrupt(PROCSIG_RECOVERY_CONFLICT_DATABASE);
-
-	if (CheckProcSignal(PROCSIG_RECOVERY_CONFLICT_TABLESPACE))
-		RecoveryConflictInterrupt(PROCSIG_RECOVERY_CONFLICT_TABLESPACE);
-
-	if (CheckProcSignal(PROCSIG_RECOVERY_CONFLICT_LOCK))
-		RecoveryConflictInterrupt(PROCSIG_RECOVERY_CONFLICT_LOCK);
-
-	if (CheckProcSignal(PROCSIG_RECOVERY_CONFLICT_SNAPSHOT))
-		RecoveryConflictInterrupt(PROCSIG_RECOVERY_CONFLICT_SNAPSHOT);
-
-	if (CheckProcSignal(PROCSIG_RECOVERY_CONFLICT_STARTUP_DEADLOCK))
-		RecoveryConflictInterrupt(PROCSIG_RECOVERY_CONFLICT_STARTUP_DEADLOCK);
-
-	if (CheckProcSignal(PROCSIG_RECOVERY_CONFLICT_BUFFERPIN))
-		RecoveryConflictInterrupt(PROCSIG_RECOVERY_CONFLICT_BUFFERPIN);
-
-	if (CheckProcSignal(PROCSIG_RESOURCE_GROUP_MOVE_QUERY))
-		HandleMoveResourceGroup();
-
-	SetLatch(MyLatch);
-
-	latch_sigusr1_handler();
 
 	errno = save_errno;
 }


### PR DESCRIPTION
`InSIGUSR1Handler` is not set with every SIGUSR1 handler, some were
missed in the merge iteration.

In https://github.com/greenplum-db/gpdb/pull/10747, Heikki brought up this issue, but the `InSIGUSR1Handler` mechanism seems important to me according to the comments of `ShouldAssignResGroupOnMaster()`, So I decided to fix but not remove it.