### PR TITLE
[Travis CI] Bump cache size to 4G

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,7 @@ python:
 before_install:
     - eval "${OVERRIDE_CC}"
     - eval "${OVERRIDE_CXX}"
+    - ccache --max-size 4G
     # ccache 3.2 (from Ubuntu Xenial) has CCACHE_CPP2 default to off (this
     # setting defaults to on starting from ccache 3.3). That default leads to
     # unlegible compiler warning outputs because GCC and Clang will emit


### PR DESCRIPTION
Historically we've lowered the cache size to 500M (from the default of
5GB) because we thought that saves us time fetching and storing the
cache. But with GCC 8 on Linux the total object file size is a little
south of 3G. That means we lose more time in compilation cache misses
than the transfer time on the cache itself. This change alone speeds up
the GCC 8 on Ubuntu bionic job by more than 50%: from 32 minutes to 14
minutes.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
