### PR TITLE
[6X Only]Eliminate warnings during compile in pg_upgrade.

### DIFF
--- a/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -18,7 +18,6 @@ typedef struct {
 	instr_time start_time;
 	instr_time end_time;
 } step_timer;
-static step_timer timer;
 
 /*
  * Enumeration for operations in the progress report

--- a/contrib/pg_upgrade/util.c
+++ b/contrib/pg_upgrade/util.c
@@ -18,6 +18,8 @@
 
 LogOpts		log_opts;
 
+static step_timer timer;
+
 /*
  * report_status()
  *


### PR DESCRIPTION
The `static step_timer timer` is only used in contrib/pg_upgrade/util.c.
So move it here.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
