### PR TITLE
Avoid panic after Abort Prepared retry fails.

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -5548,6 +5548,11 @@ sigusr1_handler(SIGNAL_ARGS)
 		signal_child(FtsProbePID(), SIGINT);
 	}
 
+	if (CheckPostmasterSignal(PMSIGNAL_WAKEN_DTX_RECOVERY) && DtxRecoveryPID() != 0)
+	{
+		signal_child(DtxRecoveryPID(), SIGINT);
+	}
+
 	if (CheckPostmasterSignal(PMSIGNAL_ADVANCE_STATE_MACHINE) &&
 		(pmState == PM_WAIT_BACKUP || pmState == PM_WAIT_BACKENDS))
 	{

--- a/src/backend/utils/misc/ps_status.c
+++ b/src/backend/utils/misc/ps_status.c
@@ -364,7 +364,7 @@ set_ps_display(const char *activity, bool force)
 
 	/* Add client session's global id. */
 	if (gp_session_id > 0 && ep - cp > 0 &&
-		strstr(ps_buffer, "bgworker") == NULL) /* ugly hack for fts, dtx cleaner */
+		strstr(ps_buffer, "bgworker") == NULL) /* ugly hack for fts, dtx recovery */
 	{
 		cp += snprintf(cp, ep - cp, "con%d ", gp_session_id);
 

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -264,6 +264,7 @@ extern DtxContext DistributedTransactionContext;
 /* state variables for how much of the log file has been flushed */
 extern volatile bool *shmDtmStarted;
 extern volatile bool *shmCleanupBackends;
+extern volatile pid_t *shmDtxRecoveryPid;
 extern volatile DistributedTransactionTimeStamp *shmDistribTimeStamp;
 extern volatile DistributedTransactionId *shmGIDSeq;
 extern uint32 *shmNextSnapshotId;
@@ -342,6 +343,7 @@ extern bool currentGxactWriterGangLost(void);
 extern void addToGxactDtxSegments(struct Gang* gp);
 extern bool CurrentDtxIsRollingback(void);
 
+extern pid_t DtxRecoveryPID(void);
 extern void DtxRecoveryMain(Datum main_arg);
 extern bool DtxRecoveryStartRule(Datum main_arg);
 

--- a/src/include/storage/pmsignal.h
+++ b/src/include/storage/pmsignal.h
@@ -33,6 +33,7 @@ typedef enum
 	PMSIGNAL_ADVANCE_STATE_MACHINE,		/* advance postmaster's state machine */
 
 	PMSIGNAL_WAKEN_FTS,         /* wake up FTS to probe segments */
+	PMSIGNAL_WAKEN_DTX_RECOVERY,         /* wake up dtx recovery to abort dtx xacts */
 
 	NUM_PMSIGNALS				/* Must be last value of enum! */
 } PMSignalReason;

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -268,14 +268,6 @@ ALTER
  t              
 (1 row)
 
-14: alter system reset dtx_phase2_retry_second;
-ALTER
-14: select pg_reload_conf();
- pg_reload_conf 
-----------------
- t              
-(1 row)
-
 -- Scenario 5: QD panics when a QE process is doing prepare but not yet finished.
 -- This should cause dtx recovery finally aborts the orphaned prepared transaction.
 15: CREATE TABLE master_reset(a int);
@@ -397,3 +389,116 @@ ALTER
  transaction | gid | prepared | owner | database 
 -------------+-----+----------+-------+----------
 (0 rows)
+
+-- Scenario 6: retry Abort Prepared on QD fails but won't cause panic. The dtx
+-- recovery process finally aborts it.
+
+-- speed up testing by setting some gucs.
+20: ALTER SYSTEM SET gp_dtx_recovery_prepared_period to 0;
+ALTER
+20: ALTER SYSTEM SET gp_dtx_recovery_interval to 5;
+ALTER
+20: ALTER SYSTEM SET dtx_phase2_retry_second to 5;
+ALTER
+20: SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+
+20: CREATE TABLE test_retry_abort(a int);
+CREATE
+
+-- master: set fault to trigger abort prepare
+-- primary 0: set fault so that retry prepared abort fails.
+20: SELECT gp_inject_fault('dtm_broadcast_prepare', 'error', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+20: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'error', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- run two phase query.
+21: INSERT INTO test_retry_abort SELECT generate_series(1,10);
+ERROR:  fault triggered, fault name:'dtm_broadcast_prepare' fault type:'error'
+
+-- verify the transaction was aborted and there is one orphaned prepared
+-- transaction on seg0.
+20: SELECT * from test_retry_abort;
+ a 
+---
+(0 rows)
+0U: SELECT count(*) from pg_prepared_xacts;
+ count 
+-------
+ 1     
+(1 row)
+
+-- dtx recovery ready to handle the orphaned prepared transaction.
+20: SELECT gp_inject_fault_infinite('before_orphaned_check', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+20: SELECT gp_wait_until_triggered_fault('before_orphaned_check', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+20: SELECT gp_inject_fault_infinite('after_orphaned_check', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- kick off abort prepared on seg0 and then dtx recovery will abort that one.
+20: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+20: SELECT gp_inject_fault_infinite('before_orphaned_check', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- verify there is no orphaned prepared transaction on seg0.
+20: SELECT gp_wait_until_triggered_fault('after_orphaned_check', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+0U: SELECT * from pg_prepared_xacts;
+ transaction | gid | prepared | owner | database 
+-------------+-----+----------+-------+----------
+(0 rows)
+
+-- cleanup
+20: ALTER SYSTEM RESET gp_dtx_recovery_interval;
+ALTER
+20: ALTER SYSTEM RESET gp_dtx_recovery_prepared_period;
+ALTER
+20: ALTER SYSTEM RESET dtx_phase2_retry_second;
+ALTER
+20: SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+20: SELECT gp_inject_fault('dtm_broadcast_prepare', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+20: SELECT gp_inject_fault_infinite('after_orphaned_check', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+20: DROP TABLE test_retry_abort;
+DROP


### PR DESCRIPTION
Previously QD panicks when Abort Prepared retry fails but this is not friendly
due to master reset (all sessions are gone). The panic is not that needed since
even Abort Prepared fails the cluster is consistent, but we still need to try
to finish the Abort since the orphaned prepared transaction still holds
resources.  Now that we do periodical handling of orphaned prepared transaction
in the dtx recovery process, QD could simply ignore and then proceed if Abort
Prepared retry fails.
