### PR TITLE
The buildGpQueryString() function should use palloc() instead of palloc0()

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -910,7 +910,7 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 		sizeof(resgroupInfo.len) +
 		resgroupInfo.len;
 
-	shared_query = palloc0(total_query_len);
+	shared_query = palloc(total_query_len);
 
 	pos = shared_query;
 


### PR DESCRIPTION
The buildGpQueryString() function should use palloc() instead of palloc0() to allocate the buffer for holding the serialized query string, thus avoiding the unnecessary cost of setting all bytes in buffer to zero.

The related issue is here: https://github.com/greenplum-db/gpdb/issues/10874.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
