### PR TITLE
Fix flaky test isolation2:terminate_in_gang_creation

### DIFF
--- a/src/test/isolation2/expected/terminate_in_gang_creation.out
+++ b/src/test/isolation2/expected/terminate_in_gang_creation.out
@@ -7,6 +7,25 @@ CREATE
 -- s/lock \[\d+,\d+\]//
 -- end_matchsubs
 
+-- skip dtx recovery check to avoid hitting the fault create_gang_in_progress.
+SELECT gp_inject_fault_infinite('before_orphaned_check', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+ALTER SYSTEM SET gp_dtx_recovery_interval to 5;
+ALTER
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+SELECT gp_wait_until_triggered_fault('before_orphaned_check', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
 -- SIGSEGV issue when freeing gangs
 --
 -- When SIGTERM is handled during gang creation we used to trigger
@@ -142,4 +161,16 @@ SELECT gp_inject_fault('fts_probe', 'reset', dbid) FROM gp_segment_configuration
  gp_inject_fault 
 -----------------
  Success:        
+(1 row)
+SELECT gp_inject_fault_infinite('before_orphaned_check', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+ALTER SYSTEM RESET gp_dtx_recovery_interval;
+ALTER
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
 (1 row)

--- a/src/test/isolation2/sql/terminate_in_gang_creation.sql
+++ b/src/test/isolation2/sql/terminate_in_gang_creation.sql
@@ -6,6 +6,14 @@ include: helpers/server_helpers.sql;
 -- s/lock \[\d+,\d+\]//
 -- end_matchsubs
 
+-- skip dtx recovery check to avoid hitting the fault create_gang_in_progress.
+SELECT gp_inject_fault_infinite('before_orphaned_check', 'skip', dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ALTER SYSTEM SET gp_dtx_recovery_interval to 5;
+SELECT pg_reload_conf();
+SELECT gp_wait_until_triggered_fault('before_orphaned_check', 1, dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content=-1;
+
 -- SIGSEGV issue when freeing gangs
 --
 -- When SIGTERM is handled during gang creation we used to trigger
@@ -85,4 +93,8 @@ SELECT pg_ctl(datadir, 'restart', 'immediate')
 11: RESET gp_vmem_idle_resource_timeout;
 
 SELECT gp_inject_fault('fts_probe', 'reset', dbid)
-FROM gp_segment_configuration WHERE role='p' AND content=-1;
+	FROM gp_segment_configuration WHERE role='p' AND content=-1;
+SELECT gp_inject_fault_infinite('before_orphaned_check', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content=-1;
+ALTER SYSTEM RESET gp_dtx_recovery_interval;
+SELECT pg_reload_conf();


### PR DESCRIPTION
The test depends on fault create_gang_in_progress. Previously the fault might
be hit by dtx recovery when creating a new gang. Let's skip
checking in dtx recovery to avoid the test flakiness.

The test flakiness looks like this:

 10&: SELECT * FROM foo a JOIN foo b USING (c2);  <waiting ...>
 +FAILED:  Forked command is not blocking; got output: c2 | c1 | c1
 +----+----+----
 +(0 rows)

 We could easily reproduce this by adding some sleep before the query.
