### PR TITLE
[6X Backport] gpstart: when standby is unreachable don't start it

### DIFF
--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -123,7 +123,7 @@ class GpStart:
                                                           logger=logger).get_master_value()
 
             if not self.skip_standby_check:
-                self._check_standby_activated()
+                self.check_standby()
             else:
                 logger.info("Skipping Standby activation status checking.")
 
@@ -234,10 +234,34 @@ class GpStart:
         else:
             controldata = PgControlData("fetching pg_controldata remotely", data_dir_path, REMOTE, remoteHost)
 
+        controldata.run(validateAfter=True)
+        return int(controldata.get_value("Latest checkpoint's TimeLineID"))
+
+    class StandbyUnreachable(Exception):
+        pass
+
+    def _standby_activated(self):
+        logger.debug("Checking if standby has been activated...")
+
+        if not self.gparray.standbyMaster:
+            return False
+
+        # fetch timelineids for both primary and standby (post-promote)
+        primary_tli = self.fetch_tli(self.master_datadir)
         try:
-            controldata.run(validateAfter=True)
-            return int(controldata.get_value("Latest checkpoint's TimeLineID"))
+            standby_tli = self.fetch_tli(self.gparray.standbyMaster.getSegmentDataDirectory(),
+                                         self.gparray.standbyMaster.getSegmentHostName())
         except base.ExecutionError as err:
+            raise GpStart.StandbyUnreachable(err)
+
+        logger.debug("Primary TLI = %d" % primary_tli)
+        logger.debug("Standby TLI = %d" % standby_tli)
+        return primary_tli < standby_tli
+
+    def check_standby(self):
+        try:
+            standby_activated = self._standby_activated()
+        except GpStart.StandbyUnreachable as err:
             logger.warning("Standby host is unreachable, cannot determine whether the standby is currently acting as the master. Received error: %s" % err)
             logger.warning("Continue only if you are certain that the standby is not acting as the master.")
             if not self.interactive or not userinput.ask_yesno(None, "\nContinue with startup", 'N'):
@@ -245,31 +269,25 @@ class GpStart:
                     logger.warning("Non interactive mode detected. Not starting the cluster. Start the cluster in interactive mode.")
                 self.shutdown_master_only()
                 raise UserAbortedException()
-            return 0  # a 0 won't lead to standby promotion, as TimeLineIDs start at 1
 
-    def _check_standby_activated(self):
-        logger.debug("Checking if standby has been activated...")
+            # If the user wants to continue when the standby is unreachable,
+            # set start_standby to False to prevent starting the unreachable
+            # standy later in the startup process.
+            self.start_standby = False
+            return
 
-        if self.gparray.standbyMaster:
+        if not standby_activated:
+            return
 
-            # fetch timelineids for both primary and standby (post-promote)
-            primary_tli = self.fetch_tli(self.master_datadir)
-            standby_tli = self.fetch_tli(self.gparray.standbyMaster.getSegmentDataDirectory(),
-                                         self.gparray.standbyMaster.getSegmentHostName())
-
-            logger.debug("Primary TLI = %d" % primary_tli)
-            logger.debug("Standby TLI = %d" % standby_tli)
-
-            if primary_tli < standby_tli:
-                # stop the master we've started up.
-                cmd = gp.GpStop("Shutting down master", masterOnly=True,
-                                fast=True, quiet=logging_is_quiet(),
-                                verbose=logging_is_verbose(),
-                                parallel=self.parallel,
-                                datadir=self.master_datadir)
-                cmd.run(validateAfter=True)
-                logger.info("Master Stopped...")
-                raise ExceptionNoStackTraceNeeded("Standby activated, this node no more can act as master.")
+        # stop the master we've started up.
+        cmd = gp.GpStop("Shutting down master", masterOnly=True,
+                        fast=True, quiet=logging_is_quiet(),
+                        verbose=logging_is_verbose(),
+                        datadir=self.master_datadir,
+                        parallel=self.parallel)
+        cmd.run(validateAfter=True)
+        logger.info("Master Stopped...")
+        raise ExceptionNoStackTraceNeeded("Standby activated, this node no more can act as master.")
 
     ######
     def _recovery_startup(self):

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -13,3 +13,16 @@ Feature: gpstart behave tests
           And gpstart should print "Skipped segment starts \(segments are marked down in configuration\) += 1" to stdout
           And gpstart should print "Successfully started [0-9]+ of [0-9]+ segment instances, skipped 1 other segments" to stdout
           And gpstart should print "Number of segments not attempted to start: 1" to stdout
+
+    Scenario: gpstart starts even if the standby host is unreachable
+        Given the database is running
+          And the catalog has a standby master entry
+
+         When the database is not running
+          And the standby host goes down
+          And gpstart is run with prompts accepted
+
+         Then gpstart should print "Continue only if you are certain that the standby is not acting as the master." to stdout
+          And gpstart should print "No standby master configured" to stdout
+          And gpstart should return a return code of 0
+          And all the segments are running

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -1,0 +1,92 @@
+import os
+import signal
+import subprocess
+
+from behave import given, when, then
+from  test.behave_utils import utils
+
+def _run_sql(sql, opts=None):
+    env = None
+
+    if opts is not None:
+        env = os.environ.copy()
+
+        options = ''
+        for key, value in opts.items():
+            options += "-c {}={} ".format(key, value)
+
+        env['PGOPTIONS'] = options
+
+    subprocess.check_call([
+        "psql",
+        "postgres",
+        "-c", sql,
+    ], env=env)
+
+@when('the standby host goes down')
+def impl(context):
+    """
+    Fakes a host failure by updating the standby segment entry to point at an
+    invalid hostname and address.
+    """
+    opts = {
+        'gp_session_role': 'utility',
+        'allow_system_table_mods': 'on',
+    }
+
+    subprocess.check_call(['gpstart', '-am'])
+    _run_sql("""
+        UPDATE gp_segment_configuration
+           SET hostname = 'standby.invalid',
+                address = 'standby.invalid'
+         WHERE content = -1 AND role = 'm'
+    """, opts=opts)
+    subprocess.check_call(['gpstop', '-am'])
+
+    def cleanup(context):
+        """
+        Reverses the above SQL by starting up in master-only utility mode. Since
+        the standby host is incorrect, a regular gpstart call won't work.
+        """
+
+        utils.stop_database_if_started(context)
+
+        subprocess.check_call(['gpstart', '-am'])
+        _run_sql("""
+            UPDATE gp_segment_configuration
+               SET hostname = master.hostname,
+                    address = master.address
+              FROM (
+                     SELECT hostname, address
+                       FROM gp_segment_configuration
+                      WHERE content = -1 and role = 'p'
+                   ) master
+             WHERE content = -1 AND role = 'm'
+        """, opts=opts)
+        subprocess.check_call(['gpstop', '-am'])
+
+    context.add_cleanup(cleanup, context)
+
+def _handle_sigpipe():
+    """
+    Work around https://bugs.python.org/issue1615376, which is not fixed until
+    Python 3.2. This bug interferes with Bash pipelines that rely on SIGPIPE to
+    exit cleanly.
+    """
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+@when('gpstart is run with prompts accepted')
+def impl(context):
+    """
+    Runs `yes | gpstart`.
+    """
+
+    p = subprocess.Popen(
+        [ "bash", "-c", "yes | gpstart" ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        preexec_fn=_handle_sigpipe,
+    )
+
+    context.stdout_message, context.stderr_message = p.communicate()
+    context.ret_code = p.returncode

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1234,6 +1234,7 @@ def impl(context):
         context.standby_host = standby
         run_gpcommand(context, 'gpinitstandby -ra')
 
+@given('the catalog has a standby master entry')
 @then('verify the standby master entries in catalog')
 def impl(context):
 	check_segment_config_query = "SELECT * FROM gp_segment_configuration WHERE content = -1 AND role = 'm'"


### PR DESCRIPTION
Backport of https://github.com/greenplum-db/gpdb/pull/10770 which is much of similar code taken from this 5X bug fix https://github.com/greenplum-db/gpdb/pull/10742


When the standby is unreachable and the user proceeds with startup, the standby would attempt to be started resulting in a stack trace. Detect when the standby is unreachable and set start_standby to False to prevent starting it later in the startup process.

Test Pipeline - [dev](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/6X_gpstart-without-standby-host) and [cm](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/6X_gpstart-without-standby-host)