### PR TITLE
[6X] Fix Orca CTAS for tables created with legacy vs non-legacy hashops (#10833)

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5522,18 +5522,15 @@ CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToDistrPolicy(
 	{
 		GPOS_ASSERT(0 < num_of_distr_cols);
 		distr_policy->nattrs = num_of_distr_cols;
-
+		IMdIdArray *opclasses = dxlop->GetDistrOpclasses();
+		GPOS_ASSERT(opclasses->Size() == num_of_distr_cols);
 		for (ULONG ul = 0; ul < num_of_distr_cols; ul++)
 		{
 			ULONG col_pos_idx = *((*distr_col_pos_array)[ul]);
-			TargetEntry *tle =
-				(TargetEntry *) gpdb::ListNth(target_list, col_pos_idx);
-			Oid typeoid = gpdb::ExprType((Node *) tle->expr);
-
 			distr_policy->attrs[ul] = col_pos_idx + 1;
-			distr_policy->opclasses[ul] =
-				m_dxl_to_plstmt_context->GetDistributionHashOpclassForType(
-					typeoid);
+
+			Oid opclass = CMDIdGPDB::CastMdid((*opclasses)[ul])->Oid();
+			distr_policy->opclasses[ul] = opclass;
 		}
 	}
 	return distr_policy;

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -887,7 +887,9 @@ CTranslatorQueryToDXL::TranslateCTASToDXL()
 	IMDRelation::Ereldistrpolicy rel_distr_policy =
 		IMDRelation::EreldistrRandom;
 	ULongPtrArray *distribution_colids = NULL;
-	IMdIdArray *distr_opfamilies = NULL;
+
+	IMdIdArray *distr_opfamilies = GPOS_NEW(m_mp) IMdIdArray(m_mp);
+	IMdIdArray *distr_opclasses = GPOS_NEW(m_mp) IMdIdArray(m_mp);
 
 	if (NULL != m_query->intoPolicy)
 	{
@@ -897,7 +899,6 @@ CTranslatorQueryToDXL::TranslateCTASToDXL()
 		if (IMDRelation::EreldistrHash == rel_distr_policy)
 		{
 			distribution_colids = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
-			distr_opfamilies = GPOS_NEW(m_mp) IMdIdArray(m_mp);
 
 			for (ULONG ul = 0; ul < (ULONG) m_query->intoPolicy->nattrs; ul++)
 			{
@@ -908,7 +909,13 @@ CTranslatorQueryToDXL::TranslateCTASToDXL()
 				Oid opfamily =
 					gpdb::GetOpclassFamily(m_query->intoPolicy->opclasses[ul]);
 				GPOS_ASSERT(InvalidOid != opfamily);
+				// We use the opfamily to populate the
+				// distribution spec within ORCA, but also need
+				// the opclass to populate the distribution
+				// policy of the created table in the catalog
 				distr_opfamilies->Append(GPOS_NEW(m_mp) CMDIdGPDB(opfamily));
+				distr_opclasses->Append(GPOS_NEW(m_mp) CMDIdGPDB(
+					m_query->intoPolicy->opclasses[ul]));
 			}
 		}
 	}
@@ -959,8 +966,9 @@ CTranslatorQueryToDXL::TranslateCTASToDXL()
 		m_mp, mdid, md_schema_name, md_relname, dxl_col_descr_array,
 		GPOS_NEW(m_mp) CDXLCtasStorageOptions(
 			md_tablespace_name, ctas_commit_action, ctas_storage_options),
-		rel_distr_policy, distribution_colids, distr_opfamilies, fTempTable,
-		has_oids, rel_storage_type, source_array, var_typmods);
+		rel_distr_policy, distribution_colids, distr_opfamilies,
+		distr_opclasses, fTempTable, has_oids, rel_storage_type, source_array,
+		var_typmods);
 
 	return GPOS_NEW(m_mp) CDXLNode(m_mp, ctas_dxlop, query_dxlnode);
 }

--- a/src/backend/gporca/data/dxl/minidump/CTAS-Random.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-Random.mdp
@@ -1,17 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+	Basic test for a simple CTAS that requires redistribution.
+
+	create table foo (a int, b int) distributed by (a);
+	explain create table bar as select * from foo distributed randomly;
+  ]]>
+  </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
-      <dxl:CTEConfig CTEInliningCutoff="0"/> 
-      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:TraceFlags Value="103027,101013,102024,102025,102115,102117,103001"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
-    <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:ColumnStatistics Mdid="1.586154.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.586154.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+    <dxl:Metadata SystemIds="0.CTAS,0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -26,7 +39,9 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
         <dxl:EqualityOp Mdid="0.96.1.0"/>
         <dxl:InequalityOp Mdid="0.518.1.0"/>
         <dxl:LessThanOp Mdid="0.97.1.0"/>
@@ -41,7 +56,9 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
         <dxl:LessThanOp Mdid="0.609.1.0"/>
@@ -56,7 +73,9 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
         <dxl:EqualityOp Mdid="0.387.1.0"/>
         <dxl:InequalityOp Mdid="0.402.1.0"/>
         <dxl:LessThanOp Mdid="0.2799.1.0"/>
@@ -71,7 +90,8 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
         <dxl:InequalityOp Mdid="0.0.0.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
@@ -86,9 +106,10 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
         <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
         <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
         <dxl:GreaterThanOp Mdid="0.0.0.0"/>
@@ -101,23 +122,8 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:CTASRelation Mdid="5.1.1.0" Name="r" IsTemporary="false" HasOids="false" StorageType="Heap" VarTypeModList="-1" DistributionPolicy="Random">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.29.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:CTASOptions OnCommitAction="NOOP"/>
-      </dxl:CTASRelation>
-      <dxl:ColumnStatistics Mdid="1.586154.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.586154.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.586154.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.586154.1.1.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.586154.1.1.0" Name="a" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.586154.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.586154.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:RelationStatistics Mdid="2.586154.1.1" Name="s" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.586154.1.1" Name="s" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+      <dxl:RelationStatistics Mdid="2.57379.1.0" Name="foo" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.57379.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -150,56 +156,85 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
       </dxl:Relation>
+      <dxl:CTASRelation Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" VarTypeModList="-1,-1" DistributionPolicy="Random">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
+      </dxl:CTASRelation>
+      <dxl:ColumnStatistics Mdid="1.57379.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
-        <dxl:Ident ColId="5" ColName="a" TypeMdid="0.29.1.0"/>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
       </dxl:OutputColumns>
       <dxl:CTEList/>
-      <dxl:LogicalCTAS Mdid="5.1.1.0" Name="r" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="5" VarTypeModList="-1">
+      <dxl:LogicalCTAS Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="1,2" VarTypeModList="-1,-1">
         <dxl:Columns>
-          <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.29.1.0"/>
+          <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.586154.1.1" TableName="s">
+          <dxl:TableDescriptor Mdid="0.57379.1.0" TableName="foo">
             <dxl:Columns>
-              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
       </dxl:LogicalCTAS>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:PhysicalCTAS Name="r" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="4" VarTypeModList="-1">
+      <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="0,1" VarTypeModList="-1,-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.027344" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.015649" Rows="1.000000" Width="8"/>
         </dxl:Properties>
+        <dxl:DistrOpclasses/>
         <dxl:Columns>
-          <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.29.1.0"/>
+          <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="4" Alias="a">
-            <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.011719" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="4" Alias="cmin">
-              <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
@@ -207,37 +242,44 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:RandomMotion InputSegments="0,1" OutputSegments="0,1">
+          <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.003906" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="4" Alias="cmin">
-                <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="4" Alias="cmin">
-                  <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.586154.1.1" TableName="s">
+              <dxl:TableDescriptor Mdid="0.57379.1.0" TableName="foo">
                 <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
@@ -25,11 +25,13 @@
           <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000" EnforceConstraintsOnDML="false"/>
-      <dxl:TraceFlags Value="101001,102074,102146,102120,103001,103014,103015,103022,103027,104003,104004,104005,105000,106000"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
-    <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+    <dxl:Metadata SystemIds="0.CTAS,0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -44,109 +46,8 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.96.1.0"/>
-        <dxl:InequalityOp Mdid="0.518.1.0"/>
-        <dxl:LessThanOp Mdid="0.97.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
-        <dxl:ComparisonOp Mdid="0.351.1.0"/>
-        <dxl:ArrayType Mdid="0.1007.1.0"/>
-        <dxl:MinAgg Mdid="0.2132.1.0"/>
-        <dxl:MaxAgg Mdid="0.2116.1.0"/>
-        <dxl:AvgAgg Mdid="0.2101.1.0"/>
-        <dxl:SumAgg Mdid="0.2108.1.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.607.1.0"/>
-        <dxl:InequalityOp Mdid="0.608.1.0"/>
-        <dxl:LessThanOp Mdid="0.609.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
-        <dxl:ComparisonOp Mdid="0.356.1.0"/>
-        <dxl:ArrayType Mdid="0.1028.1.0"/>
-        <dxl:MinAgg Mdid="0.2118.1.0"/>
-        <dxl:MaxAgg Mdid="0.2134.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
-        <dxl:EqualityOp Mdid="0.387.1.0"/>
-        <dxl:InequalityOp Mdid="0.402.1.0"/>
-        <dxl:LessThanOp Mdid="0.2799.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
-        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
-        <dxl:ArrayType Mdid="0.1010.1.0"/>
-        <dxl:MinAgg Mdid="0.2798.1.0"/>
-        <dxl:MaxAgg Mdid="0.2797.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:GPDBFunc Mdid="0.2331.1.0" Name="unnest" ReturnsSet="true" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
-        <dxl:ResultType Mdid="0.2283.1.0"/>
-      </dxl:GPDBFunc>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.385.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1012.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1011.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="false" Length="-1" PassByValue="false">
-        <dxl:EqualityOp Mdid="0.1752.1.0"/>
-        <dxl:InequalityOp Mdid="0.1753.1.0"/>
-        <dxl:LessThanOp Mdid="0.1754.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.1755.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.1756.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.1757.1.0"/>
-        <dxl:ComparisonOp Mdid="0.1769.1.0"/>
-        <dxl:ArrayType Mdid="0.1231.1.0"/>
-        <dxl:MinAgg Mdid="0.2146.1.0"/>
-        <dxl:MaxAgg Mdid="0.2130.1.0"/>
-        <dxl:AvgAgg Mdid="0.2103.1.0"/>
-        <dxl:SumAgg Mdid="0.2114.1.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:CTASRelation Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" VarTypeModList="-1" DistributionPolicy="Random">
-        <dxl:Columns>
-          <dxl:Column Name="avg" Attno="1" Mdid="0.1700.1.0" Nullable="true">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:CTASOptions OnCommitAction="NOOP"/>
-      </dxl:CTASRelation>
-      <dxl:RelationStatistics Mdid="2.57388.1.0" Name="test1" Rows="100445.000000" EmptyRelation="false"/>
-      <dxl:Relation Mdid="0.57388.1.0" Name="test1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+      <dxl:RelationStatistics Mdid="2.57363.1.0" Name="test1" Rows="100000.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.57363.1.0" Name="test1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -179,428 +80,549 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
       </dxl:Relation>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBFunc Mdid="0.2331.1.0" Name="unnest" ReturnsSet="true" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.2283.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1998.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7103.1.0"/>
+        <dxl:EqualityOp Mdid="0.1752.1.0"/>
+        <dxl:InequalityOp Mdid="0.1753.1.0"/>
+        <dxl:LessThanOp Mdid="0.1754.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1755.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1756.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1757.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1769.1.0"/>
+        <dxl:ArrayType Mdid="0.1231.1.0"/>
+        <dxl:MinAgg Mdid="0.2146.1.0"/>
+        <dxl:MaxAgg Mdid="0.2130.1.0"/>
+        <dxl:AvgAgg Mdid="0.2103.1.0"/>
+        <dxl:SumAgg Mdid="0.2114.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:CTASRelation Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" VarTypeModList="-1" DistributionPolicy="Random">
+        <dxl:Columns>
+          <dxl:Column Name="avg" Attno="1" Mdid="0.1700.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
+      </dxl:CTASRelation>
+      <dxl:ColumnStatistics Mdid="1.57363.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="661"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="661"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1016"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1016"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1344"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1344"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1675"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1675"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2001"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2001"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2338"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2338"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2676"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3008"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3008"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3336"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3336"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3665"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3665"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3995"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3995"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4337"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4337"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5345"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5345"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5682"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6003"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6003"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6346"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6346"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6674"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6674"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6998"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6998"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7329"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7329"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7658"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7658"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7996"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7996"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8322"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8322"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8667"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8667"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9666"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9666"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9996"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9996"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10329"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10329"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10659"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10659"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10998"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10998"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11327"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11327"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11655"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11994"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11994"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12333"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12333"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12677"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12677"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13018"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13018"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13351"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13351"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13683"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13683"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14006"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14006"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14332"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14332"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14668"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14997"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14997"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15330"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15676"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16006"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16006"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16340"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16340"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17017"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17017"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17358"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17358"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17702"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17702"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18035"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18035"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18364"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18364"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18702"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18702"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19029"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19029"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19358"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19358"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19690"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20030"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20030"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20373"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20373"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20715"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20715"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21052"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21052"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21389"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21721"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21721"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22049"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22049"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22378"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22378"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22709"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22709"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23035"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23035"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23374"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23374"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23710"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24043"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24043"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24384"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24384"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24711"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25039"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25371"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25371"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25701"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25701"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26031"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26031"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26357"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26357"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26689"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26689"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27023"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27023"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27355"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27355"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27688"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27688"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28015"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28015"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28357"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28357"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28686"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28686"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29020"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29354"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29354"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29697"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29697"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30025"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30025"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30359"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30359"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30683"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30683"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31023"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31023"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31345"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31345"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31672"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31672"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32014"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32352"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32352"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32698"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32698"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33021"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33021"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="33649"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
       <dxl:GPDBAgg Mdid="0.2101.1.0" Name="avg" IsSplittable="true" HashAggCapable="true">
         <dxl:ResultType Mdid="0.1700.1.0"/>
         <dxl:IntermediateResultType Mdid="0.1016.1.0"/>
       </dxl:GPDBAgg>
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:ColumnStatistics Mdid="1.57388.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="998"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="998"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1943"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1943"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2942"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2942"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3935"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3935"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4947"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4947"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6019"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6019"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6923"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6923"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7892"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7892"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8852"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8852"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9745"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9745"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10614"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10614"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11632"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11632"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12581"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12581"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13639"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13639"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14703"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14703"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15646"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15646"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16665"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16665"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17715"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17715"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18779"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18779"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19773"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19773"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20785"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20785"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21759"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21759"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22700"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22700"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23704"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23704"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24735"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24735"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25609"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25609"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26524"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26524"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27521"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27521"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28612"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28612"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29696"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29696"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30685"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30685"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31658"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31658"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32656"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32656"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33597"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33597"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34618"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34618"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35583"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35583"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36549"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36549"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37503"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37503"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38471"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38471"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39478"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39478"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40548"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40548"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41515"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41515"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42466"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42466"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43501"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43501"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44497"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44497"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45515"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45515"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46497"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46497"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47467"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47467"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48488"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48488"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49519"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49519"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50506"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50506"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51499"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51499"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52425"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52425"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53450"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53450"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54421"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54421"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55357"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55357"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56358"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56358"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57319"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57319"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58364"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58364"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59423"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59423"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60400"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60400"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61436"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61436"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62428"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62428"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63517"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63517"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64545"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64545"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65495"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65495"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66495"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66495"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67500"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67500"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68448"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68448"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69493"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69493"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70515"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70515"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71514"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71514"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72545"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72545"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73550"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73550"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74591"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74591"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75597"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75597"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76546"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76546"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77555"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77555"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78677"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78677"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79669"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79669"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80644"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80644"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81628"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81628"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82661"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82661"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83630"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83630"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84639"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84639"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85623"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85623"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86619"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86619"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87708"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87708"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88742"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88742"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89732"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89732"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90675"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90675"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91637"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91637"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92594"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92594"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93704"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93704"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94659"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94659"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95642"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95642"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96604"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96604"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97630"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97630"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98584"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1004.450000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98584"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100000"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
         <dxl:OpFunc Mdid="0.65.1.0"/>
         <dxl:Commutator Mdid="0.96.1.0"/>
         <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1977.1.0"/>
-          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.12738.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Type Mdid="0.1007.1.0" Name="_int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="false" Length="-1" PassByValue="false">
+      <dxl:Type Mdid="0.1007.1.0" Name="_int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.627.1.0"/>
         <dxl:EqualityOp Mdid="0.1070.1.0"/>
         <dxl:InequalityOp Mdid="0.1071.1.0"/>
         <dxl:LessThanOp Mdid="0.1072.1.0"/>
@@ -612,10 +634,11 @@
         <dxl:MinAgg Mdid="0.0.0.0"/>
         <dxl:MaxAgg Mdid="0.0.0.0"/>
         <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.3217.1.0"/>
+        <dxl:SumAgg Mdid="0.6217.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.1016.1.0" Name="_int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="false" Length="-1" PassByValue="false">
+      <dxl:Type Mdid="0.1016.1.0" Name="_int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.627.1.0"/>
         <dxl:EqualityOp Mdid="0.1070.1.0"/>
         <dxl:InequalityOp Mdid="0.1071.1.0"/>
         <dxl:LessThanOp Mdid="0.1072.1.0"/>
@@ -627,7 +650,7 @@
         <dxl:MinAgg Mdid="0.0.0.0"/>
         <dxl:MaxAgg Mdid="0.0.0.0"/>
         <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.3218.1.0"/>
+        <dxl:SumAgg Mdid="0.6218.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
     </dxl:Metadata>
@@ -641,6 +664,8 @@
           <dxl:Column ColId="12" Attno="1" ColName="avg" TypeMdid="0.1700.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
         <dxl:LogicalGroupBy>
           <dxl:GroupingColumns/>
           <dxl:ProjList>
@@ -652,7 +677,7 @@
           </dxl:ProjList>
           <dxl:LogicalJoin JoinType="Inner">
             <dxl:LogicalGet>
-              <dxl:TableDescriptor Mdid="0.57388.1.0" TableName="test1">
+              <dxl:TableDescriptor Mdid="0.57363.1.0" TableName="test1">
                 <dxl:Columns>
                   <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                   <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -680,11 +705,12 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalCTAS>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8">
+    <dxl:Plan Id="0" SpaceSize="14">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="10" VarTypeModList="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="438.426956" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="438.394467" Rows="1.000000" Width="8"/>
         </dxl:Properties>
+        <dxl:DistrOpclasses/>
         <dxl:Columns>
           <dxl:Column ColId="13" Attno="1" ColName="avg" TypeMdid="0.1700.1.0"/>
         </dxl:Columns>
@@ -696,7 +722,7 @@
         </dxl:ProjList>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="438.411331" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="438.378842" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="avg">
@@ -710,7 +736,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="438.411327" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="438.378838" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="avg">
@@ -721,7 +747,7 @@
             <dxl:SortingColumnList/>
             <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="438.411306" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="438.378817" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns/>
               <dxl:ProjList>
@@ -734,7 +760,7 @@
               <dxl:Filter/>
               <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="438.411305" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="438.378816" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="11" Alias="ColRef_0011">
@@ -745,7 +771,7 @@
                 <dxl:SortingColumnList/>
                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="438.411275" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="438.378787" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns/>
                   <dxl:ProjList>
@@ -758,7 +784,7 @@
                   <dxl:Filter/>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="438.396275" Rows="100445.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="438.363853" Rows="100000.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -775,7 +801,7 @@
                     </dxl:HashCondList>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.699767" Rows="100445.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.696667" Rows="100000.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="a">
@@ -783,7 +809,7 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.57388.1.0" TableName="test1">
+                      <dxl:TableDescriptor Mdid="0.57363.1.0" TableName="test1">
                         <dxl:Columns>
                           <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                           <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -808,7 +834,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr>
+                        <dxl:HashExpr Opfamily="0.1977.1.0">
                           <dxl:Ident ColId="9" ColName="unnest" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-with-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-with-Limit.mdp
@@ -36,128 +36,12 @@
           <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000" EnforceConstraintsOnDML="false"/>
-      <dxl:TraceFlags Value="102074,102146,102120,103001,103014,103015,103022,104003,104004,104005,105000,106000"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
-    <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.91.1.0"/>
-        <dxl:InequalityOp Mdid="0.85.1.0"/>
-        <dxl:LessThanOp Mdid="0.58.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
-        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
-        <dxl:ArrayType Mdid="0.1000.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.410.1.0"/>
-        <dxl:InequalityOp Mdid="0.411.1.0"/>
-        <dxl:LessThanOp Mdid="0.412.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
-        <dxl:ComparisonOp Mdid="0.351.1.0"/>
-        <dxl:ArrayType Mdid="0.1016.1.0"/>
-        <dxl:MinAgg Mdid="0.2131.1.0"/>
-        <dxl:MaxAgg Mdid="0.2115.1.0"/>
-        <dxl:AvgAgg Mdid="0.2100.1.0"/>
-        <dxl:SumAgg Mdid="0.2107.1.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.96.1.0"/>
-        <dxl:InequalityOp Mdid="0.518.1.0"/>
-        <dxl:LessThanOp Mdid="0.97.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
-        <dxl:ComparisonOp Mdid="0.351.1.0"/>
-        <dxl:ArrayType Mdid="0.1007.1.0"/>
-        <dxl:MinAgg Mdid="0.2132.1.0"/>
-        <dxl:MaxAgg Mdid="0.2116.1.0"/>
-        <dxl:AvgAgg Mdid="0.2101.1.0"/>
-        <dxl:SumAgg Mdid="0.2108.1.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.607.1.0"/>
-        <dxl:InequalityOp Mdid="0.608.1.0"/>
-        <dxl:LessThanOp Mdid="0.609.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
-        <dxl:ComparisonOp Mdid="0.356.1.0"/>
-        <dxl:ArrayType Mdid="0.1028.1.0"/>
-        <dxl:MinAgg Mdid="0.2118.1.0"/>
-        <dxl:MaxAgg Mdid="0.2134.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
-        <dxl:EqualityOp Mdid="0.387.1.0"/>
-        <dxl:InequalityOp Mdid="0.402.1.0"/>
-        <dxl:LessThanOp Mdid="0.2799.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
-        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
-        <dxl:ArrayType Mdid="0.1010.1.0"/>
-        <dxl:MinAgg Mdid="0.2798.1.0"/>
-        <dxl:MaxAgg Mdid="0.2797.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.385.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1012.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1011.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:CTASRelation Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" VarTypeModList="-1,-1" DistributionPolicy="Random">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:CTASOptions OnCommitAction="NOOP"/>
-      </dxl:CTASRelation>
-      <dxl:RelationStatistics Mdid="2.49342.1.0" Name="test1" Rows="99570.000000" EmptyRelation="false"/>
-      <dxl:Relation Mdid="0.49342.1.0" Name="test1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+    <dxl:Metadata SystemIds="0.CTAS,0.GPDB">
+      <dxl:RelationStatistics Mdid="2.57359.1.0" Name="test1" Rows="10000000.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.57359.1.0" Name="test1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -190,407 +74,540 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.49342.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1038"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1038"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2123"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2123"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3089"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3089"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4076"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4076"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5129"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5129"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6109"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6109"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7037"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7037"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8030"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8030"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8987"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8987"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10011"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10011"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10988"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10988"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11972"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11972"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13058"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13058"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14196"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14196"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15219"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15219"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16254"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16254"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17236"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17236"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18174"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18174"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19169"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19169"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20043"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20043"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20976"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20976"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21988"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21988"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23014"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23014"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23949"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23949"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24967"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24967"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25887"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25887"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26991"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26991"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27937"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27937"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28804"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28804"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29804"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29804"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30831"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30831"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31818"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31818"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32925"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32925"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33940"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33940"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34907"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34907"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35836"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35836"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36903"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36903"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37837"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37837"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38829"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38829"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39802"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39802"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40864"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40864"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41941"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41941"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42909"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42909"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43948"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43948"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44874"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44874"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45877"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45877"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46881"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46881"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47780"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47780"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48791"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48791"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49761"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49761"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50711"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50711"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51621"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51621"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52604"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52604"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53606"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53606"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54632"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54632"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55556"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55556"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56457"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56457"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57461"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57461"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58491"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58491"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59399"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59399"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60395"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60395"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61356"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61356"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62339"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62339"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63343"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63343"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64241"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64241"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65224"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65224"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66242"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66242"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67205"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67205"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68173"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68173"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69195"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69195"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70211"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70211"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71382"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71382"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72394"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72394"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73424"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73424"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74454"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74454"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75422"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75422"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76462"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76462"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77485"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77485"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78517"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78517"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79420"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79420"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80406"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80406"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81433"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81433"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82428"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82428"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83389"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83389"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84385"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84385"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85331"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85331"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86258"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86258"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87238"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87238"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88259"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88259"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89199"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89199"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90182"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90182"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91214"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91214"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92212"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92212"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93130"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93130"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94011"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94011"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95021"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95021"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96014"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96014"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97001"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97001"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98095"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="995.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98095"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99669"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:CTASRelation Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" VarTypeModList="-1,-1" DistributionPolicy="Random">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
+      </dxl:CTASRelation>
+      <dxl:ColumnStatistics Mdid="1.57359.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33312"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33312"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67224"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67224"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="130681"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="130681"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="166379"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="166379"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="199450"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="199450"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="232313"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="232313"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="262374"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="262374"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="299138"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="299138"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="331861"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="331861"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="362339"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="362339"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="397331"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="397331"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="431054"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="431054"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="465912"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="465912"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="498789"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="498789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="530884"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="530884"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="562842"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="562842"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="596605"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="596605"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="632372"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="632372"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="664683"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="664683"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="699032"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="699032"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="728417"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="728417"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="763748"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="763748"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="798176"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="798176"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="831478"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="831478"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="864911"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="864911"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="898314"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="898314"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="930326"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="930326"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="963853"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="963853"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="995999"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="995999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1030689"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1030689"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1065418"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1065418"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1098297"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1098297"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1129702"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1129702"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1162012"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1162012"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1192322"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1192322"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1226087"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1226087"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1256145"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1256145"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1292391"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1292391"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1325754"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1325754"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1358878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1358878"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1393738"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1393738"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1427353"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1427353"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1461011"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1461011"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1493530"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1493530"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1521592"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1521592"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1554502"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1554502"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1589841"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1589841"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1623212"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1623212"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1655825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1655825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1689497"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1689497"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1723517"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1723517"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1754501"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1754501"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1789222"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1789222"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1825025"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1825025"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1858196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1858196"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1890416"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1890416"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1921660"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1921660"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1953564"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1953564"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1984526"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1984526"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2017748"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2017748"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2051656"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2051656"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2085279"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2085279"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2115884"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2115884"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2153184"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2153184"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2186620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2186620"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2220748"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2220748"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2256869"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2256869"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2289065"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2289065"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2322441"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2322441"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2355679"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2355679"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2389768"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2389768"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2419912"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2419912"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2457571"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2457571"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2489653"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2489653"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2522230"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2522230"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2554754"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2554754"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2586983"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2586983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2622367"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2622367"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2656806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2656806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2689185"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2689185"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2722924"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2722924"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2758929"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2758929"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2791995"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2791995"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2828566"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2828566"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2867357"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2867357"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2898772"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2898772"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2934106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2934106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2968938"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2968938"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3003712"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3003712"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3037922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3037922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3072563"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3072563"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3104835"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3104835"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3137370"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3137370"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3169755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3169755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3204082"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3204082"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3234545"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3234545"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3270564"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3270564"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3304068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3304068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3340193"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
     </dxl:Metadata>
@@ -606,14 +623,16 @@
           <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
         <dxl:LogicalLimit TopLimitUnderDML="true">
           <dxl:SortingColumnList/>
           <dxl:LimitCount>
-            <dxl:ConstValue TypeMdid="0.20.1.0" Value="100000"/>
+            <dxl:ConstValue TypeMdid="0.20.1.0" Value="10000000"/>
           </dxl:LimitCount>
           <dxl:LimitOffset/>
           <dxl:LogicalGet>
-            <dxl:TableDescriptor Mdid="0.49342.1.0" TableName="test1">
+            <dxl:TableDescriptor Mdid="0.57359.1.0" TableName="test1">
               <dxl:Columns>
                 <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -633,8 +652,9 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="0,1" VarTypeModList="-1,-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1994.200543" Rows="99570.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="157426.133333" Rows="10000000.000000" Width="8"/>
         </dxl:Properties>
+        <dxl:DistrOpclasses/>
         <dxl:Columns>
           <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
           <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
@@ -650,7 +670,7 @@
         </dxl:ProjList>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="438.419293" Rows="99570.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1176.133333" Rows="10000000.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -667,7 +687,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="438.021013" Rows="99570.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1136.133333" Rows="10000000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -681,7 +701,7 @@
             <dxl:SortingColumnList/>
             <dxl:Limit>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="435.952612" Rows="99570.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="928.400000" Rows="10000000.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -693,7 +713,7 @@
               </dxl:ProjList>
               <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="435.156052" Rows="99570.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="848.400000" Rows="10000000.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -707,7 +727,7 @@
                 <dxl:SortingColumnList/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.693671" Rows="99570.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="500.666667" Rows="10000000.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -718,7 +738,7 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.49342.1.0" TableName="test1">
+                  <dxl:TableDescriptor Mdid="0.57359.1.0" TableName="test1">
                     <dxl:Columns>
                       <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                       <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -734,7 +754,7 @@
                 </dxl:TableScan>
               </dxl:GatherMotion>
               <dxl:LimitCount>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="100000"/>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="10000000"/>
               </dxl:LimitCount>
               <dxl:LimitOffset>
                 <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-with-hashed-distributed-external-table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-with-hashed-distributed-external-table.mdp
@@ -13,142 +13,19 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_gpfdist_ext DISTRIBUTED BY (a);
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
-      <dxl:CTEConfig CTEInliningCutoff="0"/> 
-      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
         <dxl:CostParams>
-          <dxl:CostParam Name="NLJFactor" Value="1.000000" LowerBound="0.500000" UpperBound="1.500000"/>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000"/>
-      <dxl:TraceFlags Value="103027,102120,103001,103014,103015,103022,104004,104005,105000"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
-    <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.91.1.0"/>
-        <dxl:InequalityOp Mdid="0.85.1.0"/>
-        <dxl:LessThanOp Mdid="0.58.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
-        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
-        <dxl:ArrayType Mdid="0.1000.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.96.1.0"/>
-        <dxl:InequalityOp Mdid="0.518.1.0"/>
-        <dxl:LessThanOp Mdid="0.97.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
-        <dxl:ComparisonOp Mdid="0.351.1.0"/>
-        <dxl:ArrayType Mdid="0.1007.1.0"/>
-        <dxl:MinAgg Mdid="0.2132.1.0"/>
-        <dxl:MaxAgg Mdid="0.2116.1.0"/>
-        <dxl:AvgAgg Mdid="0.2101.1.0"/>
-        <dxl:SumAgg Mdid="0.2108.1.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
-        <dxl:EqualityOp Mdid="0.98.1.0"/>
-        <dxl:InequalityOp Mdid="0.531.1.0"/>
-        <dxl:LessThanOp Mdid="0.664.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
-        <dxl:ComparisonOp Mdid="0.360.1.0"/>
-        <dxl:ArrayType Mdid="0.1009.1.0"/>
-        <dxl:MinAgg Mdid="0.2145.1.0"/>
-        <dxl:MaxAgg Mdid="0.2129.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.540684.1.1.7" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.540684.1.1.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.607.1.0"/>
-        <dxl:InequalityOp Mdid="0.608.1.0"/>
-        <dxl:LessThanOp Mdid="0.609.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
-        <dxl:ComparisonOp Mdid="0.356.1.0"/>
-        <dxl:ArrayType Mdid="0.1028.1.0"/>
-        <dxl:MinAgg Mdid="0.2118.1.0"/>
-        <dxl:MaxAgg Mdid="0.2134.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
-        <dxl:EqualityOp Mdid="0.387.1.0"/>
-        <dxl:InequalityOp Mdid="0.402.1.0"/>
-        <dxl:LessThanOp Mdid="0.2799.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
-        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
-        <dxl:ArrayType Mdid="0.1010.1.0"/>
-        <dxl:MinAgg Mdid="0.2798.1.0"/>
-        <dxl:MaxAgg Mdid="0.2797.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.385.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1012.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1011.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:CTASRelation Mdid="5.1.1.0" Name="test" IsTemporary="false" HasOids="false" StorageType="Heap" VarTypeModList="-1,-1,-1" DistributionPolicy="Hash" DistributionColumns="0">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c" Attno="3" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:CTASOptions OnCommitAction="NOOP"/>
-      </dxl:CTASRelation>
-      <dxl:ColumnStatistics Mdid="1.540684.1.1.5" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.540684.1.1.4" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:RelationStatistics Mdid="2.540684.1.1" Name="test_gpfdist_ext" Rows="1000000.000000" EmptyRelation="false"/>
-      <dxl:ExternalRelation Mdid="0.540684.1.1" Name="test_gpfdist_ext" DistributionPolicy="Random" Keys="9,3">
+    <dxl:Metadata SystemIds="0.CTAS,0.GPDB">
+      <dxl:RelationStatistics Mdid="2.57353.1.0" Name="test_gpfdist_ext" Rows="1000000.000000" EmptyRelation="false"/>
+      <dxl:ExternalRelation Mdid="0.57353.1.0" Name="test_gpfdist_ext" DistributionPolicy="Random" Keys="9,3">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -185,12 +62,143 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_gpfdist_ext DISTRIBUTED BY (a);
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:ExternalRelation>
-      <dxl:ColumnStatistics Mdid="1.540684.1.1.3" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="1000000.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:ColumnStatistics Mdid="1.540684.1.1.2" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.540684.1.1.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:ColumnStatistics Mdid="1.540684.1.1.8" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:ColumnStatistics Mdid="1.540684.1.1.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.540684.1.1.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:CTASRelation Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" VarTypeModList="-1,-1,-1" DistributionPolicy="Hash" DistributionColumns="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.25.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:DistrOpclasses>
+          <dxl:DistrOpclass Mdid="0.10027.1.0"/>
+        </dxl:DistrOpclasses>
+      </dxl:CTASRelation>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -199,36 +207,45 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_gpfdist_ext DISTRIBUTED BY (a);
         <dxl:Ident ColId="3" ColName="c" TypeMdid="0.25.1.0"/>
       </dxl:OutputColumns>
       <dxl:CTEList/>
-      <dxl:LogicalCTAS Mdid="5.1.1.0" Name="test" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" InsertColumns="1,2,3" VarTypeModList="-1,-1,-1">
+      <dxl:LogicalCTAS Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" InsertColumns="1,2,3" VarTypeModList="-1,-1,-1">
         <dxl:Columns>
           <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
           <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
           <dxl:Column ColId="13" Attno="3" ColName="c" TypeMdid="0.25.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:DistrOpclasses>
+          <dxl:DistrOpclass Mdid="0.10027.1.0"/>
+        </dxl:DistrOpclasses>
         <dxl:LogicalExternalGet>
-          <dxl:TableDescriptor Mdid="0.540684.1.1" TableName="test_gpfdist_ext">
+          <dxl:TableDescriptor Mdid="0.57353.1.0" TableName="test_gpfdist_ext">
             <dxl:Columns>
-              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
-              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.25.1.0"/>
-              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-              <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:LogicalExternalGet>
       </dxl:LogicalCTAS>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:PhysicalCTAS Name="test" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" InsertColumns="0,1,2" VarTypeModList="-1,-1,-1">
+      <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" InsertColumns="0,1,2" VarTypeModList="-1,-1,-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="31731.433333" Rows="1000000.000000" Width="20"/>
         </dxl:Properties>
+        <dxl:DistrOpclasses>
+          <dxl:DistrOpclass Mdid="0.10027.1.0"/>
+        </dxl:DistrOpclasses>
         <dxl:Columns>
           <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
           <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
@@ -284,7 +301,7 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_gpfdist_ext DISTRIBUTED BY (a);
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr>
+              <dxl:HashExpr Opfamily="0.1977.1.0">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -304,18 +321,18 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_gpfdist_ext DISTRIBUTED BY (a);
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.540684.1.1" TableName="test_gpfdist_ext">
+              <dxl:TableDescriptor Mdid="0.57353.1.0" TableName="test_gpfdist_ext">
                 <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
-                  <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.25.1.0"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:ExternalScan>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-with-randomly-distributed-external-table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-with-randomly-distributed-external-table.mdp
@@ -10,146 +10,19 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_ext DISTRIBUTED RANDOMLY;
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
-      <dxl:CTEConfig CTEInliningCutoff="0"/> 
-      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
         <dxl:CostParams>
-          <dxl:CostParam Name="NLJFactor" Value="1.000000" LowerBound="0.500000" UpperBound="1.500000"/>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000"/>
-      <dxl:TraceFlags Value="103027,102120,103001,103014,103015,103022,104004,104005,105000"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
-    <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:ColumnStatistics Mdid="1.514019.1.1.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:ColumnStatistics Mdid="1.514019.1.1.8" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:ColumnStatistics Mdid="1.514019.1.1.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.514019.1.1.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.91.1.0"/>
-        <dxl:InequalityOp Mdid="0.85.1.0"/>
-        <dxl:LessThanOp Mdid="0.58.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
-        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
-        <dxl:ArrayType Mdid="0.1000.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.96.1.0"/>
-        <dxl:InequalityOp Mdid="0.518.1.0"/>
-        <dxl:LessThanOp Mdid="0.97.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
-        <dxl:ComparisonOp Mdid="0.351.1.0"/>
-        <dxl:ArrayType Mdid="0.1007.1.0"/>
-        <dxl:MinAgg Mdid="0.2132.1.0"/>
-        <dxl:MaxAgg Mdid="0.2116.1.0"/>
-        <dxl:AvgAgg Mdid="0.2101.1.0"/>
-        <dxl:SumAgg Mdid="0.2108.1.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
-        <dxl:EqualityOp Mdid="0.98.1.0"/>
-        <dxl:InequalityOp Mdid="0.531.1.0"/>
-        <dxl:LessThanOp Mdid="0.664.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
-        <dxl:ComparisonOp Mdid="0.360.1.0"/>
-        <dxl:ArrayType Mdid="0.1009.1.0"/>
-        <dxl:MinAgg Mdid="0.2145.1.0"/>
-        <dxl:MaxAgg Mdid="0.2129.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.607.1.0"/>
-        <dxl:InequalityOp Mdid="0.608.1.0"/>
-        <dxl:LessThanOp Mdid="0.609.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
-        <dxl:ComparisonOp Mdid="0.356.1.0"/>
-        <dxl:ArrayType Mdid="0.1028.1.0"/>
-        <dxl:MinAgg Mdid="0.2118.1.0"/>
-        <dxl:MaxAgg Mdid="0.2134.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
-        <dxl:EqualityOp Mdid="0.387.1.0"/>
-        <dxl:InequalityOp Mdid="0.402.1.0"/>
-        <dxl:LessThanOp Mdid="0.2799.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
-        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
-        <dxl:ArrayType Mdid="0.1010.1.0"/>
-        <dxl:MinAgg Mdid="0.2798.1.0"/>
-        <dxl:MaxAgg Mdid="0.2797.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.385.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1012.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1011.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:CTASRelation Mdid="5.1.1.0" Schema="public" Name="test" IsTemporary="false" HasOids="false" StorageType="Heap" VarTypeModList="-1,-1,-1" DistributionPolicy="Random">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c" Attno="3" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:CTASOptions OnCommitAction="NOOP"/>
-      </dxl:CTASRelation>
-      <dxl:ColumnStatistics Mdid="1.514019.1.1.3" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="1000000.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:ColumnStatistics Mdid="1.514019.1.1.2" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.514019.1.1.5" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.514019.1.1.4" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:RelationStatistics Mdid="2.514019.1.1" Name="test_ext" Rows="1000000.000000" EmptyRelation="false"/>
-      <dxl:ExternalRelation Mdid="0.514019.1.1" Name="test_ext" DistributionPolicy="Random" Keys="9,3">
+    <dxl:Metadata SystemIds="0.CTAS,0.GPDB">
+      <dxl:RelationStatistics Mdid="2.57349.1.0" Name="test_ext" Rows="1000000.000000" EmptyRelation="false"/>
+      <dxl:ExternalRelation Mdid="0.57349.1.0" Name="test_ext" DistributionPolicy="Random" Keys="9,3">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -186,8 +59,139 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_ext DISTRIBUTED RANDOMLY;
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:ExternalRelation>
-      <dxl:ColumnStatistics Mdid="1.514019.1.1.7" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.514019.1.1.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:CTASRelation Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" VarTypeModList="-1,-1,-1" DistributionPolicy="Random">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.25.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
+      </dxl:CTASRelation>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -196,36 +200,39 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_ext DISTRIBUTED RANDOMLY;
         <dxl:Ident ColId="3" ColName="c" TypeMdid="0.25.1.0"/>
       </dxl:OutputColumns>
       <dxl:CTEList/>
-      <dxl:LogicalCTAS Mdid="5.1.1.0" Schema="public" Name="test" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="1,2,3" VarTypeModList="-1,-1,-1">
+      <dxl:LogicalCTAS Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="1,2,3" VarTypeModList="-1,-1,-1">
         <dxl:Columns>
           <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
           <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
           <dxl:Column ColId="13" Attno="3" ColName="c" TypeMdid="0.25.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
         <dxl:LogicalExternalGet>
-          <dxl:TableDescriptor Mdid="0.514019.1.1" TableName="test_ext">
+          <dxl:TableDescriptor Mdid="0.57349.1.0" TableName="test_ext">
             <dxl:Columns>
-              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
-              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.25.1.0"/>
-              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-              <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:LogicalExternalGet>
       </dxl:LogicalCTAS>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:PhysicalCTAS Schema="public" Name="test" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="0,1,2" VarTypeModList="-1,-1,-1">
+      <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="0,1,2" VarTypeModList="-1,-1,-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="31731.433333" Rows="1000000.000000" Width="20"/>
         </dxl:Properties>
+        <dxl:DistrOpclasses/>
         <dxl:Columns>
           <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
           <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
@@ -296,18 +303,18 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_ext DISTRIBUTED RANDOMLY;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.514019.1.1" TableName="test_ext">
+              <dxl:TableDescriptor Mdid="0.57349.1.0" TableName="test_ext">
                 <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
-                  <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.25.1.0"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:ExternalScan>

--- a/src/backend/gporca/data/dxl/minidump/CTAS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS.mdp
@@ -1,23 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+	Basic test for a simple CTAS that requires redistribution.
+
+	create table foo (a int, b int) distributed by (a);
+	explain create table bar as select * from foo distributed by (b);
+  ]]>
+  </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
-      <dxl:CTEConfig CTEInliningCutoff="0"/> 
-      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:TraceFlags Value="103027,101013,102024,103001"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
-    <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT">
-        <dxl:LeftType Mdid="0.23.1.0"/>
-        <dxl:RightType Mdid="0.23.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.147.1.0"/>
-        <dxl:Commutator Mdid="0.97.1.0"/>
-        <dxl:InverseOp Mdid="0.523.1.0"/>
-      </dxl:GPDBScalarOp>
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+    <dxl:Metadata SystemIds="0.CTAS,0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -32,7 +39,9 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
         <dxl:EqualityOp Mdid="0.96.1.0"/>
         <dxl:InequalityOp Mdid="0.518.1.0"/>
         <dxl:LessThanOp Mdid="0.97.1.0"/>
@@ -47,10 +56,9 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.133315.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.133315.1.1.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.133315.1.1.0" Name="a" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
         <dxl:LessThanOp Mdid="0.609.1.0"/>
@@ -65,7 +73,9 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
         <dxl:EqualityOp Mdid="0.387.1.0"/>
         <dxl:InequalityOp Mdid="0.402.1.0"/>
         <dxl:LessThanOp Mdid="0.2799.1.0"/>
@@ -80,7 +90,8 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
         <dxl:InequalityOp Mdid="0.0.0.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
@@ -95,9 +106,10 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
         <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
         <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
         <dxl:GreaterThanOp Mdid="0.0.0.0"/>
@@ -110,10 +122,8 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.133315.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.133315.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:RelationStatistics Mdid="2.133315.1.1" Name="r" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.133315.1.0" Name="r" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+      <dxl:RelationStatistics Mdid="2.57379.1.0" Name="foo" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.57379.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -145,107 +155,89 @@
         </dxl:Columns>
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
-        <dxl:CheckConstraints>
-          <dxl:CheckConstraint Mdid="0.133330.1.0"/>
-        </dxl:CheckConstraints>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Relation Mdid="0.133315.1.1" Name="r" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+      <dxl:CTASRelation Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" VarTypeModList="-1,-1" DistributionPolicy="Hash" DistributionColumns="1">
         <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
             <dxl:DefaultValue/>
           </dxl:Column>
         </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints>
-          <dxl:CheckConstraint Mdid="0.133330.1.0"/>
-        </dxl:CheckConstraints>
-      </dxl:Relation>
-      <dxl:CheckConstraint Mdid="0.133330.1.0" Name="r_b_check" RelationMdid="0.133315.1.0">
-        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-        </dxl:Comparison>
-      </dxl:CheckConstraint>
-      <dxl:ColumnStatistics Mdid="1.133315.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.133315.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.133315.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:ColumnStatistics Mdid="1.133315.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:DistrOpclasses>
+          <dxl:DistrOpclass Mdid="0.10027.1.0"/>
+        </dxl:DistrOpclasses>
+      </dxl:CTASRelation>
+      <dxl:ColumnStatistics Mdid="1.57379.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="d" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
       </dxl:OutputColumns>
       <dxl:CTEList/>
-      <dxl:LogicalCTAS Mdid="5.1.1.0" Schema="bla" Name="r_copy" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="1" InsertColumns="1,2" VarTypeModList="-1,-1">
+      <dxl:LogicalCTAS Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="1" InsertColumns="1,2" VarTypeModList="-1,-1">
         <dxl:Columns>
-          <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-          <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
-        <dxl:CTASOptions Tablespace="bla_tablespace" OnCommitAction="NOOP"/>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:DistrOpclasses>
+          <dxl:DistrOpclass Mdid="0.10027.1.0"/>
+        </dxl:DistrOpclasses>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.133315.1.1" TableName="r">
+          <dxl:TableDescriptor Mdid="0.57379.1.0" TableName="foo">
             <dxl:Columns>
-              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
       </dxl:LogicalCTAS>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:PhysicalCTAS Schema="bla" Name="r_copy" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="1" InsertColumns="0,1" VarTypeModList="-1,-1">
+      <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="1" InsertColumns="0,1" VarTypeModList="-1,-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3.046875" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.015649" Rows="1.000000" Width="8"/>
         </dxl:Properties>
+        <dxl:DistrOpclasses>
+          <dxl:DistrOpclass Mdid="0.10027.1.0"/>
+        </dxl:DistrOpclasses>
         <dxl:Columns>
-          <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-          <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
-        <dxl:CTASOptions Tablespace="bla_tablespace" OnCommitAction="NOOP"/>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="c">
+          <dxl:ProjElem ColId="0" Alias="a">
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="d">
+          <dxl:ProjElem ColId="1" Alias="b">
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2.023438" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -260,9 +252,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.011719" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -275,13 +267,13 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr>
+              <dxl:HashExpr Opfamily="0.1977.1.0">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.005859" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -292,17 +284,17 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.133315.1.1" TableName="r">
+              <dxl:TableDescriptor Mdid="0.57379.1.0" TableName="foo">
                 <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
@@ -18,44 +18,192 @@
           <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000" EnforceConstraintsOnDML="false"/>
-      <dxl:TraceFlags Value="102074,102146,102120,103001,103014,103015,103022,104003,104004,104005,105000,106000"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
-    <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:RelationStatistics Mdid="2.65536.1.0" Name="x" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.65536.1.0" Name="x" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
-        <dxl:Columns>
-          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
-      <dxl:RelationStatistics Mdid="2.65539.1.0" Name="y" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.65539.1.0" Name="y" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+    <dxl:Metadata SystemIds="0.CTAS,0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.15.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.852.1.0"/>
+        <dxl:Commutator Mdid="0.416.1.0"/>
+        <dxl:InverseOp Mdid="0.36.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.12738.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.467.1.0"/>
+        <dxl:Commutator Mdid="0.410.1.0"/>
+        <dxl:InverseOp Mdid="0.411.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.12738.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.412.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.469.1.0"/>
+        <dxl:Commutator Mdid="0.413.1.0"/>
+        <dxl:InverseOp Mdid="0.415.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.12738.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.57371.1.0" Name="y" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.470.1.0"/>
+        <dxl:Commutator Mdid="0.412.1.0"/>
+        <dxl:InverseOp Mdid="0.414.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.12738.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBFunc Mdid="0.3100.1.0" Name="row_number" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="false" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.57371.1.0" Name="y" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="j" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -85,170 +233,45 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.65536.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:GPDBScalarOp Mdid="0.15.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
-        <dxl:LeftType Mdid="0.23.1.0"/>
-        <dxl:RightType Mdid="0.20.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.852.1.0"/>
-        <dxl:Commutator Mdid="0.416.1.0"/>
-        <dxl:InverseOp Mdid="0.36.1.0"/>
-        <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.1977.1.0"/>
-          <dxl:Opfamily Mdid="0.7027.1.0"/>
-        </dxl:Opfamilies>
-      </dxl:GPDBScalarOp>
-      <dxl:GPDBFunc Mdid="0.852.1.0" Name="int48eq" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
-	    <dxl:ResultType Mdid="0.16.1.0"/>
-      </dxl:GPDBFunc>
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.91.1.0"/>
-        <dxl:InequalityOp Mdid="0.85.1.0"/>
-        <dxl:LessThanOp Mdid="0.58.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
-        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
-        <dxl:ArrayType Mdid="0.1000.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.410.1.0"/>
-        <dxl:InequalityOp Mdid="0.411.1.0"/>
-        <dxl:LessThanOp Mdid="0.412.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
-        <dxl:ComparisonOp Mdid="0.351.1.0"/>
-        <dxl:ArrayType Mdid="0.1016.1.0"/>
-        <dxl:MinAgg Mdid="0.2131.1.0"/>
-        <dxl:MaxAgg Mdid="0.2115.1.0"/>
-        <dxl:AvgAgg Mdid="0.2100.1.0"/>
-        <dxl:SumAgg Mdid="0.2107.1.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.96.1.0"/>
-        <dxl:InequalityOp Mdid="0.518.1.0"/>
-        <dxl:LessThanOp Mdid="0.97.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
-        <dxl:ComparisonOp Mdid="0.351.1.0"/>
-        <dxl:ArrayType Mdid="0.1007.1.0"/>
-        <dxl:MinAgg Mdid="0.2132.1.0"/>
-        <dxl:MaxAgg Mdid="0.2116.1.0"/>
-        <dxl:AvgAgg Mdid="0.2101.1.0"/>
-        <dxl:SumAgg Mdid="0.2108.1.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
-        <dxl:LeftType Mdid="0.20.1.0"/>
-        <dxl:RightType Mdid="0.20.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.467.1.0"/>
-        <dxl:Commutator Mdid="0.410.1.0"/>
-        <dxl:InverseOp Mdid="0.411.1.0"/>
-        <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.1977.1.0"/>
-          <dxl:Opfamily Mdid="0.7028.1.0"/>
-        </dxl:Opfamilies>
-      </dxl:GPDBScalarOp>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.607.1.0"/>
-        <dxl:InequalityOp Mdid="0.608.1.0"/>
-        <dxl:LessThanOp Mdid="0.609.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
-        <dxl:ComparisonOp Mdid="0.356.1.0"/>
-        <dxl:ArrayType Mdid="0.1028.1.0"/>
-        <dxl:MinAgg Mdid="0.2118.1.0"/>
-        <dxl:MaxAgg Mdid="0.2134.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
-        <dxl:EqualityOp Mdid="0.387.1.0"/>
-        <dxl:InequalityOp Mdid="0.402.1.0"/>
-        <dxl:LessThanOp Mdid="0.2799.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
-        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
-        <dxl:ArrayType Mdid="0.1010.1.0"/>
-        <dxl:MinAgg Mdid="0.2798.1.0"/>
-        <dxl:MaxAgg Mdid="0.2797.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.65539.1.0.0" Name="j" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:GPDBScalarOp Mdid="0.412.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
-        <dxl:LeftType Mdid="0.20.1.0"/>
-        <dxl:RightType Mdid="0.20.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.469.1.0"/>
-        <dxl:Commutator Mdid="0.413.1.0"/>
-        <dxl:InverseOp Mdid="0.415.1.0"/>
-        <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.7028.1.0"/>
-        </dxl:Opfamilies>
-      </dxl:GPDBScalarOp>
-      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
-        <dxl:LeftType Mdid="0.20.1.0"/>
-        <dxl:RightType Mdid="0.20.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.470.1.0"/>
-        <dxl:Commutator Mdid="0.412.1.0"/>
-        <dxl:InverseOp Mdid="0.414.1.0"/>
-        <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.7028.1.0"/>
-        </dxl:Opfamilies>
-      </dxl:GPDBScalarOp>
-      <dxl:GPDBFunc Mdid="0.3100.1.0" Name="row_number" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="false">
-        <dxl:ResultType Mdid="0.20.1.0"/>
-      </dxl:GPDBFunc>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.385.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1012.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1011.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.57368.1.0" Name="x" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.57368.1.0" Name="x" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
       <dxl:CTASRelation Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" VarTypeModList="-1" DistributionPolicy="Random">
         <dxl:Columns>
           <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true">
@@ -256,20 +279,24 @@
           </dxl:Column>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
       </dxl:CTASRelation>
       <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
       <dxl:MDScalarComparison Mdid="4.23.1.0;20.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.23.1.0" RightType="0.20.1.0" OperatorMdid="0.15.1.0"/>
-      <dxl:GPDBFunc Mdid="0.481.1.0" Name="int8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
+      <dxl:GPDBFunc Mdid="0.481.1.0" Name="int8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
         <dxl:ResultType Mdid="0.20.1.0"/>
       </dxl:GPDBFunc>
+      <dxl:ColumnStatistics Mdid="1.57371.1.0.0" Name="j" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
       <dxl:MDCast Mdid="3.23.1.0;20.1.0" Name="int8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.20.1.0" CastFuncId="0.481.1.0" CoercePathType="1"/>
+      <dxl:ColumnStatistics Mdid="1.57368.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -281,6 +308,8 @@
           <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
         <dxl:LogicalSelect>
           <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.15.1.0" ColId="17">
             <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
@@ -299,7 +328,7 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:LogicalGet>
-                <dxl:TableDescriptor Mdid="0.65539.1.0" TableName="y">
+                <dxl:TableDescriptor Mdid="0.57371.1.0" TableName="y">
                   <dxl:Columns>
                     <dxl:Column ColId="9" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
                     <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -315,7 +344,7 @@
             </dxl:LogicalWindow>
           </dxl:SubqueryAny>
           <dxl:LogicalGet>
-            <dxl:TableDescriptor Mdid="0.65536.1.0" TableName="x">
+            <dxl:TableDescriptor Mdid="0.57368.1.0" TableName="x">
               <dxl:Columns>
                 <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -336,6 +365,7 @@
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.010884" Rows="1.000000" Width="4"/>
         </dxl:Properties>
+        <dxl:DistrOpclasses/>
         <dxl:Columns>
           <dxl:Column ColId="22" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
@@ -401,7 +431,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
                     <dxl:Ident ColId="16" ColName="row_number" TypeMdid="0.20.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -456,7 +486,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.65539.1.0" TableName="y">
+                          <dxl:TableDescriptor Mdid="0.57371.1.0" TableName="y">
                             <dxl:Columns>
                               <dxl:Column ColId="8" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
                               <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -495,7 +525,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
                     <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
                       <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                     </dxl:Cast>
@@ -511,7 +541,7 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.65536.1.0" TableName="x">
+                  <dxl:TableDescriptor Mdid="0.57368.1.0" TableName="x">
                     <dxl:Columns>
                       <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
                       <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTable-CTAS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTable-CTAS.mdp
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Comment><![CDATA[
-     CREATE TABLE r1 AS SELECT i AS a, i AS b FROM generate_series(1, 10) i DISTRIBUTED REPLICATED;
-  ]]>
+     CREATE TABLE r1 AS SELECT i AS a, i AS b FROM generate_series(1, 10) i DISTRIBUTED REPLICATED; ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
@@ -15,11 +14,13 @@
           <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000" EnforceConstraintsOnDML="false"/>
-      <dxl:TraceFlags Value="102074,102146,102120,103001,103014,103015,103022,103027,104003,104004,104005,105000,106000"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
-    <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+    <dxl:Metadata SystemIds="0.CTAS,0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -34,7 +35,9 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
         <dxl:EqualityOp Mdid="0.96.1.0"/>
         <dxl:InequalityOp Mdid="0.518.1.0"/>
         <dxl:LessThanOp Mdid="0.97.1.0"/>
@@ -59,8 +62,10 @@
           </dxl:Column>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
       </dxl:CTASRelation>
-      <dxl:GPDBFunc Mdid="0.1067.1.0" Name="generate_series" ReturnsSet="true" Stability="Immutable" DataAccess="ReadsSQLData" IsStrict="true">
+      <dxl:GPDBFunc Mdid="0.1067.1.0" Name="generate_series" ReturnsSet="true" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
         <dxl:ResultType Mdid="0.23.1.0"/>
       </dxl:GPDBFunc>
     </dxl:Metadata>
@@ -76,6 +81,8 @@
           <dxl:Column ColId="3" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
         <dxl:LogicalTVF FuncId="0.1067.1.0" Name="generate_series" TypeMdid="0.23.1.0">
           <dxl:Columns>
             <dxl:Column ColId="1" Attno="1" ColName="generate_series" TypeMdid="0.23.1.0"/>
@@ -90,6 +97,7 @@
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="31.262000" Rows="1000.000000" Width="4"/>
         </dxl:Properties>
+        <dxl:DistrOpclasses/>
         <dxl:Columns>
           <dxl:Column ColId="2" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
           <dxl:Column ColId="3" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>

--- a/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
@@ -381,6 +381,12 @@
         <dxl:CTASOption CtasOptionType="653" Name="compression" Value="zlib" IsNull="false"/>
         <dxl:CTASOption CtasOptionType="653" Name="appendonly" Value="false" IsNull="false"/>
       </dxl:CTASOptions>
+      <dxl:DistrOpfamilies>
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+      </dxl:DistrOpfamilies>
+      <dxl:DistrOpclasses>
+        <dxl:DistrOpclass Mdid="0.10027.1.0"/>
+      </dxl:DistrOpclasses>
     </dxl:CTASRelation>
   </dxl:Metadata>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/parse_tests/q65-LogicalCTASHash.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q65-LogicalCTASHash.xml
@@ -13,6 +13,12 @@
         <dxl:CTASOption CtasOptionType="653" Name="compression" Value="zlib" IsNull="false"/>
         <dxl:CTASOption CtasOptionType="653" Name="appendonly" Value="false" IsNull="false"/>
       </dxl:CTASOptions>
+      <dxl:DistrOpfamilies>
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+      </dxl:DistrOpfamilies>
+      <dxl:DistrOpclasses>
+        <dxl:DistrOpclass Mdid="0.10027.1.0"/>
+      </dxl:DistrOpclasses>
       <dxl:LogicalProject>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="a">

--- a/src/backend/gporca/data/dxl/parse_tests/q66-LogicalCTASRandom.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q66-LogicalCTASRandom.xml
@@ -10,6 +10,8 @@
         <dxl:Column ColId="3" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
       </dxl:Columns>
       <dxl:CTASOptions OnCommitAction="PreserveRows"/>
+      <dxl:DistrOpfamilies/>
+      <dxl:DistrOpclasses/>
       <dxl:LogicalProject>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="a">

--- a/src/backend/gporca/data/dxl/parse_tests/q67-PhysicalCTAS.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q67-PhysicalCTAS.xml
@@ -5,6 +5,9 @@
       <dxl:Properties>
         <dxl:Cost StartupCost="1.005" TotalCost="5.8" Rows="10" Width="8"/>
       </dxl:Properties>
+      <dxl:DistrOpclasses>
+        <dxl:DistrOpclass Mdid="0.10027.1.0"/>
+      </dxl:DistrOpclasses>
       <dxl:Columns>
         <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
       </dxl:Columns>

--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
@@ -406,8 +406,6 @@ CMDAccessor::RegisterProvider(CSystemId sysid, IMDProvider *pmdp)
 
 	MDPHTAccessor mdhtacc(m_shtProviders, *(a_pmdpelem.Value()));
 
-	GPOS_ASSERT(NULL == mdhtacc.Find());
-
 	// insert provider in the hash table
 	mdhtacc.Insert(a_pmdpelem.Value());
 	a_pmdpelem.Reset();

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -2212,13 +2212,19 @@ CTranslatorDXLToExpr::RegisterMDRelationCtas(CDXLLogicalCTAS *pdxlopCTAS)
 
 	IntPtrArray *vartypemod_array = pdxlopCTAS->GetVarTypeModArray();
 	vartypemod_array->AddRef();
+
+	IMdIdArray *distr_opfamilies = pdxlopCTAS->GetDistrOpfamilies();
+	distr_opfamilies->AddRef();
+	IMdIdArray *distr_opclasses = pdxlopCTAS->GetDistrOpclasses();
+	distr_opclasses->AddRef();
+
 	CMDRelationCtasGPDB *pmdrel = GPOS_NEW(m_mp) CMDRelationCtasGPDB(
 		m_mp, pdxlopCTAS->MDId(), mdname_schema,
 		GPOS_NEW(m_mp) CMDName(m_mp, pdxlopCTAS->MdName()->GetMDName()),
 		pdxlopCTAS->IsTemporary(), pdxlopCTAS->HasOids(),
 		pdxlopCTAS->RetrieveRelStorageType(), pdxlopCTAS->Ereldistrpolicy(),
-		mdcol_array, pdxlopCTAS->GetDistrColPosArray(),
-		pdxlopCTAS->GetDistrOpfamilies(),
+		mdcol_array, pdxlopCTAS->GetDistrColPosArray(), distr_opfamilies,
+		distr_opclasses,
 		GPOS_NEW(m_mp) ULongPtr2dArray(m_mp),  // keyset_array,
 		pdxlopCTAS->GetDxlCtasStorageOption(), vartypemod_array);
 
@@ -3882,7 +3888,7 @@ CTranslatorDXLToExpr::AddDistributionColumns(
 		{
 			opfamily = pmdrel->GetDistrOpfamilyAt(ul);
 			GPOS_ASSERT(NULL != opfamily && opfamily->IsValid());
-			opfamily->AddRef();
+			//opfamily->AddRef();
 		}
 
 		ptabdesc->AddDistributionColumn(*pulPos, opfamily);

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -5746,14 +5746,17 @@ CTranslatorExprToDXL::PdxlnCTAS(CExpression *pexpr,
 			CMDName(m_mp, pmdrel->GetMdNameSchema()->GetMDName());
 	}
 
+	IMdIdArray *distr_opclasses = pmdrel->GetDistrOpClasses();
+	distr_opclasses->AddRef();
+
 	vartypemod_array->AddRef();
 	CDXLPhysicalCTAS *pdxlopCTAS = GPOS_NEW(m_mp) CDXLPhysicalCTAS(
 		m_mp, mdname_schema,
 		GPOS_NEW(m_mp) CMDName(m_mp, pmdrel->Mdname().GetMDName()),
 		dxl_col_descr_array, pmdrel->GetDxlCtasStorageOption(),
-		pmdrel->GetRelDistribution(), pdrgpulDistr, pmdrel->IsTemporary(),
-		pmdrel->HasOids(), pmdrel->RetrieveRelStorageType(), pdrgpul,
-		vartypemod_array);
+		pmdrel->GetRelDistribution(), pdrgpulDistr, pmdrel->GetDistrOpClasses(),
+		pmdrel->IsTemporary(), pmdrel->HasOids(),
+		pmdrel->RetrieveRelStorageType(), pdrgpul, vartypemod_array);
 
 	CDXLNode *pdxlnCTAS = GPOS_NEW(m_mp) CDXLNode(m_mp, pdxlopCTAS);
 	CDXLPhysicalProperties *dxl_properties = GetProperties(pexpr);

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLLogicalCTAS.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLLogicalCTAS.h
@@ -61,6 +61,9 @@ private:
 	// list of distribution column opfamilies
 	IMdIdArray *m_distr_opfamilies;
 
+	// list of distribution column opclasses for populating dist policy of created table
+	IMdIdArray *m_distr_opclasses;
+
 	// is this a temporary table
 	BOOL m_is_temp_table;
 
@@ -87,8 +90,8 @@ public:
 					CDXLCtasStorageOptions *dxl_ctas_storage_option,
 					IMDRelation::Ereldistrpolicy rel_distr_policy,
 					ULongPtrArray *distr_column_pos_array,
-					IMdIdArray *distr_opfamilies, BOOL fTemporary,
-					BOOL fHasOids,
+					IMdIdArray *distr_opfamilies, IMdIdArray *distr_opclasses,
+					BOOL fTemporary, BOOL fHasOids,
 					IMDRelation::Erelstoragetype rel_storage_type,
 					ULongPtrArray *src_colids_array,
 					IntPtrArray *vartypemod_array);
@@ -156,6 +159,13 @@ public:
 	GetDistrOpfamilies() const
 	{
 		return m_distr_opfamilies;
+	}
+
+	// distribution column opclasses
+	IMdIdArray *
+	GetDistrOpclasses() const
+	{
+		return m_distr_opclasses;
 	}
 
 	// source column ids

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalCTAS.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalCTAS.h
@@ -53,6 +53,9 @@ private:
 	// list of distribution column positions
 	ULongPtrArray *m_distr_column_pos_array;
 
+	// list of distriution column opclasses
+	IMdIdArray *m_distr_opclasses;
+
 	// is this a temporary table
 	BOOL m_is_temp_table;
 
@@ -78,7 +81,8 @@ public:
 					 CDXLColDescrArray *dxl_col_descr_array,
 					 CDXLCtasStorageOptions *dxl_ctas_storage_options,
 					 IMDRelation::Ereldistrpolicy rel_distr_policy,
-					 ULongPtrArray *distr_column_pos_array, BOOL is_temporary,
+					 ULongPtrArray *distr_column_pos_array,
+					 IMdIdArray *distr_opclasses, BOOL is_temporary,
 					 BOOL has_oids,
 					 IMDRelation::Erelstoragetype rel_storage_type,
 					 ULongPtrArray *src_colids_array,
@@ -156,6 +160,11 @@ public:
 		return m_dxl_ctas_storage_option;
 	}
 
+	IMdIdArray *
+	GetDistrOpclasses() const
+	{
+		return m_distr_opclasses;
+	}
 	// serialize operator in DXL format
 	virtual void SerializeToDXL(CXMLSerializer *xml_serializer,
 								const CDXLNode *dxlnode) const;

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalCTAS.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalCTAS.h
@@ -65,9 +65,6 @@ private:
 	// storage type
 	IMDRelation::Erelstoragetype m_rel_storage_type;
 
-	// distribution opfamilies parse handler
-	CParseHandlerBase *m_opfamilies_parse_handler;
-
 	// private copy ctor
 	CParseHandlerLogicalCTAS(const CParseHandlerLogicalCTAS &);
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDRelationCtas.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDRelationCtas.h
@@ -61,9 +61,6 @@ public:
 	CParseHandlerMDRelationCtas(CMemoryPool *mp,
 								CParseHandlerManager *parse_handler_mgr,
 								CParseHandlerBase *parse_handler_root);
-
-	// distribution opfamilies parse handler
-	CParseHandlerBase *m_opfamilies_parse_handler;
 };
 }  // namespace gpdxl
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -477,6 +477,9 @@ enum Edxltoken
 	EdxltokenRelDistrOpfamilies,
 	EdxltokenRelDistrOpfamily,
 
+	EdxltokenRelDistrOpclasses,
+	EdxltokenRelDistrOpclass,
+
 	EdxltokenExtRelRejLimit,
 	EdxltokenExtRelRejLimitInRows,
 	EdxltokenExtRelFmtErrRel,

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDRelationCtasGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDRelationCtasGPDB.h
@@ -80,6 +80,9 @@ private:
 	// distribution opfamilies
 	IMdIdArray *m_distr_opfamilies;
 
+	// distribution opclasses
+	IMdIdArray *m_distr_opclasses;
+
 	// array of key sets
 	ULongPtr2dArray *m_keyset_array;
 
@@ -107,16 +110,14 @@ private:
 
 public:
 	// ctor
-	CMDRelationCtasGPDB(CMemoryPool *mp, IMDId *mdid, CMDName *mdname_schema,
-						CMDName *mdname, BOOL fTemporary, BOOL fHasOids,
-						Erelstoragetype rel_storage_type,
-						Ereldistrpolicy rel_distr_policy,
-						CMDColumnArray *mdcol_array,
-						ULongPtrArray *distr_col_array,
-						IMdIdArray *distr_opfamilies,
-						ULongPtr2dArray *keyset_array,
-						CDXLCtasStorageOptions *dxl_ctas_storage_options,
-						IntPtrArray *vartypemod_array);
+	CMDRelationCtasGPDB(
+		CMemoryPool *mp, IMDId *mdid, CMDName *mdname_schema, CMDName *mdname,
+		BOOL fTemporary, BOOL fHasOids, Erelstoragetype rel_storage_type,
+		Ereldistrpolicy rel_distr_policy, CMDColumnArray *mdcol_array,
+		ULongPtrArray *distr_col_array, IMdIdArray *distr_opfamilies,
+		IMdIdArray *distr_opclasses, ULongPtr2dArray *keyset_array,
+		CDXLCtasStorageOptions *dxl_ctas_storage_options,
+		IntPtrArray *vartypemod_array);
 
 	// dtor
 	virtual ~CMDRelationCtasGPDB();
@@ -232,6 +233,12 @@ public:
 
 	// return the position of a column in the metadata object given the attribute number in the system catalog
 	virtual ULONG GetPosFromAttno(INT attno) const;
+
+	virtual IMdIdArray *
+	GetDistrOpClasses() const
+	{
+		return m_distr_opclasses;
+	}
 
 	// retrieve the id of the metadata cache index at the given position
 	virtual IMDId *IndexMDidAt(ULONG  // pos

--- a/src/backend/gporca/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
@@ -31,7 +31,7 @@ CMDRelationCtasGPDB::CMDRelationCtasGPDB(
 	BOOL fTemporary, BOOL fHasOids, Erelstoragetype rel_storage_type,
 	Ereldistrpolicy rel_distr_policy, CMDColumnArray *mdcol_array,
 	ULongPtrArray *distr_col_array, IMdIdArray *distr_opfamiles,
-	ULongPtr2dArray *keyset_array,
+	IMdIdArray *distr_opclasses, ULongPtr2dArray *keyset_array,
 	CDXLCtasStorageOptions *dxl_ctas_storage_options,
 	IntPtrArray *vartypemod_array)
 	: m_mp(mp),
@@ -45,6 +45,7 @@ CMDRelationCtasGPDB::CMDRelationCtasGPDB(
 	  m_md_col_array(mdcol_array),
 	  m_distr_col_array(distr_col_array),
 	  m_distr_opfamilies(distr_opfamiles),
+	  m_distr_opclasses(distr_opclasses),
 	  m_keyset_array(keyset_array),
 	  m_system_columns(0),
 	  m_nondrop_col_pos_array(NULL),
@@ -110,6 +111,8 @@ CMDRelationCtasGPDB::~CMDRelationCtasGPDB()
 	CRefCount::SafeRelease(m_nondrop_col_pos_array);
 	m_dxl_ctas_storage_option->Release();
 	m_vartypemod_array->Release();
+	m_distr_opfamilies->Release();
+	m_distr_opclasses->Release();
 }
 
 //---------------------------------------------------------------------------
@@ -359,13 +362,15 @@ CMDRelationCtasGPDB::Serialize(CXMLSerializer *xml_serializer) const
 	m_dxl_ctas_storage_option->Serialize(xml_serializer);
 
 	// serialize distribution opfamilies
-	if (EreldistrHash == m_rel_distr_policy && NULL != m_distr_opfamilies)
-	{
-		SerializeMDIdList(
-			xml_serializer, m_distr_opfamilies,
-			CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpfamilies),
-			CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpfamily));
-	}
+
+	SerializeMDIdList(xml_serializer, m_distr_opfamilies,
+					  CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpfamilies),
+					  CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpfamily));
+
+	SerializeMDIdList(xml_serializer, m_distr_opclasses,
+					  CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpclasses),
+					  CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpclass));
+
 
 	xml_serializer->CloseElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalCTAS.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalCTAS.cpp
@@ -36,7 +36,8 @@ CDXLPhysicalCTAS::CDXLPhysicalCTAS(
 	CDXLColDescrArray *dxl_col_descr_array,
 	CDXLCtasStorageOptions *dxl_ctas_opt,
 	IMDRelation::Ereldistrpolicy rel_distr_policy,
-	ULongPtrArray *distr_column_pos_array, BOOL is_temporary, BOOL has_oids,
+	ULongPtrArray *distr_column_pos_array, IMdIdArray *distr_opclasses,
+	BOOL is_temporary, BOOL has_oids,
 	IMDRelation::Erelstoragetype rel_storage_type,
 	ULongPtrArray *src_colids_array, IntPtrArray *vartypemod_array)
 	: CDXLPhysical(mp),
@@ -46,6 +47,7 @@ CDXLPhysicalCTAS::CDXLPhysicalCTAS(
 	  m_dxl_ctas_storage_option(dxl_ctas_opt),
 	  m_rel_distr_policy(rel_distr_policy),
 	  m_distr_column_pos_array(distr_column_pos_array),
+	  m_distr_opclasses(distr_opclasses),
 	  m_is_temp_table(is_temporary),
 	  m_has_oids(has_oids),
 	  m_rel_storage_type(rel_storage_type),
@@ -81,6 +83,7 @@ CDXLPhysicalCTAS::~CDXLPhysicalCTAS()
 	CRefCount::SafeRelease(m_distr_column_pos_array);
 	m_src_colids_array->Release();
 	m_vartypemod_array->Release();
+	m_distr_opclasses->Release();
 }
 
 //---------------------------------------------------------------------------
@@ -184,6 +187,13 @@ CDXLPhysicalCTAS::SerializeToDXL(CXMLSerializer *xml_serializer,
 
 	// serialize properties
 	dxlnode->SerializePropertiesToDXL(xml_serializer);
+
+	// serialize opclasses list
+
+	IMDCacheObject::SerializeMDIdList(
+		xml_serializer, m_distr_opclasses,
+		CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpclasses),
+		CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpclass));
 
 	// serialize column descriptors
 	xml_serializer->OpenElement(

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
@@ -43,8 +43,7 @@ CParseHandlerLogicalCTAS::CParseHandlerLogicalCTAS(
 	  m_distr_column_pos_array(NULL),
 	  m_src_colids_array(NULL),
 	  m_vartypemod_array(NULL),
-	  m_is_temp_table(false),
-	  m_opfamilies_parse_handler(NULL)
+	  m_is_temp_table(false)
 {
 }
 
@@ -57,27 +56,11 @@ CParseHandlerLogicalCTAS::CParseHandlerLogicalCTAS(
 //
 //---------------------------------------------------------------------------
 void
-CParseHandlerLogicalCTAS::StartElement(const XMLCh *const element_uri,
-									   const XMLCh *const element_local_name,
-									   const XMLCh *const element_qname,
-									   const Attributes &attrs)
+CParseHandlerLogicalCTAS::StartElement(
+	const XMLCh *const element_uri GPOS_UNUSED,
+	const XMLCh *const element_local_name,
+	const XMLCh *const element_qname GPOS_UNUSED, const Attributes &attrs)
 {
-	if (0 == XMLString::compareString(
-				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamilies),
-				 element_local_name))
-	{
-		// parse handler for check constraints
-		m_opfamilies_parse_handler = CParseHandlerFactory::GetParseHandler(
-			m_mp, CDXLTokens::XmlstrToken(EdxltokenMetadataIdList),
-			m_parse_handler_mgr, this);
-		m_parse_handler_mgr->ActivateParseHandler(m_opfamilies_parse_handler);
-		this->Append(m_opfamilies_parse_handler);
-		m_opfamilies_parse_handler->startElement(
-			element_uri, element_local_name, element_qname, attrs);
-
-		return;
-	}
-
 	if (0 !=
 		XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenLogicalCTAS),
 								 element_local_name))
@@ -159,6 +142,20 @@ CParseHandlerLogicalCTAS::StartElement(const XMLCh *const element_uri,
 			m_parse_handler_mgr, this);
 	m_parse_handler_mgr->ActivateParseHandler(child_parse_handler);
 
+	// parse handler for distr opclasses
+	CParseHandlerBase *opclasses_parse_handler =
+		CParseHandlerFactory::GetParseHandler(
+			m_mp, CDXLTokens::XmlstrToken(EdxltokenMetadataIdList),
+			m_parse_handler_mgr, this);
+	m_parse_handler_mgr->ActivateParseHandler(opclasses_parse_handler);
+
+	// parse handler for distr opfamilies
+	CParseHandlerBase *opfamilies_parse_handler =
+		CParseHandlerFactory::GetParseHandler(
+			m_mp, CDXLTokens::XmlstrToken(EdxltokenMetadataIdList),
+			m_parse_handler_mgr, this);
+	m_parse_handler_mgr->ActivateParseHandler(opfamilies_parse_handler);
+
 	//parse handler for the storage options
 	CParseHandlerBase *ctas_options_parse_handler =
 		CParseHandlerFactory::GetParseHandler(
@@ -176,6 +173,8 @@ CParseHandlerLogicalCTAS::StartElement(const XMLCh *const element_uri,
 	// store child parse handler in array
 	this->Append(col_descr_parse_handler);
 	this->Append(ctas_options_parse_handler);
+	this->Append(opfamilies_parse_handler);
+	this->Append(opclasses_parse_handler);
 	this->Append(child_parse_handler);
 }
 
@@ -203,17 +202,23 @@ CParseHandlerLogicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 				   str->GetBuffer());
 	}
 
-	GPOS_ASSERT(3 == this->Length());
+	GPOS_ASSERT(5 == this->Length());
 
 	CParseHandlerColDescr *col_descr_parse_handler =
 		dynamic_cast<CParseHandlerColDescr *>((*this)[0]);
 	CParseHandlerCtasStorageOptions *ctas_options_parse_handler =
 		dynamic_cast<CParseHandlerCtasStorageOptions *>((*this)[1]);
+	CParseHandlerMetadataIdList *opfamilies_parse_handler =
+		dynamic_cast<CParseHandlerMetadataIdList *>((*this)[2]);
+	CParseHandlerMetadataIdList *opclasses_parse_handler =
+		dynamic_cast<CParseHandlerMetadataIdList *>((*this)[3]);
 	CParseHandlerLogicalOp *child_parse_handler =
-		dynamic_cast<CParseHandlerLogicalOp *>((*this)[2]);
+		dynamic_cast<CParseHandlerLogicalOp *>((*this)[4]);
 
 	GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
 	GPOS_ASSERT(NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
+	GPOS_ASSERT(NULL != opfamilies_parse_handler->GetMdIdArray());
+	GPOS_ASSERT(NULL != opclasses_parse_handler->GetMdIdArray());
 	GPOS_ASSERT(NULL != child_parse_handler->CreateDXLNode());
 
 	CDXLColDescrArray *dxl_column_descr_array =
@@ -224,22 +229,25 @@ CParseHandlerLogicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 		ctas_options_parse_handler->GetDxlCtasStorageOption();
 	dxl_ctas_storage_opt->AddRef();
 
-	IMdIdArray *distr_opfamilies = NULL;
-	if (m_opfamilies_parse_handler != NULL)
-	{
-		distr_opfamilies = dynamic_cast<CParseHandlerMetadataIdList *>(
-							   m_opfamilies_parse_handler)
-							   ->GetMdIdArray();
-		distr_opfamilies->AddRef();
-	}
+
+	IMdIdArray *distr_opfamilies =
+		dynamic_cast<CParseHandlerMetadataIdList *>(opfamilies_parse_handler)
+			->GetMdIdArray();
+	distr_opfamilies->AddRef();
+
+	IMdIdArray *distr_opclasses =
+		dynamic_cast<CParseHandlerMetadataIdList *>(opclasses_parse_handler)
+			->GetMdIdArray();
+	distr_opclasses->AddRef();
+
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(
 		m_mp,
 		GPOS_NEW(m_mp) CDXLLogicalCTAS(
 			m_mp, m_mdid, m_mdname_schema, m_mdname, dxl_column_descr_array,
 			dxl_ctas_storage_opt, m_rel_distr_policy, m_distr_column_pos_array,
-			distr_opfamilies, m_is_temp_table, m_has_oids, m_rel_storage_type,
-			m_src_colids_array, m_vartypemod_array));
+			distr_opfamilies, distr_opclasses, m_is_temp_table, m_has_oids,
+			m_rel_storage_type, m_src_colids_array, m_vartypemod_array));
 
 	AddChildFromParseHandler(child_parse_handler);
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
@@ -56,10 +56,10 @@ CParseHandlerLogicalCTAS::CParseHandlerLogicalCTAS(
 //
 //---------------------------------------------------------------------------
 void
-CParseHandlerLogicalCTAS::StartElement(
-	const XMLCh *const element_uri GPOS_UNUSED,
-	const XMLCh *const element_local_name,
-	const XMLCh *const element_qname GPOS_UNUSED, const Attributes &attrs)
+CParseHandlerLogicalCTAS::StartElement(const XMLCh *const, /* element_uri */
+									   const XMLCh *const element_local_name,
+									   const XMLCh *const, /* element_qname */
+									   const Attributes &attrs)
 {
 	if (0 !=
 		XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenLogicalCTAS),

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMetadataIdList.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMetadataIdList.cpp
@@ -138,12 +138,24 @@ CParseHandlerMetadataIdList::StartElement(const XMLCh *const,  // element_uri,
 					  CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamily),
 					  element_local_name))
 	{
-		// opclass metadata id: array must be initialized already
+		// distr opfamily metadata id: array must be initialized already
 		GPOS_ASSERT(NULL != m_mdid_array);
 
 		IMDId *mdid = CDXLOperatorFactory::ExtractConvertAttrValueToMdId(
 			m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenMdid,
 			EdxltokenRelDistrOpfamily);
+		m_mdid_array->Append(mdid);
+	}
+	else if (0 == XMLString::compareString(
+					  CDXLTokens::XmlstrToken(EdxltokenRelDistrOpclass),
+					  element_local_name))
+	{
+		// distr opclass metadata id: array must be initialized already
+		GPOS_ASSERT(NULL != m_mdid_array);
+
+		IMDId *mdid = CDXLOperatorFactory::ExtractConvertAttrValueToMdId(
+			m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenMdid,
+			EdxltokenRelDistrOpclass);
 		m_mdid_array->Append(mdid);
 	}
 	else
@@ -183,6 +195,9 @@ CParseHandlerMetadataIdList::EndElement(const XMLCh *const,	 // element_uri,
 				 element_local_name) ||
 		0 == XMLString::compareString(
 				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamilies),
+				 element_local_name) ||
+		0 == XMLString::compareString(
+				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpclasses),
 				 element_local_name))
 	{
 		// end the index or partition metadata id list
@@ -223,7 +238,9 @@ CParseHandlerMetadataIdList::FSupportedElem(const XMLCh *const xml_str)
 		0 == XMLString::compareString(
 				 CDXLTokens::XmlstrToken(EdxltokenOpfamily), xml_str) ||
 		0 == XMLString::compareString(
-				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamily), xml_str));
+				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamily), xml_str) ||
+		0 == XMLString::compareString(
+				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpclass), xml_str));
 }
 
 //---------------------------------------------------------------------------
@@ -246,9 +263,11 @@ CParseHandlerMetadataIdList::FSupportedListType(const XMLCh *const xml_str)
 				 CDXLTokens::XmlstrToken(EdxltokenCheckConstraints), xml_str) ||
 		0 == XMLString::compareString(
 				 CDXLTokens::XmlstrToken(EdxltokenOpfamilies), xml_str) ||
-		0 ==
-			XMLString::compareString(
-				CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamilies), xml_str));
+		0 == XMLString::compareString(
+				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamilies),
+				 xml_str) ||
+		0 == XMLString::compareString(
+				 CDXLTokens::XmlstrToken(EdxltokenRelDistrOpclasses), xml_str));
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalCTAS.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalCTAS.cpp
@@ -14,6 +14,7 @@
 
 #include "naucrates/dxl/parser/CParseHandlerColDescr.h"
 #include "naucrates/dxl/parser/CParseHandlerCtasStorageOptions.h"
+#include "naucrates/dxl/parser/CParseHandlerMetadataIdList.h"
 #include "naucrates/dxl/parser/CParseHandlerProjList.h"
 #include "naucrates/dxl/parser/CParseHandlerProperties.h"
 #include "naucrates/dxl/parser/CParseHandlerUtils.h"
@@ -158,6 +159,13 @@ CParseHandlerPhysicalCTAS::StartElement(const XMLCh *const,	 // element_uri,
 			m_parse_handler_mgr, this);
 	m_parse_handler_mgr->ActivateParseHandler(col_descr_parse_handler);
 
+	//parse handler for distr opclasses
+	CParseHandlerBase *opclasses_parse_handler =
+		CParseHandlerFactory::GetParseHandler(
+			m_mp, CDXLTokens::XmlstrToken(EdxltokenMetadataIdList),
+			m_parse_handler_mgr, this);
+	m_parse_handler_mgr->ActivateParseHandler(opclasses_parse_handler);
+
 	//parse handler for the properties of the operator
 	CParseHandlerBase *prop_parse_handler =
 		CParseHandlerFactory::GetParseHandler(
@@ -167,6 +175,7 @@ CParseHandlerPhysicalCTAS::StartElement(const XMLCh *const,	 // element_uri,
 
 	// store child parse handler in array
 	this->Append(prop_parse_handler);
+	this->Append(opclasses_parse_handler);
 	this->Append(col_descr_parse_handler);
 	this->Append(ctas_options_parse_handler);
 	this->Append(proj_list_parse_handler);
@@ -197,21 +206,24 @@ CParseHandlerPhysicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 				   str->GetBuffer());
 	}
 
-	GPOS_ASSERT(5 == this->Length());
+	GPOS_ASSERT(6 == this->Length());
 
 	CParseHandlerProperties *prop_parse_handler =
 		dynamic_cast<CParseHandlerProperties *>((*this)[0]);
+	CParseHandlerMetadataIdList *opclasses_parse_handler =
+		dynamic_cast<CParseHandlerMetadataIdList *>((*this)[1]);
 	CParseHandlerColDescr *col_descr_parse_handler =
-		dynamic_cast<CParseHandlerColDescr *>((*this)[1]);
+		dynamic_cast<CParseHandlerColDescr *>((*this)[2]);
 	CParseHandlerCtasStorageOptions *ctas_options_parse_handler =
-		dynamic_cast<CParseHandlerCtasStorageOptions *>((*this)[2]);
+		dynamic_cast<CParseHandlerCtasStorageOptions *>((*this)[3]);
 	CParseHandlerProjList *proj_list_parse_handler =
-		dynamic_cast<CParseHandlerProjList *>((*this)[3]);
+		dynamic_cast<CParseHandlerProjList *>((*this)[4]);
 	GPOS_ASSERT(NULL != proj_list_parse_handler->CreateDXLNode());
 	CParseHandlerPhysicalOp *child_parse_handler =
-		dynamic_cast<CParseHandlerPhysicalOp *>((*this)[4]);
+		dynamic_cast<CParseHandlerPhysicalOp *>((*this)[5]);
 
 	GPOS_ASSERT(NULL != prop_parse_handler->GetProperties());
+	GPOS_ASSERT(NULL != opclasses_parse_handler->GetMdIdArray());
 	GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
 	GPOS_ASSERT(NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
 	GPOS_ASSERT(NULL != proj_list_parse_handler->CreateDXLNode());
@@ -225,12 +237,15 @@ CParseHandlerPhysicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 		ctas_options_parse_handler->GetDxlCtasStorageOption();
 	ctas_options->AddRef();
 
+	IMdIdArray *opclasses_array = opclasses_parse_handler->GetMdIdArray();
+	opclasses_array->AddRef();
+
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(
 		m_mp, GPOS_NEW(m_mp) CDXLPhysicalCTAS(
 				  m_mp, m_mdname_schema, m_mdname, dxl_col_descr_array,
 				  ctas_options, m_rel_distr_policy, m_distr_column_pos_array,
-				  m_is_temp_table, m_has_oids, m_rel_storage_type,
-				  m_src_colids_array, m_vartypemod_array));
+				  opclasses_array, m_is_temp_table, m_has_oids,
+				  m_rel_storage_type, m_src_colids_array, m_vartypemod_array));
 	// set statistics and physical properties
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -526,6 +526,9 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenRelDistrOpfamilies, GPOS_WSZ_LIT("DistrOpfamilies")},
 		{EdxltokenRelDistrOpfamily, GPOS_WSZ_LIT("DistrOpfamily")},
 
+		{EdxltokenRelDistrOpclasses, GPOS_WSZ_LIT("DistrOpclasses")},
+		{EdxltokenRelDistrOpclass, GPOS_WSZ_LIT("DistrOpclass")},
+
 		{EdxltokenExtRelRejLimit, GPOS_WSZ_LIT("RejectLimit")},
 		{EdxltokenExtRelRejLimitInRows, GPOS_WSZ_LIT("RejectLimitInRows")},
 		{EdxltokenExtRelFmtErrRel, GPOS_WSZ_LIT("FormatErrorRelId")},

--- a/src/test/regress/expected/gpdist_legacy_opclasses.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses.out
@@ -436,3 +436,57 @@ select * from try_distinct_array a, try_distinct_array b where a.test_array=b.te
  y         | {1,1}      | n         | {1,1}
 (4 rows)
 
+-- CTAS should use value of gp_use_legacy_hashops when setting the distribution policy based on an existing table
+set gp_use_legacy_hashops=on;
+create table ctas_base_legacy as select unnest(array[1,2,3]) as col distributed by (col);
+set gp_use_legacy_hashops=off;
+create table ctas_from_legacy as select * from ctas_base_legacy distributed by (col);
+create table ctas_explicit_legacy as select * from ctas_base_legacy distributed by (col cdbhash_int4_ops);
+create table ctas_base_nonlegacy as select unnest(array[1,2,3]) as col distributed by (col);
+set gp_use_legacy_hashops=on;
+create table ctas_from_nonlegacy as select * from ctas_base_nonlegacy distributed by (col);
+create table ctas_explicit_nonlegacy as select * from ctas_base_nonlegacy distributed by (col int4_ops);
+select dp.localoid::regclass as name, opc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass opc
+    on ARRAY[opc.oid]::oidvector = dp.distclass
+ where dp.localoid in ('ctas_base_legacy'::regclass,
+                       'ctas_from_legacy'::regclass,
+                       'ctas_base_nonlegacy'::regclass,
+                       'ctas_from_nonlegacy'::regclass,
+                       'ctas_explicit_legacy'::regclass,
+                       'ctas_explicit_nonlegacy'::regclass);
+          name           |     opcname      
+-------------------------+------------------
+ ctas_explicit_nonlegacy | int4_ops
+ ctas_base_nonlegacy     | int4_ops
+ ctas_from_legacy        | int4_ops
+ ctas_from_nonlegacy     | cdbhash_int4_ops
+ ctas_explicit_legacy    | cdbhash_int4_ops
+ ctas_base_legacy        | cdbhash_int4_ops
+(6 rows)
+
+select * from ctas_from_legacy where col=1;
+ col 
+-----
+   1
+(1 row)
+
+select * from ctas_explicit_legacy where col=1;
+ col 
+-----
+   1
+(1 row)
+
+select * from ctas_from_nonlegacy where col=1;
+ col 
+-----
+   1
+(1 row)
+
+select * from ctas_explicit_nonlegacy where col=1;
+ col 
+-----
+   1
+(1 row)
+

--- a/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
@@ -430,3 +430,57 @@ select * from try_distinct_array a, try_distinct_array b where a.test_array=b.te
  y         | {1,1}      | n         | {1,1}
 (4 rows)
 
+-- CTAS should use value of gp_use_legacy_hashops when setting the distribution policy based on an existing table
+set gp_use_legacy_hashops=on;
+create table ctas_base_legacy as select unnest(array[1,2,3]) as col distributed by (col);
+set gp_use_legacy_hashops=off;
+create table ctas_from_legacy as select * from ctas_base_legacy distributed by (col);
+create table ctas_explicit_legacy as select * from ctas_base_legacy distributed by (col cdbhash_int4_ops);
+create table ctas_base_nonlegacy as select unnest(array[1,2,3]) as col distributed by (col);
+set gp_use_legacy_hashops=on;
+create table ctas_from_nonlegacy as select * from ctas_base_nonlegacy distributed by (col);
+create table ctas_explicit_nonlegacy as select * from ctas_base_nonlegacy distributed by (col int4_ops);
+select dp.localoid::regclass as name, opc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass opc
+    on ARRAY[opc.oid]::oidvector = dp.distclass
+ where dp.localoid in ('ctas_base_legacy'::regclass,
+                       'ctas_from_legacy'::regclass,
+                       'ctas_base_nonlegacy'::regclass,
+                       'ctas_from_nonlegacy'::regclass,
+                       'ctas_explicit_legacy'::regclass,
+                       'ctas_explicit_nonlegacy'::regclass);
+          name           |     opcname      
+-------------------------+------------------
+ ctas_explicit_nonlegacy | int4_ops
+ ctas_base_nonlegacy     | int4_ops
+ ctas_from_legacy        | int4_ops
+ ctas_from_nonlegacy     | cdbhash_int4_ops
+ ctas_explicit_legacy    | cdbhash_int4_ops
+ ctas_base_legacy        | cdbhash_int4_ops
+(6 rows)
+
+select * from ctas_from_legacy where col=1;
+ col 
+-----
+   1
+(1 row)
+
+select * from ctas_explicit_legacy where col=1;
+ col 
+-----
+   1
+(1 row)
+
+select * from ctas_from_nonlegacy where col=1;
+ col 
+-----
+   1
+(1 row)
+
+select * from ctas_explicit_nonlegacy where col=1;
+ col 
+-----
+   1
+(1 row)
+

--- a/src/test/regress/sql/gpdist_legacy_opclasses.sql
+++ b/src/test/regress/sql/gpdist_legacy_opclasses.sql
@@ -232,7 +232,6 @@ select dp.localoid::regclass::name as name, oc.opcname
     on oc.oid::text = dp.distclass::text
  where dp.localoid in ('ctastest_on'::regclass::oid,
                        'ctastest_off'::regclass::oid);
-
 set gp_use_legacy_hashops=on;
 create table try_distinct_array (test_char varchar,test_array integer[]);
 insert into try_distinct_array select 'y',string_to_array('1~1','~')::int[];
@@ -243,3 +242,30 @@ select distinct test_array from try_distinct_array;
 -- Hash join on column that does not have legacy hashop
 explain (costs off) select * from try_distinct_array a, try_distinct_array b where a.test_array=b.test_array;
 select * from try_distinct_array a, try_distinct_array b where a.test_array=b.test_array;
+
+-- CTAS should use value of gp_use_legacy_hashops when setting the distribution policy based on an existing table
+set gp_use_legacy_hashops=on;
+create table ctas_base_legacy as select unnest(array[1,2,3]) as col distributed by (col);
+set gp_use_legacy_hashops=off;
+create table ctas_from_legacy as select * from ctas_base_legacy distributed by (col);
+create table ctas_explicit_legacy as select * from ctas_base_legacy distributed by (col cdbhash_int4_ops);
+
+create table ctas_base_nonlegacy as select unnest(array[1,2,3]) as col distributed by (col);
+set gp_use_legacy_hashops=on;
+create table ctas_from_nonlegacy as select * from ctas_base_nonlegacy distributed by (col);
+create table ctas_explicit_nonlegacy as select * from ctas_base_nonlegacy distributed by (col int4_ops);
+
+select dp.localoid::regclass as name, opc.opcname
+  from gp_distribution_policy dp
+  join pg_opclass opc
+    on ARRAY[opc.oid]::oidvector = dp.distclass
+ where dp.localoid in ('ctas_base_legacy'::regclass,
+                       'ctas_from_legacy'::regclass,
+                       'ctas_base_nonlegacy'::regclass,
+                       'ctas_from_nonlegacy'::regclass,
+                       'ctas_explicit_legacy'::regclass,
+                       'ctas_explicit_nonlegacy'::regclass);
+select * from ctas_from_legacy where col=1;
+select * from ctas_explicit_legacy where col=1;
+select * from ctas_from_nonlegacy where col=1;
+select * from ctas_explicit_nonlegacy where col=1;


### PR DESCRIPTION
This is a trivial backport from master.

For CTAS creating tables with non-legacy hashop distribution from tables
with legacy hashops, CTAS with Orca would distribute the data according
to the value of gp_use_legacy_hashops; however, it would set the table's
distribution policy hashop to the value of the original table. This
caused queries to give incorrect results as the distribution policy
mismatched the data distribution.

The data was being distributed correctly as we used the correct opfamily
internally in Orca when determining the distribution spec. However, when
populating the distribution policy value in the table in
CTranslatorDXLToPlStmt.cpp, we were trying to derive the opclass from
the opfamily. This doesn't work, and instead we need to pass the opclass
from the query through Orca and to the plan statement. Hence we use the
opfamily internally within Orca, and simply pass through the opclass to
populate the gp_distribution_policy value correctly.

Additionally, CTAS minidumps have been failing for quite a while, and
subsequent changes made this a bit difficult to untangle. Since we only
have ~10 mdp files, I simply regenerated most of these files and made
the opfamily/opclasses arrays required as part of CMDRelationCTAS,
LogicalCTAS, and PhysicalCTAS.

Also, remove the `GPOS_ASSERT(NULL == mdhtacc.Find());` assert in
CMDAccessor.cpp. We've been hitting this with newly created mdps since
at least a couple of years, but haven't added new CTAS mdps since then.
Removing the assert doesn't seem to cause any problems and it's only
relevant for mdps.

(cherry picked from commit a8eb84a23a48be871db517b9bd7b503664955ee2)