### PR TITLE
Fix assertion failure with GROUP BY on FULL JOIN.

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -1560,7 +1560,8 @@ choose_grouping_locus(PlannerInfo *root, Path *path,
 		CdbPathLocus_MakeSingleQE(&locus, getgpsegmentCount());
 	}
 	/* If the input is already suitably distributed, no need to redistribute */
-	else if (cdbpathlocus_is_hashed_on_tlist(path->locus, group_tles, true))
+	else if (!CdbPathLocus_IsHashedOJ(path->locus) &&
+			 cdbpathlocus_is_hashed_on_tlist(path->locus, group_tles, true))
 	{
 		need_redistribute = false;
 		CdbPathLocus_MakeNull(&locus);

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1720,6 +1720,50 @@ SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y G
     |  500
 (16 rows)
 
+EXPLAIN (COSTS OFF)
+SELECT a.x, b.y, count(*) FROM pagg_tab1 a FULL JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x, b.y;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: a.x, b.y
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: a.x, b.y
+               ->  Hash Full Join
+                     Hash Cond: (a.x = b.y)
+                     ->  Seq Scan on pagg_tab1 a
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: b.y
+                                 ->  Seq Scan on pagg_tab2 b
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+SELECT a.x, b.y, count(*) FROM pagg_tab1 a FULL JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x, b.y;
+ x  | y  | count 
+----+----+-------
+ 26 |    |    10
+ 28 |    |    10
+  4 |    |    10
+    | 15 |    10
+  6 |  6 |   100
+  8 |    |    10
+  2 |    |    10
+ 22 |    |    10
+ 10 |    |    10
+    |  9 |    10
+    | 21 |    10
+  0 |  0 |   100
+ 14 |    |    10
+ 12 | 12 |   100
+    |  3 |    10
+ 16 |    |    10
+    | 27 |    10
+ 18 | 18 |   100
+ 20 |    |    10
+ 24 | 24 |   100
+(20 rows)
+
 --
 -- Test GROUP BY with a constant
 --

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1722,6 +1722,53 @@ SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y G
     |  500
 (16 rows)
 
+EXPLAIN (COSTS OFF)
+SELECT a.x, b.y, count(*) FROM pagg_tab1 a FULL JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x, b.y;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: pagg_tab1.x, pagg_tab2.y
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: pagg_tab1.x, pagg_tab2.y
+               ->  Merge Full Join
+                     Merge Cond: (pagg_tab1.x = pagg_tab2.y)
+                     ->  Sort
+                           Sort Key: pagg_tab1.x
+                           ->  Seq Scan on pagg_tab1
+                     ->  Sort
+                           Sort Key: pagg_tab2.y
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: pagg_tab2.y
+                                 ->  Seq Scan on pagg_tab2
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
+SELECT a.x, b.y, count(*) FROM pagg_tab1 a FULL JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x, b.y;
+ x  | y  | count 
+----+----+-------
+ 26 |    |    10
+ 28 |    |    10
+  4 |    |    10
+    | 15 |    10
+  6 |  6 |   100
+  8 |    |    10
+  2 |    |    10
+ 22 |    |    10
+ 10 |    |    10
+    |  9 |    10
+    | 21 |    10
+  0 |  0 |   100
+ 14 |    |    10
+ 12 | 12 |   100
+    |  3 |    10
+ 16 |    |    10
+    | 27 |    10
+ 18 | 18 |   100
+ 20 |    |    10
+ 24 | 24 |   100
+(20 rows)
+
 --
 -- Test GROUP BY with a constant
 --

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1433,6 +1433,11 @@ EXPLAIN (COSTS OFF)
 SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x ORDER BY 1 NULLS LAST;
 SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x ORDER BY 1 NULLS LAST;
 
+
+EXPLAIN (COSTS OFF)
+SELECT a.x, b.y, count(*) FROM pagg_tab1 a FULL JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x, b.y;
+SELECT a.x, b.y, count(*) FROM pagg_tab1 a FULL JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x, b.y;
+
 --
 -- Test GROUP BY with a constant
 --


### PR DESCRIPTION
Bumped into this while merging 'master' to the PostgreSQL v12 merge
branch. An upstream test query similar to that added to the
'bfv_aggregate' test in this commit failed on the merge branch, in the
'partition_aggregate' test.
