### PR TITLE
6X: ic-proxy: support hostname as proxy addresses

### DIFF
--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -61,19 +61,17 @@ function make_cluster() {
 
       delta=-3000
 
-      psql -tqA -d postgres -P pager=off -F ' ' \
-          -c "select dbid, content, port+\$delta as port, address from gp_segment_configuration order by 1" \
-      | while read -r dbid content port addr; do
-          ip=127.0.0.1
-          echo "\$dbid:\$content:\$ip:\$port"
-        done \
-      | paste -sd, - \
-      | xargs -rI'{}' gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'{}'"
+      psql -tqA -d postgres -P pager=off -F: -R, \
+          -c "select dbid, content, address, port+\$delta as port
+                from gp_segment_configuration
+               order by 1" \
+      | xargs -rI'{}' \
+        gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'{}'"
 
       # also have to enlarge gp_interconnect_tcp_listener_backlog
       gpconfig -c gp_interconnect_tcp_listener_backlog -v 1024
 
-      gpstop -raqi
+      gpstop -u
 EOF
   fi
 

--- a/src/backend/cdb/motion/ic_proxy_addr.h
+++ b/src/backend/cdb/motion/ic_proxy_addr.h
@@ -22,6 +22,20 @@ struct ICProxyAddr
 
 	int			dbid;
 	int			content;
+
+	/*
+	 * Below two attributes are arguments to uv_getaddrinfo().
+	 *
+	 * That API allows "service" to be either a port number or a service name,
+	 * like "http".  In our case each segment needs a unique port on its host,
+	 * so it is more convenient to specify port numbers directly, so we only
+	 * support the port numbers in gp_interconnect_proxy_addresses, service
+	 * names will be considered as syntax errors.
+	 */
+	char		hostname[HOST_NAME_MAX];	/* hostname or IP */
+	char		service[32];				/* port number as a string */
+
+	uv_getaddrinfo_t req;
 };
 
 
@@ -31,9 +45,12 @@ struct ICProxyAddr
 extern List		   *ic_proxy_addrs;
 
 
-extern void ic_proxy_reload_addresses(void);
-extern int ic_proxy_get_my_port(void);
+extern void ic_proxy_reload_addresses(uv_loop_t *loop);
+extern const ICProxyAddr *ic_proxy_get_my_addr(void);
 extern int ic_proxy_addr_get_port(const ICProxyAddr *addr);
+extern int ic_proxy_extract_addr(const struct sockaddr *addr,
+								 char *name, size_t namelen,
+								 int *port, int *family);
 
 
 #endif   /* IC_PROXY_ADDR_H */


### PR DESCRIPTION
The GUC gp_interconnect_proxy_addresses is used to set the listener
addresses and ports of all the proxy bgworkers, only IP addresses were
supported previously, which is inconvenient to use.

Now we add the support for hostnames too, the IP addresses are also
supported.

Note that if a hostname is bound to a different IP at runtime, we must
reload the setting with the "gpstop -u" command.

Reviewed-by: Hubert Zhang <hzhang@pivotal.io>
(cherry picked from commit 2a1794bc47e58ea033e68ee1d8ef3ab2f999706f)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
