### PR TITLE
Fix gpexpand help usage

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -93,7 +93,7 @@ Remaining TODO items:
 
 _usage = """[-f hosts_file]
 
-gpexpand -i input_file [-B batch_size] [-V] [-t segment_tar_dir] [-S]
+gpexpand -i input_file [-B batch_size] [-t segment_tar_dir] [-S]
 
 gpexpand [-d duration[hh][:mm[:ss]] | [-e 'YYYY-MM-DD hh:mm:ss']]
          [-a] [-n parallel_processes]


### PR DESCRIPTION
In commit 5eaa5889, the `--novacuum` option is removed, however the help
page of gpexpand keeps the `-V` option, which is a short option for
`--novacuum`.

This pull request remove the `-V` option in gpexpand help page.
