### PR TITLE
[5X-only] Do not read a persistent tuple after it is freed

### DIFF
--- a/src/backend/cdb/cdbpersistentfilesysobj.c
+++ b/src/backend/cdb/cdbpersistentfilesysobj.c
@@ -1567,11 +1567,26 @@ PersistentFileSysObjStateChangeResult PersistentFileSysObj_StateChange(
 
 		pfree(newValues);
 		pfree(replaces);
+
+		if (Debug_persistent_print)
+		{
+			heap_freetuple(tupleCopy);
+
+			PersistentFileSysObj_ReadTuple(
+				fsObjType,
+				persistentTid,
+				values,
+				&tupleCopy);
+
+			(*fileSysObjData->storeData.printTupleCallback)(
+				Persistent_DebugPrintLevel(),
+				"STATE CHANGE",
+				persistentTid,
+				values);
+		}
 	}
 	else
 	{
-		heap_freetuple(tupleCopy);
-
 		PersistentFileSysObj_FreeTuple(
 									fileSysObjData,
 									fileSysObjSharedData,
@@ -1580,23 +1595,7 @@ PersistentFileSysObjStateChangeResult PersistentFileSysObj_StateChange(
 									flushToXLog);
 	}
 
-	if (Debug_persistent_print)
-	{
-		PersistentFileSysObj_ReadTuple(
-								fsObjType,
-								persistentTid,
-								values,
-								&tupleCopy);
-
-		(*fileSysObjData->storeData.printTupleCallback)(
-									Persistent_DebugPrintLevel(),
-									"STATE CHANGE",
-									persistentTid,
-									values);
-
-		heap_freetuple(tupleCopy);
-	}
-
+	heap_freetuple(tupleCopy);
 	pfree(values);
 
 	return PersistentFileSysObjStateChangeResult_StateChangeOk;


### PR DESCRIPTION
This bug was found in a production environment where vacuum on gp_persistent_relation was concurrently running with a backend performing end-of-xact filesystem operations.  And the GUC debug_persistent_print was enabled.

The *_ReadTuple() function was called on a persistent TID after the corresponding tuple was deleted with frozen transaction ID.  The concurrent vacuum recycled the tuple and it led to a SIGSEGV when the backend tried to access values from the tuple.

Fix it by avoiding the debug log message in case when the persistent tuple is freed (transitioning to FREE state).  All other state transitions are logged.

In absence of concurrent vacuum, things worked just fine because the *_ReadTuple() interface reads tuples from persistent tables directly using TID.

This change was tested manually by holding a committing backend in a debugger and running concurrent vacuum.  If found necessary during review, writing an isolation2 test shouldn't be hard.