### PR TITLE
[5X Backport] Align Orca relhasindex behavior with Planner (#10788)

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2448,8 +2448,11 @@ gpdb::GetRelationIndexes
 {
 	GP_WRAP_START;
 	{
-		/* catalog tables: from relcache */
-		return RelationGetIndexList(relation);
+		if (relation->rd_rel->relhasindex)
+		{
+			/* catalog tables: from relcache */
+			return RelationGetIndexList(relation);
+		}
 	}
 	GP_WRAP_END;
 	return NIL;

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -3422,6 +3422,7 @@ CTranslatorRelcacheToDXL::IsIndexSupported
 	// index expressions and index constraints not supported
 	return gpdb::HeapAttIsNull(tup, Anum_pg_index_indexprs) &&
 		gpdb::HeapAttIsNull(tup, Anum_pg_index_indpred) &&
+		index_rel->rd_index->indisvalid &&
 		(BTREE_AM_OID == index_rel->rd_rel->relam || BITMAP_AM_OID == index_rel->rd_rel->relam  || GIST_AM_OID == index_rel->rd_rel->relam);
 }
 

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -48,6 +48,25 @@ explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i
  Optimizer status: legacy query optimizer
 (8 rows)
 
+-- Test that we do not choose to perform an index scan if indisvalid=false.
+create table bfv_tab1_with_invalid_index (like bfv_tab1 including indexes);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+set allow_system_table_mods='DML';
+update pg_index set indisvalid=false where indrelid='bfv_tab1_with_invalid_index'::regclass;
+reset allow_system_table_mods;
+explain select * from bfv_tab1_with_invalid_index where unique1>42;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=244)
+   ->  Seq Scan on bfv_tab1_with_invalid_index  (cost=0.00..0.00 rows=1 width=244)
+         Filter: unique1 > 42
+ Settings:  gp_enable_relsize_collection=on
+ Optimizer status: legacy query optimizer
+(5 rows)
+
+-- Cannot currently upgrade table with invalid index
+-- (see https://github.com/greenplum-db/gpdb/issues/10805).
+drop table bfv_tab1_with_invalid_index;
 reset gp_enable_relsize_collection;
 --start_ignore
 DROP TABLE IF EXISTS bfv_tab2_facttable1;

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -52,6 +52,25 @@ explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i
  Optimizer status: PQO version 2.35.1
 (10 rows)
 
+-- Test that we do not choose to perform an index scan if indisvalid=false.
+create table bfv_tab1_with_invalid_index (like bfv_tab1 including indexes);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+set allow_system_table_mods='DML';
+update pg_index set indisvalid=false where indrelid='bfv_tab1_with_invalid_index'::regclass;
+reset allow_system_table_mods;
+explain select * from bfv_tab1_with_invalid_index where unique1>42;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=244)
+   ->  Table Scan on bfv_tab1_with_invalid_index  (cost=0.00..431.00 rows=1 width=244)
+         Filter: unique1 > 42
+ Settings:  gp_enable_relsize_collection=on
+ Optimizer status: PQO version 3.110.0
+(5 rows)
+
+-- Cannot currently upgrade table with invalid index
+-- (see https://github.com/greenplum-db/gpdb/issues/10805).
+drop table bfv_tab1_with_invalid_index;
 reset gp_enable_relsize_collection;
 --start_ignore
 DROP TABLE IF EXISTS bfv_tab2_facttable1;

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -30,6 +30,16 @@ set gp_enable_relsize_collection=on;
 explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
     WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
 
+-- Test that we do not choose to perform an index scan if indisvalid=false.
+create table bfv_tab1_with_invalid_index (like bfv_tab1 including indexes);
+set allow_system_table_mods='DML';
+update pg_index set indisvalid=false where indrelid='bfv_tab1_with_invalid_index'::regclass;
+reset allow_system_table_mods;
+explain select * from bfv_tab1_with_invalid_index where unique1>42;
+-- Cannot currently upgrade table with invalid index
+-- (see https://github.com/greenplum-db/gpdb/issues/10805).
+drop table bfv_tab1_with_invalid_index;
+
 reset gp_enable_relsize_collection;
 
 --start_ignore


### PR DESCRIPTION
Trivial conflict in `IsIndexSupported()` due to eae823f4d7d0
Passed ICW: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-dkimura

---

Function `RelationGetIndexList()` does not filter out invalid indexes.
That responsiblity is left to the caller (e.g. `get_relation_info()`).
Issue is that Orca was not checking index validity.

This commit also introduces an optimization to Orca that is already used
in Planner whereby we first check relhasindex before checking pg_index.

(cherry picked from commit b011c3518bb068a4c886d2898b50664f640eec5e)
