### PR TITLE
Avoid repetitively constructing a QE's SegmentDatabaseDescriptor.whoami string.

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -809,9 +809,10 @@ cdbcomponent_allocateIdleQE(int contentId, SegmentType segmentType)
 		 */
 		isWriter = contentId == -1 ? false: (cdbinfo->numIdleQEs == 0 && cdbinfo->numActiveQEs == 0);
 		segdbDesc = cdbconn_createSegmentDescriptor(cdbinfo, nextQEIdentifer(cdbinfo->cdbs), isWriter);
-	}
 
-	cdbconn_setQEIdentifier(segdbDesc, -1);
+		/* Set QE identifier for this newly created SegmentDescriptor. */
+		cdbconn_setQEIdentifier(segdbDesc, -1);
+	}
 
 	INCR_COUNT(cdbinfo, numActiveQEs);
 

--- a/src/include/cdb/cdbconn.h
+++ b/src/include/cdb/cdbconn.h
@@ -46,11 +46,24 @@ typedef struct SegmentDatabaseDescriptor
     /*
      * Connection info saved at most recent PQconnectdb.
      *
-     * NB: Use malloc/free, not palloc/pfree, for the items below.
+     * whoami stores a string of QE identifier for log messages. It may
+     * be changed upon events such as QE connection establishment and
+     * recycling of this SegmentDatabaseDescriptor. It is computed by
+     * cdbconn_setQEIdentifier() function.
+     *
+     * defaultWhoami also stores a string of QE identifier that contains
+     * backendPid but no slice index. Once set by cdbconn_setQEIdentifier(),
+     * its contents never changes.
+     *
+     * whoami would point to defaultWhoami whenever appropriate (e.g., when
+     * SegmentDatabaseDescriptor is recycled or the QE has no slice index),
+     * so that cdbconn_setQEIdentifier() does not have to re-construct this
+     * contents from scratch every time.
      */
     uint32		            motionListener; /* interconnect listener port */
     int32					backendPid;
     char                   *whoami;         /* QE identifier for msgs */
+	char                   *defaultWhoami;  /* Default QE identifier for msgs */
 	bool					isWriter;
 	int						identifier;		/* unique identifier in the cdbcomponent segment pool */
 } SegmentDatabaseDescriptor;


### PR DESCRIPTION
Avoid repetitively constructing a QE's SegmentDatabaseDescriptor.whoami string.

1. Add a string field called `defaultWhoami` to `SegmentDatabaseDescriptor`. It stores a string of QE identifier that contains `backendPid` but no slice index. `whoami` would point to `defaultWhoami` whenever appropriate (e.g., when `SegmentDatabaseDescriptor` is recycled or the QE has no slice index), so that `cdbconn_setQEIdentifier()` does not have to re-construct this contents from scratch every time.

2. `cdbcomponent_allocateIdleQE()` should only call `cdbconn_setQEIdentifier()` when a `SegmentDatabaseDescriptor` is newly created.

3. When constructing a new QE identifier string, `cdbcomponent_allocateIdleQE()` should use a buffer whose initial size is 128 Bytes instead of 1024 Bytes, as QE identifier are usually within that range.

The related issue is here: https://github.com/greenplum-db/gpdb/issues/10888

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
