### PR TITLE
Fix assertion failure with sorted plans with grouping sets.

### DIFF
--- a/src/test/regress/expected/groupingsets.out
+++ b/src/test/regress/expected/groupingsets.out
@@ -635,7 +635,7 @@ explain (costs off)
    ->  Sort
          Sort Key: a
          ->  Finalize HashAggregate
-               Group Key: (GROUPINGSET_ID()), a
+               Group Key: a, (GROUPINGSET_ID())
                Filter: (a IS DISTINCT FROM 1)
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: a, (GROUPINGSET_ID())

--- a/src/test/regress/expected/olap_plans.out
+++ b/src/test/regress/expected/olap_plans.out
@@ -263,6 +263,40 @@ explain select a, b, d, sum(d) from olap_test group by grouping sets((a, b), (a)
 (11 rows)
 
 -- do not execute this query as it would produce too many tuples.
+-- Test that when the second-stage Agg doesn't try to preserve the
+-- GROUPINGSET_ID(), used internally in the plan, in the result order. We had
+-- a bug like that at one point.
+--
+-- The notable thing in the plan is that the Sort node has GROUPINGSET_ID() in
+-- the Sort Key, as needed for the Finalize GroupAggregate, but in the Motion
+-- above the Finalize GroupAggregate, the GROUPINGSET_ID() has been dropped
+-- from the Merge Key.
+set enable_hashagg=off;
+explain select a, b, c, sum(d) from olap_test group by grouping sets((a, b), (a), (b, c)) limit 200;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=777.19..912.19 rows=200 width=20)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=777.19..1182.19 rows=600 width=20)
+         Merge Key: a, b, c
+         ->  Limit  (cost=777.19..782.19 rows=200 width=20)
+               ->  Finalize GroupAggregate  (cost=776.52..783.20 rows=267 width=20)
+                     Group Key: a, b, c, (GROUPINGSET_ID())
+                     ->  Sort  (cost=776.52..777.19 rows=267 width=20)
+                           Sort Key: a, b, c, (GROUPINGSET_ID())
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=234.38..765.76 rows=267 width=20)
+                                 Hash Key: a, b, c, (GROUPINGSET_ID())
+                                 ->  Partial GroupAggregate  (cost=234.38..498.76 rows=267 width=20)
+                                       Group Key: a, b
+                                       Group Key: a
+                                       Sort Key: b, c
+                                         Group Key: b, c
+                                       ->  Sort  (cost=234.38..242.71 rows=3333 width=16)
+                                             Sort Key: a, b
+                                             ->  Seq Scan on olap_test  (cost=0.00..39.33 rows=3333 width=16)
+ Optimizer: Postgres query optimizer
+(19 rows)
+
+reset enable_hashagg;
 --
 -- Test an optimization in the grouping planner for CREATE TABLE AS, where
 -- partial aggregation results are redistributed directly according to the

--- a/src/test/regress/expected/olap_plans_optimizer.out
+++ b/src/test/regress/expected/olap_plans_optimizer.out
@@ -264,6 +264,40 @@ explain select a, b, d, sum(d) from olap_test group by grouping sets((a, b), (a)
 (11 rows)
 
 -- do not execute this query as it would produce too many tuples.
+-- Test that when the second-stage Agg doesn't try to preserve the
+-- GROUPINGSET_ID(), used internally in the plan, in the result order. We had
+-- a bug like that at one point.
+--
+-- The notable thing in the plan is that the Sort node has GROUPINGSET_ID() in
+-- the Sort Key, as needed for the Finalize GroupAggregate, but in the Motion
+-- above the Finalize GroupAggregate, the GROUPINGSET_ID() has been dropped
+-- from the Merge Key.
+set enable_hashagg=off;
+explain select a, b, c, sum(d) from olap_test group by grouping sets((a, b), (a), (b, c)) limit 200;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=777.19..912.19 rows=200 width=20)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=777.19..1182.19 rows=600 width=20)
+         Merge Key: a, b, c
+         ->  Limit  (cost=777.19..782.19 rows=200 width=20)
+               ->  Finalize GroupAggregate  (cost=776.52..783.20 rows=267 width=20)
+                     Group Key: a, b, c, (GROUPINGSET_ID())
+                     ->  Sort  (cost=776.52..777.19 rows=267 width=20)
+                           Sort Key: a, b, c, (GROUPINGSET_ID())
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=234.38..765.76 rows=267 width=20)
+                                 Hash Key: a, b, c, (GROUPINGSET_ID())
+                                 ->  Partial GroupAggregate  (cost=234.38..498.76 rows=267 width=20)
+                                       Group Key: a, b
+                                       Group Key: a
+                                       Sort Key: b, c
+                                         Group Key: b, c
+                                       ->  Sort  (cost=234.38..242.71 rows=3333 width=16)
+                                             Sort Key: a, b
+                                             ->  Seq Scan on olap_test  (cost=0.00..39.33 rows=3333 width=16)
+ Optimizer: Postgres query optimizer
+(19 rows)
+
+reset enable_hashagg;
 --
 -- Test an optimization in the grouping planner for CREATE TABLE AS, where
 -- partial aggregation results are redistributed directly according to the

--- a/src/test/regress/sql/olap_plans.sql
+++ b/src/test/regress/sql/olap_plans.sql
@@ -69,6 +69,17 @@ select a, b, c, sum(d) from olap_test group by grouping sets((a, b), (a), (b, c)
 explain select a, b, d, sum(d) from olap_test group by grouping sets((a, b), (a), (b, d));
 -- do not execute this query as it would produce too many tuples.
 
+-- Test that when the second-stage Agg doesn't try to preserve the
+-- GROUPINGSET_ID(), used internally in the plan, in the result order. We had
+-- a bug like that at one point.
+--
+-- The notable thing in the plan is that the Sort node has GROUPINGSET_ID() in
+-- the Sort Key, as needed for the Finalize GroupAggregate, but in the Motion
+-- above the Finalize GroupAggregate, the GROUPINGSET_ID() has been dropped
+-- from the Merge Key.
+set enable_hashagg=off;
+explain select a, b, c, sum(d) from olap_test group by grouping sets((a, b), (a), (b, c)) limit 200;
+reset enable_hashagg;
 
 --
 -- Test an optimization in the grouping planner for CREATE TABLE AS, where


### PR DESCRIPTION
For two-stage GROUPING SETS plans, we use an internal GROUPINGSET_ID()
expression to distinguish the rolled up rows. The input to the Finalize
GroupAggregate node is sorted using GROUPINGSET_ID(), but it is not in
the target list. It was nevertheless included in its pathkeys, which led
to confusion, if there was e.g. a Motion on top of the Finalize
GroupAggregate that tried to preserve the sort order.

Without assertions, I believe this generated the error:

ERROR: GroupingSetId found in non-Agg plan node (execExpr.c:872)

as we saw on the perf pipeline, although I didn't test that. With assertions
you got:

FATAL:  Unexpected internal error (tlist.c:393)
DETAIL:  FailedAssertion("!(list_length(dest_tlist) == list_length(src_tlist))", File: "tlist.c", Line: 393)
