### PR TITLE
Update the filename for the test check_orphaned_toastrels

### DIFF
--- a/src/bin/pg_upgrade/greenplum/check_gp.c
+++ b/src/bin/pg_upgrade/greenplum/check_gp.c
@@ -331,7 +331,7 @@ check_orphaned_toastrels(void)
 
 	prep_status("Checking for orphaned TOAST relations");
 
-	snprintf(output_path, sizeof(output_path), "partitioned_tables.txt");
+	snprintf(output_path, sizeof(output_path), "orphaned_toast_tables.txt");
 
 	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
 	{


### PR DESCRIPTION
Earlier the output filename for the test check_orphaned_toastrels
was partitioned_tables.txt, so updated that to represent toast tables

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
