### PR TITLE
Improve the efficiency of serializing resource group information during query dispatch.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -887,9 +887,10 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 		command_len = pg_mbcliplen(command, command_len,
 								   QUERY_STRING_TRUNCATE_SIZE-1) + 1;
 
-	initStringInfo(&resgroupInfo);
+	resgroupInfo.data = NULL;
+	resgroupInfo.len = 0;
 	if (IsResGroupActivated())
-		SerializeResGroupInfo(&resgroupInfo);
+		SerializeResGroupInfo(&resgroupInfo, false);
 
 	total_query_len = 1 /* 'M' */ +
 		sizeof(len) /* message length */ +
@@ -1001,6 +1002,7 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 	{
 		memcpy(pos, resgroupInfo.data, resgroupInfo.len);
 		pos += resgroupInfo.len;
+		pfree(resgroupInfo.data);
 	}
 
 	len = pos - shared_query - 1;

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -155,7 +155,7 @@ extern void	InitResGroups(void);
 
 extern void AllocResGroupEntry(Oid groupId, const ResGroupCaps *caps);
 
-extern void SerializeResGroupInfo(StringInfo str);
+extern void SerializeResGroupInfo(StringInfo str, bool append);
 extern void DeserializeResGroupInfo(struct ResGroupCaps *capsOut,
 									Oid *groupId,
 									const char *buf,


### PR DESCRIPTION
Improve the efficiency of serializing resource group information during query dispatch:

1. SerializeResGroupInfo() allocates the exact amount of memory to store serialized resource group information.

2. buildGpQueryString() only calls SerializeResGroupInfo() when resource group is activated, and free the memory for serialized data after use.

The related issue is here: https://github.com/greenplum-db/gpdb/issues/10886

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
