### PR TITLE
[5X only] Don't dispatch client_encoding to QE

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5573,6 +5573,13 @@ DispatchSetPGVariable(const char *name, List *args, bool is_local)
 	if (Gp_role != GP_ROLE_DISPATCH || IsBootstrapProcessingMode())
 		return;
 
+	/*
+	 * client_encoding is always kept at SQL_ASCII in QE processes. (See also
+	 * cdbconn_doConnectStart().)
+	 */
+	if (strcmp(name, "client_encoding") == 0)
+		return;
+
 	initStringInfo( &buffer );
 
 	if (args == NIL)

--- a/src/test/regress/expected/dispatch_encoding.out
+++ b/src/test/regress/expected/dispatch_encoding.out
@@ -1,0 +1,12 @@
+-- Don't dispatch 'client_encoding'
+-- When client_encoding is dispatch to QE, error messages generated in QEs were
+-- converted to client_encoding, but QD assumed that they were in server encoding,
+-- it will leads to corruption. 
+set client_encoding = 'latin1';
+create function raise_error(t text) returns void as $$
+begin
+  raise exception 'raise_error called on "%"', t;
+end;
+$$ language plpgsql;
+select raise_error('funny char ' || chr(196)) from gp_dist_random('gp_id');
+ERROR:  raise_error called on "funny char Ä"  (seg0 slice1 172.17.0.2:25432 pid=227665)

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -19,7 +19,7 @@ test: gp_metadata variadic_parameters default_parameters function_extensions spi
 
 test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gp_create_table gp_create_view resource_queue_with_rule
 test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions
-test: bitmap_index gp_dump_query_oids analyze gp_owner_permission incremental_analyze gang_reuse
+test: bitmap_index gp_dump_query_oids analyze gp_owner_permission incremental_analyze gang_reuse dispatch_encoding
 test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules motion_gp
 # dispatch should always run seperately from other cases.
 test: dispatch

--- a/src/test/regress/sql/dispatch_encoding.sql
+++ b/src/test/regress/sql/dispatch_encoding.sql
@@ -1,0 +1,13 @@
+-- Don't dispatch 'client_encoding'
+-- When client_encoding is dispatch to QE, error messages generated in QEs were
+-- converted to client_encoding, but QD assumed that they were in server encoding,
+-- it will leads to corruption. 
+
+set client_encoding = 'latin1';
+create function raise_error(t text) returns void as $$
+begin
+  raise exception 'raise_error called on "%"', t;
+end;
+$$ language plpgsql;
+
+select raise_error('funny char ' || chr(196)) from gp_dist_random('gp_id');


### PR DESCRIPTION
When client_encoding is dispatch to QE, error messages generated in QEs were
converted to client_encoding, but QD assumed that they were in server encoding,
it will leads to corruption.

This is fixed in 6X in a6c9b4, but this skips the gpcopy changes since 5X
doesn't support syntax 'COPY...ENCODING'.

Fix issue: https://github.com/greenplum-db/gpdb/issues/10815

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
