### PR TITLE
Fix possible wrong completionTag in Copy From

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -629,7 +629,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 				segment_rows_rejected = res->numRejected;
 
 			/*
-			 * When COPY FROM ON SEGMENT, need to calculate the number of this
+			 * When COPY FROM, need to calculate the number of this
 			 * segment's completed rows
 			 */
 			if (res->numCompleted > 0)

--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -323,8 +323,7 @@ SendNumRows(int64 numrejected, int64 numcompleted)
 
 	pq_beginmessage(&buf, 'j'); /* 'j' is the msg code for rejected records */
 	pq_sendint64(&buf, numrejected);
-	if (numcompleted > 0)		/* optional send completed num for COPY FROM
-								 * ON SEGMENT */
+	if (numcompleted > 0)		/* optional send completed num */
 		pq_sendint64(&buf, numcompleted);
 	pq_endmessage(&buf);
 }

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -963,7 +963,7 @@ processResults(CdbDispatchResult *dispatchResult)
 				dispatchResult->numrowsrejected += pRes->numRejected;
 
 			/*
-			 * COPY FROM ON SEGMENT - get the number of rows completed by QE
+			 * COPY FROM - get the number of rows completed by QE
 			 * if any
 			 */
 			if (pRes->numCompleted > 0)

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4711,6 +4711,23 @@ CopyFrom(CopyState cstate)
 		cdbCopyEnd(cdbCopy,
 				   &total_completed_from_qes,
 				   &total_rejected_from_qes);
+
+		/*
+		 * Reset returned processed to total_completed_from_qes.
+		 *
+		 * processed above excludes only rejected rows on QD, it
+		 * should also exclude rejected rows on QEs.
+		 *
+		 * NOTE:
+		 *  total_completed_from_qes + total_rejected_from_qes <= # of
+		 *  input file rows
+		 *
+		 * total_rejected_from_qes includes only rows rejected by
+		 * SREH; however, total_completed_from_qes excludes both
+		 * SREH-rejected rows and TRIGGER-rejected rows.
+		 */
+		processed = total_completed_from_qes;
+
 		if (cstate->cdbsreh)
 		{
 			/* emit a NOTICE with number of rejected rows */
@@ -4746,16 +4763,12 @@ CopyFrom(CopyState cstate)
 	AfterTriggerEndQuery(estate);
 
 	/*
-	 * If SREH and in executor mode send the number of rejected
-	 * rows to the client (QD COPY).
-	 * If COPY ... FROM/TO ... ON SEGMENT, then we need to send the number of
-	 * completed rows as well.
+	 * In QE, send the number of rejected rows to the client (QD COPY) if
+	 * SREH is on, always send the number of completed rows.
 	 */
-	if ((cstate->errMode != ALL_OR_NOTHING && cstate->dispatch_mode == COPY_EXECUTOR)
-		|| cstate->on_segment)
+	if (Gp_role == GP_ROLE_EXECUTE)
 	{
-		SendNumRows((cstate->errMode != ALL_OR_NOTHING) ? cstate->cdbsreh->rejectcount : 0,
-				cstate->on_segment ? processed : 0);
+		SendNumRows((cstate->errMode != ALL_OR_NOTHING) ? cstate->cdbsreh->rejectcount : 0, processed);
 	}
 
 	ExecResetTupleTable(estate->es_tupleTable, false);

--- a/src/include/cdb/cdbdispatchresult.h
+++ b/src/include/cdb/cdbdispatchresult.h
@@ -107,7 +107,7 @@ typedef struct CdbDispatchResult
 	/* num rows rejected in SREH mode */
 	int	numrowsrejected;
 
-	/* num rows completed in COPY FROM ON SEGMENT */
+	/* num rows completed in COPY FROM */
 	int	numrowscompleted;
 } CdbDispatchResult;
 

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -457,7 +457,7 @@ pqParseInput3(PGconn *conn)
 
 					conn->result->numRejected += numRejected;
 
-					/* Optionally receive completed number when COPY FROM ON SEGMENT */
+					/* Optionally receive completed number when COPY FROM */
 					if (msgLength >= 12 && !pqGetInt64(&numCompleted, conn))
 					{
 						conn->result->numCompleted += numCompleted;

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -249,7 +249,7 @@ struct pg_result
 
 	/* GPDB: number of rows rejected in SREH (protocol message 'j') */
 	int64		numRejected;
-	/* GPDB: number of rows completed when COPY FROM ON SEGMENT */
+	/* GPDB: number of rows completed when COPY FROM */
 	int64		numCompleted;
 	/* GPDB */
 	int		nWaits;

--- a/src/test/regress/expected/gpcopy_dispatch.out
+++ b/src/test/regress/expected/gpcopy_dispatch.out
@@ -137,7 +137,7 @@ SELECT tableoid::regclass, count(*) FROM partdisttest GROUP BY 1;
 (1 row)
 
 DROP TABLE partdisttest;
--- Log errors on QEs
+-- Log errors on QEs for partitions
 CREATE TABLE partdisttest(id INT, t TIMESTAMP, d VARCHAR(4))
   DISTRIBUTED BY (id)
   PARTITION BY RANGE (t)
@@ -145,7 +145,78 @@ CREATE TABLE partdisttest(id INT, t TIMESTAMP, d VARCHAR(4))
     PARTITION p2020 START ('2020-01-01'::TIMESTAMP) END ('2021-01-01'::TIMESTAMP),
     DEFAULT PARTITION extra
   );
+\set QUIET off
 COPY partdisttest FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 2;
 INFO:  first field processed in the QE: 1
 NOTICE:  found 1 data formatting errors (1 or more input rows), rejected related input data
+COPY 1
+\set QUIET on
 DROP TABLE partdisttest;
+-- Check completion tags when COPY FROM
+CREATE TABLE copydisttest(id INT, d VARCHAR(4))
+  DISTRIBUTED BY (id);
+CREATE FUNCTION copydisttest_ignore_even() RETURNS trigger
+LANGUAGE plpgsql AS $$ 
+BEGIN
+  IF new.id % 2 = 0 THEN
+    RETURN NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+CREATE TRIGGER copydisttest_before_ins BEFORE INSERT ON copydisttest
+FOR EACH ROW EXECUTE PROCEDURE copydisttest_ignore_even();
+\set QUIET off
+-- COPY on QD
+-- expect 'COPY 2'
+COPY copydisttest(d, id) FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 3;
+INFO:  all fields will be processed in the QD
+COPY 2
+-- expect 'COPY 1'
+COPY copydisttest(d, id) FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 3;
+INFO:  all fields will be processed in the QD
+NOTICE:  found 1 data formatting errors (1 or more input rows), rejected related input data
+COPY 1
+-- expect 'COPY 0'
+COPY copydisttest(d, id) FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 3;
+INFO:  all fields will be processed in the QD
+NOTICE:  found 2 data formatting errors (2 or more input rows), rejected related input data
+COPY 0
+-- expect 'COPY 0'
+COPY copydisttest(d, id) FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 3;
+INFO:  all fields will be processed in the QD
+NOTICE:  found 1 data formatting errors (1 or more input rows), rejected related input data
+COPY 0
+-- expect 'COPY 0'
+COPY copydisttest(d, id) FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 3;
+INFO:  all fields will be processed in the QD
+NOTICE:  found 2 data formatting errors (2 or more input rows), rejected related input data
+COPY 0
+-- COPY on QE
+-- expect 'COPY 2'
+COPY copydisttest(id, d) FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 3;
+INFO:  first field processed in the QE: 1
+COPY 2
+-- expect 'COPY 1'
+COPY copydisttest(id, d) FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 3;
+INFO:  first field processed in the QE: 1
+NOTICE:  found 1 data formatting errors (1 or more input rows), rejected related input data
+COPY 1
+-- expect 'COPY 0'
+COPY copydisttest(id, d) FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 3;
+INFO:  first field processed in the QE: 1
+NOTICE:  found 2 data formatting errors (2 or more input rows), rejected related input data
+COPY 0
+-- expect 'COPY 0'
+COPY copydisttest(id, d) FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 3;
+INFO:  first field processed in the QE: 1
+NOTICE:  found 1 data formatting errors (1 or more input rows), rejected related input data
+COPY 0
+-- expect 'COPY 0'
+COPY copydisttest(id, d) FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 3;
+INFO:  first field processed in the QE: 1
+NOTICE:  found 2 data formatting errors (2 or more input rows), rejected related input data
+COPY 0
+\set QUIET on
+DROP TABLE copydisttest;
+DROP FUNCTION copydisttest_ignore_even();


### PR DESCRIPTION
`Copy rowcount` might have a wrong number when COPY FROM. This happens
if SREH or BEFORE-TIGGER has rejected rows on QEs.

PR #9932 has already added a test, but its regression result
did not contain the completion tag:

```sql
DROP TABLE IF EXISTS partdisttest;
CREATE TABLE partdisttest(id INT, t TIMESTAMP, d VARCHAR(4))
DISTRIBUTED BY (id)
PARTITION BY RANGE (t)
(
  PARTITION p2020 START ('2020-01-01'::TIMESTAMP) END ('2021-01-01'::TIMESTAMP),
  DEFAULT PARTITION extra
);

COPY partdisttest FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 2;
1	'2020-09-24'	abcde
1	'2020-09-24'	abc
\.

COPY 2
```

The correct completion tag should be `COPY 1`, e.g. COPY on **QD**:

```
COPY partdisttest(id, d, t) FROM STDIN LOG ERRORS SEGMENT REJECT LIMIT 2;
1	abcde	'2020-09-24'
1	abc	'2020-09-24'
\.

COPY 1
```

Reproduce the same issue using BEFORE INSERT row trigger:

```sql
DROP TABLE IF EXISTS partdisttest;
CREATE TABLE partdisttest(id INT);

CREATE FUNCTION partdisttest_ignore() RETURNS TRIGGER
LANGUAGE plpgsql AS $$ BEGIN return NULL; END; $$;

CREATE TRIGGER partdisttest_before_ins BEFORE INSERT ON partdisttest
FOR EACH ROW EXECUTE PROCEDURE partdisttest_ignore();

COPY partdisttest FROM STDIN;
1
2
\.

COPY 2
```

The reason is returned `processed` does not exclude rejected rows on
segments. To Fix this issue, QD should set `processed` to the total
of completed rows of all QEs. Now, on QEs, we always call SendNumRows
and send processed number back to QD, this change can also fix a BUG:

```
touch /tmp/data-1
PGOPTIONS='-c gp_role=utility' psql
=# COPY partdisttest(id, d, t, d2) FROM '/tmp/data<SEGID>' on segment;
FATAL:  SendNumRows: called outside of execute context
```

### NOTE:

SendNumRows() is located at cdbserh.h/.c, thus its 1st param `numrejected`
is only # of rejected rows by SREH; its second param `numcompleted` keeps
optional, one reason is to maintain backward compatibility, another reason
is that readable external tables also support SREH, SendNumRows() will be
called inside external_endscan() with numcompleted = 0, it is hard to
get # of completed rows here.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
