### PR TITLE
[BUGFIX] Fix segment crash on deserialization of incoming internal executor record-type parameters

### DIFF
--- a/src/backend/cdb/motion/tupleremap.c
+++ b/src/backend/cdb/motion/tupleremap.c
@@ -266,6 +266,9 @@ TRRemapDatum(TupleRemapper *remapper, Oid typeid, Datum value)
 	TupleRemapInfo *remapinfo;
 	bool		changed;
 
+	if (value == 0)
+		return value;
+
 	remapinfo = BuildTupleRemapInfo(typeid, remapper->mycontext);
 
 	if (!remapinfo)

--- a/src/test/regress/expected/gpparams.out
+++ b/src/test/regress/expected/gpparams.out
@@ -1,5 +1,5 @@
 --
--- All derived from MPP-3613: use of incorrect parameters in queries
+-- Derived from MPP-3613: use of incorrect parameters in queries
 -- which intermix initPlans with "internal" parameters.
 --
 --
@@ -258,3 +258,29 @@ select * from create_target_list_sql(30);
 --select * from create_target_list(30, 1);
 --truncate module_targets;
 --select * from create_target_list_sql(30);
+--
+-- Test case on using initPlan with internal not-evaluated parameter of RECORD
+-- type that have to be transmited to QEs from master node
+--
+CREATE TABLE users_unmasked (
+    user_id bigint NOT NULL,
+    params text
+) DISTRIBUTED BY (user_id);
+ALTER TABLE ONLY users_unmasked
+ADD CONSTRAINT users_20171219_pkey PRIMARY KEY (user_id);
+-- query that on segment side deserializes not-evaluated zero parameter
+-- corresponding to returning 'row(u.user_id)' tuple from subquery inside WHERE
+-- stmt
+SELECT cte."userId" FROM ( SELECT 7 as "userId" ) cte WHERE (
+    SELECT
+        row(u.user_id)
+    FROM
+        users_unmasked u
+    WHERE
+        u.user_id = 7
+) IS NOT NULL;
+ userId 
+--------
+(0 rows)
+
+DROP TABLE users_unmasked;


### PR DESCRIPTION
## Problem description

The master node dispatches external and internal (gathered from plan tree) parameters along with query plan. Internal ones might include not initialized values, e.g., used for storing results of not yet evaluated initPlans. Those parameters are transmitted as zero values that cases segfault on segments in deserialization procedure of complex type value.

The current fix intercepts on QE side handling of zero value parameter before further deserialization process.

## Scenario to reproduce
```sql
CREATE TABLE users_unmasked (
  user_id bigint NOT NULL,
  params text
) DISTRIBUTED BY (user_id);

ALTER TABLE ONLY users_unmasked
ADD CONSTRAINT users_20171219_pkey PRIMARY KEY (user_id);

-- faulty query
SELECT cte."userId" FROM ( SELECT 7 as "userId" ) cte WHERE (
  SELECT
    row(u.user_id)
  FROM
    test_schema.users_unmasked u
  WHERE
    u.user_id = 7
) IS NOT NULL;
```
Faulty query have to has the following plan:
```
                                 QUERY PLAN                                  
-----------------------------------------------------------------------------
 Result
   One-Time Filter: ($0 IS NOT NULL)
   InitPlan 1 (returns $0)  (slice2)
     ->  Gather Motion 1:1  (slice1; segments: 1)
           ->  Index Only Scan using users_20171219_pkey on users_unmasked u
                 Index Cond: (user_id = 7)
   ->  Result
 Optimizer: Postgres query optimize
```
Internal executor parameter here is $0 that is used in “One-Time Filter” of Result node.

## Affected versions

GPDB 6X and 5X are sensitive to this error.
On master branch a huge refactoring was done by @hlinnaka in place of dispatching executor parameters - commit 53d12bd . In particular, it [separates](https://github.com/greenplum-db/gpdb/blob/ef09a3a6ab9d8871bfe8e3267256d2ded90dc0a5/src/include/executor/execdesc.h#L62-L66) external and internal parameters in serialized representation of transmitted data as well as separates deserialization procedures of [external](https://github.com/greenplum-db/gpdb/blob/ef09a3a6ab9d8871bfe8e3267256d2ded90dc0a5/src/backend/cdb/dispatcher/cdbdisp_query.c#L1247) and [internal](https://github.com/greenplum-db/gpdb/blob/ef09a3a6ab9d8871bfe8e3267256d2ded90dc0a5/src/backend/executor/execUtils.c#L1878-L1902) ones. Deserialization procedure for internal parameters doesn't use buggy `TRRemapDatum()` and because of this GP7 doesn't fail on query. I cannot realize how much the rejection of `TRRemapDatum()` call in deserialization of internal parameters is right and I would like to see comments about this.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
