### PR TITLE
Partially fix CTAS pg_resgroup_get_status()

### DIFF
--- a/src/backend/utils/resgroup/resgroup_helper.c
+++ b/src/backend/utils/resgroup/resgroup_helper.c
@@ -301,21 +301,21 @@ pg_resgroup_get_status(PG_FUNCTION_ARGS)
 		values[0] = row->groupId;
 		groupId = DatumGetObjectId(values[0]);
 
-		if (Gp_role == GP_ROLE_DISPATCH)
-		{
-			values[1] = ResGroupGetStat(groupId, RES_GROUP_STAT_NRUNNING);
-			values[2] = ResGroupGetStat(groupId, RES_GROUP_STAT_NQUEUEING);
-			values[3] = ResGroupGetStat(groupId, RES_GROUP_STAT_TOTAL_QUEUED);
-			values[4] = ResGroupGetStat(groupId, RES_GROUP_STAT_TOTAL_EXECUTED);
-			values[5] = ResGroupGetStat(groupId, RES_GROUP_STAT_TOTAL_QUEUE_TIME);
-		}
-		else
+		if (Gp_role == GP_ROLE_UTILITY)
 		{
 			nulls[1] = true;
 			nulls[2] = true;
 			nulls[3] = true;
 			nulls[4] = true;
 			nulls[5] = true;
+		}
+		else
+		{
+			values[1] = ResGroupGetStat(groupId, RES_GROUP_STAT_NRUNNING);
+			values[2] = ResGroupGetStat(groupId, RES_GROUP_STAT_NQUEUEING);
+			values[3] = ResGroupGetStat(groupId, RES_GROUP_STAT_TOTAL_QUEUED);
+			values[4] = ResGroupGetStat(groupId, RES_GROUP_STAT_TOTAL_EXECUTED);
+			values[5] = ResGroupGetStat(groupId, RES_GROUP_STAT_TOTAL_QUEUE_TIME);
 		}
 
 		values[6] = CStringGetTextDatum(row->cpuUsage->data);

--- a/src/test/isolation2/expected/resgroup/resgroup_functions.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_functions.out
@@ -1,0 +1,17 @@
+-- start_ignore
+SELECT s.groupid, s.num_running, s.num_queueing, s.num_queued, s.num_executed FROM pg_resgroup_get_status(NULL::oid) s(groupid, num_running, num_queueing, num_queued, num_executed, total_queue_duration, cpu_usage, memory_usage);
+ groupid | num_running | num_queueing | num_queued | num_executed 
+---------+-------------+--------------+------------+--------------
+(0 rows)
+-- end_ignore
+CREATE TEMP TABLE resgroup_function_test(LIKE gp_toolkit.gp_resgroup_status);
+CREATE
+
+INSERT INTO resgroup_function_test(groupid, num_running, num_queueing, num_queued, num_executed) SELECT s.groupid, s.num_running, s.num_queueing, s.num_queued, s.num_executed FROM pg_resgroup_get_status(NULL::oid) s(groupid, num_running, num_queueing, num_queued, num_executed, total_queue_duration, cpu_usage, memory_usage) LIMIT 1;
+INSERT 1
+
+SELECT count(num_executed)>0 FROM resgroup_function_test WHERE num_executed IS NOT NULL;
+ ?column? 
+----------
+ t        
+(1 row)

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -41,6 +41,7 @@ test: resgroup/resgroup_move_query
 # regression tests
 test: resgroup/resgroup_recreate
 test: resgroup/resgroup_operator_memory
+test: resgroup/resgroup_functions
 
 # parallel tests
 #test: resgroup/restore_default_resgroup

--- a/src/test/isolation2/sql/resgroup/resgroup_functions.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_functions.sql
@@ -1,0 +1,11 @@
+-- start_ignore
+SELECT s.groupid, s.num_running, s.num_queueing, s.num_queued, s.num_executed
+FROM pg_resgroup_get_status(NULL::oid) s(groupid, num_running, num_queueing, num_queued, num_executed, total_queue_duration, cpu_usage, memory_usage);
+-- end_ignore
+CREATE TEMP TABLE resgroup_function_test(LIKE gp_toolkit.gp_resgroup_status);
+
+INSERT INTO resgroup_function_test(groupid, num_running, num_queueing, num_queued, num_executed)
+SELECT s.groupid, s.num_running, s.num_queueing, s.num_queued, s.num_executed
+FROM pg_resgroup_get_status(NULL::oid) s(groupid, num_running, num_queueing, num_queued, num_executed, total_queue_duration, cpu_usage, memory_usage) LIMIT 1;
+
+SELECT count(num_executed)>0 FROM resgroup_function_test WHERE num_executed IS NOT NULL;


### PR DESCRIPTION
This is the 6X version of
https://github.com/greenplum-db/gpdb/pull/10856.

The query `INSERT INTO .. SELECT .. FROM pg_resgroup_get_status()` will
execute the UDF on a QE started on the master node, it's not right to
check `if (Gp_role == GP_ROLE_DISPATCH)`.

It's not a complete fix since 6X could not have a catalog change, a more
complex query might start the QE on a segment which has no such stats.
Better than nothing.

Fixes #10794