### PR TITLE
Fix flaky test uao_crash_compaction_column

### DIFF
--- a/src/test/isolation2/expected/prepared_xact_deadlock_pg_rewind.out
+++ b/src/test/isolation2/expected/prepared_xact_deadlock_pg_rewind.out
@@ -66,8 +66,18 @@ ERROR:  Error on receive from seg0 10.152.8.141:7002 pid=20285: server closed th
 -- postgres starting in InitPostgres() and thus pg_rewind hangs forever.
 !\retcode gprecoverseg -a;
 (exited with code 0)
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
 !\retcode gprecoverseg -ar;
 (exited with code 0)
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
 
 -- reset fts GUCs.
 3: alter system reset gp_fts_probe_retries;

--- a/src/test/isolation2/sql/prepared_xact_deadlock_pg_rewind.sql
+++ b/src/test/isolation2/sql/prepared_xact_deadlock_pg_rewind.sql
@@ -30,7 +30,9 @@ include: helpers/server_helpers.sql;
 -- with mode 5, but that conflicts with the mode 3 lock which is needed during
 -- postgres starting in InitPostgres() and thus pg_rewind hangs forever.
 !\retcode gprecoverseg -a;
+select wait_until_all_segments_synchronized();
 !\retcode gprecoverseg -ar;
+select wait_until_all_segments_synchronized();
 
 -- reset fts GUCs.
 3: alter system reset gp_fts_probe_retries;


### PR DESCRIPTION
@@ -14,11 +14,11 @@
  role | preferred_role | content | mode | status
  ------+----------------+---------+------+--------
  m    | m              | -1      | s    | u
- m    | m              | 0       | s    | u
+ m    | m              | 0       | n    | u

The root cause has nothing to do with this test case.  It's because test
prepared_xact_deadlock_pg_rewind finally calls gprecoverseg to recover the
cluster but does not wait until the cluster state restores.