### PR TITLE
[6X Backport]PANIC when register file to a non-active workfile set.

### DIFF
--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -234,8 +234,9 @@ RegisterFileWithSet(File file, workfile_set *work_set)
 
 	LWLockAcquire(WorkFileManagerLock, LW_EXCLUSIVE);
 
-	Assert(work_set->active);
-	Assert(work_set->perquery->active);
+	if (!work_set->active || !work_set->perquery->active)
+		ereport(PANIC,
+				(errmsg("Register file to a non-active workfile_set/per-query summary is illegal")));
 
 	localEntry->work_set = work_set;
 	work_set->num_files++;
@@ -386,8 +387,9 @@ WorkFileDeleted(File file)
 	perquery = work_set->perquery;
 	oldsize = localEntry->size;
 
-	Assert(work_set->active);
-	Assert(perquery->active);
+	if (!work_set->active || !work_set->perquery->active)
+		ereport(PANIC,
+				(errmsg("workfile_set/per-query summarry is not active")));
 
 	/*
 	 * Update the summaries in shared memory


### PR DESCRIPTION
We used to have `Assert` to check `RegisterFileWithSet` never register
file to a non-active workfile_set. But in production, there could be
some corner cases that caller register file to a non-active workfile_set.
It'll cause inconsistent `workfile_shared->num_active` with the real
active workfile_sets numbers under some situations.
For example,
1. `RegisterFileWithSet` a file to a created work_set. (current
`work_set->num_files` is 1)
2. `FileClose` closes the file and causes `WorkFileDeleted` to detele
the work_set since current `work_set->num_files` is 0 after detele file.
Which also decrease `workfile_shared->num_active`.
3.  `RegisterFileWithSet` another file to the created work_set(which
actually is not active now, but we dont't prevent that, only uses
`Assert` to check).
4. `FileClose` closes the file and causes `WorkFileDeleted` to detele
the work_set again. The `workfile_shared->num_active` gets decreased
again.

Raise PANIC to expose the coner cases.
Normally the caller of `RegisterFileWithSet` should ensure the correctness.
But we lack of the check in the `RegisterFileWithSet`.

(cherry picked from commit c23980cb7cecd880da78803d138e03f22e046801)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
