### PR TITLE
6X: Fall back for selects of outer refs in scalar subquery in ORCA

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CSubqueryHandler.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CSubqueryHandler.h
@@ -61,6 +61,9 @@ namespace gpopt
 				// subquery has outer references
 				BOOL m_fHasOuterRefs;
 
+				// the returned column is an outer reference
+				BOOL m_fReturnedPcrIsOuterRef;
+
 				// subquery has skip level correlations -- when inner expression refers to columns defined above the immediate outer expression
 				BOOL m_fHasSkipLevelCorrelations;
 
@@ -85,6 +88,7 @@ namespace gpopt
 					m_returns_set(false),
 					m_fHasVolatileFunctions(false),
 					m_fHasOuterRefs(false),
+					m_fReturnedPcrIsOuterRef(false),
 					m_fHasSkipLevelCorrelations(false),
 					m_fHasCountAgg(false),
 					m_pcrCountAgg(NULL),
@@ -251,7 +255,14 @@ namespace gpopt
 
 			// create subquery descriptor
 			static
-			SSubqueryDesc *Psd(CMemoryPool *mp, CExpression *pexprSubquery, CExpression *pexprOuter, ESubqueryCtxt esqctxt);
+			SSubqueryDesc *Psd
+				(
+				CMemoryPool *mp,
+				CExpression *pexprSubquery,
+				CExpression *pexprOuter,
+				const CColRef *pcrSubquery,
+				ESubqueryCtxt esqctxt
+				);
 
 			// detect subqueries with expressions over count aggregate similar to
 			// (SELECT 'abc' || (SELECT count(*) from X))

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -12657,3 +12657,39 @@ ERROR:  correlated subquery with skip-level correlations is not supported
 -- where out.b in (select coalesce(tcorr2.a, 99)
 --                 from tcorr1 full outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
 reset optimizer_join_order;
+-- test selecting an outer ref from a scalar subquery, this will fall back to planner
+-- expect 0 rows
+SELECT 1
+FROM   tcorr1
+WHERE  tcorr1.a IS NULL OR
+       tcorr1.a = (SELECT tcorr1.a
+                   FROM   (SELECT rtrim(tcorr1.a::text) AS userid,
+                                  rtrim(tcorr1.b::text) AS part_pls
+                           FROM   tcorr2) al
+                   WHERE  3 = tcorr1.a
+                  );
+ ?column? 
+----------
+(0 rows)
+
+-- expect 1 row, subquery returns a row, falls back in ORCA
+select * from tcorr1 where b = (select tcorr1.b from tcorr2);
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+-- expect 0 rows, subquery returns no rows, falls back in ORCA
+select * from tcorr1 where b = (select tcorr1.b from tcorr2 where b=33);
+ a | b 
+---+---
+(0 rows)
+
+-- expect 1 row, subquery returns nothing, so a < 22 is true, falls back in ORCA
+select * from tcorr1 where a < coalesce((select tcorr1.a from tcorr2 where a = 11), 22);
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+reset optimizer_trace_fallback;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -12864,3 +12864,47 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
 -- where out.b in (select coalesce(tcorr2.a, 99)
 --                 from tcorr1 full outer join tcorr2 on tcorr1.a=tcorr2.a+out.a);
 reset optimizer_join_order;
+-- test selecting an outer ref from a scalar subquery, this will fall back to planner
+-- expect 0 rows
+SELECT 1
+FROM   tcorr1
+WHERE  tcorr1.a IS NULL OR
+       tcorr1.a = (SELECT tcorr1.a
+                   FROM   (SELECT rtrim(tcorr1.a::text) AS userid,
+                                  rtrim(tcorr1.b::text) AS part_pls
+                           FROM   tcorr2) al
+                   WHERE  3 = tcorr1.a
+                  );
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
+ ?column? 
+----------
+(0 rows)
+
+-- expect 1 row, subquery returns a row, falls back in ORCA
+select * from tcorr1 where b = (select tcorr1.b from tcorr2);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+-- expect 0 rows, subquery returns no rows, falls back in ORCA
+select * from tcorr1 where b = (select tcorr1.b from tcorr2 where b=33);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
+ a | b 
+---+---
+(0 rows)
+
+-- expect 1 row, subquery returns nothing, so a < 22 is true, falls back in ORCA
+select * from tcorr1 where a < coalesce((select tcorr1.a from tcorr2 where a = 11), 22);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+reset optimizer_trace_fallback;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2654,6 +2654,29 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
 
 reset optimizer_join_order;
 
+-- test selecting an outer ref from a scalar subquery, this will fall back to planner
+-- expect 0 rows
+SELECT 1
+FROM   tcorr1
+WHERE  tcorr1.a IS NULL OR
+       tcorr1.a = (SELECT tcorr1.a
+                   FROM   (SELECT rtrim(tcorr1.a::text) AS userid,
+                                  rtrim(tcorr1.b::text) AS part_pls
+                           FROM   tcorr2) al
+                   WHERE  3 = tcorr1.a
+                  );
+
+-- expect 1 row, subquery returns a row, falls back in ORCA
+select * from tcorr1 where b = (select tcorr1.b from tcorr2);
+
+-- expect 0 rows, subquery returns no rows, falls back in ORCA
+select * from tcorr1 where b = (select tcorr1.b from tcorr2 where b=33);
+
+-- expect 1 row, subquery returns nothing, so a < 22 is true, falls back in ORCA
+select * from tcorr1 where a < coalesce((select tcorr1.a from tcorr2 where a = 11), 22);
+
+reset optimizer_trace_fallback;
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
This is a backport of the changes in #10799 to 6X_STABLE.

When we have an outer ref in a subquery, like this

select * from foo where foo.a is null or foo.a = (select foo.b from bar)

then we can't simply use the outer reference for the condition when
we unnest the subquery into an apply. This is because if the subquery
returns no rows, then we must be using a NULL instead of the outer
reference.

We have code to handle this for quantified subqueries, but not for
scalar subqueries.

When we translate the generated DXL to a plan, we assert when we find
an outer reference in the project list of a subquery. In rare cases,
we might also crash, when the subquery contained a project with multiple
values below the outer reference (see added test in gporca.sql).

The "fix" (more a workaround) is to force a fallback when we detect
this situation during unnesting of a scalar subquery.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
