### PR TITLE
Remove unittest2 dependency

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1079,8 +1079,7 @@ SOFTWARE.
 
 
 =================================================================
-  For: Regents of the University of California Content, Open BSD,
-       Tsearch2, unittest2
+  For: Regents of the University of California Content, Open BSD
 =================================================================
 
 /*

--- a/python-dependencies.txt
+++ b/python-dependencies.txt
@@ -9,5 +9,4 @@ parse==1.8.2
 psutil==5.7.0
 pygresql==5.2
 setuptools==36.6.0
-unittest2==0.5.1
 pyyaml==5.3.1


### PR DESCRIPTION
It was vendored under src/test/tinc/ext/unittest2, but not anymore.

Fixes #4028