### PR TITLE
Fix crash when planning for sub-queries that have grouping sets

### DIFF
--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -2315,7 +2315,7 @@ rebuild_append_simple_rel_and_rte(PlannerInfo *root,
 		splan = (SubqueryScan *)lfirst(l3);
 
 		rel->subroot = sroot;
-		if (splan != NULL)
+		if (splan != NULL && IsA(splan, SubqueryScan))
 		{
 			splan->scan.scanrelid = i;
 			rel->subplan = splan->subplan;

--- a/src/test/regress/expected/aggregate_with_groupingsets.out
+++ b/src/test/regress/expected/aggregate_with_groupingsets.out
@@ -88,3 +88,66 @@ ORDER BY type, s_quant;
 -- Reset settings
 --
 reset optimizer;
+---
+--- Planning for sub-queries that have grouping sets
+---
+--
+-- Turn off GPORCA
+--
+set optimizer to off;
+explain (costs off) WITH table1 AS (
+	SELECT 2 AS city_id, 5 AS cnt
+	UNION ALL
+	SELECT 2 AS city_id, 1 AS cnt
+	UNION ALL
+	SELECT 3 AS city_id, 2 AS cnt
+	UNION ALL
+	SELECT 3 AS city_id, 7 AS cnt
+),
+fin AS (
+SELECT
+	coalesce(country_id, city_id) AS location_id,
+	total
+FROM (
+	SELECT
+	1 as country_id,
+	city_id,
+	sum(cnt) as total
+	FROM table1
+	GROUP BY GROUPING SETS (1,2)
+	) base
+)
+SELECT *
+FROM fin
+WHERE location_id = 1;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Subquery Scan on base
+   Filter: (COALESCE(base.country_id, base.city_id) = 1)
+   ->  Append
+         ->  GroupAggregate
+               Group Key: table1.city_id, (1)
+               ->  Sort
+                     Sort Key: table1.city_id
+                     ->  Subquery Scan on table1
+                           ->  Append
+                                 ->  Result
+                                 ->  Result
+                                 ->  Result
+                                 ->  Result
+         ->  GroupAggregate
+               Group Key: (1), table1_1.city_id
+               ->  Sort
+                     ->  Subquery Scan on table1_1
+                           ->  Append
+                                 ->  Result
+                                 ->  Result
+                                 ->  Result
+                                 ->  Result
+ Optimizer: Postgres query optimizer
+(23 rows)
+
+--
+-- Reset settings
+--
+reset optimizer;

--- a/src/test/regress/sql/aggregate_with_groupingsets.sql
+++ b/src/test/regress/sql/aggregate_with_groupingsets.sql
@@ -71,3 +71,44 @@ ORDER BY type, s_quant;
 -- Reset settings
 --
 reset optimizer;
+
+
+---
+--- Planning for sub-queries that have grouping sets
+---
+
+--
+-- Turn off GPORCA
+--
+set optimizer to off;
+
+explain (costs off) WITH table1 AS (
+	SELECT 2 AS city_id, 5 AS cnt
+	UNION ALL
+	SELECT 2 AS city_id, 1 AS cnt
+	UNION ALL
+	SELECT 3 AS city_id, 2 AS cnt
+	UNION ALL
+	SELECT 3 AS city_id, 7 AS cnt
+),
+fin AS (
+SELECT
+	coalesce(country_id, city_id) AS location_id,
+	total
+FROM (
+	SELECT
+	1 as country_id,
+	city_id,
+	sum(cnt) as total
+	FROM table1
+	GROUP BY GROUPING SETS (1,2)
+	) base
+)
+SELECT *
+FROM fin
+WHERE location_id = 1;
+
+--
+-- Reset settings
+--
+reset optimizer;


### PR DESCRIPTION
When constructing plans for a list of rollups, the rollup_subplan may be
retrieved from root->simple_rel_array[i]->subplan, which is not always type of
SubqueryScan. So later in function rebuild_append_simple_rel_and_rte(), we need
to verify if the subplan is a SubqueryScan node before assigning a scanrelid to
it.

Fixes issue #10813 and issue #10841

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
