### PR TITLE
EXCLUDE in window functions works now, remove 'gp_ignore_window_exclude'.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -233,9 +233,6 @@ bool		gp_maintenance_conn;
 bool		allow_segment_DML;
 bool		gp_allow_rename_relation_without_lock = false;
 
-/* ignore EXCLUDE clauses in window spec for backwards compatibility */
-bool		gp_ignore_window_exclude = false;
-
 /* Time based authentication GUC */
 char	   *gp_auth_time_override_str = NULL;
 
@@ -1730,17 +1727,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_log_dynamic_partition_pruning,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"gp_ignore_window_exclude", PGC_USERSET, COMPAT_OPTIONS_PREVIOUS,
-			gettext_noop("Ignore EXCLUDE in window frame specifications."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&gp_ignore_window_exclude,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -336,8 +336,6 @@ extern bool gp_maintenance_conn;
 extern bool allow_segment_DML;
 extern bool gp_allow_rename_relation_without_lock;
 
-extern bool gp_ignore_window_exclude;
-
 extern bool gp_ignore_error_table;
 
 extern bool	Debug_dtm_action_primary;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -204,7 +204,6 @@
 		"gp_gang_creation_retry_timer",
 		"gp_global_deadlock_detector_period",
 		"gp_heap_require_relhasoids_match",
-		"gp_ignore_window_exclude",
 		"gp_instrument_shmem_size",
 		"gp_interconnect_cache_future_packets",
 		"gp_is_writer",

--- a/src/test/regress/expected/olap_window.out
+++ b/src/test/regress/expected/olap_window.out
@@ -632,29 +632,66 @@ order by t;
 (9 rows)
 
 ---- 6 -- Exclude clause ----
--- MPP-13628: exclude clause doesn't work
 select vn, sum(vn) over (w)
 from sale
 window w as (order by vn rows between unbounded preceding and unbounded following exclude CURRENT ROW);
-ERROR:  window EXCLUDE clause not yet implemented
+ vn | sum 
+----+-----
+ 10 | 400
+ 20 | 390
+ 30 | 380
+ 30 | 380
+ 30 | 380
+ 30 | 380
+ 40 | 370
+ 40 | 370
+ 40 | 370
+ 40 | 370
+ 50 | 360
+ 50 | 360
+(12 rows)
+
 select vn, sum(vn) over (w)
 from sale
 window w as (order by vn rows between unbounded preceding and unbounded following exclude GROUP);
-ERROR:  window EXCLUDE clause not yet implemented
+ vn | sum 
+----+-----
+ 10 | 400
+ 20 | 390
+ 30 | 290
+ 30 | 290
+ 30 | 290
+ 30 | 290
+ 40 | 250
+ 40 | 250
+ 40 | 250
+ 40 | 250
+ 50 | 310
+ 50 | 310
+(12 rows)
+
 select vn, sum(vn) over (w)
 from sale
 window w as (order by vn rows between unbounded preceding and unbounded following exclude TIES);
-ERROR:  window EXCLUDE clause not yet implemented
+ vn | sum 
+----+-----
+ 10 | 410
+ 20 | 410
+ 30 | 320
+ 30 | 320
+ 30 | 320
+ 30 | 320
+ 40 | 290
+ 40 | 290
+ 40 | 290
+ 40 | 290
+ 50 | 360
+ 50 | 360
+(12 rows)
+
 select vn, sum(vn) over (w)
 from sale
 window w as (order by vn rows between unbounded preceding and unbounded following exclude NO OTHERS);
-ERROR:  window EXCLUDE clause not yet implemented
--- MPP-14244: add guc to ignore exclude clause so the above won't error.
--- Note: produces the wrong answer, we will probably want to remove this once we fix the MPP-13628
-set gp_ignore_window_exclude = true;
-select vn, sum(vn) over (w)
-from sale
-window w as (order by vn rows between unbounded preceding and unbounded following exclude GROUP);
  vn | sum 
 ----+-----
  10 | 410

--- a/src/test/regress/expected/olap_window_optimizer.out
+++ b/src/test/regress/expected/olap_window_optimizer.out
@@ -632,29 +632,66 @@ order by t;
 (9 rows)
 
 ---- 6 -- Exclude clause ----
--- MPP-13628: exclude clause doesn't work
 select vn, sum(vn) over (w)
 from sale
 window w as (order by vn rows between unbounded preceding and unbounded following exclude CURRENT ROW);
-ERROR:  window EXCLUDE clause not yet implemented
+ vn | sum 
+----+-----
+ 10 | 400
+ 20 | 390
+ 30 | 380
+ 30 | 380
+ 30 | 380
+ 30 | 380
+ 40 | 370
+ 40 | 370
+ 40 | 370
+ 40 | 370
+ 50 | 360
+ 50 | 360
+(12 rows)
+
 select vn, sum(vn) over (w)
 from sale
 window w as (order by vn rows between unbounded preceding and unbounded following exclude GROUP);
-ERROR:  window EXCLUDE clause not yet implemented
+ vn | sum 
+----+-----
+ 10 | 400
+ 20 | 390
+ 30 | 290
+ 30 | 290
+ 30 | 290
+ 30 | 290
+ 40 | 250
+ 40 | 250
+ 40 | 250
+ 40 | 250
+ 50 | 310
+ 50 | 310
+(12 rows)
+
 select vn, sum(vn) over (w)
 from sale
 window w as (order by vn rows between unbounded preceding and unbounded following exclude TIES);
-ERROR:  window EXCLUDE clause not yet implemented
+ vn | sum 
+----+-----
+ 10 | 410
+ 20 | 410
+ 30 | 320
+ 30 | 320
+ 30 | 320
+ 30 | 320
+ 40 | 290
+ 40 | 290
+ 40 | 290
+ 40 | 290
+ 50 | 360
+ 50 | 360
+(12 rows)
+
 select vn, sum(vn) over (w)
 from sale
 window w as (order by vn rows between unbounded preceding and unbounded following exclude NO OTHERS);
-ERROR:  window EXCLUDE clause not yet implemented
--- MPP-14244: add guc to ignore exclude clause so the above won't error.
--- Note: produces the wrong answer, we will probably want to remove this once we fix the MPP-13628
-set gp_ignore_window_exclude = true;
-select vn, sum(vn) over (w)
-from sale
-window w as (order by vn rows between unbounded preceding and unbounded following exclude GROUP);
  vn | sum 
 ----+-----
  10 | 410

--- a/src/test/regress/sql/olap_window.sql
+++ b/src/test/regress/sql/olap_window.sql
@@ -217,7 +217,6 @@ window w1 as (order by a nulls first, t),
 order by t;
 
 ---- 6 -- Exclude clause ----
--- MPP-13628: exclude clause doesn't work
 select vn, sum(vn) over (w)
 from sale
 window w as (order by vn rows between unbounded preceding and unbounded following exclude CURRENT ROW);
@@ -233,13 +232,6 @@ window w as (order by vn rows between unbounded preceding and unbounded followin
 select vn, sum(vn) over (w)
 from sale
 window w as (order by vn rows between unbounded preceding and unbounded following exclude NO OTHERS);
-
--- MPP-14244: add guc to ignore exclude clause so the above won't error.
--- Note: produces the wrong answer, we will probably want to remove this once we fix the MPP-13628
-set gp_ignore_window_exclude = true;
-select vn, sum(vn) over (w)
-from sale
-window w as (order by vn rows between unbounded preceding and unbounded following exclude GROUP);
 
 
 ---- X -- Miscellaneous (e.g. old bugs, etc.) ----


### PR DESCRIPTION
Previously, GPDB did not support the SQL "EXCLUDE [CURRENT ROW | GROU |
TIES]" syntax in window functions. We got support for that from upstream
with the PostgreSQL v12 merge. That left the GUC obsolete and unused.

Update the 'olap_window' test accordingly. NOTE: 'olap_window' test isn't
currently run as part of the regression suite! I don't know why it's been
neglected like that, but that's not this patch's fault. The upstream
'window' test has queries with the EXCLUDE clause, so it's covered.
