### PR TITLE
Fix flaky brin_ao regress test

### DIFF
--- a/src/test/regress/expected/brin_aocs.out
+++ b/src/test/regress/expected/brin_aocs.out
@@ -409,11 +409,11 @@ VACUUM brintest_aocs;  -- force a summarization cycle in brinaocsidx
 UPDATE brintest_aocs SET int8col = int8col * int4col;
 UPDATE brintest_aocs SET textcol = '' WHERE textcol IS NOT NULL;
 -- Vaccum again so that a new segment file is created.
-VACUUM brintest_ao;
-INSERT INTO brintest_ao SELECT * FROM brintest_ao;
+VACUUM brintest_aocs;
+INSERT INTO brintest_aocs SELECT * FROM brintest_aocs;
 -- We should have two segment files per Greenplum segment (QE).
 -- start_ignore
-SELECT segment_id, segno, tupcount, state FROM gp_toolkit.__gp_aoseg('brintest_ao');
+SELECT segment_id, segno, tupcount, state FROM gp_toolkit.__gp_aoseg('brintest_aocs');
  segment_id | segno | tupcount | state 
 ------------+-------+----------+-------
           1 |     1 |       78 |     1

--- a/src/test/regress/sql/brin_aocs.sql
+++ b/src/test/regress/sql/brin_aocs.sql
@@ -420,11 +420,11 @@ UPDATE brintest_aocs SET int8col = int8col * int4col;
 UPDATE brintest_aocs SET textcol = '' WHERE textcol IS NOT NULL;
 
 -- Vaccum again so that a new segment file is created.
-VACUUM brintest_ao;
-INSERT INTO brintest_ao SELECT * FROM brintest_ao;
+VACUUM brintest_aocs;
+INSERT INTO brintest_aocs SELECT * FROM brintest_aocs;
 -- We should have two segment files per Greenplum segment (QE).
 -- start_ignore
-SELECT segment_id, segno, tupcount, state FROM gp_toolkit.__gp_aoseg('brintest_ao');
+SELECT segment_id, segno, tupcount, state FROM gp_toolkit.__gp_aoseg('brintest_aocs');
 -- end_ignore
 
 -- Tests for brin_summarize_new_values


### PR DESCRIPTION
In the brin_ao regress test we create a table brintest_ao with a brin
index, then performs brin indexscan on different columns to verify the
correctness.  After that we also perform some vacuum tests, first vacuum
that table, then copy all the data to itself, and finally vacuum again.

There is also a similar brin_aocs regress test, the only difference is
that its table is brintest_aocs.

However there is a typo in brin_aocs, it vacuums brintest_ao instead of
brintest_aocs, as well as the data doubling.  So in brin_ao we can
randomly see below message:

    +WARNING:  unexpected number of results 106 for (int4rangecol,>,int4range,empty,53)

The actual number of results is double size of the expected one, that's
simply because that the data does is doubled concurrently.

Corrected the typo, both the brin_ao and brin_aocs should be stable now.

Co-authored-by: Pengzhou Tang <ptang@pivotal.io>
Co-authored-by: Ning Yu <nyu@pivotal.io>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
