### PR TITLE
Cherry pick another pg_regress enhancement

### DIFF
--- a/src/common/pg_get_line.c
+++ b/src/common/pg_get_line.c
@@ -21,11 +21,38 @@
 #include "common/string.h"
 #include "lib/stringinfo.h"
 
+
+/*
+ * pg_get_line_buf()
+ *
+ * This has similar behavior to pg_get_line(), and thence to fgets(),
+ * except that the collected data is returned in a caller-supplied
+ * StringInfo buffer.  This is a convenient API for code that just
+ * wants to read and process one line at a time, without any artificial
+ * limit on line length.
+ *
+ * Returns true if a line was successfully collected (including the
+ * case of a non-newline-terminated line at EOF).  Returns false if
+ * there was an I/O error or no data was available before EOF.
+ * (Check ferror(stream) to distinguish these cases.)
+ *
+ * In the false-result case, buf is reset to empty.
+ */
+bool
+pg_get_line_buf(FILE *stream, StringInfo buf)
+{
+	/* We just need to drop any data from the previous call */
+	resetStringInfo(buf);
+	return pg_get_line_append(stream, buf);
+}
+
 /*
  * pg_get_line_append()
  *
  * This has similar behavior to pg_get_line(), and thence to fgets(),
  * except that the collected data is appended to whatever is in *buf.
+ * This is useful in preference to pg_get_line_buf() if the caller wants
+ * to merge some lines together, e.g. to implement backslash continuation.
  *
  * Returns true if a line was successfully collected (including the
  * case of a non-newline-terminated line at EOF).  Returns false if

--- a/src/include/common/string.h
+++ b/src/include/common/string.h
@@ -18,6 +18,7 @@ extern int	strtoint(const char *pg_restrict str, char **pg_restrict endptr,
 extern void pg_clean_ascii(char *str);
 
 /* functions in src/common/pg_get_line.c */
+extern bool pg_get_line_buf(FILE *stream, struct StringInfoData *buf);
 extern bool pg_get_line_append(FILE *stream, struct StringInfoData *buf);
 
 #endif							/* COMMON_STRING_H */

--- a/src/interfaces/ecpg/test/pg_regress_ecpg.c
+++ b/src/interfaces/ecpg/test/pg_regress_ecpg.c
@@ -48,7 +48,7 @@ ecpg_filter(const char *sourcefile, const char *outfile)
 
 	initStringInfo(&linebuf);
 
-	while (pg_get_line_append(s, &linebuf))
+	while (pg_get_line_buf(s, &linebuf))
 	{
 		/* check for "#line " in the beginning */
 		if (strstr(linebuf.data, "#line ") == linebuf.data)
@@ -68,7 +68,6 @@ ecpg_filter(const char *sourcefile, const char *outfile)
 			}
 		}
 		fputs(linebuf.data, t);
-		resetStringInfo(&linebuf);
 	}
 
 	pfree(linebuf.data);

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -664,7 +664,7 @@ generate_uao_sourcefiles(const char *src_dir, const char *dest_dir, const char *
 		initStringInfo(&line);
 		initStringInfo(&line_row);
 
-		while (pg_get_line_append(infile, &line))
+		while (pg_get_line_buf(infile, &line))
 		{
 			appendStringInfoString(&line_row, line.data);
 			repls->amname = "ao_row";
@@ -679,7 +679,7 @@ generate_uao_sourcefiles(const char *src_dir, const char *dest_dir, const char *
 			 */
 			if (!has_tokens && strstr(line.data, "@gp") != NULL)
 				has_tokens = true;
-			resetStringInfo(&line);
+
 			resetStringInfo(&line_row);
 		}
 
@@ -869,7 +869,7 @@ convert_sourcefiles_in(const char *source_subdir, const char *dest_dir, const ch
 
 		initStringInfo(&line);
 
-		while (pg_get_line_append(infile, &line))
+		while (pg_get_line_buf(infile, &line))
 		{
 			convert_line(&line, &repls);
 			fputs(line.data, outfile);
@@ -880,8 +880,6 @@ convert_sourcefiles_in(const char *source_subdir, const char *dest_dir, const ch
 			 */
 			if (!has_tokens && strstr(line.data, "@gp") != NULL)
 				has_tokens = true;
-
-			resetStringInfo(&line);
 		}
 
 		pfree(line.data);


### PR DESCRIPTION
We have already cherry picked the pg_get_line_append() API that is needed by pg_regress.  The API was recently enhanced in upstream by commit [931487018c4](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=931487018c409a3102452f965ccaa48367244a41).  This patch brings in relevant parts of that commit from PostgreSQL master branch.  Original commit message follows.

Rethink API for pg_get_line.c, one more time.

Further experience says that the appending behavior offered by
pg_get_line_append is useful to only a very small minority of callers.
For most, the requirement to reset the buffer after each line is just
an error-prone nuisance.  Hence, invent another alternative call
pg_get_line_buf, which takes care of that detail.

Noted while reviewing a patch from Daniel Gustafsson.

Discussion: https://postgr.es/m/48A4FA71-524E-41B9-953A-FD04EF36E2E7@yesql.se

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
