### PR TITLE
Fix the planner crash when the group key is an expression in multi-agg

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -4060,7 +4060,13 @@ deconstruct_expr_mutator(Node *node, MppGroupContext *ctx)
 			prelim_tle->ressortgroupref = sub_tle->ressortgroupref;
 			prelim_tle->resjunk = false;
 			ctx->grps_tlist = lappend(ctx->grps_tlist, prelim_tle);
-			return node;
+
+			Var			*var = makeVar(grp_varno, prelim_tle->resno,
+										  exprType((Node *) prelim_tle->expr),
+										  exprTypmod((Node *) prelim_tle->expr),
+										  exprCollation((Node *) prelim_tle->expr),
+										  0);
+			return (Node*) var;
 		}
 	}
 

--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -3639,6 +3639,32 @@ find_group_dependent_targets(Node *node, struct groupdep_ctx *ctx)
 	return expression_tree_walker(node, find_group_dependent_targets, ctx);
 }
 
+/*
+ * Constructing the target list for the preliminary Agg node by
+ * placing targets for the grouping attributes on the grps_tlist
+ * temporary. Make sure ressortgroupref matches the original. Copying the
+ * expression may be overkill, but it is safe.
+ */
+static TargetEntry *
+construct_prelim_tle(TargetEntry *sub_tle, MppGroupContext *ctx)
+{
+	char *resname;
+	TargetEntry *prelim_tle;
+	if (sub_tle->resname)
+		resname = pstrdup(sub_tle->resname);
+	else
+		resname = psprintf("prelim_aggref_%d", sub_tle->ressortgroupref);
+
+	prelim_tle = makeTargetEntry(copyObject(sub_tle->expr),
+								 list_length(ctx->grps_tlist) + 1,
+								 resname,
+								 false);
+	prelim_tle->ressortgroupref = sub_tle->ressortgroupref;
+	prelim_tle->resjunk = false;
+	ctx->grps_tlist = lappend(ctx->grps_tlist, prelim_tle);
+	return prelim_tle;
+}
+
 /* Function: deconstruct_agg_info
  *
  * Top-level deconstruction of the target list and having qual of an
@@ -3666,32 +3692,12 @@ deconstruct_agg_info(MppGroupContext *ctx)
 	ctx->fin_tlist = NIL;
 	ctx->fin_hqual = NIL;
 
-	/*
-	 * Begin constructing the target list for the preliminary Agg node by
-	 * placing targets for the grouping attributes on the grps_tlist
-	 * temporary. Make sure ressortgroupref matches the original. Copying the
-	 * expression may be overkill, but it is safe.
-	 */
 	for (i = 0; i < ctx->numGroupCols; i++)
 	{
-		TargetEntry *sub_tle,
-				   *prelim_tle;
-		char	   *resname;
+		TargetEntry *sub_tle;
 
 		sub_tle = get_tle_by_resno(ctx->sub_tlist, ctx->groupColIdx[i]);
-
-		if (sub_tle->resname)
-			resname = pstrdup(sub_tle->resname);
-		else
-			resname = psprintf("prelim_aggref_%d", sub_tle->ressortgroupref);
-
-		prelim_tle = makeTargetEntry(copyObject(sub_tle->expr),
-									 list_length(ctx->grps_tlist) + 1,
-									 resname,
-									 false);
-		prelim_tle->ressortgroupref = sub_tle->ressortgroupref;
-		prelim_tle->resjunk = false;
-		ctx->grps_tlist = lappend(ctx->grps_tlist, prelim_tle);
+		construct_prelim_tle(sub_tle, ctx);
 	}
 
 	/*
@@ -4037,31 +4043,18 @@ deconstruct_expr_mutator(Node *node, MppGroupContext *ctx)
 		return (Node*) var;
 	}
 
-	 
+
 	if (IsA(node, Var))
 	{
 		TargetEntry *sub_tle;
-		TargetEntry *prelim_tle;
-
-		char *resname;
 
 		sub_tle = tlist_member_ignore_relabel(node, ctx->sub_tlist);
 		if (sub_tle != NULL)
 		{
-			if (sub_tle->resname)
-				resname = pstrdup(sub_tle->resname);
-			else
-				resname = psprintf("prelim_aggref_%d", sub_tle->ressortgroupref);
-
-			prelim_tle = makeTargetEntry(copyObject(sub_tle->expr),
-										 list_length(ctx->grps_tlist) + 1,
-										 resname,
-										 false);
-			prelim_tle->ressortgroupref = sub_tle->ressortgroupref;
-			prelim_tle->resjunk = false;
-			ctx->grps_tlist = lappend(ctx->grps_tlist, prelim_tle);
-
-			Var			*var = makeVar(grp_varno, prelim_tle->resno,
+			TargetEntry *prelim_tle;
+			Var *var;
+			prelim_tle = construct_prelim_tle(sub_tle, ctx);
+			var = makeVar(grp_varno, prelim_tle->resno,
 										  exprType((Node *) prelim_tle->expr),
 										  exprTypmod((Node *) prelim_tle->expr),
 										  exprCollation((Node *) prelim_tle->expr),

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -412,3 +412,39 @@ select count(distinct j), count(distinct k), count(distinct m) from (select j,k,
 (10 rows)
 
 drop table multiagg_with_subquery;
+-- Test multi-phase aggregate with an expression as the group key
+create table multiagg_expr_group_tbl (i int, j int) distributed by (i);
+insert into multiagg_expr_group_tbl values(-1, -2), (-1, -1), (0, 1), (1, 2);
+explain (costs off) select j >= 0, not j >= 0 from multiagg_expr_group_tbl group by 1;
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  HashAggregate
+         Group Key: ((multiagg_expr_group_tbl.j >= 0))
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: ((multiagg_expr_group_tbl.j >= 0))
+               ->  HashAggregate
+                     Group Key: (multiagg_expr_group_tbl.j >= 0)
+                     ->  Seq Scan on multiagg_expr_group_tbl
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select j >= 0, not j >= 0 from multiagg_expr_group_tbl group by 1;
+ ?column? | ?column? 
+----------+----------
+ t        | f
+ f        | t
+(2 rows)
+
+select j >= 0,
+		case when not j >= 0 then
+			'not greater than 0'
+		end
+		from multiagg_expr_group_tbl group by 1;
+ ?column? |        case        
+----------+--------------------
+ t        | 
+ f        | not greater than 0
+(2 rows)
+
+drop table multiagg_expr_group_tbl;

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -448,3 +448,20 @@ select j >= 0,
 (2 rows)
 
 drop table multiagg_expr_group_tbl;
+CREATE TABLE multiagg_expr_group_tbl2 (
+	A int,
+	B int,
+	C text ) DISTRIBUTED RANDOMLY;
+CREATE VIEW multiagg_expr_group_view as select B, rtrim(C) AS C FROM multiagg_expr_group_tbl2;
+INSERT INTO multiagg_expr_group_tbl2 VALUES(1,1,1), (2,2,2);
+SELECT v1.B
+  FROM multiagg_expr_group_view v1
+  GROUP BY
+  v1.B, v1.C
+  HAVING ( v1.B= ( SELECT v2.B FROM multiagg_expr_group_view v2 WHERE v1.C = v2.C));
+ b 
+---
+ 1
+ 2
+(2 rows)
+

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -156,3 +156,16 @@ explain (costs off)
 select count(distinct j), count(distinct k), count(distinct m) from (select j,k,m from multiagg_with_subquery group by j,k,m ) sub group by j;
 select count(distinct j), count(distinct k), count(distinct m) from (select j,k,m from multiagg_with_subquery group by j,k,m ) sub group by j;
 drop table multiagg_with_subquery;
+
+-- Test multi-phase aggregate with an expression as the group key
+create table multiagg_expr_group_tbl (i int, j int) distributed by (i);
+insert into multiagg_expr_group_tbl values(-1, -2), (-1, -1), (0, 1), (1, 2);
+explain (costs off) select j >= 0, not j >= 0 from multiagg_expr_group_tbl group by 1;
+select j >= 0, not j >= 0 from multiagg_expr_group_tbl group by 1;
+select j >= 0,
+		case when not j >= 0 then
+			'not greater than 0'
+		end
+		from multiagg_expr_group_tbl group by 1;
+
+drop table multiagg_expr_group_tbl;

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -169,3 +169,16 @@ select j >= 0,
 		from multiagg_expr_group_tbl group by 1;
 
 drop table multiagg_expr_group_tbl;
+
+CREATE TABLE multiagg_expr_group_tbl2 (
+	A int,
+	B int,
+	C text ) DISTRIBUTED RANDOMLY;
+CREATE VIEW multiagg_expr_group_view as select B, rtrim(C) AS C FROM multiagg_expr_group_tbl2;
+INSERT INTO multiagg_expr_group_tbl2 VALUES(1,1,1), (2,2,2);
+SELECT v1.B
+  FROM multiagg_expr_group_view v1
+  GROUP BY
+  v1.B, v1.C
+  HAVING ( v1.B= ( SELECT v2.B FROM multiagg_expr_group_view v2 WHERE v1.C = v2.C));
+


### PR DESCRIPTION
When the group key is an expression, i.e. not a column name, and
there are some other ungrouped targets that reference the group key,
the planner may crash or produce incorrect result.

Normally, the function check_ungrouped_columns() will scan the
expression trees for ungrouped variables on the target list.
Later, subquery_planner() may transafer the target list to a
new equivalent list, for example,

SELECT dttm >= 0, NOT dttm >= 0 FROM foo GROUP BY 1;

`NOT dttm >= 0` will be converted to `dttm < 0`. In multi-agg,
deconstruct_agg_info() calls deconstruct_expr() to generate
the final target list. Since `dttm < 0` is not an Aggref, it
should reference the group key as the original expression.

The idea to fix this issue is to add the column names to the
output in the first aggregate, so `dttm` could reference the
output of the first aggregate.

Reported-by: github.com/oSkrobuk
Co-authored-by: Jinbao Chen <cjinbao@vmware.com>
Co-authored-by: Weinan Wang <wweinan@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
