### PR TITLE
Fix gpfdists hostname issue on centos7

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -685,14 +685,28 @@ fill_buffer(URL_CURL_FILE *curl, int want)
 						e, curl_easy_strerror(e));
 		}
 
-		if (maxfd <= 0)
+		if (maxfd == 0)
 		{
 			elog(LOG, "curl_multi_fdset set maxfd = %d", maxfd);
 			curl->still_running = 0;
 			break;
 		}
-		nfds = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
-
+		/* When libcurl returns -1 in max_fd, it is because libcurl currently does something
+		 * that isn't possible for your application to monitor with a socket and unfortunately
+		 * you can then not know exactly when the current action is completed using select().
+		 * You then need to wait a while before you proceed and call curl_multi_perform anyway
+		 */
+		if (maxfd == -1)
+		{
+			elog(DEBUG2, "curl_multi_fdset set maxfd = %d", maxfd);
+			pg_usleep(100000);
+			// to call curl_multi_perform
+			nfds = 1;
+		}
+		else
+		{
+			nfds = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
+		}
 		if (nfds == -1)
 		{
 			if (errno == EINTR || errno == EAGAIN)

--- a/src/bin/gpfdist/regress/.gitignore
+++ b/src/bin/gpfdist/regress/.gitignore
@@ -6,5 +6,7 @@ expected
 results
 data/gpfdist_ssl/tbl2.tbl
 data/gpfdist_ssl/certs_matching
+data/gpfdist_ssl/certs_multiCA
+data/gpfdist_ssl/certs_not_matching/root.crt
 regression.diffs
 regression.out

--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -6,9 +6,9 @@ default: installcheck
 REGRESS = exttab1 custom_format gpfdist2
 
 ifeq ($(enable_gpfdist),yes)
-#ifeq ($(with_openssl),yes)
-#	REGRESS += gpfdist_ssl
-#endif
+ifeq ($(with_openssl),yes)
+	REGRESS += gpfdist_ssl gpfdists_multiCA
+endif
 endif
 
 PSQLDIR = $(prefix)/bin
@@ -16,10 +16,10 @@ REGRESS_OPTS = --init-file=init_file
 
 installcheck: watchdog
 ifeq ($(enable_gpfdist),yes)
-#ifeq ($(with_openssl),yes)
-#	cp -rf $(MASTER_DATA_DIRECTORY)/gpfdists data/gpfdist_ssl/certs_matching
-#	cp data/gpfdist_ssl/certs_matching/root.crt data/gpfdist_ssl/certs_not_matching
-#endif
+ifeq ($(with_openssl),yes)
+	cp -rf $(MASTER_DATA_DIRECTORY)/gpfdists data/gpfdist_ssl/certs_matching
+	cp data/gpfdist_ssl/certs_matching/root.crt data/gpfdist_ssl/certs_not_matching
+endif
 endif
 	$(top_builddir)/src/test/regress/pg_regress --psqldir=$(PSQLDIR) --dbname=gpfdist_regression $(REGRESS) $(REGRESS_OPTS)
 

--- a/src/bin/gpfdist/regress/change_client_cert.bash
+++ b/src/bin/gpfdist/regress/change_client_cert.bash
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+for dir in $(find $MASTER_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+    do
+	if [ -d $(dirname $dir)/gpfdists ]; then
+	    cp $(dirname $dir)/gpfdists/client2.crt $(dirname $dir)/gpfdists/client.crt
+	    cp $(dirname $dir)/gpfdists/client2.key $(dirname $dir)/gpfdists/client.key
+	fi
+done

--- a/src/bin/gpfdist/regress/gen_multiCA_certs.bash
+++ b/src/bin/gpfdist/regress/gen_multiCA_certs.bash
@@ -21,7 +21,7 @@ openssl x509 -req -in $1ca.csr -CA $1root.crt -CAkey $1root.key \
     -days 365 -out $1ca.crt -sha256 -CAcreateserial
 
 openssl req -new -newkey rsa:2048 -nodes \
-    -subj "/C=US/ST=California/L=Palo Alto/O=Pivotal/CN=127.0.0.1" \
+    -subj "/C=US/ST=California/L=Palo Alto/O=Pivotal/CN=localhost" \
     -keyout $1.key  -out $1.csr
 
 openssl x509 -req -in $1.csr -CA $1ca.crt -CAkey $1ca.key \

--- a/src/bin/gpfdist/regress/gen_multiCA_certs.bash
+++ b/src/bin/gpfdist/regress/gen_multiCA_certs.bash
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: gen_multiCA_certs.bash CERTS_PATH"
+    exit 1
+fi
+
+CERTS_PATH=$1
+
+function gencert() {
+openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 \
+    -subj "/C=US/ST=California/L=Palo Alto/O=Pivotal/CN=$1root" \
+    -keyout $1root.key  -out $1root.crt
+
+openssl req -new -newkey rsa:4096 -nodes \
+    -subj "/C=US/ST=California/L=Palo Alto/O=Pivotal/CN=$1ca" \
+    -keyout $1ca.key -out $1ca.csr
+
+openssl x509 -req -in $1ca.csr -CA $1root.crt -CAkey $1root.key \
+    -extfile <(printf "basicConstraints=CA:TRUE") \
+    -days 365 -out $1ca.crt -sha256 -CAcreateserial
+
+openssl req -new -newkey rsa:2048 -nodes \
+    -subj "/C=US/ST=California/L=Palo Alto/O=Pivotal/CN=127.0.0.1" \
+    -keyout $1.key  -out $1.csr
+
+openssl x509 -req -in $1.csr -CA $1ca.crt -CAkey $1ca.key \
+    -days 365 -out $1.crt -sha256 -CAcreateserial
+}
+
+function generate_gpfdist_certs() {
+	mkdir -p ${CERTS_PATH}
+	pushd ${CERTS_PATH}
+	rm -f *.crt *.key *.csr *.srl
+	gencert server
+	gencert client
+	gencert client2
+	cp clientroot.crt root.crt
+	cat clientca.crt >> root.crt
+	cat client2root.crt >> root.crt
+	cat client2ca.crt >> root.crt
+	cat serverca.crt >> server.crt
+	rm -f *.csr *.srl
+	popd
+}
+
+function update_gpdb_certs() {
+    for dir in $(find $MASTER_DATA_DIRECTORY/../../.. -name pg_hba.conf)
+        do
+        if [ -d $(dirname $dir)/gpfdists ]; then
+            rm -rf $(dirname $dir)/gpfdists/*
+            cp -rf ${CERTS_PATH}/* $(dirname $dir)/gpfdists
+            cp $(dirname $dir)/gpfdists/serverroot.crt $(dirname $dir)/gpfdists/root.crt
+        fi
+    done
+}
+
+generate_gpfdist_certs
+update_gpdb_certs
+

--- a/src/bin/gpfdist/regress/input/gpfdists_multiCA.source
+++ b/src/bin/gpfdist/regress/input/gpfdists_multiCA.source
@@ -11,7 +11,7 @@ drop external table if exists gpfdist_ssl_stop;
 -- 'gpfdists' protocol
 -- --------------------------------------
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_multiCA </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_multiCA </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl -k https://localhost:7070 >/dev/null 2>&1; [ $? -ne 7 ] && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 
@@ -49,7 +49,7 @@ INSERT INTO tbl_on_heap VALUES
 ('ccc','twoc','shpits','2011-06-01 12:30:30',23,732,834567,45.67,789.123,7.12345,123.456789 );
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE WRITABLE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl SELECT * FROM tbl_on_heap;
 SELECT * FROM tbl_on_heap ORDER BY s1;
@@ -63,7 +63,7 @@ CREATE TABLE tbl_on_heap2 (
             n5 numeric, n6 real, n7 double precision);
 DROP EXTERNAL TABLE IF EXISTS tbl2;
 CREATE EXTERNAL TABLE tbl2 (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap2 SELECT * FROM tbl2;
 SELECT * FROM tbl_on_heap2 ORDER BY s1;
@@ -77,7 +77,7 @@ CREATE TABLE tbl_on_heap (
             n5 numeric, n6 real, n7 double precision);
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl','gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl','gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap SELECT * FROM tbl;
 SELECT * FROM tbl_on_heap ORDER BY s1;
@@ -90,7 +90,7 @@ SELECT * FROM tbl_on_heap ORDER BY s1;
 -- client cert changed
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 SELECT * FROM tbl;
 

--- a/src/bin/gpfdist/regress/input/gpfdists_multiCA.source
+++ b/src/bin/gpfdist/regress/input/gpfdists_multiCA.source
@@ -1,0 +1,99 @@
+--
+-- GPFDISTS test cases
+--
+
+-- start_ignore
+drop external table if exists gpfdist_ssl_start;
+drop external table if exists gpfdist_ssl_stop;
+-- end_ignore
+
+-- --------------------------------------
+-- 'gpfdists' protocol
+-- --------------------------------------
+CREATE EXTERNAL WEB TABLE gpfdist_ssl_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_multiCA </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+CREATE EXTERNAL WEB TABLE gpfdist_ssl_stop (x text)
+execute E'(ps -A -o pid,comm |grep [g]pfdist |grep -v postgres: |awk \'{print $1;}\' |xargs kill) > /dev/null 2>&1; echo "stopping..."'
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+-- start_ignore
+\! bash gen_multiCA_certs.bash data/gpfdist_ssl/certs_multiCA
+select * from gpfdist_ssl_stop;
+select * from gpfdist_ssl_start;
+-- end_ignore
+
+-- Helper to remove the output file
+DROP EXTERNAL WEB TABLE IF EXISTS clean_out_file;
+CREATE EXTERNAL WEB TABLE clean_out_file (x text)
+EXECUTE E'(rm -f @abs_srcdir@/data/gpfdist_ssl/tbl2.tbl)'
+on SEGMENT 0
+FORMAT 'text';
+
+-- Execute query to clean out the output file
+SELECT * FROM clean_out_file;
+
+-- gpfdists_multiCA case 1
+-- writable external table
+DROP TABLE IF EXISTS tbl_on_heap;
+CREATE TABLE tbl_on_heap (
+            s1 text, s2 text, s3 text, dt timestamp,
+            n1 smallint, n2 integer, n3 bigint, n4 decimal,
+            n5 numeric, n6 real, n7 double precision);
+INSERT INTO tbl_on_heap VALUES
+('aaa','twoa','shpits','2011-06-01 12:30:30',23,732,834567,45.67,789.123,7.12345,123.456789),
+('bbb','twob','shpits','2011-06-01 12:30:30',23,732,834567,45.67,789.123,7.12345,123.456789),
+('ccc','twoc','shpits','2011-06-01 12:30:30',23,732,834567,45.67,789.123,7.12345,123.456789 );
+DROP EXTERNAL TABLE IF EXISTS tbl;
+CREATE WRITABLE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
+LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+FORMAT 'TEXT' (DELIMITER '|' );
+INSERT INTO tbl SELECT * FROM tbl_on_heap;
+SELECT * FROM tbl_on_heap ORDER BY s1;
+
+-- gpfdists_multiCA case 2
+-- readable external table
+DROP TABLE IF EXISTS tbl_on_heap2;
+CREATE TABLE tbl_on_heap2 (
+            s1 text, s2 text, s3 text, dt timestamp,
+            n1 smallint, n2 integer, n3 bigint, n4 decimal,
+            n5 numeric, n6 real, n7 double precision);
+DROP EXTERNAL TABLE IF EXISTS tbl2;
+CREATE EXTERNAL TABLE tbl2 (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
+LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+FORMAT 'TEXT' (DELIMITER '|' );
+INSERT INTO tbl_on_heap2 SELECT * FROM tbl2;
+SELECT * FROM tbl_on_heap2 ORDER BY s1;
+
+-- gpfdists_multiCA case 3
+-- multiple location on same ETL server
+DROP TABLE IF EXISTS tbl_on_heap;
+CREATE TABLE tbl_on_heap (
+            s1 text, s2 text, s3 text, dt timestamp,
+            n1 smallint, n2 integer, n3 bigint, n4 decimal,
+            n5 numeric, n6 real, n7 double precision);
+DROP EXTERNAL TABLE IF EXISTS tbl;
+CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
+LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl','gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+FORMAT 'TEXT' (DELIMITER '|' );
+INSERT INTO tbl_on_heap SELECT * FROM tbl;
+SELECT * FROM tbl_on_heap ORDER BY s1;
+
+-- start_ignore
+\! bash change_client_cert.bash 
+-- end_ignore
+
+-- gpfdists_multiCA case 4
+-- client cert changed
+DROP EXTERNAL TABLE IF EXISTS tbl;
+CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
+LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+FORMAT 'TEXT' (DELIMITER '|' );
+SELECT * FROM tbl;
+
+-- start_ignore
+select * from gpfdist_ssl_stop;
+-- end_ignore

--- a/src/bin/gpfdist/regress/output/gpfdists_multiCA.source
+++ b/src/bin/gpfdist/regress/output/gpfdists_multiCA.source
@@ -7,7 +7,7 @@
 -- 'gpfdists' protocol
 -- --------------------------------------
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_multiCA </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_multiCA </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl -k https://localhost:7070 >/dev/null 2>&1; [ $? -ne 7 ] && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_stop (x text)
@@ -58,7 +58,7 @@ INSERT INTO tbl_on_heap VALUES
 DROP EXTERNAL TABLE IF EXISTS tbl;
 NOTICE:  table "tbl" does not exist, skipping
 CREATE WRITABLE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl SELECT * FROM tbl_on_heap;
 SELECT * FROM tbl_on_heap ORDER BY s1;
@@ -82,7 +82,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 DROP EXTERNAL TABLE IF EXISTS tbl2;
 NOTICE:  table "tbl2" does not exist, skipping
 CREATE EXTERNAL TABLE tbl2 (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap2 SELECT * FROM tbl2;
 SELECT * FROM tbl_on_heap2 ORDER BY s1;
@@ -104,7 +104,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl','gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl','gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap SELECT * FROM tbl;
 SELECT * FROM tbl_on_heap ORDER BY s1;
@@ -130,7 +130,7 @@ SELECT * FROM tbl_on_heap ORDER BY s1;
 DROP EXTERNAL TABLE IF EXISTS tbl;
 NOTICE:  table "tbl" does not exist, skipping
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 SELECT * FROM tbl;
  s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     

--- a/src/bin/gpfdist/regress/output/gpfdists_multiCA.source
+++ b/src/bin/gpfdist/regress/output/gpfdists_multiCA.source
@@ -7,11 +7,7 @@
 -- 'gpfdists' protocol
 -- --------------------------------------
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_matching </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
-on SEGMENT 0
-FORMAT 'text' (delimiter '|');
-CREATE EXTERNAL WEB TABLE gpfdist_ssl_not_matching_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_not_matching </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_multiCA </dev/null >/dev/null 2>&1 &); for i in `seq 1 60`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE gpfdist_ssl_stop (x text)
@@ -34,6 +30,7 @@ select * from gpfdist_ssl_start;
 -- end_ignore
 -- Helper to remove the output file
 DROP EXTERNAL WEB TABLE IF EXISTS clean_out_file;
+NOTICE:  table "clean_out_file" does not exist, skipping
 CREATE EXTERNAL WEB TABLE clean_out_file (x text)
 EXECUTE E'(rm -f @abs_srcdir@/data/gpfdist_ssl/tbl2.tbl)'
 on SEGMENT 0
@@ -44,7 +41,8 @@ SELECT * FROM clean_out_file;
 ---
 (0 rows)
 
--- gpfdist_ssl case 1
+-- gpfdists_multiCA case 1
+-- writable external table
 DROP TABLE IF EXISTS tbl_on_heap;
 NOTICE:  table "tbl_on_heap" does not exist, skipping
 CREATE TABLE tbl_on_heap (
@@ -58,6 +56,7 @@ INSERT INTO tbl_on_heap VALUES
 ('bbb','twob','shpits','2011-06-01 12:30:30',23,732,834567,45.67,789.123,7.12345,123.456789),
 ('ccc','twoc','shpits','2011-06-01 12:30:30',23,732,834567,45.67,789.123,7.12345,123.456789 );
 DROP EXTERNAL TABLE IF EXISTS tbl;
+NOTICE:  table "tbl" does not exist, skipping
 CREATE WRITABLE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
 LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
@@ -70,7 +69,8 @@ SELECT * FROM tbl_on_heap ORDER BY s1;
  ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
 (3 rows)
 
--- gpfdist_ssl case 2
+-- gpfdists_multiCA case 2
+-- readable external table
 DROP TABLE IF EXISTS tbl_on_heap2;
 NOTICE:  table "tbl_on_heap2" does not exist, skipping
 CREATE TABLE tbl_on_heap2 (
@@ -80,6 +80,7 @@ CREATE TABLE tbl_on_heap2 (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 DROP EXTERNAL TABLE IF EXISTS tbl2;
+NOTICE:  table "tbl2" does not exist, skipping
 CREATE EXTERNAL TABLE tbl2 (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
 LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
@@ -92,8 +93,8 @@ SELECT * FROM tbl_on_heap2 ORDER BY s1;
  ccc | twoc | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
 (3 rows)
 
--- gpfdist_ssl case 3
--- on same ETL server
+-- gpfdists_multiCA case 3
+-- multiple location on same ETL server
 DROP TABLE IF EXISTS tbl_on_heap;
 CREATE TABLE tbl_on_heap (
             s1 text, s2 text, s3 text, dt timestamp,
@@ -124,64 +125,13 @@ SELECT * FROM tbl_on_heap ORDER BY s1;
  jjj | twoj | shpits | Wed Jun 01 12:30:30 2011 | 23 | 732 | 834567 | 45.67 | 789.123 | 7.12345 | 123.456789
 (13 rows)
 
--- gpfdist_ssl case 4
-DROP TABLE IF EXISTS tbl_on_heap;
-CREATE TABLE tbl_on_heap (
-            s1 text, s2 text, s3 text, dt timestamp,
-            n1 smallint, n2 integer, n3 bigint, n4 decimal,
-            n5 numeric, n6 real, n7 double precision);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- gpfdists_multiCA case 4
+-- client cert changed
 DROP EXTERNAL TABLE IF EXISTS tbl;
-CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdist://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
-FORMAT 'TEXT' (DELIMITER '|' );
-INSERT INTO tbl_on_heap SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for gpfdist://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl. effective url: http://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl. error code = 104 (Connection reset by peer)  (seg1 slice1 172.17.0.2:25433 pid=59561)
-SELECT * FROM tbl_on_heap ORDER BY s1;
- s1 | s2 | s3 | dt | n1 | n2 | n3 | n4 | n5 | n6 | n7 
-----+----+----+----+----+----+----+----+----+----+----
-(0 rows)
-
--- gpfdist_ssl case 5
-DROP TABLE IF EXISTS tbl_on_heap;
-CREATE TABLE tbl_on_heap (
-            s1 text, s2 text, s3 text, dt timestamp,
-            n1 smallint, n2 integer, n3 bigint, n4 decimal,
-            n5 numeric, n6 real, n7 double precision);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-DROP EXTERNAL TABLE IF EXISTS tbl;
-CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl','gpfdist://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
-FORMAT 'TEXT' (DELIMITER '|' );
-ERROR:  URI protocols must be the same for all data sources
-HINT:  Available protocols are 'http', 'file', 'gpfdist' and 'gpfdists'
-DROP TABLE IF EXISTS tbl_on_heap;
--- start_ignore
-select * from gpfdist_ssl_stop;
-      x      
--------------
- stopping...
-(1 row)
-
-select * from gpfdist_ssl_not_matching_start;
-       x       
----------------
- 10000 gpfdist
-(1 row)
-
--- end_ignore
--- gpfdist_ssl case 6
-DROP EXTERNAL TABLE IF EXISTS tbl;
+NOTICE:  table "tbl" does not exist, skipping
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
 LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
-SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl. effective url: https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl.  (seg0 slice1 172.17.0.2:25432 pid=59537)
-DETAIL:  SSL certificate problem: self signed certificate
-SET verify_gpfdists_cert=off; 
-WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
 SELECT * FROM tbl;
  s1  |  s2  |   s3   |            dt            | n1 | n2  |   n3   |  n4   |   n5    |   n6    |     n7     
 -----+------+--------+--------------------------+----+-----+--------+-------+---------+---------+------------


### PR DESCRIPTION
On centos7, the system libcurl uses NSS instead of OpenSSL as backend
for TLS/SSL connections. Previously it will fail if hostname is used in external
table location, probably due to initialization issues.
This is fixed by commit 89a1211c on master. 

Backport d7e86dda, 89a1211c, 2f4aa7eb to fix gpfdists external table
issue on centos7. 
