### PR TITLE
[5X backport] Allow setting direct dispatch info if predicate on column gp_segment_id

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.109.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.110.", GPORCA_VERSION_STRING, 6);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.109.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.110.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12487,7 +12487,7 @@ int
 main ()
 {
 
-return strncmp("3.109.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.110.", GPORCA_VERSION_STRING, 6);
 
   ;
   return 0;
@@ -12497,7 +12497,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.109.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.110.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/depends/conanfile_orca.txt
+++ b/depends/conanfile_orca.txt
@@ -1,5 +1,5 @@
 [requires]
-orca/v3.109.0@gpdb/stable
+orca/v3.110.0@gpdb/stable
 
 [imports]
 include, * -> build/include

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.109.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.110.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4502,12 +4502,50 @@ CTranslatorDXLToPlStmt::TranslateDXLDirectDispatchInfo
 	{
 		return NIL;
 	}
-	
+
 	CDXLDatumArray *dxl_datum_array = (*dispatch_identifier_datum_arrays)[0];
 	GPOS_ASSERT(0 < dxl_datum_array->Size());
-		
-	ULONG hash_code = GetDXLDatumGPDBHash(dxl_datum_array);
+
 	const ULONG length = dispatch_identifier_datum_arrays->Size();
+
+	if (dxl_direct_dispatch_info->FContainsRawValues()) {
+		List *segids_list = NIL;
+		INT segid;
+		Const *const_expr = NULL;
+
+		for (ULONG ul = 0; ul < length; ul++)
+		{
+			CDXLDatumArray *dispatch_identifier_datum_array = (*dispatch_identifier_datum_arrays)[ul];
+			GPOS_ASSERT(1 == dispatch_identifier_datum_array->Size());
+			const_expr = (Const *) m_translator_dxl_to_scalar->TranslateDXLDatumToScalar(
+				(*dispatch_identifier_datum_array)[0]
+			);
+
+			segid = DatumGetInt32(const_expr->constvalue);
+			if (segid >= -1 && segid < (INT)m_num_of_segments)
+			{
+				segids_list = gpdb::LAppendInt(segids_list, segid);
+			}
+		}
+
+		if (segids_list == NIL && const_expr)
+		{
+			// If no valid segids were found, and there were items in the
+			// dispatch identifier array, then append the last item to behave
+			// in same manner as Planner for consistency. Currently this will
+			// lead to a FATAL in the backend when we dispatch.
+			segids_list = gpdb::LAppendInt(segids_list, segid);
+		}
+
+		if (list_length(segids_list) > 1)
+		{
+			return NIL;
+		}
+
+		return segids_list;
+	}
+
+	ULONG hash_code = GetDXLDatumGPDBHash(dxl_datum_array);
 	for (ULONG ul = 0; ul < length; ul++)
 	{
 		CDXLDatumArray *dispatch_identifier_datum_array = (*dispatch_identifier_datum_arrays)[ul];

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -547,6 +547,68 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 drop sequence ddtestseq;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- test direct dispatch via gp_segment_id qual
+create table t_test_dd_via_segid(id int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into t_test_dd_via_segid select * from generate_series(1, 6);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+explain select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1302.50 rows=32067 width=8)
+   ->  Seq Scan on t_test_dd_via_segid  (cost=0.00..1302.50 rows=10689 width=8)
+         Filter: gp_segment_id = 0
+ Optimizer status: legacy query optimizer
+(4 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+INFO:  Dispatch command to ALL contents
+ gp_segment_id | id 
+---------------+----
+             0 |  1
+             0 |  2
+(2 rows)
+
+explain select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1302.50 rows=32067 width=8)
+   ->  Seq Scan on t_test_dd_via_segid  (cost=0.00..1302.50 rows=10689 width=8)
+         Filter: gp_segment_id = 1
+ Optimizer status: legacy query optimizer
+(4 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+INFO:  Dispatch command to ALL contents
+ gp_segment_id | id 
+---------------+----
+             1 |  3
+             1 |  4
+             1 |  5
+             1 |  6
+(4 rows)
+
+explain select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1302.50 rows=32067 width=8)
+   ->  Seq Scan on t_test_dd_via_segid  (cost=0.00..1302.50 rows=10689 width=8)
+         Filter: gp_segment_id = 2
+ Optimizer status: legacy query optimizer
+(4 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+INFO:  Dispatch command to ALL contents
+ gp_segment_id | id 
+---------------+----
+(0 rows)
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -555,6 +555,71 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 drop sequence ddtestseq;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+-- test direct dispatch via gp_segment_id qual
+create table t_test_dd_via_segid(id int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+insert into t_test_dd_via_segid select * from generate_series(1, 6);
+INFO:  Dispatch command to ALL contents
+INFO:  Dispatch command to ALL contents
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+explain select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Result
+         ->  Table Scan on t_test_dd_via_segid
+               Filter: (gp_segment_id = 0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+INFO:  Dispatch command to SINGLE content
+ gp_segment_id | id 
+---------------+----
+             0 |  1
+             0 |  2
+(2 rows)
+
+explain select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=8)
+   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+         ->  Table Scan on t_test_dd_via_segid  (cost=0.00..431.00 rows=1 width=8)
+               Filter: gp_segment_id = 1
+ Optimizer status: PQO version 3.110.0
+(5 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+INFO:  Dispatch command to SINGLE content
+ gp_segment_id | id 
+---------------+----
+             1 |  3
+             1 |  4
+             1 |  5
+             1 |  6
+(4 rows)
+
+explain select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=8)
+   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+         ->  Table Scan on t_test_dd_via_segid  (cost=0.00..431.00 rows=1 width=8)
+               Filter: gp_segment_id = 2
+ Optimizer status: PQO version 3.110.0
+(5 rows)
+
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+INFO:  Dispatch command to SINGLE content
+ gp_segment_id | id 
+---------------+----
+(0 rows)
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;

--- a/src/test/regress/sql/direct_dispatch.sql
+++ b/src/test/regress/sql/direct_dispatch.sql
@@ -256,6 +256,19 @@ drop table ddtesttab;
 drop sequence ddtestseq;
 
 
+-- test direct dispatch via gp_segment_id qual
+create table t_test_dd_via_segid(id int);
+insert into t_test_dd_via_segid select * from generate_series(1, 6);
+
+explain select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+
+explain select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+
+explain select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 


### PR DESCRIPTION
Mostly clean backport, however can't direct dispatch to multiple segments as that was not implemented until GPDB 6X commit 576690f.  Straightforward diff 39fe59cb085e

---

This approach special cases gp_segment_id enough to include the column
as a distributed column constraint. It also updates direct dispatch info
to be aware of gp_segment_id which represents the raw value of the
segment where the data resides. This is different than other columns
which hash the datum value to decide where the data resides.

After this change the following DDL shows Gather Motion from 2 segments
on a 3 segment demo cluster.

```
CREATE TABLE t(a int, b int) DISTRIBUTED BY (a);
EXPLAIN SELECT gp_segment_id, * FROM t WHERE gp_segment_id=1 or gp_segment_id=2;
                                  QUERY PLAN
-------------------------------------------------------------------------------
 Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=12)
   ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=12)
         Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2))
 Optimizer: Pivotal Optimizer (GPORCA)
(4 rows)

```

(cherry picked from commit 10e2b2d)