### PR TITLE
Include private ip address range on loopback interfaces

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -39,6 +39,7 @@ Feature: Tests for gpaddmirrors
         And gpaddmirrors adds mirrors
         And pg_hba file "/tmp/gpaddmirrors/data/primary/gpseg0/pg_hba.conf" on host "sdw1" contains only cidr addresses
         And pg_hba file "/tmp/gpaddmirrors/data/primary/gpseg0/pg_hba.conf" on host "sdw1" contains entries for "samehost"
+        And verify that the file "pg_hba.conf" in each segment data directory has "no" line starting with "host.*replication.*\(127.0.0\|::1\).*trust"
         Then verify the database has mirrors
         And the information of a "mirror" segment on a remote host is saved
         When user kills a "mirror" process with the saved information

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -94,3 +94,9 @@ Feature: Tests for gpinitstandby feature
         When the user runs pg_controldata against the standby data directory
         Then pg_controldata should print "Data page checksum version:           0" to stdout
 
+    Scenario: gpinitstandby does not add entries for 127.0.0.x and ::1 in pg_hba.conf
+        Given the database is running
+        And the standby is not initialized
+        And the user runs gpinitstandby with options " "
+        Then gpinitstandby should return a return code of 0
+        And verify that the file "pg_hba.conf" in the master data directory has "no" line starting with "host.*replication.*(127.0.0.1|::1).*trust"


### PR DESCRIPTION
Customers can configure private address range on their loopback and use
it for communication on the greenplum cluster. If those addresses are
excluded from the replciation entries utilities like gpinitstandby or
gpaddmirrors can fail.

This commit updates the ifaddrs utility to include such addresses.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
