### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,44 @@
+# git-blame ignore list
+#
+# Since version 2.23 (released in August 2019), git-blame has a feature to
+# ignore or bypass certain commits.
+#
+# This file contains a list of commits that are unlikely what you are looking
+# for in a typical git-blame, such as mass reformatting or renaming. There are
+# three ways to use this file:
+#
+# 1. Most typically, you would want to configure git to use this file as the
+#    default ignore file for git-blame:
+#
+#    $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+#    This allows git-blame to act like git-hyper-blame, skipping specified
+#    commits and trying harder to attribute changes to "interesting" commits in
+#    the history. This also allows tools (most notably, IDE's and text editors)
+#    that lack options to adopt this behavior.
+#
+# 1. If you have configured Git as above, but occasionally needs the "real",
+#    unadulterated annotation, you can suppress this setting one-off by
+#    supplying an empty ignore-revs-file argument to blame like the following:
+#
+#    $ git blame --ignore-revs-file '' -w CTranslatorExprToDXL.cpp
+#
+# 1. For those paranoids out there who'd like to keep the default behavior,
+#    they can always manually ignore commits in this file manually:
+#
+#    $ git blame --ignore-revs-file .git-blame-ignore-revs -w -- src/backend/gpopt/gpdbwrappers.cpp
+
+# Hungarian notation removal specific to GPOS and Naucrates libraries
+d334b0163fceb0385be7cd98c7f8c87f93dc3bf5
+
+# Revert "Hungarian notation removal specific to GPOS and Naucrates libraries"
+8324e984dcd307fca307f968494353e9a7db5afe
+
+# Hungarian notation removal specific to GPOS and Naucrates libraries (5X_STABLE)
+5d30d4f58bb520e8040e4428429c980e2748bbc5
+
+# Hungarian notation removal specific to GPOS and Naucrates libraries
+2a38a9cdbbe5b70da5ed542e7c1a1ee93a41e1ca
+
+# Hungarian notation removal: GPOS and Naucrates libraries (GPORCA)
+f3da624ccd796364bb8bb84496cd6bf5b2828c1e


### PR DESCRIPTION
## TL;DR

This file will be used to record commits to be ignored by git-blame (user still
has to opt in). This is intended to include large (generally automated)
reformatting or renaming commits.

## Motivation

This came out of discussion over at #10357, and on gpdb-dev mailing list [1].

On pull request #10357, I proposed a sweeting formatting change. In
conversations I've had, people generally have no objection to such changes as
long as they feel assured git-blame won't be impacted. Or to put it another
way, there's a a little bit of fear when it comes to massive (automated)
changes when "it breaks git-blame". And the example brought up was almost
always "Naucrates-specific Hungarian notation removal" (#5197).

For years, the Chromium project has had a solution to this: [git-hyper-blame](https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/git-hyper-blame.html)
[2]. It works by looking up a configuration file [`.git-blame-ignore-revs`](https://github.com/chromium/chromium/commit/844fee69d193b942146fc2502dad41e7effdbb0c#diff-08a2b9071e83474511b15c4fadf12c7d)[4]
at the root of your Git repository, and cleverly teaches `git-blame` to skip
certain uninteresting commits in the config file. Out side of Chromium, a
couple of open source projects have also adopted git-hyper-blame, the most
famous of which is Firefox [3] and Gerrit [15]. Last summer, someone
independently implemented this feature in upstream Git [9][8]. This means that,
like Chromium developers, we can now make formatting changes without breaking
`git-blame` [10].

## Community adoption

Community adoption of the new git-blame feature was nearly immediate, a small
sample of high-profile projects adopting this feature (usually with sweeping
formatting change):

* [LLVM](https://reviews.llvm.org/D67145) [5]
* [iPython](https://github.com/ipython/ipython/pull/12091) [6]
* [KDE](https://github.com/KDE/okular/commit/4fb455220a323a376b5b27f355029685632c87ec#diff-08a2b9071e83474511b15c4fadf12c7d) [16]
* [Django](https://github.com/django/deps/pull/61/files) [14]
* Python's code formatter [black recommending](https://github.com/psf/black/pull/1419) [12] this
* VIM's most popular Git plugin fugitive [adding support to the new flags in blame](https://github.com/tpope/vim-fugitive/commit/c212d854d5c872f43e0a3f064241b086d07fbb6f) [13]


## References

[1] "[RFC] use clang-format for gpopt and gporca" https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/AaRKbwGkXEA/m/nAUQKVN2CQAJ

[2] https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/git-hyper-blame.html
[3] https://phabricator.services.mozilla.com/D12701
[4] https://github.com/chromium/chromium/commit/844fee69d193b942146fc2502dad41e7effdbb0c#diff-08a2b9071e83474511b15c4fadf12c7d
[5] https://reviews.llvm.org/D67145
[6] https://github.com/ipython/ipython/pull/12091
[7] https://github.com/greenplum-db/gpdb/pull/5197
[8] https://public-inbox.org/git/20190107213013.231514-1-brho@google.com/
[9] https://github.com/git/git/commit/209f0755934a0c9b448408f9b7c9849c15041ecc
[10] https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt
[11] https://twitter.com/llanga/status/1163767833706323970
[12] https://github.com/psf/black/pull/1419
[13] https://github.com/tpope/vim-fugitive/commit/c212d854d5c872f43e0a3f064241b086d07fbb6f
[14] https://github.com/django/deps/pull/61/files
[15] https://github.com/GerritCodeReview/gerrit/commit/17c372a16b06ad933d59f98cd355bf8f82517aea#diff-08a2b9071e83474511b15c4fadf12c7d
[16] https://github.com/KDE/okular/commit/4fb455220a323a376b5b27f355029685632c87ec#diff-08a2b9071e83474511b15c4fadf12c7d
