### PR TITLE
Use the same code for generating two-stage DISTINCT plans as GROUP BY

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -5,7 +5,7 @@
  *    execution.  This is, essentially, an extension of the file
  *    optimizer/plan/planner.c, although some functions are not
  *    externalized.
-
+ *
  *
  * The general shape of the generated plan is similar to the parallel
  * aggregation plans in upstream:
@@ -84,23 +84,56 @@ typedef enum
  */
 typedef struct
 {
+	/* From the Query */
+	bool		hasAggs;
+	List	   *groupClause;	/* a list of SortGroupClause's */
+	List	   *groupingSets;	/* a list of GroupingSet's if present */
+	List	   *group_tles;
+
 	/* Inputs from the caller */
-	DQAType     type;
-	List	   *havingQual;
+	List	   *havingQual;		/* qualifications applied to groups */
 	PathTarget *target;			/* targetlist of final aggregated result */
+	bool		can_sort;
+	bool		can_hash;
 	double		dNumGroupsTotal;		/* total number of groups in the result, across all QEs */
 	const AggClauseCosts *agg_costs;
 	const AggClauseCosts *agg_partial_costs;
 	const AggClauseCosts *agg_final_costs;
 	List	   *rollups;
 
-	List	   *group_tles;
-
 	PathTarget *partial_grouping_target;	/* targetlist of partially aggregated result */
 	List	   *final_groupClause;			/* SortGroupClause for final grouping */
 	List	   *final_group_tles;
-	List	   *final_group_input_pathkeys;	/* order of the input to (sorted) second stage */
-	List	   *final_group_pathkeys;		/* order of the result of sorted second stage */
+	Index		gsetid_sortref;
+
+	/*
+	 * Pathkeys representing GROUP BY.
+	 *
+	 * 'partial_needed_pathkeys' represents a sort order that's needed for
+	 * doing a sorted GroupAggregate in the first
+	 * stage. 'partial_sort_pathkey' is normally the same, but in case of
+	 * DISTINCT ON and ORDER BY it can include extra columns that are presentt
+	 * in the ORDER BY but not in DISTINCT ON. The idea is the needed_pathkeys
+	 * are sufficient to perform the grouping, but if we have to sort the
+	 * input, we sort using sort_pathkeys. By including the extra columns in
+	 * the Sort we can avoid sorting the data again later to satisfy the ORDER
+	 * BY.
+	 *
+	 * 'final_needed_pathkeys' is the sort order needed to perform the 2nd
+	 * stage by sorted GroupAggregate.  In normal GROUP BY it is the same as
+	 * 'partial_needed_pathkeys', but if there are GROUPING SETS,
+	 * 'final_needed_pathkeys' includes the internal GROUPINGSET_ID()
+	 * expression, used to distinguish the rolled up rows. And
+	 * 'final_sort_pathkeys' is the same, but might include extra ORDER BY
+	 * columns.
+	 *
+	 */
+	List	   *partial_needed_pathkeys;
+	List	   *partial_sort_pathkeys;
+	List	   *final_needed_pathkeys;
+	List	   *final_sort_pathkeys;
+
+	DQAType     type;
 
 	/*
 	 * partial_rel holds the partially aggregated results from the first stage.
@@ -124,6 +157,8 @@ typedef struct
 
 } cdb_multi_dqas_info;
 
+static void create_two_stage_paths(PlannerInfo *root, cdb_agg_planning_context *ctx,
+								   RelOptInfo *input_rel, RelOptInfo *output_rel);
 static List *get_common_group_tles(PathTarget *target,
 								   List *groupClause,
 								   List *rollups);
@@ -135,6 +170,7 @@ static CdbPathLocus choose_grouping_locus(PlannerInfo *root, Path *path,
 static Index add_gsetid_tlist(List *tlist);
 
 static SortGroupClause *create_gsetid_groupclause(Index groupref);
+static List *strip_gsetid_from_pathkeys(Index gsetid_sortref, List *pathkeys);
 
 static void add_first_stage_group_agg_path(PlannerInfo *root,
 										   Path *path,
@@ -191,34 +227,34 @@ static PathTarget *
 strip_aggdistinct(PathTarget *target);
 
 /*
- * Function: cdb_grouping_planner
+ * cdb_create_multistage_grouping_paths
  *
  * This is basically an extension of the function create_grouping_paths() from
  * planner.c.  It creates two- and three-stage Paths to implement aggregates
  * and/or GROUP BY.
  *
- * The caller already constructed a one-stage plan, we are only concerned
- * about more complicated multi-stage plans here.
+ * The caller already constructed Paths for one-stage plans, we are only
+ * concerned about more complicated multi-stage plans here.
  */
 void
-cdb_create_twostage_grouping_paths(PlannerInfo *root,
-								   RelOptInfo *input_rel,
-								   RelOptInfo *output_rel,
-								   PathTarget *target,
-								   PathTarget *partial_grouping_target,
-								   List *havingQual,
-								   bool can_sort,
-								   bool can_hash,
-								   double dNumGroupsTotal,
-								   const AggClauseCosts *agg_costs,
-								   const AggClauseCosts *agg_partial_costs,
-								   const AggClauseCosts *agg_final_costs,
-								   List *rollups)
+cdb_create_multistage_grouping_paths(PlannerInfo *root,
+									 RelOptInfo *input_rel,
+									 RelOptInfo *output_rel,
+									 PathTarget *target,
+									 PathTarget *partial_grouping_target,
+									 List *havingQual,
+									 double dNumGroupsTotal,
+									 const AggClauseCosts *agg_costs,
+									 const AggClauseCosts *agg_partial_costs,
+									 const AggClauseCosts *agg_final_costs,
+									 List *rollups)
 {
 	Query	   *parse = root->parse;
 	Path	   *cheapest_path = input_rel->cheapest_total_path;
 	bool		has_ordered_aggs = agg_costs->numPureOrderedAggs > 0;
 	cdb_agg_planning_context ctx;
+	bool		can_sort;
+	bool		can_hash;
 
 	/* The caller should've checked these already */
 	Assert(parse->hasAggs || parse->groupClause);
@@ -247,18 +283,37 @@ cdb_create_twostage_grouping_paths(PlannerInfo *root,
 		return;
 
 	/*
+	 * Is the input hashable / sortable? This is largely the same logic as in
+	 * upstream create_grouping_paths(), but we can do hashing in limited ways
+	 * even if there are DISTINCT aggs or grouping setst.
+	 *
+	 * GPDB_12_MERGE:FIXME: the similar rules in planner.c got more complicated.
+	 * Does this need to be more fine-grained too? See GROUPING_CAN_USE_SORT and
+	 * GROUPING_CAN_USE_HASH.
+	 */
+	can_sort = grouping_is_sortable(parse->groupClause);
+	can_hash = (parse->groupClause != NIL &&
+				agg_costs->numPureOrderedAggs == 0 &&
+				grouping_is_hashable(parse->groupClause));
+
+	/*
 	 * Prepare a struct to hold the arguments and intermediate results
 	 * across subroutines.
 	 */
 	memset(&ctx, 0, sizeof(ctx));
-	ctx.havingQual = havingQual;
+	ctx.can_sort = can_sort;
+	ctx.can_hash = can_hash;
 	ctx.target = target;
 	ctx.dNumGroupsTotal = dNumGroupsTotal;
 	ctx.agg_costs = agg_costs;
 	ctx.agg_partial_costs = agg_partial_costs;
 	ctx.agg_final_costs = agg_final_costs;
 	ctx.rollups = rollups;
-
+	ctx.hasAggs = parse->hasAggs;
+	ctx.groupClause = parse->groupClause;
+	ctx.groupingSets = parse->groupingSets;
+	ctx.havingQual = havingQual;
+	ctx.partial_rel = fetch_upper_rel(root, UPPERREL_CDB_FIRST_STAGE_GROUP_AGG, NULL);
 	/* create a partial rel similar to make_grouping_rel() */
 	if (IS_OTHER_REL(input_rel))
 	{
@@ -271,6 +326,8 @@ cdb_create_twostage_grouping_paths(PlannerInfo *root,
 		ctx.partial_rel = fetch_upper_rel(root, UPPERREL_CDB_FIRST_STAGE_GROUP_AGG,
 										  NULL);
 	}
+	ctx.partial_needed_pathkeys = root->group_pathkeys;
+	ctx.partial_sort_pathkeys = root->group_pathkeys;
 
 	ctx.group_tles = get_common_group_tles(target,
 										   parse->groupClause,
@@ -331,13 +388,11 @@ cdb_create_twostage_grouping_paths(PlannerInfo *root,
 	 */
 	if (parse->groupingSets)
 	{
-		Index		groupref;
 		GroupingSetId *gsetid;
 		List	   *grouping_sets_tlist;
 		SortGroupClause *gsetcl;
 		List	   *gcls;
 		List	   *tlist;
-		List	   *pl;
 
 		/* GPDB_12_MERGE_FIXME: For now, bail out if there are any unsortable
 		 * refs. PostgreSQL supports hashing with grouping sets nowadays, but
@@ -354,148 +409,51 @@ cdb_create_twostage_grouping_paths(PlannerInfo *root,
 
 		gsetid = makeNode(GroupingSetId);
 		grouping_sets_tlist = copyObject(root->processed_tlist);
-		groupref = add_gsetid_tlist(grouping_sets_tlist);
+		ctx.gsetid_sortref = add_gsetid_tlist(grouping_sets_tlist);
 
-		gsetcl = create_gsetid_groupclause(groupref);
+		gsetcl = create_gsetid_groupclause(ctx.gsetid_sortref);
 
 		ctx.final_groupClause = lappend(copyObject(parse->groupClause), gsetcl);
 
 		ctx.partial_grouping_target = copyObject(partial_grouping_target);
 		if (!list_member(ctx.partial_grouping_target->exprs, gsetid))
 			add_column_to_pathtarget(ctx.partial_grouping_target,
-									 (Expr *) gsetid, groupref);
+									 (Expr *) gsetid, ctx.gsetid_sortref);
 
 		gcls = get_all_rollup_groupclauses(rollups);
+		gcls = lappend(gcls, gsetcl);
 		tlist = make_tlist_from_pathtarget(ctx.partial_grouping_target);
 
-		/* The final result will be sorted by this */
-		ctx.final_group_pathkeys = make_pathkeys_for_sortclauses(root, gcls, tlist);
-
 		/*
-		 * The input to the second-stage sorted Agg has GROUPINGSET_ID() as the last
-		 * sort key. It is not present in the final Agg result.
+		 * The input to the final stage will be sorted by this. It includes the
+		 * GROUPINGSET_ID() column.
 		 */
-		pl = make_pathkeys_for_sortclauses(root, list_make1(gsetcl), tlist);
-		ctx.final_group_input_pathkeys = list_concat(list_copy(ctx.final_group_pathkeys), pl);
+		ctx.final_needed_pathkeys = make_pathkeys_for_sortclauses(root, gcls, tlist);
 	}
 	else
 	{
 		ctx.partial_grouping_target = partial_grouping_target;
 		ctx.final_groupClause = parse->groupClause;
-		ctx.final_group_input_pathkeys = root->group_pathkeys;
-		ctx.final_group_pathkeys = root->group_pathkeys;
+		ctx.final_needed_pathkeys = root->group_pathkeys;
+		ctx.gsetid_sortref = 0;
 	}
+	ctx.final_sort_pathkeys = ctx.final_needed_pathkeys;
 	ctx.final_group_tles = get_common_group_tles(ctx.partial_grouping_target,
 												 ctx.final_groupClause,
 												 NIL);
 	ctx.partial_rel->reltarget = ctx.partial_grouping_target;
 
 	/*
-	 * Consider ways to do the first Aggregate stage.
-	 *
-	 * The first stage's output is Partially Aggregated. The paths are
-	 * collected to the ctx->partial_rel, by calling add_path(). We do *not*
-	 * use add_partial_path(), these partially aggregated paths are considered
-	 * more like MPP paths in Greenplum in general.
-	 *
-	 * First consider sorted Aggregate paths.
+	 * All set, generate the two-stage paths.
 	 */
-	if (can_sort)
-	{
-		ListCell   *lc;
-
-		foreach(lc, input_rel->pathlist)
-		{
-			Path	   *path = (Path *) lfirst(lc);
-			bool		is_sorted;
-
-			/*
-			 * If the input is neatly distributed along the GROUP BY columns,
-			 * there's no point in a two-stage plan. The code in planner.c
-			 * already created the straightforward one-stage plan.
-			 */
-			if (cdbpathlocus_collocates_tlist(root, path->locus, ctx.group_tles))
-				continue;
-
-			/*
-			 * Consider input paths that are already sorted, and the one with
-			 * the lowest total cost.
-			 */
-			is_sorted = pathkeys_contained_in(root->group_pathkeys,
-											  path->pathkeys);
-			if (path == cheapest_path || is_sorted)
-				add_first_stage_group_agg_path(root, path, is_sorted, &ctx);
-		}
-	}
-
-	/*
-	 * Consider Hash Aggregate over the cheapest input path.
-	 *
-	 * Hashing is not possible with DQAs.
-	 *
-	 * GPDB_12_MERGE_FIXME: hashing not supported on GROUPING SETS, until
-	 * PostgreSQL v12. We do support hashing in the second stage even with
-	 * GROUPING SETS, though.
-	 */
-	if (can_hash &&
-		list_length(agg_costs->distinctAggrefs) == 0 &&
-		parse->groupingSets == NIL)
-	{
-		/*
-		 * If the input is neatly distributed along the GROUP BY columns,
-		 * there's no point in a two-stage plan. The code in planner.c already
-		 * created the straightforward one-stage plan.
-		 */
-		if (!cdbpathlocus_collocates_tlist(root, cheapest_path->locus, ctx.group_tles))
-			add_first_stage_hash_agg_path(root, cheapest_path, &ctx);
-	}
-
-	/*
-	 * We now have partially aggregated paths in ctx->partial_rel. Consider
-	 * different ways of performing the Finalize Aggregate stage.
-	 */
-	if (ctx.partial_rel->pathlist)
-	{
-		Path	   *cheapest_first_stage_path;
-
-		set_cheapest(ctx.partial_rel);
-		cheapest_first_stage_path = ctx.partial_rel->cheapest_total_path;
-		if (can_sort)
-		{
-			ListCell   *lc;
-
-			foreach(lc, ctx.partial_rel->pathlist)
-			{
-				Path	   *path = (Path *) lfirst(lc);
-				bool		is_sorted;
-
-				/*
-				 * In two-stage GROUPING SETS paths, the second stage's grouping
-				 * will include GROUPINGSET_ID(), which is not included in
-				 * root->pathkeys. The first stage's sort order does not include
-				 * that, so we know it's not sorted.
-				 */
-				if (!parse->groupingSets)
-					is_sorted = pathkeys_contained_in(root->group_pathkeys,
-													  path->pathkeys);
-				else
-					is_sorted = false;
-				if (path == cheapest_first_stage_path || is_sorted)
-					add_second_stage_group_agg_path(root, path, is_sorted,
-													&ctx, output_rel);
-			}
-		}
-
-		if (can_hash && list_length(agg_costs->distinctAggrefs) == 0)
-			add_second_stage_hash_agg_path(root, cheapest_first_stage_path,
-										   &ctx, output_rel);
-	}
+	create_two_stage_paths(root, &ctx, input_rel, output_rel);
 
 	/*
 	 * Aggregates with DISTINCT arguments are more complicated, and are not
-	 * handled above (except for the case of a single DQA that happens to
-	 * be collocated with the input, see add_first_stage_group_agg_path()).
-	 * Consider ways to implement them, too.
+	 * handled by create_two_stage_paths() (except for the case of a single
+	 * DQA that happens to be collocated with the input, see
+	 * add_first_stage_group_agg_path()). Consider ways to implement them,
+	 * too.
 	 */
 	if ((can_hash || parse->groupClause == NIL) &&
 		!parse->groupingSets &&
@@ -553,6 +511,235 @@ cdb_create_twostage_grouping_paths(PlannerInfo *root,
 }
 
 /*
+ * cdb_create_twostage_distinct_paths
+ *
+ * Alternative entry point for DISTINCT planning.
+ *
+ * This is basically an extension of the function create_distinct_paths() in
+ * planner.c.  It creates two-stage Aggregate Paths to implement DISTINCT.
+ * The caller already constructed a Paths for one-stage plans.
+ *
+ * 'input_rel' is usually the result of query_planner(), but it can also be
+ * the result of windowing and/or GROUP BY planning, if the query contains
+ * both DISTINCT and GROUP BY/windowing.
+ */
+void
+cdb_create_twostage_distinct_paths(PlannerInfo *root,
+								   RelOptInfo *input_rel,
+								   RelOptInfo *output_rel,
+								   PathTarget *target,
+								   double dNumGroupsTotal)
+{
+	Query	   *parse = root->parse;
+	Path	   *cheapest_path = input_rel->cheapest_total_path;
+	AggClauseCosts zero_agg_costs;
+	cdb_agg_planning_context ctx;
+	bool		allow_sort;
+	bool		allow_hash;
+
+	/*
+	 * We are currently unwilling to redistribute a gathered intermediate
+	 * across the cluster.  This might change one day.
+	 */
+	if (!CdbPathLocus_IsPartitioned(cheapest_path->locus))
+		return;
+
+	/*
+	 * Is the input hashable / sortable?
+	 */
+	allow_sort = grouping_is_sortable(parse->distinctClause);
+	if (parse->hasDistinctOn || !enable_hashagg)
+		allow_hash = false;		/* policy-based decision not to hash */
+	else if (!grouping_is_hashable(parse->distinctClause))
+		allow_hash = false;
+	else
+		allow_hash = true;
+
+	/* Set up a dummy AggClauseCosts struct. There are no aggregates. */
+	memset(&zero_agg_costs, 0, sizeof(zero_agg_costs));
+
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.can_sort = allow_sort;
+	ctx.can_hash = allow_hash;
+	ctx.target = target;
+	ctx.partial_grouping_target = target;
+	ctx.dNumGroupsTotal = dNumGroupsTotal;
+	ctx.agg_costs = &zero_agg_costs;
+	ctx.agg_partial_costs = &zero_agg_costs;
+	ctx.agg_final_costs = &zero_agg_costs;
+	ctx.rollups = NIL;
+	ctx.partial_rel = fetch_upper_rel(root, UPPERREL_CDB_FIRST_STAGE_DISTINCT, NULL);
+
+	/*
+	 * Set up these fields to look like a query with a GROUP BY on all the
+	 * DISTINCT columns. No HAVING or aggregates; the DISTINCT processing happens
+	 * logically after grouping and aggregation, so those have already been
+	 * handled in the grouping stage.
+	 */
+	ctx.hasAggs = false;
+	ctx.groupingSets = NIL;
+	ctx.havingQual = NULL;
+	ctx.groupClause = parse->distinctClause;
+	ctx.group_tles = get_common_group_tles(target, parse->distinctClause, NIL);
+	ctx.final_groupClause = ctx.groupClause;
+	ctx.final_group_tles = ctx.group_tles;
+	ctx.gsetid_sortref = 0;
+
+	if (ctx.can_sort)
+	{
+		/*
+		 * First, if we have any adequately-presorted paths, just stick a
+		 * Unique node on those.  Then consider doing an explicit sort of the
+		 * cheapest input path and Unique'ing that.
+		 *
+		 * When we have DISTINCT ON, we must sort by the more rigorous of
+		 * DISTINCT and ORDER BY, else it won't have the desired behavior.
+		 * Also, if we do have to do an explicit sort, we might as well use
+		 * the more rigorous ordering to avoid a second sort later.  (Note
+		 * that the parser will have ensured that one clause is a prefix of
+		 * the other.)
+		 */
+		if (parse->hasDistinctOn &&
+			list_length(root->distinct_pathkeys) <
+			list_length(root->sort_pathkeys))
+			ctx.partial_needed_pathkeys = root->sort_pathkeys;
+		else
+			ctx.partial_needed_pathkeys = root->distinct_pathkeys;
+
+		/* For explicit-sort case, always use the more rigorous clause */
+		if (list_length(root->distinct_pathkeys) <
+			list_length(root->sort_pathkeys))
+		{
+			ctx.partial_sort_pathkeys = root->sort_pathkeys;
+			/* Assert checks that parser didn't mess up... */
+			Assert(pathkeys_contained_in(root->distinct_pathkeys,
+										 ctx.partial_sort_pathkeys));
+		}
+		else
+			ctx.partial_sort_pathkeys = root->distinct_pathkeys;
+		ctx.final_needed_pathkeys = ctx.partial_needed_pathkeys;
+		ctx.final_sort_pathkeys = ctx.partial_sort_pathkeys;
+	}
+
+	/*
+	 * All set, generate the two-stage paths.
+	 */
+	create_two_stage_paths(root, &ctx, input_rel, output_rel);
+}
+
+/*
+ * Guts of GROUP BY and DISTINCT planning.
+ */
+static void
+create_two_stage_paths(PlannerInfo *root, cdb_agg_planning_context *ctx,
+					   RelOptInfo *input_rel, RelOptInfo *output_rel)
+{
+	Path	   *cheapest_path = input_rel->cheapest_total_path;
+
+	/*
+	 * Consider ways to do the first Aggregate stage.
+	 *
+	 * The first stage's output is Partially Aggregated. The paths are
+	 * collected to the ctx->partial_rel, by calling add_path(). We do *not*
+	 * use add_partial_path(), these partially aggregated paths are considered
+	 * more like MPP paths in Greenplum in general.
+	 *
+	 * First consider sorted Aggregate paths.
+	 */
+	if (ctx->can_sort)
+	{
+		ListCell   *lc;
+
+		foreach(lc, input_rel->pathlist)
+		{
+			Path	   *path = (Path *) lfirst(lc);
+			bool		is_sorted;
+
+			/*
+			 * If the input is neatly distributed along the GROUP BY columns,
+			 * there's no point in a two-stage plan. The code in planner.c
+			 * already created the straightforward one-stage plan.
+			 */
+			if (cdbpathlocus_collocates_tlist(root, path->locus, ctx->group_tles))
+				continue;
+
+			/*
+			 * Consider input paths that are already sorted, and the one with
+			 * the lowest total cost.
+			 */
+			is_sorted = pathkeys_contained_in(ctx->partial_needed_pathkeys,
+											  path->pathkeys);
+			if (path == cheapest_path || is_sorted)
+				add_first_stage_group_agg_path(root, path, is_sorted, ctx);
+		}
+	}
+
+	/*
+	 * Consider Hash Aggregate over the cheapest input path.
+	 *
+	 * Hashing is not possible with DQAs.
+	 *
+	 * GPDB_12_MERGE_FIXME: hashing not supported on GROUPING SETS, until
+	 * PostgreSQL v12. We do support hashing in the second stage even with
+	 * GROUPING SETS, though.
+	 */
+	if (ctx->can_hash &&
+		list_length(ctx->agg_costs->distinctAggrefs) == 0 &&
+		root->parse->groupingSets == NIL)
+	{
+		/*
+		 * If the input is neatly distributed along the GROUP BY columns,
+		 * there's no point in a two-stage plan. The code in planner.c already
+		 * created the straightforward one-stage plan.
+		 */
+		if (!cdbpathlocus_collocates_tlist(root, cheapest_path->locus, ctx->group_tles))
+			add_first_stage_hash_agg_path(root, cheapest_path, ctx);
+	}
+
+	/*
+	 * We now have partially aggregated paths in ctx->partial_rel. Consider
+	 * different ways of performing the Finalize Aggregate stage.
+	 */
+	if (ctx->partial_rel->pathlist)
+	{
+		Path	   *cheapest_first_stage_path;
+
+		set_cheapest(ctx->partial_rel);
+		cheapest_first_stage_path = ctx->partial_rel->cheapest_total_path;
+		if (ctx->can_sort)
+		{
+			ListCell   *lc;
+
+			foreach(lc, ctx->partial_rel->pathlist)
+			{
+				Path	   *path = (Path *) lfirst(lc);
+				bool		is_sorted;
+
+				/*
+				 * In two-stage GROUPING SETS paths, the second stage's grouping
+				 * will include GROUPINGSET_ID(), which is not included in
+				 * root->pathkeys. The first stage's sort order does not include
+				 * that, so we know it's not sorted.
+				 */
+				if (!root->parse->groupingSets)
+					is_sorted = pathkeys_contained_in(ctx->final_needed_pathkeys,
+													  path->pathkeys);
+				else
+					is_sorted = false;
+				if (path == cheapest_first_stage_path || is_sorted)
+					add_second_stage_group_agg_path(root, path, is_sorted,
+													ctx, output_rel);
+			}
+		}
+
+		if (ctx->can_hash && list_length(ctx->agg_costs->distinctAggrefs) == 0)
+			add_second_stage_hash_agg_path(root, cheapest_first_stage_path,
+										   ctx, output_rel);
+	}
+}
+
+
+/*
  * Add a TargetEntry node of type GroupingSetId to the tlist.
  * Return its ressortgroupref.
  */
@@ -606,6 +793,36 @@ create_gsetid_groupclause(Index groupref)
 	return gc;
 }
 
+static List *
+strip_gsetid_from_pathkeys(Index gsetid_sortref, List *pathkeys)
+{
+	ListCell   *lc;
+	List	   *new_pathkeys;
+
+	if (gsetid_sortref == 0)
+		return pathkeys;
+
+	new_pathkeys = NIL;
+	foreach(lc, pathkeys)
+	{
+		PathKey	   *pathkey = lfirst(lc);
+		EquivalenceClass *eclass = pathkey->pk_eclass;
+
+		if (eclass->ec_sortref == gsetid_sortref)
+		{
+			/*
+			 * The GROUPINGSETID_EXPR() should be the last pathkey. But just in
+			 * case it's not, any columns after it won't be in right order i
+			 * we remove it from the middle.
+			 */
+			break;
+		}
+
+		new_pathkeys = lappend(new_pathkeys, pathkey);
+	}
+	return new_pathkeys;
+}
+
 /*
  * Create a partially aggregated path from given input 'path' by sorting (if
  * input isn't sorted already).
@@ -616,7 +833,6 @@ add_first_stage_group_agg_path(PlannerInfo *root,
 							   bool is_sorted,
 							   cdb_agg_planning_context *ctx)
 {
-	Query	   *parse = root->parse;
 	DQAType     dqa_type;
 
 	/*
@@ -657,11 +873,11 @@ add_first_stage_group_agg_path(PlannerInfo *root,
 		path = (Path *) create_sort_path(root,
 										 ctx->partial_rel,
 										 path,
-										 root->group_pathkeys,
+										 ctx->partial_sort_pathkeys,
 										 -1.0);
 	}
 
-	if (parse->groupingSets)
+	if (ctx->groupingSets)
 	{
 		/*
 		 * We have grouping sets, possibly with aggregation.  Make
@@ -686,17 +902,17 @@ add_first_stage_group_agg_path(PlannerInfo *root,
 																			 path->rows, path->locus));
 		add_path(ctx->partial_rel, first_stage_agg_path);
 	}
-	else if (parse->hasAggs || parse->groupClause)
+	else if (ctx->hasAggs || ctx->groupClause)
 	{
 		add_path(ctx->partial_rel,
 			(Path *) create_agg_path(root,
 									 ctx->partial_rel,
 									 path,
 									 ctx->partial_grouping_target,
-									 parse->groupClause ? AGG_SORTED : AGG_PLAIN,
-									 AGGSPLIT_INITIAL_SERIAL,
+									 ctx->groupClause ? AGG_SORTED : AGG_PLAIN,
+									 ctx->hasAggs ? AGGSPLIT_INITIAL_SERIAL : AGGSPLIT_SIMPLE,
 									 false, /* streaming */
-									 parse->groupClause,
+									 ctx->groupClause,
 									 NIL,
 									 ctx->agg_partial_costs,
 									 estimate_num_groups_on_segment(ctx->dNumGroupsTotal,
@@ -719,7 +935,6 @@ add_second_stage_group_agg_path(PlannerInfo *root,
 								RelOptInfo *output_rel)
 {
 	Path	   *path;
-	List	   *pathkeys;
 	CdbPathLocus singleQE_locus;
 	CdbPathLocus group_locus;
 	bool		need_redistribute;
@@ -752,32 +967,31 @@ add_second_stage_group_agg_path(PlannerInfo *root,
 	 * We generate a Path for both, and let add_path() decide which ones
 	 * to keep.
 	 */
-	pathkeys = ctx->final_group_input_pathkeys;
-
 	/* Alternative 1: Redistribute -> Sort -> Agg */
 	if (CdbPathLocus_IsHashed(group_locus))
 	{
 		path = cdbpath_create_motion_path(root, initial_agg_path, NIL,
 											 false, group_locus);
 
-		path = (Path *) create_sort_path(root,
-										 output_rel,
-										 path,
-										 pathkeys,
-										 -1.0);
+		if (ctx->final_sort_pathkeys)
+			path = (Path *) create_sort_path(root,
+											 output_rel,
+											 path,
+											 ctx->final_sort_pathkeys,
+											 -1.0);
 
 		path = (Path *) create_agg_path(root,
 										output_rel,
 										path,
 										ctx->target,
 										(ctx->final_groupClause ? AGG_SORTED : AGG_PLAIN),
-										AGGSPLIT_FINAL_DESERIAL,
+										ctx->hasAggs ? AGGSPLIT_FINAL_DESERIAL : AGGSPLIT_SIMPLE,
 										false, /* streaming */
 										ctx->final_groupClause,
 										ctx->havingQual,
 										ctx->agg_final_costs,
 										ctx->dNumGroupsTotal);
-		path->pathkeys = ctx->final_group_pathkeys;
+		path->pathkeys = strip_gsetid_from_pathkeys(ctx->gsetid_sortref, path->pathkeys);
 
 		add_path(output_rel, path);
 	}
@@ -793,12 +1007,12 @@ add_second_stage_group_agg_path(PlannerInfo *root,
 		path = (Path *) create_sort_path(root,
 										 output_rel,
 										 path,
-										 pathkeys,
+										 ctx->final_sort_pathkeys,
 										 -1.0);
 	}
 
 	path = cdbpath_create_motion_path(root, path,
-									  pathkeys,
+									  path->pathkeys,
 									  false, singleQE_locus);
 
 	path = (Path *) create_agg_path(root,
@@ -806,13 +1020,13 @@ add_second_stage_group_agg_path(PlannerInfo *root,
 									path,
 									ctx->target,
 									(ctx->final_groupClause ? AGG_SORTED : AGG_PLAIN),
-									AGGSPLIT_FINAL_DESERIAL,
+									ctx->hasAggs ? AGGSPLIT_FINAL_DESERIAL : AGGSPLIT_SIMPLE,
 									false, /* streaming */
 									ctx->final_groupClause,
 									ctx->havingQual,
 									ctx->agg_final_costs,
 									ctx->dNumGroupsTotal);
-	path->pathkeys = ctx->final_group_pathkeys;
+	path->pathkeys = strip_gsetid_from_pathkeys(ctx->gsetid_sortref, path->pathkeys);
 	add_path(output_rel, path);
 }
 
@@ -824,7 +1038,6 @@ add_first_stage_hash_agg_path(PlannerInfo *root,
 							  Path *path,
 							  cdb_agg_planning_context *ctx)
 {
-	Query	   *parse = root->parse;
 	double		dNumGroups;
 
 	dNumGroups = estimate_num_groups_on_segment(ctx->dNumGroupsTotal,
@@ -836,9 +1049,9 @@ add_first_stage_hash_agg_path(PlannerInfo *root,
 									  path,
 									  ctx->partial_grouping_target,
 									  AGG_HASHED,
-									  AGGSPLIT_INITIAL_SERIAL,
+									  ctx->hasAggs ? AGGSPLIT_INITIAL_SERIAL : AGGSPLIT_SIMPLE,
 									  false, /* streaming */
-									  parse->groupClause,
+									  ctx->groupClause,
 									  NIL,
 									  ctx->agg_partial_costs,
 									  dNumGroups));
@@ -853,7 +1066,6 @@ add_second_stage_hash_agg_path(PlannerInfo *root,
 							   cdb_agg_planning_context *ctx,
 							   RelOptInfo *output_rel)
 {
-	Query	   *parse = root->parse;
 	CdbPathLocus group_locus;
 	bool		needs_redistribute;
 	double		dNumGroups;
@@ -889,10 +1101,10 @@ add_second_stage_hash_agg_path(PlannerInfo *root,
 										path,
 										ctx->target,
 										AGG_HASHED,
-										AGGSPLIT_FINAL_DESERIAL,
+										ctx->hasAggs ? AGGSPLIT_FINAL_DESERIAL : AGGSPLIT_SIMPLE,
 										false, /* streaming */
 										ctx->final_groupClause,
-										(List *) parse->havingQual,
+										ctx->havingQual,
 										ctx->agg_final_costs,
 										dNumGroups);
 		add_path(output_rel, path);
@@ -926,10 +1138,10 @@ add_second_stage_hash_agg_path(PlannerInfo *root,
 											path,
 											ctx->target,
 											AGG_HASHED,
-											AGGSPLIT_FINAL_DESERIAL,
+											ctx->hasAggs ? AGGSPLIT_FINAL_DESERIAL : AGGSPLIT_SIMPLE,
 											false, /* streaming */
 											ctx->final_groupClause,
-											(List *) parse->havingQual,
+											ctx->havingQual,
 											ctx->agg_final_costs,
 											ctx->dNumGroupsTotal);
 			add_path(output_rel, path);
@@ -976,7 +1188,6 @@ static void add_single_mixed_dqa_hash_agg_path(PlannerInfo *root,
                                                PathTarget *input_target,
                                                List       *dqa_group_clause)
 {
-	Query	   *parse = root->parse;
 	List	   *dqa_group_tles;
 	CdbPathLocus distinct_locus;
 	bool		distinct_need_redistribute;
@@ -985,7 +1196,7 @@ static void add_single_mixed_dqa_hash_agg_path(PlannerInfo *root,
 	if (!gp_enable_agg_distinct)
 		return;
 
-	if (parse->groupClause)
+	if (ctx->groupClause)
 		return;
 
 	/*
@@ -1015,7 +1226,7 @@ static void add_single_mixed_dqa_hash_agg_path(PlannerInfo *root,
 									AGG_PLAIN,
 									AGGSPLIT_INITIAL_SERIAL,
 									false, /* streaming */
-									parse->groupClause,
+									ctx->groupClause,
 									NIL,
 									ctx->agg_partial_costs, /* FIXME */
 									estimate_num_groups_on_segment(ctx->dNumGroupsTotal,
@@ -1031,7 +1242,7 @@ static void add_single_mixed_dqa_hash_agg_path(PlannerInfo *root,
 									AGG_PLAIN,
 									AGGSPLIT_FINAL_DESERIAL,
 									false, /* streaming */
-									parse->groupClause,
+									ctx->groupClause,
 									ctx->havingQual,
 									ctx->agg_final_costs,
 									ctx->dNumGroupsTotal);
@@ -1050,7 +1261,6 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 							 List       *dqa_group_clause,
 							 double dNumDistinctGroups)
 {
-	Query	   *parse = root->parse;
 	List	   *dqa_group_tles;
 	int			num_input_segments;
 	List	   *group_tles;
@@ -1085,7 +1295,7 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 	 * Calculate the number of groups in the final stage, per segment.
 	 * group_locus is the corresponding locus for the final stage.
 	 */
-	group_tles = get_common_group_tles(input_target, parse->groupClause, NIL);
+	group_tles = get_common_group_tles(input_target, ctx->groupClause, NIL);
 	group_locus = choose_grouping_locus(root, path,
 										group_tles,
 										&group_need_redistribute);
@@ -1137,11 +1347,11 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 										output_rel,
 										path,
 										ctx->target,
-										parse->groupClause ? AGG_HASHED : AGG_PLAIN,
+										ctx->groupClause ? AGG_HASHED : AGG_PLAIN,
 										AGGSPLIT_DEDUPLICATED,
 										false, /* streaming */
-										parse->groupClause,
-										(List *) parse->havingQual,
+										ctx->groupClause,
+										ctx->havingQual,
 										ctx->agg_final_costs,
 										dNumGroups);
 		add_path(output_rel, path);
@@ -1193,11 +1403,11 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 										output_rel,
 										path,
 										ctx->target,
-										parse->groupClause ? AGG_HASHED : AGG_PLAIN,
+										ctx->groupClause ? AGG_HASHED : AGG_PLAIN,
 										AGGSPLIT_DEDUPLICATED,
 										false, /* streaming */
-										parse->groupClause,
-										(List *) parse->havingQual,
+										ctx->groupClause,
+										ctx->havingQual,
 										ctx->agg_final_costs,
 										dNumGroups);
 		add_path(output_rel, path);
@@ -1246,10 +1456,10 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 										output_rel,
 										path,
 										strip_aggdistinct(ctx->partial_grouping_target),
-										parse->groupClause ? AGG_HASHED : AGG_PLAIN,
+										ctx->groupClause ? AGG_HASHED : AGG_PLAIN,
 										AGGSPLIT_INITIAL_SERIAL | AGGSPLITOP_DEDUPLICATED,
 										false, /* streaming */
-										parse->groupClause,
+										ctx->groupClause,
 										NIL,
 										ctx->agg_partial_costs,
 										estimate_num_groups_on_segment(ctx->dNumGroupsTotal, input_rows, path->locus));
@@ -1260,11 +1470,11 @@ add_single_dqa_hash_agg_path(PlannerInfo *root,
 										output_rel,
 										path,
 										ctx->target,
-										parse->groupClause ? AGG_HASHED : AGG_PLAIN,
+										ctx->groupClause ? AGG_HASHED : AGG_PLAIN,
 										AGGSPLIT_FINAL_DESERIAL | AGGSPLITOP_DEDUPLICATED,
 										false, /* streaming */
-										parse->groupClause,
-										(List *) parse->havingQual,
+										ctx->groupClause,
+										ctx->havingQual,
 										ctx->agg_final_costs,
 										dNumGroups);
 
@@ -1328,7 +1538,7 @@ add_multi_dqas_hash_agg_path(PlannerInfo *root,
 										  output_rel,
 										  path,
 										  info->tup_split_target,
-										  root->parse->groupClause,
+										  ctx->groupClause,
 										  info->dqa_expr_lst);
 
 	AggClauseCosts DedupCost = {};
@@ -1383,7 +1593,7 @@ add_multi_dqas_hash_agg_path(PlannerInfo *root,
 	PathTarget *partial_target = info->partial_target;
 	double		input_rows = path->rows;
 
-	if (root->parse->groupClause)
+	if (ctx->groupClause)
 	{
 		path = (Path *) create_agg_path(root,
 										output_rel,
@@ -1409,7 +1619,7 @@ add_multi_dqas_hash_agg_path(PlannerInfo *root,
 									split,
 									AGGSPLIT_INITIAL_SERIAL | DEDUPLICATED_FLAG,
 									false, /* streaming */
-									root->parse->groupClause,
+									ctx->groupClause,
 									NIL,
 									ctx->agg_partial_costs,
 									estimate_num_groups_on_segment(ctx->dNumGroupsTotal,
@@ -1430,8 +1640,8 @@ add_multi_dqas_hash_agg_path(PlannerInfo *root,
 									split,
 									AGGSPLIT_FINAL_DESERIAL | DEDUPLICATED_FLAG,
 									false, /* streaming */
-									root->parse->groupClause,
-									(List *) root->parse->havingQual,
+									ctx->groupClause,
+									ctx->havingQual,
 									ctx->agg_final_costs,
 									ctx->dNumGroupsTotal);
 
@@ -1763,7 +1973,7 @@ fetch_multi_dqas_info(PlannerInfo *root,
 		num_input_segments = 1;
 	num_total_input_rows = path->rows * num_input_segments;
 
-	group_exprs = get_sortgrouplist_exprs(root->parse->groupClause,
+	group_exprs = get_sortgrouplist_exprs(ctx->groupClause,
 										  make_tlist_from_pathtarget(path->pathtarget));
 
 	proj_target = copy_pathtarget(path->pathtarget);
@@ -1943,7 +2153,7 @@ fetch_multi_dqas_info(PlannerInfo *root,
 	}
 
 	info->dqa_group_clause = list_concat(info->dqa_group_clause,
-										 list_copy(root->parse->groupClause));
+										 list_copy(ctx->groupClause));
 
 	info->partial_target= ctx->partial_grouping_target;
 	info->final_target = ctx->target;
@@ -1982,7 +2192,7 @@ fetch_single_dqa_info(PlannerInfo *root,
 	else
 		info->input_proj_target->sortgrouprefs = (Index *) palloc0(list_length(exprLst) * sizeof(Index));
 
-	dqa_group_exprs = get_sortgrouplist_exprs(root->parse->groupClause,
+	dqa_group_exprs = get_sortgrouplist_exprs(ctx->groupClause,
 											  make_tlist_from_pathtarget(path->pathtarget));
 
 	Aggref	   *aggref = list_nth(ctx->agg_costs->distinctAggrefs, 0);
@@ -2022,7 +2232,7 @@ fetch_single_dqa_info(PlannerInfo *root,
 		dqa_group_exprs = lappend(dqa_group_exprs, arg_tle->expr);
 	}
 
-	info->dqa_group_clause = list_concat(list_copy(root->parse->groupClause),
+	info->dqa_group_clause = list_concat(list_copy(ctx->groupClause),
 										 info->dqa_group_clause);
 
 	/*

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -4474,30 +4474,6 @@ create_grouping_paths(PlannerInfo *root,
 			 (gd ? gd->any_hashable : grouping_is_hashable(parse->groupClause))))
 			flags |= GROUPING_CAN_USE_HASH;
 
-
-		/* GPDB_12_MERGE_FIXME: this belongs here now, but add a new bitmask bit for it? */
-#if 0
-		/*
-		 * cdb_create_twostage_grouping_paths() can use hashing (in limited ways)
-		 * even if there are DISTINCT aggs or grouping sets.
-		 */
-		can_mpp_hash = (parse->groupClause != NIL &&
-						agg_costs->numPureOrderedAggs == 0 &&
-						grouping_is_hashable(parse->groupClause));
-#endif
-
-		/*
-		 * In GPDB, the hash aggregate can spill to disk, and it needs combine function
-		 * support for that.
-		 *
-		 * GPDB_12_MERGE_FIXME: we ripped spilling out in the merge. But might put it
-		 * back later?
-		 */
-#if 0
-		if (agg_costs->hasNonCombine)
-			can_hash = can_mpp_hash = false;
-#endif
-
 		/*
 		 * Determine whether partial aggregation is possible.
 		 */
@@ -5450,114 +5426,15 @@ create_distinct_paths(PlannerInfo *root,
 {
 	Query	   *parse = root->parse;
 	Path	   *cheapest_input_path = input_rel->cheapest_total_path;
-	Path	   *hash_input_path = NULL;
 	RelOptInfo *distinct_rel;
 	double		numDistinctRowsTotal;
 	double		numInputRowsTotal;
-	double		numDistinctRowsHash = 0;
 	bool		allow_hash;
-	bool		must_hash;
 	Path	   *path;
 	ListCell   *lc;
-	List	   *distinct_dist_pathkeys = NIL;
-	List	   *distinct_dist_exprs = NIL;
-	List	   *distinct_dist_opfamilies = NIL;
-	List	   *distinct_dist_sortrefs = NIL;
 
 	/* For now, do all work in the (DISTINCT, NULL) upperrel */
 	distinct_rel = fetch_upper_rel(root, UPPERREL_DISTINCT, NULL);
-
-
-	/*
-	 * MPP: If there's a DISTINCT clause and we're not collocated on the
-	 * distinct key, we need to redistribute on that key.  In addition, we
-	 * need to consider whether to "pre-unique" by doing a Sort-Unique
-	 * operation on the data as currently distributed, redistributing on the
-	 * district key, and doing the Sort-Unique again. This 2-phase approach
-	 * will be a win, if the cost of redistributing the entire input exceeds
-	 * the cost of an extra Redistribute-Sort-Unique on the pre-uniqued
-	 * (reduced) input.
-	 */
-	make_distribution_exprs_for_groupclause(root,
-											parse->distinctClause,
-			make_tlist_from_pathtarget(root->upper_targets[UPPERREL_WINDOW]),
-											&distinct_dist_pathkeys,
-											&distinct_dist_exprs,
-											&distinct_dist_opfamilies,
-											&distinct_dist_sortrefs);
-
-#if 0
-	if (Gp_role == GP_ROLE_DISPATCH && CdbPathLocus_IsPartitioned(path->locus))
-	{
-		/* Apply the preunique optimization, if enabled and worthwhile. */
-		/* GPDB_84_MERGE_FIXME: pre-unique for hash distinct not implemented. */
-		/* GPDB_96_MERGE_FIXME: disabled altogether */
-		if (gp_enable_preunique && needMotion && !use_hashed_distinct)
-		{
-			double		base_cost,
-				alt_cost;
-			Path		sort_path;	/* dummy for result of cost_sort */
-
-			base_cost = motion_cost_per_row * result_plan->plan_rows;
-			alt_cost = motion_cost_per_row * numDistinct;
-			cost_sort(&sort_path, root, NIL, alt_cost,
-					  numDistinct, result_plan->plan_rows,
-					  0, work_mem, -1.0);
-			alt_cost += sort_path.startup_cost;
-			alt_cost += cpu_operator_cost * numDistinct
-				* list_length(parse->distinctClause);
-
-			if (alt_cost < base_cost || gp_eager_preunique)
-			{
-				/*
-				 * Reduce the number of rows to move by adding a [Sort
-				 * and] Unique prior to the redistribute Motion.
-				 */
-				if (root->sort_pathkeys)
-				{
-					if (!pathkeys_contained_in(root->sort_pathkeys, current_pathkeys))
-					{
-						result_plan = (Plan *) make_sort_from_pathkeys(root,
-																	   result_plan,
-																	   root->sort_pathkeys,
-																	   limit_tuples,
-																	   true);
-						((Sort *) result_plan)->noduplicates = gp_enable_sort_distinct;
-						current_pathkeys = root->sort_pathkeys;
-					}
-				}
-
-				result_plan = (Plan *) make_unique(result_plan, parse->distinctClause);
-
-				result_plan->plan_rows = numDistinct;
-
-				/*
-				 * Our sort node (under the unique node), unfortunately
-				 * can't guarantee uniqueness -- so we aren't allowed to
-				 * push the limit into the sort; but we can avoid moving
-				 * the entire sorted result-set by plunking a limit on the
-				 * top of the unique-node.
-				 */
-				if (parse->limitCount)
-				{
-					/*
-					 * Our extra limit operation is basically a
-					 * third-phase on multi-phase limit (see 2-phase limit
-					 * below)
-					 */
-					result_plan = pushdown_preliminary_limit(result_plan, parse->limitCount, parse->limitOffset, limit_tuples);
-				}
-			}
-		}
-	}
-	else if ( result_plan->flow->flotype == FLOW_SINGLETON )
-		; /* Already collocated. */
-	else
-	{
-		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-						errmsg("unexpected input locus to distinct")));
-	}
-#endif
 
 	/*
 	 * We don't compute anything at this level, so distinct_rel will be
@@ -5641,23 +5518,16 @@ create_distinct_paths(PlannerInfo *root,
 			{
 				double		numDistinctRows;
 
-				if (!cdbpathlocus_collocates_pathkeys(root, path->locus,
-													  distinct_dist_pathkeys, false /* exact_match */ ))
-				{
-					/*
-					 * If the input path's locus is not suitable, gather the
-					 * result. We don't want to redistribute it because that
-					 * would break the input ordering, and we'd need to re-Sort
-					 * it. (We'll consider the explicit-sort case below, on top
-					 * of the cheapest overall path.)
-					 */
-					CdbPathLocus locus;
+				path = cdb_prepare_path_for_sorted_agg(root,
+													   true, /* is_sorted */
+													   distinct_rel,
+													   path, path->pathtarget,
+													   needed_pathkeys,
+													   -1.0,
+													   parse->distinctClause,
+													   NIL);
 
-					CdbPathLocus_MakeSingleQE(&locus, getgpsegmentCount());
-
-					path = cdbpath_create_motion_path(root, path, path->pathkeys, false, locus);
-				}
-
+				/* On how many segments will the distinct result reside? */
 				if (CdbPathLocus_IsPartitioned(path->locus))
 					numDistinctRows = numDistinctRowsTotal / CdbPathLocus_NumSegments(path->locus);
 				else
@@ -5684,59 +5554,16 @@ create_distinct_paths(PlannerInfo *root,
 			needed_pathkeys = root->distinct_pathkeys;
 
 		path = cheapest_input_path;
-		if (!pathkeys_contained_in(needed_pathkeys, path->pathkeys))
-		{
-			if (!cdbpathlocus_collocates_pathkeys(root, path->locus,
-												  distinct_dist_pathkeys, false /* exact_match */ ))
-			{
-				CdbPathLocus locus;
 
-				if (distinct_dist_exprs)
-				{
-					locus = cdbpathlocus_from_exprs(root,
-													path->parent,
-													distinct_dist_exprs,
-													distinct_dist_opfamilies,
-													distinct_dist_sortrefs,
-													getgpsegmentCount());
-				}
-				else
-				{
-					CdbPathLocus_MakeSingleQE(&locus, getgpsegmentCount());
-				}
-				/* we're about to sort the data, so don't try preserving any existing order. */
-				path = cdbpath_create_motion_path(root, path, NIL, false, locus);
-			}
-
-			path = (Path *) create_sort_path(root, distinct_rel,
-											 path,
-											 needed_pathkeys,
-											 -1.0);
-		}
-		else
-		{
-			if (!cdbpathlocus_collocates_pathkeys(root, path->locus,
-												  distinct_dist_pathkeys, false /* exact_match */ ))
-			{
-				CdbPathLocus locus;
-
-				if (distinct_dist_exprs)
-				{
-					locus = cdbpathlocus_from_exprs(root,
-													path->parent,
-													distinct_dist_exprs,
-													distinct_dist_opfamilies,
-													distinct_dist_sortrefs,
-													getgpsegmentCount());
-				}
-				else
-				{
-					CdbPathLocus_MakeSingleQE(&locus, getgpsegmentCount());
-				}
-				/* preserve any existing order */
-				path = cdbpath_create_motion_path(root, path, path->pathkeys, false, locus);
-			}
-		}
+		path = cdb_prepare_path_for_sorted_agg(root,
+											   pathkeys_contained_in(needed_pathkeys, cheapest_input_path->pathkeys),
+											   distinct_rel,
+											   cheapest_input_path,
+											   cheapest_input_path->pathtarget,
+											   needed_pathkeys,
+											   -1.0,
+											   parse->distinctClause,
+											   NIL);
 
 		double		numDistinctRows;
 
@@ -5756,90 +5583,49 @@ create_distinct_paths(PlannerInfo *root,
 	 * Consider hash-based implementations of DISTINCT, if possible.
 	 *
 	 * If we were not able to make any other types of path, we *must* hash or
-	 * die trying.  If we do have other choices, there are several things that
+	 * die trying.  If we do have other choices, there are two things that
 	 * should prevent selection of hashing: if the query uses DISTINCT ON
 	 * (because it won't really have the expected behavior if we hash), or if
-	 * enable_hashagg is off, or if it looks like the hashtable will exceed
-	 * work_mem.
+	 * enable_hashagg is off.
 	 *
 	 * Note: grouping_is_hashable() is much more expensive to check than the
 	 * other gating conditions, so we want to do it last.
 	 */
 	if (distinct_rel->pathlist == NIL)
-	{
 		allow_hash = true;		/* we have no alternatives */
-		must_hash = true;
-	}
 	else if (parse->hasDistinctOn || !enable_hashagg)
-	{
 		allow_hash = false;		/* policy-based decision not to hash */
-		must_hash = false;
-	}
 	else
-	{
-		allow_hash = true;
-		must_hash = false;
-	}
-
-	if (allow_hash)
-	{
-		Path	   *path;
-
-		path = cheapest_input_path;
-		if (!cdbpathlocus_collocates_pathkeys(root, path->locus,
-											  distinct_dist_pathkeys, false /* exact_match */ ))
-		{
-			CdbPathLocus locus;
-
-			if (distinct_dist_exprs)
-			{
-				locus = cdbpathlocus_from_exprs(root,
-												path->parent,
-												distinct_dist_exprs,
-												distinct_dist_opfamilies,
-												distinct_dist_sortrefs,
-												getgpsegmentCount());
-			}
-			else
-			{
-				CdbPathLocus_MakeSingleQE(&locus, getgpsegmentCount());
-			}
-
-			path = cdbpath_create_motion_path(root, path, path->pathkeys, false, locus);
-		}
-
-		hash_input_path = path;
-
-		if (CdbPathLocus_IsPartitioned(path->locus))
-			numDistinctRowsHash = numDistinctRowsTotal / CdbPathLocus_NumSegments(path->locus);
-		else
-			numDistinctRowsHash = numDistinctRowsTotal;
-
-		if (!must_hash)
-		{
-			Size		hashentrysize = hash_agg_entry_size(
-				0, cheapest_input_path->pathtarget->width, 0);
-
-			/* Allow hashing only if hashtable is predicted to fit in work_mem */
-			allow_hash = (hashentrysize * numDistinctRowsHash <= work_mem * 1024L);
-		}
-	}
+		allow_hash = true;		/* default */
 
 	if (allow_hash && grouping_is_hashable(parse->distinctClause))
 	{
 		/* Generate hashed aggregate path --- no sort needed */
+		double		numDistinctRows;
+
+		path = cdb_prepare_path_for_hashed_agg(root,
+											   cheapest_input_path,
+											   cheapest_input_path->pathtarget,
+											   parse->distinctClause,
+											   NIL);
+
+		if (CdbPathLocus_IsPartitioned(path->locus))
+			numDistinctRows = clamp_row_est(numDistinctRowsTotal / CdbPathLocus_NumSegments(path->locus));
+		else
+			numDistinctRows = numDistinctRowsTotal;
+
 		add_path(distinct_rel, (Path *)
 				 create_agg_path(root,
 								 distinct_rel,
-								 hash_input_path,
-								 hash_input_path->pathtarget,
+								 path,
+								 path->pathtarget,
 								 AGG_HASHED,
 								 AGGSPLIT_SIMPLE,
 								 false, /* streaming */
 								 parse->distinctClause,
 								 NIL,
 								 NULL,
-								 numDistinctRowsHash));
+								 numDistinctRows));
 	}
 
 	/* Give a helpful error if we failed to find any implementation */
@@ -5848,6 +5634,16 @@ create_distinct_paths(PlannerInfo *root,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("could not implement DISTINCT"),
 				 errdetail("Some of the datatypes only support hashing, while others only support sorting.")));
+
+	/*
+	 * Add GPDB two-stage agg plans
+	 */
+	if (Gp_role == GP_ROLE_DISPATCH && gp_enable_preunique)
+		cdb_create_twostage_distinct_paths(root,
+										   input_rel,
+										   distinct_rel,
+										   cheapest_input_path->pathtarget,
+										   numDistinctRowsTotal);
 
 	/*
 	 * If there is an FDW that's responsible for all baserels of the query,
@@ -7797,7 +7593,6 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 	 * Add GPDB two-and three-stage agg plans
 	 */
 	bool try_mpp_multistage_aggregation = false;
-	bool can_mpp_hash = false;
 
 	/*
 	 * In PostgreSQL, partial_grouping_target and the partial/final agg
@@ -7863,24 +7658,17 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 			extra->partial_costs_set = true;
 		}
 
-		can_mpp_hash = (parse->groupClause != NIL &&
-			parse->groupingSets == NIL &&
-			agg_costs->numPureOrderedAggs == 0 &&
-			grouping_is_hashable(parse->groupClause));
-
-		cdb_create_twostage_grouping_paths(root,
-										   input_rel,
-										   grouped_rel,
-										   grouped_rel->reltarget,
-										   partially_grouped_target,
-										   havingQual,
-                                           ((extra->flags & GROUPING_CAN_USE_SORT) != 0), /* can_sort */
-										   can_mpp_hash,
-										   dNumGroupsTotal,
-										   agg_costs,
-										   &extra->agg_partial_costs,
-										   &extra->agg_final_costs,
-										   gd ? gd->rollups : NIL);
+		cdb_create_multistage_grouping_paths(root,
+											 input_rel,
+											 grouped_rel,
+											 grouped_rel->reltarget,
+											 partially_grouped_target,
+											 havingQual,
+											 dNumGroupsTotal,
+											 agg_costs,
+											 &extra->agg_partial_costs,
+											 &extra->agg_final_costs,
+											 gd ? gd->rollups : NIL);
 	}
 }
 

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -4294,6 +4294,8 @@ create_sort_path(PlannerInfo *root,
 {
 	SortPath   *pathnode = makeNode(SortPath);
 
+	Assert(pathkeys != NIL);
+
 	pathnode->path.pathtype = T_Sort;
 	pathnode->path.parent = rel;
 	/* Sort doesn't project, so use source path's pathtarget */

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1404,28 +1404,10 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 	else if (linitial(stmt->distinctClause) == NULL)
 	{
 		/* We had SELECT DISTINCT */
-		if (!pstate->p_hasAggs && !pstate->p_hasWindowFuncs &&
-			qry->groupClause == NIL && qry->groupingSets == NIL &&
-			qry->targetList != NIL)
-		{
-			/*
-			 * GPDB: We convert the DISTINCT to an equivalent GROUP BY, when
-			 * possible, because the planner can generate smarter plans for
-			 * GROUP BY. In particular, the "pre-unique" optimization has not
-			 * been implemented for DISTINCT.
-			 */
-			qry->distinctClause = transformDistinctToGroupBy(pstate,
-															 &qry->targetList,
-															 &qry->sortClause,
-															 &qry->groupClause);
-		}
-		else
-		{
-			qry->distinctClause = transformDistinctClause(pstate,
-														  &qry->targetList,
-														  qry->sortClause,
-														  false);
-		}
+		qry->distinctClause = transformDistinctClause(pstate,
+													  &qry->targetList,
+													  qry->sortClause,
+													  false);
 		qry->hasDistinctOn = false;
 	}
 	else

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -257,7 +257,6 @@ bool		gp_enable_predicate_propagation = false;
 bool		gp_enable_minmax_optimization = true;
 bool		gp_enable_multiphase_agg = true;
 bool		gp_enable_preunique = true;
-bool		gp_eager_preunique = false;
 bool		gp_enable_agg_distinct = true;
 bool		gp_enable_dqa_pruning = true;
 bool		gp_dynamic_partition_pruning = true;
@@ -692,17 +691,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_enable_preunique,
 		true,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"gp_eager_preunique", PGC_USERSET, QUERY_TUNING_METHOD,
-			gettext_noop("Experimental feature: 2-phase duplicate removal - cost override."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&gp_eager_preunique,
-		false,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/cdb/cdbgroupingpaths.h
+++ b/src/include/cdb/cdbgroupingpaths.h
@@ -16,19 +16,23 @@
 
 #include "nodes/pathnodes.h"
 
-extern void cdb_create_twostage_grouping_paths(PlannerInfo *root,
+extern void cdb_create_multistage_grouping_paths(PlannerInfo *root,
+												 RelOptInfo *input_rel,
+												 RelOptInfo *output_rel,
+												 PathTarget *target,
+												 PathTarget *partial_grouping_target,
+												 List *havingQual,
+												 double dNumGroupsTotal,
+												 const AggClauseCosts *agg_costs,
+												 const AggClauseCosts *agg_partial_costs,
+												 const AggClauseCosts *agg_final_costs,
+												 List *rollups);
+
+extern void cdb_create_twostage_distinct_paths(PlannerInfo *root,
 											   RelOptInfo *input_rel,
 											   RelOptInfo *output_rel,
 											   PathTarget *target,
-											   PathTarget *partial_grouping_target,
-											   List *havingQual,
-											   bool can_sort,
-											   bool can_hash,
-											   double dNumGroupsTotal,
-											   const AggClauseCosts *agg_costs,
-											   const AggClauseCosts *agg_partial_costs,
-											   const AggClauseCosts *agg_final_costs,
-											   List *rollups);
+											   double dNumGroupsTotal);
 
 extern Path *cdb_prepare_path_for_sorted_agg(PlannerInfo *root,
 											 bool is_sorted,

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -561,12 +561,6 @@ extern bool gp_enable_dqa_pruning;
  */
 extern bool gp_enable_preunique;
 
-/* If gp_enable_preunique is true, then  apply the associated optimzation
- * in an "eager" fashion.  In effect, this setting overrides the cost-
- * based decision whether to use a 2-phase approach to duplicate removal.
- */
-extern bool gp_eager_preunique;
-
 /* May Greenplum dump statistics for all segments as a huge ugly string
  * during EXPLAIN ANALYZE?
  *

--- a/src/include/nodes/pathnodes.h
+++ b/src/include/nodes/pathnodes.h
@@ -94,6 +94,7 @@ typedef enum UpperRelationKind
 	UPPERREL_CDB_FIRST_STAGE_GROUP_AGG,
 	UPPERREL_WINDOW,			/* result of window functions, if any */
 	UPPERREL_DISTINCT,			/* result of "SELECT DISTINCT", if any */
+	UPPERREL_CDB_FIRST_STAGE_DISTINCT,
 	UPPERREL_ORDERED,			/* result of ORDER BY, if any */
 	UPPERREL_FINAL				/* result of any remaining top-level actions */
 	/* NB: UPPERREL_FINAL must be last enum entry; it's used to size arrays */

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -36,8 +36,6 @@ extern List *transformWindowDefinitions(ParseState *pstate,
 										List *windowdefs,
 										List **targetlist);
 
-extern List *transformDistinctToGroupBy(ParseState *pstate, List **targetlist,
-						   List **sortClause, List **groupClause);
 extern List *transformDistinctClause(ParseState *pstate,
 									 List **targetlist, List *sortClause, bool is_agg);
 extern List *transformDistinctOnClause(ParseState *pstate, List *distinctlist,

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -172,7 +172,6 @@
 		"gp_dtx_recovery_interval",
 		"gp_dtx_recovery_prepared_period",
 		"gp_dynamic_partition_pruning",
-		"gp_eager_preunique",
 		"gp_enable_agg_distinct",
 		"gp_enable_agg_distinct_pruning",
 		"gp_enable_direct_dispatch",

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -1148,10 +1148,10 @@ explain (costs off) select * from t1 group by a,b,c,d;
 explain (costs off) select a,c from t1 group by a,c,d;
                    QUERY PLAN                   
 ------------------------------------------------
- Finalize HashAggregate
+ HashAggregate
    Group Key: a, c, d
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial HashAggregate
+         ->  HashAggregate
                Group Key: a, c, d
                ->  Seq Scan on t1
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/gp_distinct_plans.out
+++ b/src/test/regress/expected/gp_distinct_plans.out
@@ -1,0 +1,271 @@
+--
+-- Test all the different plan shapes that the planner can generate for
+-- DISTINCT queries
+--
+create table distinct_test (a int, b int, c int) distributed by (a);
+insert into distinct_test select g / 1000, g / 2000, g from generate_series(1, 10000) g;
+analyze distinct_test;
+--
+-- With the default cost settings, you get hashed plans
+--
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=55.00..56.10 rows=66 width=8)
+   ->  HashAggregate  (cost=55.00..55.22 rows=22 width=8)
+         Group Key: a, b
+         ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=8)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select distinct a, b from distinct_test;
+ a  | b 
+----+---
+  1 | 0
+  0 | 0
+  6 | 3
+  9 | 4
+ 10 | 5
+  5 | 2
+  3 | 1
+  4 | 2
+  2 | 1
+  7 | 3
+  8 | 4
+(11 rows)
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=46.86..46.96 rows=6 width=4)
+   ->  Finalize HashAggregate  (cost=46.86..46.88 rows=2 width=4)
+         Group Key: b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=46.67..46.85 rows=6 width=4)
+               Hash Key: b
+               ->  Partial HashAggregate  (cost=46.67..46.73 rows=6 width=4)
+                     Group Key: b
+                     ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select distinct b from distinct_test;
+ b 
+---
+ 5
+ 2
+ 4
+ 3
+ 1
+ 0
+(6 rows)
+
+-- The two-stage aggregation can be disabled with GUC
+set gp_enable_preunique = off;
+explain select distinct b from distinct_test;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=113.33..113.43 rows=6 width=4)
+   ->  HashAggregate  (cost=113.33..113.35 rows=2 width=4)
+         Group Key: b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..105.00 rows=3333 width=4)
+               Hash Key: b
+               ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+reset gp_enable_preunique;
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=113.33..280.00 rows=10000 width=4)
+   ->  HashAggregate  (cost=113.33..146.67 rows=3333 width=4)
+         Group Key: c
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..105.00 rows=3333 width=4)
+               Hash Key: c
+               ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+ count 
+-------
+ 10000
+(1 row)
+
+--
+-- Repeat the same tests with sorted Unique plans
+--
+set enable_hashagg=off;
+set optimizer_enable_hashagg=off;
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=233.38..259.26 rows=66 width=8)
+   Merge Key: a, b
+   ->  Unique  (cost=233.38..258.38 rows=22 width=8)
+         Group Key: a, b
+         ->  Sort  (cost=233.38..241.71 rows=3333 width=8)
+               Sort Key: a, b
+               ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=8)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select distinct a, b from distinct_test;
+ a  | b 
+----+---
+  0 | 0
+  1 | 0
+  2 | 1
+  3 | 1
+  4 | 2
+  5 | 2
+  6 | 3
+  7 | 3
+  8 | 4
+  9 | 4
+ 10 | 5
+(11 rows)
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Finalize GroupAggregate  (cost=233.38..250.45 rows=6 width=4)
+   Group Key: b
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=233.38..250.35 rows=18 width=4)
+         Merge Key: b
+         ->  Partial GroupAggregate  (cost=233.38..250.11 rows=6 width=4)
+               Group Key: b
+               ->  Sort  (cost=233.38..241.71 rows=3333 width=4)
+                     Sort Key: b
+                     ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select distinct b from distinct_test;
+ b 
+---
+ 0
+ 1
+ 2
+ 3
+ 4
+ 5
+(6 rows)
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=300.05..450.05 rows=10000 width=4)
+   Merge Key: c
+   ->  Unique  (cost=300.05..316.71 rows=3333 width=4)
+         Group Key: c
+         ->  Sort  (cost=300.05..308.38 rows=3333 width=4)
+               Sort Key: c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..105.00 rows=3333 width=4)
+                     Hash Key: c
+                     ->  Seq Scan on distinct_test  (cost=0.00..38.33 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+ count 
+-------
+ 10000
+(1 row)
+
+--
+-- Also test paths where the explicit Sort is not needed
+--
+create index on distinct_test (a, b);
+create index on distinct_test (b);
+create index on distinct_test (c);
+set random_page_cost=1;
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.16..206.04 rows=66 width=8)
+   Merge Key: a, b
+   ->  Unique  (cost=0.16..205.16 rows=22 width=8)
+         Group Key: a, b
+         ->  Index Only Scan using distinct_test_a_b_idx on distinct_test  (cost=0.16..188.49 rows=3333 width=8)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select distinct a, b from distinct_test;
+ a  | b 
+----+---
+  0 | 0
+  1 | 0
+  2 | 1
+  3 | 1
+  4 | 2
+  5 | 2
+  6 | 3
+  7 | 3
+  8 | 4
+  9 | 4
+ 10 | 5
+(11 rows)
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Finalize GroupAggregate  (cost=0.16..197.23 rows=6 width=4)
+   Group Key: b
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.16..197.13 rows=18 width=4)
+         Merge Key: b
+         ->  Partial GroupAggregate  (cost=0.16..196.89 rows=6 width=4)
+               Group Key: b
+               ->  Index Only Scan using distinct_test_b_idx on distinct_test  (cost=0.16..188.49 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select distinct b from distinct_test;
+ b 
+---
+ 0
+ 1
+ 2
+ 3
+ 4
+ 5
+(6 rows)
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Unique  (cost=0.16..346.83 rows=10000 width=4)
+   Group Key: c
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.16..321.83 rows=10000 width=4)
+         Merge Key: c
+         ->  Index Only Scan using distinct_test_c_idx on distinct_test  (cost=0.16..188.49 rows=3333 width=4)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+ count 
+-------
+ 10000
+(1 row)
+

--- a/src/test/regress/expected/gp_distinct_plans_optimizer.out
+++ b/src/test/regress/expected/gp_distinct_plans_optimizer.out
@@ -1,0 +1,287 @@
+--
+-- Test all the different plan shapes that the planner can generate for
+-- DISTINCT queries
+--
+create table distinct_test (a int, b int, c int) distributed by (a);
+insert into distinct_test select g / 1000, g / 2000, g from generate_series(1, 10000) g;
+analyze distinct_test;
+--
+-- With the default cost settings, you get hashed plans
+--
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.93 rows=38 width=8)
+   ->  HashAggregate  (cost=0.00..431.93 rows=13 width=8)
+         Group Key: a, b
+         ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select distinct a, b from distinct_test;
+ a  | b 
+----+---
+  1 | 0
+  0 | 0
+  6 | 3
+  9 | 4
+ 10 | 5
+  5 | 2
+  3 | 1
+  4 | 2
+  2 | 1
+  7 | 3
+  8 | 4
+(11 rows)
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.51 rows=6 width=4)
+   ->  GroupAggregate  (cost=0.00..431.51 rows=2 width=4)
+         Group Key: b
+         ->  Sort  (cost=0.00..431.51 rows=2 width=4)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.51 rows=2 width=4)
+                     Hash Key: b
+                     ->  Streaming HashAggregate  (cost=0.00..431.51 rows=2 width=4)
+                           Group Key: b
+                           ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select distinct b from distinct_test;
+ b 
+---
+ 5
+ 2
+ 4
+ 3
+ 1
+ 0
+(6 rows)
+
+-- The two-stage aggregation can be disabled with GUC
+set gp_enable_preunique = off;
+explain select distinct b from distinct_test;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.51 rows=6 width=4)
+   ->  GroupAggregate  (cost=0.00..431.51 rows=2 width=4)
+         Group Key: b
+         ->  Sort  (cost=0.00..431.51 rows=2 width=4)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.51 rows=2 width=4)
+                     Hash Key: b
+                     ->  Streaming HashAggregate  (cost=0.00..431.51 rows=2 width=4)
+                           Group Key: b
+                           ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+reset gp_enable_preunique;
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.70 rows=10000 width=4)
+   ->  HashAggregate  (cost=0.00..431.55 rows=3334 width=4)
+         Group Key: c
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
+               Hash Key: c
+               ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+ count 
+-------
+ 10000
+(1 row)
+
+--
+-- Repeat the same tests with sorted Unique plans
+--
+set enable_hashagg=off;
+set optimizer_enable_hashagg=off;
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.92 rows=38 width=8)
+   ->  GroupAggregate  (cost=0.00..432.92 rows=13 width=8)
+         Group Key: a, b
+         ->  Sort  (cost=0.00..432.90 rows=3334 width=8)
+               Sort Key: a, b
+               ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select distinct a, b from distinct_test;
+ a  | b 
+----+---
+  0 | 0
+  1 | 0
+  5 | 2
+  6 | 3
+  9 | 4
+ 10 | 5
+  2 | 1
+  3 | 1
+  4 | 2
+  7 | 3
+  8 | 4
+(11 rows)
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.00 rows=6 width=4)
+   ->  GroupAggregate  (cost=0.00..432.00 rows=2 width=4)
+         Group Key: b
+         ->  Sort  (cost=0.00..432.00 rows=2 width=4)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..432.00 rows=2 width=4)
+                     Hash Key: b
+                     ->  GroupAggregate  (cost=0.00..432.00 rows=2 width=4)
+                           Group Key: b
+                           ->  Sort  (cost=0.00..431.99 rows=3334 width=4)
+                                 Sort Key: b
+                                 ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+select distinct b from distinct_test;
+ b 
+---
+ 2
+ 3
+ 4
+ 0
+ 1
+ 5
+(6 rows)
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.20 rows=10000 width=4)
+   ->  GroupAggregate  (cost=0.00..432.05 rows=3334 width=4)
+         Group Key: c
+         ->  Sort  (cost=0.00..432.03 rows=3334 width=4)
+               Sort Key: c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
+                     Hash Key: c
+                     ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+ count 
+-------
+ 10000
+(1 row)
+
+--
+-- Also test paths where the explicit Sort is not needed
+--
+create index on distinct_test (a, b);
+create index on distinct_test (b);
+create index on distinct_test (c);
+set random_page_cost=1;
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.92 rows=38 width=8)
+   ->  GroupAggregate  (cost=0.00..432.92 rows=13 width=8)
+         Group Key: a, b
+         ->  Sort  (cost=0.00..432.90 rows=3334 width=8)
+               Sort Key: a, b
+               ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select distinct a, b from distinct_test;
+ a  | b 
+----+---
+  0 | 0
+  1 | 0
+  5 | 2
+  6 | 3
+  9 | 4
+ 10 | 5
+  2 | 1
+  3 | 1
+  4 | 2
+  7 | 3
+  8 | 4
+(11 rows)
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.00 rows=6 width=4)
+   ->  GroupAggregate  (cost=0.00..432.00 rows=2 width=4)
+         Group Key: b
+         ->  Sort  (cost=0.00..432.00 rows=2 width=4)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..432.00 rows=2 width=4)
+                     Hash Key: b
+                     ->  GroupAggregate  (cost=0.00..432.00 rows=2 width=4)
+                           Group Key: b
+                           ->  Sort  (cost=0.00..431.99 rows=3334 width=4)
+                                 Sort Key: b
+                                 ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+select distinct b from distinct_test;
+ b 
+---
+ 0
+ 1
+ 5
+ 2
+ 3
+ 4
+(6 rows)
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.20 rows=10000 width=4)
+   ->  GroupAggregate  (cost=0.00..432.05 rows=3334 width=4)
+         Group Key: c
+         ->  Sort  (cost=0.00..432.03 rows=3334 width=4)
+               Sort Key: c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
+                     Hash Key: c
+                     ->  Seq Scan on distinct_test  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+ count 
+-------
+ 10000
+(1 row)
+

--- a/src/test/regress/expected/gpdist_legacy_opclasses.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses.out
@@ -418,16 +418,19 @@ insert into try_distinct_array select 'y',string_to_array('1~1','~')::int[];
 insert into try_distinct_array select 'n',string_to_array('1~1','~')::int[];
 -- Aggregate with grouping column that does not have legacy hashop
 explain (costs off) select distinct test_array from try_distinct_array;
-                    QUERY PLAN                    
---------------------------------------------------
- Finalize HashAggregate
-   Group Key: test_array
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial HashAggregate
-               Group Key: test_array
-               ->  Seq Scan on try_distinct_array
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: test_array
+   ->  Unique
+         Group Key: test_array
+         ->  Sort
+               Sort Key: test_array
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: test_array
+                     ->  Seq Scan on try_distinct_array
  Optimizer: Postgres query optimizer
-(7 rows)
+(10 rows)
 
 select distinct test_array from try_distinct_array;
  test_array 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11959,7 +11959,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c'
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- GroupAggregate  (cost=5.25..5.31 rows=3 width=8)
+ Unique  (cost=5.25..5.28 rows=3 width=8)
    Output: l1.c, l1.lid
    Group Key: l1.c, l1.lid
    ->  Sort  (cost=5.25..5.26 rows=3 width=8)

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -4563,19 +4563,21 @@ select d.* from d left join (select * from b group by b.id, b.c_id) s
 explain (costs off)
 select d.* from d left join (select distinct * from b) s
   on d.a = s.id;
-                 QUERY PLAN                  
----------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Left Join
          Hash Cond: (d.a = s.id)
          ->  Seq Scan on d
          ->  Hash
                ->  Subquery Scan on s
-                     ->  HashAggregate
-                           Group Key: b.id
-                           ->  Seq Scan on b
+                     ->  Unique
+                           Group Key: b.id, b.c_id
+                           ->  Sort
+                                 Sort Key: b.id, b.c_id
+                                 ->  Seq Scan on b
  Optimizer: Postgres query optimizer
-(10 rows)
+(12 rows)
 
 -- check join removal works when uniqueness of the join condition is enforced
 -- by a UNION

--- a/src/test/regress/expected/olap_plans.out
+++ b/src/test/regress/expected/olap_plans.out
@@ -314,13 +314,13 @@ insert into foo_ctas select g%5, g%2 from generate_series(1, 100) g;
 explain create table bar_ctas as select * from foo_ctas group by a, b distributed by (b);
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=11.59..11.76 rows=10 width=8)
+ GroupAggregate  (cost=11.59..11.76 rows=10 width=8)
    Group Key: a, b
    ->  Sort  (cost=11.59..11.61 rows=10 width=8)
          Sort Key: a, b
          ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1.50..11.42 rows=10 width=8)
                Hash Key: b
-               ->  Partial HashAggregate  (cost=1.50..1.60 rows=10 width=8)
+               ->  HashAggregate  (cost=1.50..1.60 rows=10 width=8)
                      Group Key: a, b
                      ->  Seq Scan on foo_ctas  (cost=0.00..1.33 rows=33 width=8)
  Optimizer: Postgres query optimizer
@@ -335,13 +335,13 @@ explain insert into bar_ctas select * from foo_ctas group by a, b;
  Insert on bar_ctas  (cost=11.59..21.86 rows=10 width=8)
    ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=11.59..21.86 rows=10 width=8)
          Hash Key: foo_ctas.b
-         ->  Finalize GroupAggregate  (cost=11.59..11.76 rows=10 width=8)
+         ->  GroupAggregate  (cost=11.59..11.76 rows=10 width=8)
                Group Key: foo_ctas.a, foo_ctas.b
                ->  Sort  (cost=11.59..11.61 rows=10 width=8)
                      Sort Key: foo_ctas.a, foo_ctas.b
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.50..11.42 rows=10 width=8)
                            Hash Key: foo_ctas.a, foo_ctas.b
-                           ->  Partial HashAggregate  (cost=1.50..1.60 rows=10 width=8)
+                           ->  HashAggregate  (cost=1.50..1.60 rows=10 width=8)
                                  Group Key: foo_ctas.a, foo_ctas.b
                                  ->  Seq Scan on foo_ctas  (cost=0.00..1.33 rows=33 width=8)
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/partition_aggregate.out
+++ b/src/test/regress/expected/partition_aggregate.out
@@ -308,29 +308,29 @@ SELECT c FROM pagg_tab GROUP BY c ORDER BY 1;
 -------------------------------------------------------
  Merge Append
    Sort Key: pagg_tab_p1.c
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: pagg_tab_p1.c
          ->  Gather Motion 3:1  (slice1; segments: 3)
                Merge Key: pagg_tab_p1.c
-               ->  Partial GroupAggregate
+               ->  GroupAggregate
                      Group Key: pagg_tab_p1.c
                      ->  Sort
                            Sort Key: pagg_tab_p1.c
                            ->  Seq Scan on pagg_tab_p1
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: pagg_tab_p2.c
          ->  Gather Motion 3:1  (slice2; segments: 3)
                Merge Key: pagg_tab_p2.c
-               ->  Partial GroupAggregate
+               ->  GroupAggregate
                      Group Key: pagg_tab_p2.c
                      ->  Sort
                            Sort Key: pagg_tab_p2.c
                            ->  Seq Scan on pagg_tab_p2
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: pagg_tab_p3.c
          ->  Gather Motion 3:1  (slice3; segments: 3)
                Merge Key: pagg_tab_p3.c
-               ->  Partial GroupAggregate
+               ->  GroupAggregate
                      Group Key: pagg_tab_p3.c
                      ->  Sort
                            Sort Key: pagg_tab_p3.c

--- a/src/test/regress/expected/partition_aggregate_optimizer.out
+++ b/src/test/regress/expected/partition_aggregate_optimizer.out
@@ -323,29 +323,29 @@ SELECT c FROM pagg_tab GROUP BY c ORDER BY 1;
 -------------------------------------------------------
  Merge Append
    Sort Key: pagg_tab_p1.c
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: pagg_tab_p1.c
          ->  Gather Motion 3:1  (slice1; segments: 3)
                Merge Key: pagg_tab_p1.c
-               ->  Partial GroupAggregate
+               ->  GroupAggregate
                      Group Key: pagg_tab_p1.c
                      ->  Sort
                            Sort Key: pagg_tab_p1.c
                            ->  Seq Scan on pagg_tab_p1
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: pagg_tab_p2.c
          ->  Gather Motion 3:1  (slice2; segments: 3)
                Merge Key: pagg_tab_p2.c
-               ->  Partial GroupAggregate
+               ->  GroupAggregate
                      Group Key: pagg_tab_p2.c
                      ->  Sort
                            Sort Key: pagg_tab_p2.c
                            ->  Seq Scan on pagg_tab_p2
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: pagg_tab_p3.c
          ->  Gather Motion 3:1  (slice3; segments: 3)
                Merge Key: pagg_tab_p3.c
-               ->  Partial GroupAggregate
+               ->  GroupAggregate
                      Group Key: pagg_tab_p3.c
                      ->  Sort
                            Sort Key: pagg_tab_p3.c

--- a/src/test/regress/expected/pg_lsn.out
+++ b/src/test/regress/expected/pg_lsn.out
@@ -74,7 +74,7 @@ SELECT DISTINCT (i || '/' || j)::pg_lsn f
   ORDER BY f;
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
- GroupAggregate
+ Unique
    Group Key: (((((i.i)::text || '/'::text) || (j.j)::text))::pg_lsn)
    ->  Sort
          Sort Key: (((((i.i)::text || '/'::text) || (j.j)::text))::pg_lsn)

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3525,21 +3525,24 @@ EXPLAIN SELECT a FROM qp_tab1 f1 LEFT JOIN qp_tab2 on a=c WHERE NOT EXISTS(SELEC
 EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=3.15..3.18 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..10001.04 rows=1 width=4)
+   Merge Key: qp_tab1.a
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.02..2.14 rows=4 width=1)
-           ->  Hash Semi Join  (cost=1.02..2.07 rows=2 width=1)
+     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.02..2.09 rows=3 width=1)
+           ->  Hash Semi Join  (cost=1.02..2.05 rows=1 width=1)
                  Hash Cond: (qp_tab2.c = qp_tab3.e)
                  ->  Seq Scan on qp_tab2  (cost=0.00..1.01 rows=1 width=4)
                  ->  Hash  (cost=1.01..1.01 rows=1 width=4)
                        ->  Seq Scan on qp_tab3  (cost=0.00..1.01 rows=1 width=4)
-   ->  HashAggregate  (cost=3.15..3.16 rows=1 width=4)
+   ->  Unique  (cost=1.02..10001.03 rows=0 width=4)
          Group Key: qp_tab1.a
-         ->  Result  (cost=0.00..1.01 rows=1 width=4)
-               One-Time Filter: (NOT $0)
-               ->  Seq Scan on qp_tab1  (cost=0.00..1.01 rows=1 width=4)
+         ->  Sort  (cost=1.02..1.02 rows=1 width=4)
+               Sort Key: qp_tab1.a
+               ->  Result  (cost=0.00..1.01 rows=1 width=4)
+                     One-Time Filter: (NOT $0)
+                     ->  Seq Scan on qp_tab1  (cost=0.00..1.01 rows=1 width=4)
  Optimizer: Postgres query optimizer
-(14 rows)
+(17 rows)
 
 SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
  a 

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -3642,21 +3642,24 @@ GPDB_12_MERGE_FIXME: Fallsback due to unsupported exec location.
 EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=3.15..3.18 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..10001.04 rows=1 width=4)
+   Merge Key: qp_tab1.a
    InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.02..2.14 rows=4 width=1)
-           ->  Hash Semi Join  (cost=1.02..2.07 rows=2 width=1)
+     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.02..2.09 rows=3 width=1)
+           ->  Hash Semi Join  (cost=1.02..2.05 rows=1 width=1)
                  Hash Cond: (qp_tab2.c = qp_tab3.e)
                  ->  Seq Scan on qp_tab2  (cost=0.00..1.01 rows=1 width=4)
                  ->  Hash  (cost=1.01..1.01 rows=1 width=4)
                        ->  Seq Scan on qp_tab3  (cost=0.00..1.01 rows=1 width=4)
-   ->  HashAggregate  (cost=3.15..3.16 rows=1 width=4)
+   ->  Unique  (cost=1.02..10001.03 rows=0 width=4)
          Group Key: qp_tab1.a
-         ->  Result  (cost=0.00..1.01 rows=1 width=4)
-               One-Time Filter: (NOT $0)
-               ->  Seq Scan on qp_tab1  (cost=0.00..1.01 rows=1 width=4)
+         ->  Sort  (cost=1.02..1.02 rows=1 width=4)
+               Sort Key: qp_tab1.a
+               ->  Result  (cost=0.00..1.01 rows=1 width=4)
+                     One-Time Filter: (NOT $0)
+                     ->  Seq Scan on qp_tab1  (cost=0.00..1.01 rows=1 width=4)
  Optimizer: Postgres query optimizer
-(14 rows)
+(17 rows)
 
 SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
  a 

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -3636,12 +3636,12 @@ select i as a, i as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a
 explain select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=10000002790.97..10000002940.97 rows=2000 width=8)
-   Group Key: (GROUPINGSET_ID()), j, j
+ GroupAggregate  (cost=10000002790.97..10000002940.97 rows=2000 width=8)
+   Group Key: j, j, (GROUPINGSET_ID())
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=10000002790.97..10000002875.97 rows=6000 width=8)
-         Merge Key: (GROUPINGSET_ID()), j
+         Merge Key: j, (GROUPINGSET_ID())
          ->  Sort  (cost=10000002790.97..10000002795.97 rows=2000 width=8)
-               Sort Key: (GROUPINGSET_ID()), j
+               Sort Key: j, (GROUPINGSET_ID())
                ->  Partial GroupAggregate  (cost=10000002446.06..10000002681.31 rows=2000 width=8)
                      Group Key: j, j
                      Group Key: j
@@ -4764,10 +4764,10 @@ else 'Unidentify' end
 ;
                                                                                                                              QUERY PLAN                                                                                                                              
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize HashAggregate  (cost=284.32..306.82 rows=1000 width=96)
+ HashAggregate  (cost=284.32..306.82 rows=1000 width=96)
    Group Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=75.08..270.74 rows=2714 width=102)
-         ->  Partial HashAggregate  (cost=75.08..89.79 rows=905 width=102)
+         ->  HashAggregate  (cost=75.08..89.79 rows=905 width=102)
                Group Key: CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END, CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END
                ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..65.42 rows=1933 width=102)
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -3628,7 +3628,7 @@ select i as a, i as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a
 explain select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=10000002790.97..10000002940.97 rows=2000 width=8)
+ GroupAggregate  (cost=10000002790.97..10000002940.97 rows=2000 width=8)
    Group Key: j, j, (GROUPINGSET_ID())
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=10000002790.97..10000002875.97 rows=6000 width=8)
          Merge Key: j, (GROUPINGSET_ID())
@@ -3641,7 +3641,7 @@ explain select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping 
                            Sort Key: j
                            ->  Seq Scan on tbl7553_test  (cost=10000000000.00..10000000321.00 rows=28700 width=8)
  Optimizer: Postgres query optimizer
-(16 rows)
+(13 rows)
 
 select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
  a | b 

--- a/src/test/regress/expected/regex_gp.out
+++ b/src/test/regress/expected/regex_gp.out
@@ -5071,7 +5071,7 @@ select DISTINCT lname, regexp_matches(lname, '(dad)') from phone_book_substr ;
 --(0 rows)
 --Changed to First Name from Last Name.
 select DISTINCT fname, regexp_matches(fname, '(dad)') from phone_book_substr order by lname;
-ERROR:  column "phone_book_substr.lname" must appear in the GROUP BY clause or be used in an aggregate function
+ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
 LINE 1: ...tches(fname, '(dad)') from phone_book_substr order by lname;
                                                                  ^
 --  fname  | regexp_matches 

--- a/src/test/regress/expected/select_distinct.out
+++ b/src/test/regress/expected/select_distinct.out
@@ -138,7 +138,7 @@ SELECT count(*) FROM
          Output: (PARTIAL count(*))
          ->  Partial Aggregate
                Output: PARTIAL count(*)
-               ->  Finalize GroupAggregate
+               ->  GroupAggregate
                      Output: tenk1.two, tenk1.four, tenk1.two
                      Group Key: tenk1.two, tenk1.four, tenk1.two
                      ->  Sort
@@ -147,7 +147,7 @@ SELECT count(*) FROM
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Output: tenk1.two, tenk1.four, tenk1.two
                                  Hash Key: tenk1.two, tenk1.four, tenk1.two
-                                 ->  Partial HashAggregate
+                                 ->  HashAggregate
                                        Output: tenk1.two, tenk1.four, tenk1.two
                                        Group Key: tenk1.two, tenk1.four, tenk1.two
                                        ->  Seq Scan on public.tenk1
@@ -177,7 +177,7 @@ EXPLAIN (costs off)
 SELECT DISTINCT g%1000 FROM generate_series(0,9999) g;
                    QUERY PLAN                   
 ------------------------------------------------
- GroupAggregate
+ Unique
    Group Key: ((g % 1000))
    ->  Sort
          Sort Key: ((g % 1000))

--- a/src/test/regress/expected/select_parallel.out
+++ b/src/test/regress/expected/select_parallel.out
@@ -260,10 +260,10 @@ explain (costs off)
 	select length(stringu1) from tenk1 group by length(stringu1);
                     QUERY PLAN                     
 ---------------------------------------------------
- Finalize HashAggregate
+ HashAggregate
    Group Key: (length((stringu1)::text))
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial HashAggregate
+         ->  HashAggregate
                Group Key: length((stringu1)::text)
                ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -263,10 +263,10 @@ explain (costs off)
 	select length(stringu1) from tenk1 group by length(stringu1);
                     QUERY PLAN                     
 ---------------------------------------------------
- Finalize HashAggregate
+ HashAggregate
    Group Key: (length((stringu1)::text))
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial HashAggregate
+         ->  HashAggregate
                Group Key: length((stringu1)::text)
                ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/tsrf.out
+++ b/src/test/regress/expected/tsrf.out
@@ -596,17 +596,13 @@ ORDER BY a, b DESC, g DESC;
 (18 rows)
 
 -- only SRF mentioned in DISTINCT ON
--- GPDB: the result is not well-defined, because for rows with same 'g',
--- any row can legally be returned. GPDB chooses a different plan than
--- upstream, one that redistributes the data. (That's probably not a
--- good plan in this simple case, but it's not incorrect.)
 SELECT DISTINCT ON (g) a, b, generate_series(1,3) g
 FROM (VALUES (3, 2), (3,1), (1,1), (1,4), (5,3), (5,1)) AS t(a, b);
  a | b | g 
 ---+---+---
  3 | 2 | 1
- 3 | 2 | 2
- 5 | 3 | 3
+ 5 | 1 | 2
+ 3 | 1 | 3
 (3 rows)
 
 -- LIMIT / OFFSET is evaluated after SRF evaluation

--- a/src/test/regress/expected/tsrf_optimizer.out
+++ b/src/test/regress/expected/tsrf_optimizer.out
@@ -613,17 +613,13 @@ ORDER BY a, b DESC, g DESC;
 (18 rows)
 
 -- only SRF mentioned in DISTINCT ON
--- GPDB: the result is not well-defined, because for rows with same 'g',
--- any row can legally be returned. GPDB chooses a different plan than
--- upstream, one that redistributes the data. (That's probably not a
--- good plan in this simple case, but it's not incorrect.)
 SELECT DISTINCT ON (g) a, b, generate_series(1,3) g
 FROM (VALUES (3, 2), (3,1), (1,1), (1,4), (5,3), (5,1)) AS t(a, b);
  a | b | g 
 ---+---+---
  3 | 2 | 1
- 3 | 2 | 2
- 5 | 3 | 3
+ 5 | 1 | 2
+ 3 | 1 | 3
 (3 rows)
 
 -- LIMIT / OFFSET is evaluated after SRF evaluation

--- a/src/test/regress/expected/union.out
+++ b/src/test/regress/expected/union.out
@@ -973,24 +973,30 @@ select distinct q1 from
    union all
    select distinct * from int8_tbl i82) ss
 where q2 = q2;
-                        QUERY PLAN                        
-----------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
+   Merge Key: "*SELECT* 1".q1
+   ->  Unique
          Group Key: "*SELECT* 1".q1
-         ->  Append
+         ->  Merge Append
+               Sort Key: "*SELECT* 1".q1
                ->  Subquery Scan on "*SELECT* 1"
-                     ->  HashAggregate
+                     ->  Unique
                            Group Key: i81.q1, i81.q2
-                           ->  Seq Scan on int8_tbl i81
-                                 Filter: (q2 IS NOT NULL)
+                           ->  Sort
+                                 Sort Key: i81.q1, i81.q2
+                                 ->  Seq Scan on int8_tbl i81
+                                       Filter: (q2 IS NOT NULL)
                ->  Subquery Scan on "*SELECT* 2"
-                     ->  HashAggregate
+                     ->  Unique
                            Group Key: i82.q1, i82.q2
-                           ->  Seq Scan on int8_tbl i82
-                                 Filter: (q2 IS NOT NULL)
+                           ->  Sort
+                                 Sort Key: i82.q1, i82.q2
+                                 ->  Seq Scan on int8_tbl i82
+                                       Filter: (q2 IS NOT NULL)
  Optimizer: Postgres query optimizer
-(15 rows)
+(21 rows)
 
 select distinct q1 from
   (select distinct * from int8_tbl i81
@@ -1012,23 +1018,27 @@ where -q1 = q2;
                           QUERY PLAN                          
 --------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   Merge Key: "*SELECT* 1".q1
+   ->  Unique
          Group Key: "*SELECT* 1".q1
-         ->  Sort
+         ->  Merge Append
                Sort Key: "*SELECT* 1".q1
-               ->  Append
-                     ->  Subquery Scan on "*SELECT* 1"
-                           ->  HashAggregate
-                                 Group Key: i81.q1, i81.q2
+               ->  Subquery Scan on "*SELECT* 1"
+                     ->  Unique
+                           Group Key: i81.q1, i81.q2
+                           ->  Sort
+                                 Sort Key: i81.q1, i81.q2
                                  ->  Seq Scan on int8_tbl i81
                                        Filter: ((- q1) = q2)
-                     ->  Subquery Scan on "*SELECT* 2"
-                           ->  HashAggregate
-                                 Group Key: i82.q1, i82.q2
+               ->  Subquery Scan on "*SELECT* 2"
+                     ->  Unique
+                           Group Key: i82.q1, i82.q2
+                           ->  Sort
+                                 Sort Key: i82.q1, i82.q2
                                  ->  Seq Scan on int8_tbl i82
                                        Filter: ((- q1) = q2)
  Optimizer: Postgres query optimizer
-(17 rows)
+(21 rows)
 
 select distinct q1 from
   (select distinct * from int8_tbl i81

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -137,7 +137,7 @@ SELECT table_name, column_name, is_updatable
 -- Read-only views
 DELETE FROM ro_view1;
 ERROR:  cannot delete from view "ro_view1"
-DETAIL:  Views containing GROUP BY are not automatically updatable.
+DETAIL:  Views containing DISTINCT are not automatically updatable.
 HINT:  To enable deleting from the view, provide an INSTEAD OF DELETE trigger or an unconditional ON DELETE DO INSTEAD rule.
 DELETE FROM ro_view2;
 ERROR:  cannot delete from view "ro_view2"
@@ -319,7 +319,7 @@ DELETE FROM rw_view16 WHERE a=-3; -- should be OK
 -- Read-only views
 INSERT INTO ro_view17 VALUES (3, 'ROW 3');
 ERROR:  cannot insert into view "ro_view1"
-DETAIL:  Views containing GROUP BY are not automatically updatable.
+DETAIL:  Views containing DISTINCT are not automatically updatable.
 HINT:  To enable inserting into the view, provide an INSTEAD OF INSERT trigger or an unconditional ON INSERT DO INSTEAD rule.
 DELETE FROM ro_view18;
 ERROR:  cannot delete from view "ro_view18"

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -137,7 +137,7 @@ SELECT table_name, column_name, is_updatable
 -- Read-only views
 DELETE FROM ro_view1;
 ERROR:  cannot delete from view "ro_view1"
-DETAIL:  Views containing GROUP BY are not automatically updatable.
+DETAIL:  Views containing DISTINCT are not automatically updatable.
 HINT:  To enable deleting from the view, provide an INSTEAD OF DELETE trigger or an unconditional ON DELETE DO INSTEAD rule.
 DELETE FROM ro_view2;
 ERROR:  cannot delete from view "ro_view2"
@@ -319,7 +319,7 @@ DELETE FROM rw_view16 WHERE a=-3; -- should be OK
 -- Read-only views
 INSERT INTO ro_view17 VALUES (3, 'ROW 3');
 ERROR:  cannot insert into view "ro_view1"
-DETAIL:  Views containing GROUP BY are not automatically updatable.
+DETAIL:  Views containing DISTINCT are not automatically updatable.
 HINT:  To enable inserting into the view, provide an INSTEAD OF INSERT trigger or an unconditional ON INSERT DO INSTEAD rule.
 DELETE FROM ro_view18;
 ERROR:  cannot delete from view "ro_view18"

--- a/src/test/regress/expected/write_parallel.out
+++ b/src/test/regress/expected/write_parallel.out
@@ -19,13 +19,13 @@ explain (costs off) create table parallel_write as
     select length(stringu1) from tenk1 group by length(stringu1);
                          QUERY PLAN                         
 ------------------------------------------------------------
- Finalize GroupAggregate
+ GroupAggregate
    Group Key: (length((stringu1)::text))
    ->  Sort
          Sort Key: (length((stringu1)::text))
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: (length((stringu1)::text))
-               ->  Partial HashAggregate
+               ->  HashAggregate
                      Group Key: length((stringu1)::text)
                      ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
@@ -38,13 +38,13 @@ explain (costs off) select length(stringu1) into parallel_write
     from tenk1 group by length(stringu1);
                          QUERY PLAN                         
 ------------------------------------------------------------
- Finalize GroupAggregate
+ GroupAggregate
    Group Key: (length((stringu1)::text))
    ->  Sort
          Sort Key: (length((stringu1)::text))
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: (length((stringu1)::text))
-               ->  Partial HashAggregate
+               ->  HashAggregate
                      Group Key: length((stringu1)::text)
                      ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
@@ -57,13 +57,13 @@ explain (costs off) create materialized view parallel_mat_view as
     select length(stringu1) from tenk1 group by length(stringu1);
                          QUERY PLAN                         
 ------------------------------------------------------------
- Finalize GroupAggregate
+ GroupAggregate
    Group Key: (length((stringu1)::text))
    ->  Sort
          Sort Key: (length((stringu1)::text))
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: (length((stringu1)::text))
-               ->  Partial HashAggregate
+               ->  HashAggregate
                      Group Key: length((stringu1)::text)
                      ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
@@ -76,13 +76,13 @@ prepare prep_stmt as select length(stringu1) from tenk1 group by length(stringu1
 explain (costs off) create table parallel_write as execute prep_stmt;
                          QUERY PLAN                         
 ------------------------------------------------------------
- Finalize GroupAggregate
+ GroupAggregate
    Group Key: (length((stringu1)::text))
    ->  Sort
          Sort Key: (length((stringu1)::text))
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: (length((stringu1)::text))
-               ->  Partial HashAggregate
+               ->  HashAggregate
                      Group Key: length((stringu1)::text)
                      ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer

--- a/src/test/regress/output/table_functions.source
+++ b/src/test/regress/output/table_functions.source
@@ -1925,13 +1925,13 @@ explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER
 explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER BY a, b SCATTER BY a) );
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.54 rows=10 width=36)
-   ->  Table Function Scan on multiset_5  (cost=2.27..2.54 rows=4 width=36)
-         ->  GroupAggregate  (cost=2.27..2.44 rows=4 width=16)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.06..1.59 rows=30 width=36)
+   ->  Table Function Scan on multiset_5  (cost=1.06..1.19 rows=10 width=36)
+         ->  Unique  (cost=1.06..1.09 rows=3 width=16)
                Group Key: example.a, example.b
-               ->  Sort  (cost=2.27..2.29 rows=4 width=16)
+               ->  Sort  (cost=1.06..1.07 rows=3 width=16)
                      Sort Key: example.a, example.b
-                     ->  Seq Scan on example  (cost=0.00..2.10 rows=4 width=16)
+                     ->  Seq Scan on example  (cost=0.00..1.03 rows=3 width=16)
  Optimizer: Postgres query optimizer
 (8 rows)
 
@@ -1953,18 +1953,18 @@ explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER
 explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER BY b, a LIMIT 2 SCATTER RANDOMLY) );
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.33 rows=2 width=36)
-   ->  Table Function Scan on multiset_5  (cost=2.27..2.33 rows=1 width=36)
-         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.27..2.31 rows=2 width=36)
-               ->  Limit  (cost=2.27..2.31 rows=2 width=36)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=2.27..2.31 rows=2 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.07..1.28 rows=9 width=36)
+   ->  Table Function Scan on multiset_5  (cost=1.07..1.16 rows=3 width=36)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=1.07..1.13 rows=1 width=16)
+               ->  Limit  (cost=1.07..1.10 rows=2 width=16)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.07..1.16 rows=6 width=16)
                            Merge Key: example.b, example.a
-                           ->  Limit  (cost=2.27..2.27 rows=1 width=36)
-                                 ->  GroupAggregate  (cost=2.27..2.44 rows=27 width=36)
+                           ->  Limit  (cost=1.07..1.08 rows=2 width=16)
+                                 ->  Unique  (cost=1.06..1.09 rows=3 width=16)
                                        Group Key: example.b, example.a
-                                       ->  Sort  (cost=2.27..2.29 rows=4 width=16)
+                                       ->  Sort  (cost=1.06..1.07 rows=3 width=16)
                                              Sort Key: example.b, example.a
-                                             ->  Seq Scan on example  (cost=0.00..2.10 rows=4 width=16)
+                                             ->  Seq Scan on example  (cost=0.00..1.03 rows=3 width=16)
  Optimizer: Postgres query optimizer
 (13 rows)
 

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -1925,13 +1925,13 @@ explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER
 explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER BY a, b SCATTER BY a) );
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.54 rows=10 width=36)
-   ->  Table Function Scan on multiset_5  (cost=2.27..2.54 rows=4 width=36)
-         ->  GroupAggregate  (cost=2.27..2.44 rows=4 width=16)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.06..1.59 rows=30 width=36)
+   ->  Table Function Scan on multiset_5  (cost=1.06..1.19 rows=10 width=36)
+         ->  Unique  (cost=1.06..1.09 rows=3 width=16)
                Group Key: example.a, example.b
-               ->  Sort  (cost=2.27..2.29 rows=4 width=16)
+               ->  Sort  (cost=1.06..1.07 rows=3 width=16)
                      Sort Key: example.a, example.b
-                     ->  Seq Scan on example  (cost=0.00..2.10 rows=4 width=16)
+                     ->  Seq Scan on example  (cost=0.00..1.03 rows=3 width=16)
  Optimizer: Postgres query optimizer
 (8 rows)
 
@@ -1953,18 +1953,18 @@ explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER
 explain SELECT * FROM multiset_5( TABLE (SELECT DISTINCT a, b FROM example ORDER BY b, a LIMIT 2 SCATTER RANDOMLY) );
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2.27..2.33 rows=2 width=36)
-   ->  Table Function Scan on multiset_5  (cost=2.27..2.33 rows=1 width=36)
-         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=2.27..2.31 rows=2 width=36)
-               ->  Limit  (cost=2.27..2.31 rows=2 width=36)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=2.27..2.31 rows=2 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.07..1.28 rows=9 width=36)
+   ->  Table Function Scan on multiset_5  (cost=1.07..1.16 rows=3 width=36)
+         ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=1.07..1.13 rows=1 width=16)
+               ->  Limit  (cost=1.07..1.10 rows=2 width=16)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.07..1.16 rows=6 width=16)
                            Merge Key: example.b, example.a
-                           ->  Limit  (cost=2.27..2.27 rows=1 width=36)
-                                 ->  GroupAggregate  (cost=2.27..2.44 rows=27 width=36)
+                           ->  Limit  (cost=1.07..1.08 rows=2 width=16)
+                                 ->  Unique  (cost=1.06..1.09 rows=3 width=16)
                                        Group Key: example.b, example.a
-                                       ->  Sort  (cost=2.27..2.29 rows=4 width=16)
+                                       ->  Sort  (cost=1.06..1.07 rows=3 width=16)
                                              Sort Key: example.b, example.a
-                                             ->  Seq Scan on example  (cost=0.00..2.10 rows=4 width=16)
+                                             ->  Seq Scan on example  (cost=0.00..1.03 rows=3 width=16)
  Optimizer: Postgres query optimizer
 (13 rows)
 

--- a/src/test/regress/sql/gp_distinct_plans.sql
+++ b/src/test/regress/sql/gp_distinct_plans.sql
@@ -1,0 +1,79 @@
+--
+-- Test all the different plan shapes that the planner can generate for
+-- DISTINCT queries
+--
+create table distinct_test (a int, b int, c int) distributed by (a);
+insert into distinct_test select g / 1000, g / 2000, g from generate_series(1, 10000) g;
+analyze distinct_test;
+
+--
+-- With the default cost settings, you get hashed plans
+--
+
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+select distinct a, b from distinct_test;
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+select distinct b from distinct_test;
+
+-- The two-stage aggregation can be disabled with GUC
+set gp_enable_preunique = off;
+explain select distinct b from distinct_test;
+reset gp_enable_preunique;
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+
+--
+-- Repeat the same tests with sorted Unique plans
+--
+set enable_hashagg=off;
+set optimizer_enable_hashagg=off;
+
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+select distinct a, b from distinct_test;
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+select distinct b from distinct_test;
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;
+
+--
+-- Also test paths where the explicit Sort is not needed
+--
+create index on distinct_test (a, b);
+create index on distinct_test (b);
+create index on distinct_test (c);
+set random_page_cost=1;
+
+
+-- If the DISTINCT is a superset of the table's distribution keys, the
+-- duplicates can be eliminated independently in the segments.
+explain select distinct a, b from distinct_test;
+select distinct a, b from distinct_test;
+
+-- Otherwise, redistribution is needed
+explain select distinct b from distinct_test;
+select distinct b from distinct_test;
+
+-- If the input is highly unique already the pre-Unique step is not worthwhile.
+-- (Only print count(*) of the result because it returns so many rows)
+explain select distinct c from distinct_test;
+select count(*) from (
+        select distinct c from distinct_test
+offset 0) as x;

--- a/src/test/regress/sql/tsrf.sql
+++ b/src/test/regress/sql/tsrf.sql
@@ -150,10 +150,6 @@ FROM (VALUES (3, 2), (3,1), (1,1), (1,4), (5,3), (5,1)) AS t(a, b)
 ORDER BY a, b DESC, g DESC;
 
 -- only SRF mentioned in DISTINCT ON
--- GPDB: the result is not well-defined, because for rows with same 'g',
--- any row can legally be returned. GPDB chooses a different plan than
--- upstream, one that redistributes the data. (That's probably not a
--- good plan in this simple case, but it's not incorrect.)
 SELECT DISTINCT ON (g) a, b, generate_series(1,3) g
 FROM (VALUES (3, 2), (3,1), (1,1), (1,4), (5,3), (5,1)) AS t(a, b);
 


### PR DESCRIPTION
Previously, we had a parse analysis step to convert DISTINCT into a
corresponding GROUP BY query, because the planner was smarter about GROUP
BY than DISTINCT. The DISTINCT planning code was still needed for more
complicated cases, though, where you had both DISTINCT and GROUP BY or
aggregates in the same query. The DISTINCT planning code was badly
dilapidated, there was broken commented-out remnants of "pre-unique"
optimization in the DISTINCT planner code, for example, that got broken
in the 8.4 and 9.6 merges, but we hadn't bothered to fix.

Clean that up. Instead of transforming DISTINCT into GROUP BY in the
parse analysis stage, re-use the GROUP BY planning code for DISTINCT
queries in the planner.

This removes the gp_eager_preunique GUC, that was previously used to
force two-stage DISTINCT plans. It was undocumented, only had an effect
in the limited cases that we didn't transform the DISTINCT to GROUP BY,
so we probably don't want it in that form. It would make some sense to
have a GUC to force multi-stage DISTINCT and aggregation, perhaps by
adding a penalty cost to one-stage plans, but that should be a separate
PR.
