### PR TITLE
Cherry pick pg_regress enhancement from PostgreSQL master

### DIFF
--- a/src/backend/lib/Makefile
+++ b/src/backend/lib/Makefile
@@ -13,6 +13,6 @@ top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
 OBJS = binaryheap.o bipartite_match.o hyperloglog.o ilist.o pairingheap.o \
-       rbtree.o stringinfo.o
+       rbtree.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/bin/pg_xlogdump/compat.c
+++ b/src/bin/pg_xlogdump/compat.c
@@ -21,7 +21,6 @@
 #include <time.h>
 
 #include "utils/datetime.h"
-#include "lib/stringinfo.h"
 
 /* copied from timestamp.c */
 pg_time_t
@@ -72,30 +71,4 @@ timestamptz_to_str(TimestampTz dt)
 #endif
 
 	return buf;
-}
-
-/*
- * Provide a hacked up compat layer for StringInfos so xlog desc functions can
- * be linked/called.
- */
-void
-appendStringInfo(StringInfo str, const char *fmt,...)
-{
-	va_list		args;
-
-	va_start(args, fmt);
-	vprintf(fmt, args);
-	va_end(args);
-}
-
-void
-appendStringInfoString(StringInfo str, const char *string)
-{
-	appendStringInfo(str, "%s", string);
-}
-
-void
-appendStringInfoChar(StringInfo str, char ch)
-{
-	appendStringInfo(str, "%c", ch);
 }

--- a/src/bin/pg_xlogdump/pg_xlogdump.c
+++ b/src/bin/pg_xlogdump/pg_xlogdump.c
@@ -428,6 +428,7 @@ XLogDumpDisplayRecord(XLogDumpConfig *config, XLogReaderState *record)
 	int			block_id;
 	uint8		info = XLogRecGetInfo(record);
 	XLogRecPtr	xl_prev = XLogRecGetPrev(record);
+	StringInfoData s;
 
 	id = desc->rm_identify(info);
 	if (id == NULL)
@@ -441,8 +442,10 @@ XLogDumpDisplayRecord(XLogDumpConfig *config, XLogReaderState *record)
 		   (uint32) (xl_prev >> 32), (uint32) xl_prev);
 	printf("desc: %s ", id);
 
-	/* the desc routine will printf the description directly to stdout */
-	desc->rm_desc(NULL, record);
+	initStringInfo(&s);
+	desc->rm_desc(&s, record);
+	printf("%s", s.data);
+	pfree(s.data);
 
 	if (!config->bkp_details)
 	{

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -38,7 +38,7 @@ override CPPFLAGS += -DVAL_LIBS="\"$(LIBS)\""
 
 OBJS_COMMON = config_info.o controldata_utils.o exec.o keywords.o \
 	pg_lzcompress.o pgfnames.o psprintf.o relpath.o rmtree.o \
-	string.o username.o wait_error.o
+	string.o stringinfo.o username.o wait_error.o
 
 OBJS_FRONTEND = $(OBJS_COMMON) fe_memutils.o restricted_token.o
 

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -37,7 +37,7 @@ override CPPFLAGS += -DVAL_LDFLAGS_SL="\"$(LDFLAGS_SL)\""
 override CPPFLAGS += -DVAL_LIBS="\"$(LIBS)\""
 
 OBJS_COMMON = config_info.o controldata_utils.o exec.o keywords.o \
-	pg_lzcompress.o pgfnames.o psprintf.o relpath.o rmtree.o \
+	pg_get_line.o pg_lzcompress.o pgfnames.o psprintf.o relpath.o rmtree.o \
 	string.o stringinfo.o username.o wait_error.o
 
 OBJS_FRONTEND = $(OBJS_COMMON) fe_memutils.o restricted_token.o

--- a/src/common/pg_get_line.c
+++ b/src/common/pg_get_line.c
@@ -1,0 +1,67 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_get_line.c
+ *	  fgets() with an expansible result buffer
+ *
+ * Portions Copyright (c) 1996-2020, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  src/common/pg_get_line.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef FRONTEND
+#include "postgres.h"
+#else
+#include "postgres_fe.h"
+#endif
+
+#include "common/string.h"
+#include "lib/stringinfo.h"
+
+/*
+ * pg_get_line_append()
+ *
+ * This has similar behavior to pg_get_line(), and thence to fgets(),
+ * except that the collected data is appended to whatever is in *buf.
+ *
+ * Returns true if a line was successfully collected (including the
+ * case of a non-newline-terminated line at EOF).  Returns false if
+ * there was an I/O error or no data was available before EOF.
+ * (Check ferror(stream) to distinguish these cases.)
+ *
+ * In the false-result case, the contents of *buf are logically unmodified,
+ * though it's possible that the buffer has been resized.
+ */
+bool
+pg_get_line_append(FILE *stream, StringInfo buf)
+{
+	int			orig_len = buf->len;
+
+	/* Read some data, appending it to whatever we already have */
+	while (fgets(buf->data + buf->len, buf->maxlen - buf->len, stream) != NULL)
+	{
+		buf->len += strlen(buf->data + buf->len);
+
+		/* Done if we have collected a newline */
+		if (buf->len > orig_len && buf->data[buf->len - 1] == '\n')
+			return true;
+
+		/* Make some more room in the buffer, and loop to read more data */
+		enlargeStringInfo(buf, 128);
+	}
+
+	/* Check for I/O errors and EOF */
+	if (ferror(stream) || buf->len == orig_len)
+	{
+		/* Discard any data we collected before detecting error */
+		buf->len = orig_len;
+		buf->data[orig_len] = '\0';
+		return false;
+	}
+
+	/* No newline at EOF, but we did collect some data */
+	return true;
+ }

--- a/src/common/stringinfo.c
+++ b/src/common/stringinfo.c
@@ -2,21 +2,34 @@
  *
  * stringinfo.c
  *
- * StringInfo provides an indefinitely-extensible string data type.
- * It can be used to buffer either ordinary C strings (null-terminated text)
- * or arbitrary binary data.  All storage is allocated with palloc().
+ * StringInfo provides an extensible string data type (currently limited to a
+ * length of 1GB).  It can be used to buffer either ordinary C strings
+ * (null-terminated text) or arbitrary binary data.  All storage is allocated
+ * with palloc() (falling back to malloc in frontend code).
  *
  * Portions Copyright (c) 1996-2016, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- *	  src/backend/lib/stringinfo.c
+ *	  src/common/stringinfo.c
  *
  *-------------------------------------------------------------------------
  */
+
+#ifndef FRONTEND
+
 #include "postgres.h"
+#include "utils/memutils.h"
+
+#else
+
+#include "postgres_fe.h"
+
+/* It's possible we could use a different value for this in frontend code */
+#define MaxAllocSize	((Size) 0x3fffffff) /* 1 gigabyte - 1 */
+
+#endif
 
 #include "lib/stringinfo.h"
-#include "utils/memutils.h"
 
 
 /*
@@ -252,10 +265,10 @@ appendBinaryStringInfo(StringInfo str, const void *data, int datalen)
  * can save some palloc overhead by enlarging the buffer before starting
  * to store data in it.
  *
- * NB: because we use repalloc() to enlarge the buffer, the string buffer
- * will remain allocated in the same memory context that was current when
- * initStringInfo was called, even if another context is now current.
- * This is the desired and indeed critical behavior!
+ * NB: In the backend, because we use repalloc() to enlarge the buffer, the
+ * string buffer will remain allocated in the same memory context that was
+ * current when initStringInfo was called, even if another context is now
+ * current.  This is the desired and indeed critical behavior!
  */
 void
 enlargeStringInfo(StringInfo str, int needed)
@@ -267,13 +280,29 @@ enlargeStringInfo(StringInfo str, int needed)
 	 * an overflow or infinite loop in the following.
 	 */
 	if (needed < 0)				/* should not happen */
+	{
+#ifndef FRONTEND
 		elog(ERROR, "invalid string enlargement request size: %d", needed);
+#else
+		fprintf(stderr, "invalid string enlargement request size: %d\n", needed);
+		exit(EXIT_FAILURE);
+#endif
+	}
 	if (((Size) needed) >= (MaxAllocSize - (Size) str->len))
+	{
+#ifndef FRONTEND
 		ereport(ERROR,
 				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
 				 errmsg("out of memory"),
 				 errdetail("Cannot enlarge string buffer containing %d bytes by %d more bytes.",
 						   str->len, needed)));
+#else
+		fprintf(stderr,
+				_("out of memory\n\nCannot enlarge string buffer containing %d bytes by %d more bytes.\n"),
+				str->len, needed);
+		exit(EXIT_FAILURE);
+#endif
+	}
 
 	needed += str->len + 1;		/* total space required now */
 

--- a/src/include/common/string.h
+++ b/src/include/common/string.h
@@ -10,6 +10,11 @@
 #ifndef COMMON_STRING_H
 #define COMMON_STRING_H
 
+struct StringInfoData;			/* avoid including stringinfo.h here */
+
 extern bool pg_str_endswith(const char *str, const char *end);
+
+/* functions in src/common/pg_get_line.c */
+extern bool pg_get_line_append(FILE *stream, struct StringInfoData *buf);
 
 #endif   /* COMMON_STRING_H */

--- a/src/include/lib/stringinfo.h
+++ b/src/include/lib/stringinfo.h
@@ -3,9 +3,10 @@
  * stringinfo.h
  *	  Declarations/definitions for "StringInfo" functions.
  *
- * StringInfo provides an indefinitely-extensible string data type.
- * It can be used to buffer either ordinary C strings (null-terminated text)
- * or arbitrary binary data.  All storage is allocated with palloc().
+ * StringInfo provides an extensible string data type (currently limited to a
+ * length of 1GB).  It can be used to buffer either ordinary C strings
+ * (null-terminated text) or arbitrary binary data.  All storage is allocated
+ * with palloc() (falling back to malloc in frontend code).
  *
  * Portions Copyright (c) 1996-2016, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California

--- a/src/test/regress/pg_regress.h
+++ b/src/test/regress/pg_regress.h
@@ -19,6 +19,8 @@
 #define INVALID_PID INVALID_HANDLE_VALUE
 #endif
 
+struct StringInfoData;			/* avoid including stringinfo.h here */
+
 /* simple list of strings */
 typedef struct _stringlist
 {
@@ -53,6 +55,7 @@ int regression_main(int argc, char *argv[],
 				init_function ifunc, test_function tfunc);
 void		add_stringlist_item(_stringlist **listhead, const char *str);
 PID_TYPE	spawn_process(const char *cmdline);
+void		replace_string(struct StringInfoData *string,
+						   const char *replace, const char *replacement);
 void		exit_nicely(int code);
-void		replace_string(char *string, char *replace, char *replacement);
 bool		file_exists(const char *file);

--- a/src/tools/msvc/Mkvcbuild.pm
+++ b/src/tools/msvc/Mkvcbuild.pm
@@ -116,7 +116,7 @@ sub mkvcbuild
 	our @pgcommonallfiles = qw(
 	  config_info.c controldata_utils.c exec.c keywords.c
 	  pg_lzcompress.c pgfnames.c psprintf.c relpath.c rmtree.c
-	  string.c username.c wait_error.c);
+	  string.c stringinfo.c username.c wait_error.c);
 
 	our @pgcommonfrontendfiles = (
 		@pgcommonallfiles, qw(fe_memutils.c


### PR DESCRIPTION
This PR cherry picks commit [784b1ba1a2](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=784b1ba1a2b9306697544bedb2ef9425185dd206).  Also cherry-picked are dependencies: [26aaf97b68](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=26aaf97b683d6258c098859e6b1268e1f5da242f) and parts of [8e3c58e6e4](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=8e3c58e6e459b285d37edb6129e412ed25cd90c1) from PostgreSQL master.  The problem fixed in [784b1ba1a2](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=784b1ba1a2b9306697544bedb2ef9425185dd206) was found while working on PostgreSQL v12 merge branch.  The fix is necessary to properly convert isolation2 test `uao/selectinsert_while_vacuum.source` to `.sql`, with newly introduced access method names in v12.

Please see commit messages for more details.
