### PR TITLE
[5X Backport] Use return instead of exit() in configure

### DIFF
--- a/config/c-compiler.m4
+++ b/config/c-compiler.m4
@@ -84,8 +84,10 @@ int does_int64_work()
     return 0;
   return 1;
 }
+
+int
 main() {
-  exit(! does_int64_work());
+  return (! does_int64_work());
 }],
 [Ac_cachevar=yes],
 [Ac_cachevar=no],

--- a/config/c-library.m4
+++ b/config/c-library.m4
@@ -250,8 +250,10 @@ int does_int64_snprintf_work()
     return 0;			/* either multiply or snprintf is busted */
   return 1;
 }
+
+int
 main() {
-  exit(! does_int64_snprintf_work());
+  return (! does_int64_snprintf_work());
 }],
 [pgac_cv_snprintf_long_long_int_format=$pgac_format; break],
 [],

--- a/configure
+++ b/configure
@@ -16443,8 +16443,10 @@ int does_int64_work()
     return 0;
   return 1;
 }
+
+int
 main() {
-  exit(! does_int64_work());
+  return (! does_int64_work());
 }
 _ACEOF
 if ac_fn_c_try_run "$LINENO"; then :
@@ -16525,8 +16527,10 @@ int does_int64_work()
     return 0;
   return 1;
 }
+
+int
 main() {
-  exit(! does_int64_work());
+  return (! does_int64_work());
 }
 _ACEOF
 if ac_fn_c_try_run "$LINENO"; then :
@@ -16627,8 +16631,10 @@ int does_int64_snprintf_work()
     return 0;			/* either multiply or snprintf is busted */
   return 1;
 }
+
+int
 main() {
-  exit(! does_int64_snprintf_work());
+  return (! does_int64_snprintf_work());
 }
 _ACEOF
 if ac_fn_c_try_run "$LINENO"; then :


### PR DESCRIPTION
Master and 6X Backport of https://github.com/greenplum-db/gpdb/pull/10762 and https://github.com/greenplum-db/gpdb/pull/10768

GPDB was failing to configure on macOS Catalina 10.15 with clang version 12.0.0 (clang-1200.0.31.1) with the following error: `configure: error: Cannot find a working 64-bit integer type.`

This is a cherry-pick commit from upstream that fixes the above issue. See upstream mailing list discussion:
https://www.postgresql.org/message-id/flat/09A4B554-82B1-4536-B191-2461342EE0BB%40icloud.com

Thanks to @d  for his help in this!

[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/5X_configure_fix_int64)
