### PR TITLE
Align Orca relhasindex behavior with Planner

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2484,8 +2484,11 @@ gpdb::GetRelationIndexes
 {
 	GP_WRAP_START;
 	{
-		/* catalog tables: from relcache */
-		return RelationGetIndexList(relation);
+		if (relation->rd_rel->relhasindex)
+		{
+			/* catalog tables: from relcache */
+			return RelationGetIndexList(relation);
+		}
 	}
 	GP_WRAP_END;
 	return NIL;

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -3301,6 +3301,7 @@ CTranslatorRelcacheToDXL::IsIndexSupported
 	// index expressions and index constraints not supported
 	return gpdb::HeapAttIsNull(tup, Anum_pg_index_indexprs) &&
 		gpdb::HeapAttIsNull(tup, Anum_pg_index_indpred) &&
+		index_rel->rd_index->indisvalid &&
 		(BTREE_AM_OID == index_rel->rd_rel->relam || BITMAP_AM_OID == index_rel->rd_rel->relam || GIST_AM_OID == index_rel->rd_rel->relam ||
 		 	GIN_AM_OID == index_rel->rd_rel->relam);
 }

--- a/src/bin/pg_upgrade/test_gpdb_pre.sql
+++ b/src/bin/pg_upgrade/test_gpdb_pre.sql
@@ -40,3 +40,7 @@ DROP VIEW IF EXISTS sums_1_100 CASCADE;
 -- Cannot currently handle partitioned table with a composite type as
 -- partitioning key (see https://github.com/greenplum-db/gpdb/issues/9405).
 drop table public.employee_table;
+
+-- Cannot currently handle table with invalid index
+-- (see https://github.com/greenplum-db/gpdb/issues/10805).
+DROP TABLE public.bfv_tab1_with_invalid_index;

--- a/src/bin/pg_upgrade/test_gpdb_pre.sql
+++ b/src/bin/pg_upgrade/test_gpdb_pre.sql
@@ -40,7 +40,3 @@ DROP VIEW IF EXISTS sums_1_100 CASCADE;
 -- Cannot currently handle partitioned table with a composite type as
 -- partitioning key (see https://github.com/greenplum-db/gpdb/issues/9405).
 drop table public.employee_table;
-
--- Cannot currently handle table with invalid index
--- (see https://github.com/greenplum-db/gpdb/issues/10805).
-DROP TABLE public.bfv_tab1_with_invalid_index;

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -55,14 +55,17 @@ set allow_system_table_mods=on;
 update pg_index set indisvalid=false where indrelid='bfv_tab1_with_invalid_index'::regclass;
 reset allow_system_table_mods;
 explain select * from bfv_tab1_with_invalid_index where unique1>42;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.05 rows=3 width=244)
    ->  Seq Scan on bfv_tab1_with_invalid_index  (cost=0.00..0.01 rows=1 width=244)
          Filter: (unique1 > 42)
  Optimizer: Postgres query optimizer
 (4 rows)
 
+-- Cannot currently upgrade table with invalid index
+-- (see https://github.com/greenplum-db/gpdb/issues/10805).
+drop table bfv_tab1_with_invalid_index;
 reset gp_enable_relsize_collection;
 --start_ignore
 DROP TABLE IF EXISTS bfv_tab2_facttable1;

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -48,6 +48,21 @@ explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i
  Optimizer status: Postgres query optimizer
 (8 rows)
 
+-- Test that we do not choose to perform an index scan if indisvalid=false.
+create table bfv_tab1_with_invalid_index (like bfv_tab1 including indexes);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+set allow_system_table_mods=on;
+update pg_index set indisvalid=false where indrelid='bfv_tab1_with_invalid_index'::regclass;
+reset allow_system_table_mods;
+explain select * from bfv_tab1_with_invalid_index where unique1>42;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.05 rows=3 width=244)
+   ->  Seq Scan on bfv_tab1_with_invalid_index  (cost=0.00..0.01 rows=1 width=244)
+         Filter: (unique1 > 42)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
 reset gp_enable_relsize_collection;
 --start_ignore
 DROP TABLE IF EXISTS bfv_tab2_facttable1;

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -51,6 +51,21 @@ explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i
  Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
 (9 rows)
 
+-- Test that we do not choose to perform an index scan if indisvalid=false.
+create table bfv_tab1_with_invalid_index (like bfv_tab1 including indexes);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+set allow_system_table_mods=on;
+update pg_index set indisvalid=false where indrelid='bfv_tab1_with_invalid_index'::regclass;
+reset allow_system_table_mods;
+explain select * from bfv_tab1_with_invalid_index where unique1>42;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=244)
+   ->  Seq Scan on bfv_tab1_with_invalid_index  (cost=0.00..431.00 rows=1 width=244)
+         Filter: (unique1 > 42)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
 reset gp_enable_relsize_collection;
 --start_ignore
 DROP TABLE IF EXISTS bfv_tab2_facttable1;

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -66,6 +66,9 @@ explain select * from bfv_tab1_with_invalid_index where unique1>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
+-- Cannot currently upgrade table with invalid index
+-- (see https://github.com/greenplum-db/gpdb/issues/10805).
+drop table bfv_tab1_with_invalid_index;
 reset gp_enable_relsize_collection;
 --start_ignore
 DROP TABLE IF EXISTS bfv_tab2_facttable1;

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -30,6 +30,13 @@ set gp_enable_relsize_collection=on;
 explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
     WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
 
+-- Test that we do not choose to perform an index scan if indisvalid=false.
+create table bfv_tab1_with_invalid_index (like bfv_tab1 including indexes);
+set allow_system_table_mods=on;
+update pg_index set indisvalid=false where indrelid='bfv_tab1_with_invalid_index'::regclass;
+reset allow_system_table_mods;
+explain select * from bfv_tab1_with_invalid_index where unique1>42;
+
 reset gp_enable_relsize_collection;
 
 --start_ignore

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -36,6 +36,9 @@ set allow_system_table_mods=on;
 update pg_index set indisvalid=false where indrelid='bfv_tab1_with_invalid_index'::regclass;
 reset allow_system_table_mods;
 explain select * from bfv_tab1_with_invalid_index where unique1>42;
+-- Cannot currently upgrade table with invalid index
+-- (see https://github.com/greenplum-db/gpdb/issues/10805).
+drop table bfv_tab1_with_invalid_index;
 
 reset gp_enable_relsize_collection;
 


### PR DESCRIPTION
Function `RelationGetIndexList()` does not filter out invalid indexes.
That responsiblity is left to the caller (e.g. `get_relation_info()`).
Issue is that Orca was not checking index validity.

This commit also introduces an optimization to Orca that is already used
in Planner whereby we first check relhasindex before checking pg_index.