### PR TITLE
Introduce a way to validate cluster state during regression tests

### DIFF
--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -47,6 +47,10 @@ function _main() {
         exit 1
     fi
 
+    if [ -n "${VALIDATE_SYSTEM_TESTNAME}" ]; then
+	MAKE_TEST_COMMAND="EXTRA_REGRESS_OPTS=--validate-system=${VALIDATE_SYSTEM_TESTNAME} ${MAKE_TEST_COMMAND}"
+    fi
+
     if [ -z "$TEST_OS" ]; then
         echo "FATAL: TEST_OS is not set"
         exit 1

--- a/concourse/tasks/ic_gpdb.yml
+++ b/concourse/tasks/ic_gpdb.yml
@@ -13,5 +13,6 @@ params:
   TEST_OS: ""
   CONFIGURE_FLAGS: ""
   WITH_MIRRORS:
+  VALIDATE_SYSTEM_TESTNAME: "check_cluster"
 run:
   path: gpdb_src/concourse/scripts/ic_gpdb.bash

--- a/src/test/isolation/expected/check_cluster.out
+++ b/src/test/isolation/expected/check_cluster.out
@@ -1,0 +1,6 @@
+Parsed test spec with 1 sessions
+
+starting permutation: down_segments
+step down_segments: select dbid, content, status, role, preferred_role, mode from gp_segment_configuration where status = 'd' or preferred_role != role;
+dbid           content        status         role           preferred_role mode           
+

--- a/src/test/isolation/specs/check_cluster.spec
+++ b/src/test/isolation/specs/check_cluster.spec
@@ -1,0 +1,4 @@
+session "s1"
+step "down_segments" {select dbid, content, status, role, preferred_role, mode from gp_segment_configuration where status = 'd' or preferred_role != role;}
+
+permutation "down_segments"

--- a/src/test/isolation2/expected/check_cluster.out
+++ b/src/test/isolation2/expected/check_cluster.out
@@ -1,0 +1,4 @@
+select dbid, content, status, role, preferred_role, mode from gp_segment_configuration where status = 'd' or preferred_role != role;
+ dbid | content | status | role | preferred_role | mode 
+------+---------+--------+------+----------------+------
+(0 rows)

--- a/src/test/isolation2/sql/check_cluster.sql
+++ b/src/test/isolation2/sql/check_cluster.sql
@@ -1,0 +1,1 @@
+select dbid, content, status, role, preferred_role, mode from gp_segment_configuration where status = 'd' or preferred_role != role;

--- a/src/test/regress/expected/check_cluster.out
+++ b/src/test/regress/expected/check_cluster.out
@@ -1,0 +1,5 @@
+select dbid, content, status, role, preferred_role, mode from gp_segment_configuration where status = 'd' or preferred_role != role;
+ dbid | content | status | role | preferred_role | mode 
+------+---------+--------+------+----------------+------
+(0 rows)
+

--- a/src/test/regress/sql/check_cluster.sql
+++ b/src/test/regress/sql/check_cluster.sql
@@ -1,0 +1,1 @@
+select dbid, content, status, role, preferred_role, mode from gp_segment_configuration where status = 'd' or preferred_role != role;


### PR DESCRIPTION
It is often observed in CI that a test that leaves the cluster in an inconsistent state (e.g. primary-mirror pair is not in sync, or primary has not finished crash recovery) cause several following tests in the schedule to fail.  What's worse, the culprit test itself may be reported as passed because its validation criteria did not include the state of the cluster.  This has found to mislead debugging efforts, ultimately waste of time.

To make debugging CI failures more efficient, this patch adds `--validate-system=TEST` option to `pg_regress`.  It specifies the name of the test that `pg_regress` would run to validate cluster state before running an actual test from a schedule.  If the validation test fails, further testing is aborted.  The validation is performed before running a group of tests specified on one line in the schedule file. Alternatively, validation could be performed before every single test, but let's not get there until absolutely necessary.

When the cluster validation is found to fail, the culprit is in the previously run test group.

The new option is turned off by default, leaving developer workflow unchanged.  It is enabled only in CI jobs.

This patch is built on the ground work and analysis laid out in PR #9865 by @gfphoenix78.  In particular, Wu Hao found that the validation overhead is small enough to make the proposed patch viable.

A sample `pg_regress` with this change output looks as follows.  The command was:
```
make PGPORT=7000 EXTRA_REGRESS_OPTS=--validate-system=check_cluster -C src/test/regress installcheck-good
```
It generated this output, note the `test check_cluster lines`:
```
test check_cluster            ... ok (0.03 sec)
test namespace                ... ok (0.17 sec)  (diff:0.08 sec)
test check_cluster            ... ok (0.03 sec)
parallel group (16 tests):  init_privs drop_operator lock security_label groupingsets replica_identity object_address join_hash spgist collate gist gin privileges tablesample rowsecurity brin
     brin                     ... ok (27.78 sec)  (diff:0.11 sec)
     gin                      ... ok (4.69 sec)  (diff:0.07 sec)
     gist                     ... ok (4.08 sec)  (diff:0.08 sec)
     spgist                   ... ok (2.64 sec)  (diff:0.08 sec)
     privileges               ... ok (6.51 sec)  (diff:0.15 sec)
     init_privs               ... ok (0.27 sec)  (diff:0.07 sec)
     security_label           ... ok (1.07 sec)  (diff:0.08 sec)
     collate                  ... ok (2.92 sec)  (diff:0.10 sec)
     lock                     ... ok (0.82 sec)  (diff:0.08 sec)
     replica_identity         ... ok (1.76 sec)  (diff:0.08 sec)
     rowsecurity              ... ok (8.62 sec)  (diff:0.23 sec)
     object_address           ... ok (2.00 sec)  (diff:0.22 sec)
     tablesample              ... ok (8.50 sec)  (diff:0.09 sec)
     groupingsets             ... ok (1.31 sec)  (diff:0.10 sec)
     drop_operator            ... ok (0.43 sec)  (diff:0.07 sec)
     join_hash                ... ok (2.43 sec)  (diff:0.08 sec)
test check_cluster            ... FAILED

========================
 1 of 138 tests failed.
========================
```