### PR TITLE
A couple of fixes for issues reported by Coverity

### DIFF
--- a/gpcontrib/pxf_fdw/pxf_bridge.c
+++ b/gpcontrib/pxf_fdw/pxf_bridge.c
@@ -167,7 +167,7 @@ BuildUriForWrite(PxfFdwModifyState *pxfmstate)
 	PxfOptions *options = pxfmstate->options;
 
 	resetStringInfo(&pxfmstate->uri);
-	appendStringInfo(&pxfmstate->uri, "http://%s/%s/%s/Writable/stream", psprintf("%s:%d", options->pxf_host, options->pxf_port), PXF_SERVICE_PREFIX, PXF_VERSION);
+	appendStringInfo(&pxfmstate->uri, "http://%s:%d/%s/%s/Writable/stream", options->pxf_host, options->pxf_port, PXF_SERVICE_PREFIX, PXF_VERSION);
 	elog(DEBUG2, "pxf_fdw: uri %s with file name for write: %s", pxfmstate->uri.data, options->resource);
 }
 

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -2924,19 +2924,20 @@ regression_main(int argc, char *argv[], init_function ifunc, test_function tfunc
 									  strlen(".sql") +
 									  1 /* '\0' */);
 		sprintf(fullname, "%s/sql/hooks/%s.sql", inputdir, prehook);
-		prehook = fullname;
 
-		if (!file_exists(prehook))
+		if (!file_exists(fullname))
 		{
 			convert_sourcefiles_in("input/hooks", outputdir, "sql/hooks", "sql");
 
-			if (!file_exists(prehook))
+			if (!file_exists(fullname))
 			{
 				fprintf(stderr, _("%s: could not open file \"%s\" for reading: %s\n"),
-						progname, prehook, strerror(errno));
+						progname, fullname, strerror(errno));
 				exit(2);
 			}
 		}
+		free(prehook);
+		free(fullname);
 	}
 
 	initialize_environment();


### PR DESCRIPTION
One in pg_regress and another one in pxf_fdw.

In the pg_regress fix, I couldn't find usage of `--prehook` in code, @pivotal-ning-yu where is it used?