### PR TITLE
Test gpfdists external table with hostname

### DIFF
--- a/src/bin/gpfdist/regress/gen_multiCA_certs.bash
+++ b/src/bin/gpfdist/regress/gen_multiCA_certs.bash
@@ -21,7 +21,7 @@ openssl x509 -req -in $1ca.csr -CA $1root.crt -CAkey $1root.key \
     -days 365 -out $1ca.crt -sha256 -CAcreateserial
 
 openssl req -new -newkey rsa:2048 -nodes \
-    -subj "/C=US/ST=California/L=Palo Alto/O=Pivotal/CN=127.0.0.1" \
+    -subj "/C=US/ST=California/L=Palo Alto/O=Pivotal/CN=localhost" \
     -keyout $1.key  -out $1.csr
 
 openssl x509 -req -in $1.csr -CA $1ca.crt -CAkey $1ca.key \

--- a/src/bin/gpfdist/regress/input/gpfdists_multiCA.source
+++ b/src/bin/gpfdist/regress/input/gpfdists_multiCA.source
@@ -11,7 +11,7 @@ drop external table if exists gpfdist_ssl_stop;
 -- 'gpfdists' protocol
 -- --------------------------------------
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_multiCA </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_multiCA </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl -k https://localhost:7070 >/dev/null 2>&1; [ $? -ne 7 ] && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 
@@ -49,7 +49,7 @@ INSERT INTO tbl_on_heap VALUES
 ('ccc','twoc','shpits','2011-06-01 12:30:30',23,732,834567,45.67,789.123,7.12345,123.456789 );
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE WRITABLE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl SELECT * FROM tbl_on_heap;
 SELECT * FROM tbl_on_heap ORDER BY s1;
@@ -63,7 +63,7 @@ CREATE TABLE tbl_on_heap2 (
             n5 numeric, n6 real, n7 double precision);
 DROP EXTERNAL TABLE IF EXISTS tbl2;
 CREATE EXTERNAL TABLE tbl2 (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap2 SELECT * FROM tbl2;
 SELECT * FROM tbl_on_heap2 ORDER BY s1;
@@ -77,7 +77,7 @@ CREATE TABLE tbl_on_heap (
             n5 numeric, n6 real, n7 double precision);
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl','gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl','gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap SELECT * FROM tbl;
 SELECT * FROM tbl_on_heap ORDER BY s1;
@@ -90,7 +90,7 @@ SELECT * FROM tbl_on_heap ORDER BY s1;
 -- client cert changed
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 SELECT * FROM tbl;
 

--- a/src/bin/gpfdist/regress/output/gpfdists_multiCA.source
+++ b/src/bin/gpfdist/regress/output/gpfdists_multiCA.source
@@ -7,7 +7,7 @@
 -- 'gpfdists' protocol
 -- --------------------------------------
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_multiCA </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_multiCA </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl -k https://localhost:7070 >/dev/null 2>&1; [ $? -ne 7 ] && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_stop (x text)
@@ -58,7 +58,7 @@ INSERT INTO tbl_on_heap VALUES
 DROP EXTERNAL TABLE IF EXISTS tbl;
 NOTICE:  table "tbl" does not exist, skipping
 CREATE WRITABLE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl SELECT * FROM tbl_on_heap;
 SELECT * FROM tbl_on_heap ORDER BY s1;
@@ -82,7 +82,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 DROP EXTERNAL TABLE IF EXISTS tbl2;
 NOTICE:  table "tbl2" does not exist, skipping
 CREATE EXTERNAL TABLE tbl2 (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap2 SELECT * FROM tbl2;
 SELECT * FROM tbl_on_heap2 ORDER BY s1;
@@ -104,7 +104,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl','gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl','gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap SELECT * FROM tbl;
 SELECT * FROM tbl_on_heap ORDER BY s1;
@@ -130,7 +130,7 @@ SELECT * FROM tbl_on_heap ORDER BY s1;
 DROP EXTERNAL TABLE IF EXISTS tbl;
 NOTICE:  table "tbl" does not exist, skipping
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 SELECT * FROM tbl;
  s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     


### PR DESCRIPTION
On centos7, the system libcurl uses NSS instead of OpenSSL as backend
for TLS/SSL connections. Previously it will fail if hostname is used
in external table location, probably due to initialization issues.
This is fixed by commit 89a1211c. Modify original test case to use
hostname.

curl is used for connection testing in gpfdist_ssl_start. But it will
always fail since we are now using SSL. Change the condition to not
equal to 7. This code can be found at curl documentation:
https://curl.haxx.se/libcurl/c/libcurl-errors.html