### PR TITLE
Use 64bit gxid for distributed transaction

### DIFF
--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -243,7 +243,7 @@ mdunlink_ao(RelFileNodeBackend rnode, ForkNumber forkNumber, bool isRedo)
 		int pathSize = strlen(path);
 		char *segPath = (char *) palloc(pathSize + SEGNO_SUFFIX_LENGTH);
 		char *segPathSuffixPosition = segPath + pathSize;
-		struct mdunlink_ao_callback_ctx unlinkFiles = { 0 };
+		struct mdunlink_ao_callback_ctx unlinkFiles;
 		unlinkFiles.isRedo = isRedo;
 		unlinkFiles.rnode = rnode.node;
 

--- a/src/backend/access/rmgrdesc/xactdesc.c
+++ b/src/backend/access/rmgrdesc/xactdesc.c
@@ -142,7 +142,6 @@ ParseCommitRecord(uint8 info, xl_xact_commit *xlrec, xl_xact_parsed_commit *pars
 	{
 		xl_xact_distrib *xl_distrib = (xl_xact_distrib *) data;
 
-		parsed->distribTimeStamp = xl_distrib->distrib_timestamp;
 		parsed->distribXid = xl_distrib->distrib_xid;
 		data += sizeof(xl_xact_distrib);
 	}
@@ -313,10 +312,9 @@ xact_desc_commit(StringInfo buf, uint8 info, xl_xact_commit *xlrec, RepOriginId 
 						 timestamptz_to_str(parsed.origin_timestamp));
 	}
 
-	if (parsed.distribTimeStamp != 0 || parsed.distribXid != InvalidDistributedTransactionId)
+	if (parsed.distribXid != InvalidDistributedTransactionId)
 	{
-		appendStringInfo(buf, " gid = %u-%.10u", parsed.distribTimeStamp, parsed.distribXid);
-		appendStringInfo(buf, " gxid = %u", parsed.distribXid);
+		appendStringInfo(buf, " gxid = "UINT64_FORMAT, parsed.distribXid);
 	}
 }
 
@@ -328,15 +326,13 @@ xact_desc_distributed_commit(StringInfo buf, uint8 info, xl_xact_commit *xlrec, 
 	ParseCommitRecord(info, xlrec, &parsed);
 
 	appendStringInfoString(buf, timestamptz_to_str(xlrec->xact_time));
-	appendStringInfo(buf, " gid = %u-%.10u, gxid = %u",
-					 parsed.distribTimeStamp, parsed.distribXid, parsed.distribXid);
+	appendStringInfo(buf, " gxid = "UINT64_FORMAT, parsed.distribXid);
 }
 
 static void
 xact_desc_distributed_forget(StringInfo buf, xl_xact_distributed_forget *xlrec)
 {
-	appendStringInfo(buf, " gid = %s, gxid = %u",
-					 xlrec->gxact_log.gid, xlrec->gxact_log.gxid);
+	appendStringInfo(buf, "gxid = "UINT64_FORMAT, xlrec->gxid);
 }
 
 static void

--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -171,7 +171,6 @@ DistributedLog_InitOldestXmin(void)
  */
 TransactionId
 DistributedLog_AdvanceOldestXmin(TransactionId oldestLocalXmin,
-								 DistributedTransactionTimeStamp distribTransactionTimeStamp,
 								 DistributedTransactionId xminAllDistributedSnapshots)
 {
 	TransactionId oldestXmin;
@@ -246,8 +245,7 @@ DistributedLog_AdvanceOldestXmin(TransactionId oldestLocalXmin,
 		 * And the distributed xid is just a plain counter, so we just use the `>=` for
 		 * the comparison of gxid
 		 */
-		if (ptr->distribTimeStamp == distribTransactionTimeStamp &&
-				ptr->distribXid >= xminAllDistributedSnapshots)
+		if (ptr->distribXid >= xminAllDistributedSnapshots)
 			break;
 
 		TransactionIdAdvance(oldestXmin);
@@ -320,7 +318,6 @@ static void
 DistributedLog_SetCommittedWithinAPage(
 	int                                 numLocIds,
 	TransactionId 						*localXid,
-	DistributedTransactionTimeStamp		distribTimeStamp,
 	DistributedTransactionId 			distribXid,
 	bool								isRedo)
 {
@@ -362,32 +359,27 @@ DistributedLog_SetCommittedWithinAPage(
 
 		int	entryno = TransactionIdToEntry(localXid[i]);
 
-		if (ptr[entryno].distribTimeStamp != 0 || ptr[entryno].distribXid != 0)
+		if (ptr[entryno].distribXid != 0)
 		{
-			if (ptr[entryno].distribTimeStamp != distribTimeStamp)
-				elog(ERROR,
-					 "Current distributed timestamp = %u does not match input timestamp = %u for local xid = %u in distributed log (page = %d, entryno = %d)",
-					 ptr[entryno].distribTimeStamp, distribTimeStamp,
-					 localXid[i], page, entryno);
-
 			if (ptr[entryno].distribXid != distribXid)
 				elog(ERROR,
-					 "Current distributed xid = %u does not match input distributed xid = %u for local xid = %u in distributed log (page = %d, entryno = %d)",
+					 "Current distributed xid = "UINT64_FORMAT" does not match"
+					 " input distributed xid = "UINT64_FORMAT" for "
+					 "local xid = %u in distributed log (page = %d, entryno = %d)",
 					 ptr[entryno].distribXid, distribXid, localXid[i], page, entryno);
 
 			alreadyThere = true;
 		}
 		else
 		{
-			ptr[entryno].distribTimeStamp = distribTimeStamp;
 			ptr[entryno].distribXid = distribXid;
 
 			DistributedLogCtl->shared->page_dirty[slotno] = true;
 		}
 
 		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "DistributedLog_SetCommitted with local xid = %d (page = %d, entryno = %d) and distributed transaction xid = %u (timestamp = %u) status = %s",
-			 localXid[i], page, entryno, distribXid, distribTimeStamp,
+			 "DistributedLog_SetCommitted with local xid = %d (page = %d, entryno = %d) and distributed transaction xid = "UINT64_FORMAT" status = %s",
+			 localXid[i], page, entryno, distribXid,
 			 (alreadyThere ? "already there" : "set"));
 	}
 
@@ -401,7 +393,6 @@ DistributedLog_SetCommittedWithinAPage(
  */
 static void
 DistributedLog_SetCommittedByPages(int nsubxids, TransactionId *subxids,
-								   DistributedTransactionTimeStamp distribTimeStamp,
 								   DistributedTransactionId distribXid,
 								   bool isRedo)
 {
@@ -421,7 +412,7 @@ DistributedLog_SetCommittedByPages(int nsubxids, TransactionId *subxids,
 		}
 
 		DistributedLog_SetCommittedWithinAPage(num_on_page, subxids + start_of_range,
-											   distribTimeStamp, distribXid, isRedo);
+											   distribXid, isRedo);
 	}
 }
 
@@ -431,18 +422,15 @@ DistributedLog_SetCommittedByPages(int nsubxids, TransactionId *subxids,
  */
 void
 DistributedLog_SetCommittedTree(TransactionId xid, int nxids, TransactionId *xids,
-								DistributedTransactionTimeStamp	distribTimeStamp,
 								DistributedTransactionId distribXid,
 								bool isRedo)
 {
 	if (!IS_QUERY_DISPATCHER())
 	{
-		DistributedLog_SetCommittedWithinAPage(1, &xid, distribTimeStamp,
-											   distribXid, isRedo);
+		DistributedLog_SetCommittedWithinAPage(1, &xid, distribXid, isRedo);
 
 		/* add entry for sub-transaction page at time */
-		DistributedLog_SetCommittedByPages(nxids, xids, distribTimeStamp,
-										   distribXid, isRedo);
+		DistributedLog_SetCommittedByPages(nxids, xids, distribXid, isRedo);
 	}
 }
 
@@ -452,7 +440,6 @@ DistributedLog_SetCommittedTree(TransactionId xid, int nxids, TransactionId *xid
 void
 DistributedLog_GetDistributedXid(
 	TransactionId 						localXid,
-	DistributedTransactionTimeStamp		*distribTimeStamp,
 	DistributedTransactionId 			*distribXid)
 {
 	int			page = TransactionIdToPage(localXid);
@@ -465,7 +452,6 @@ DistributedLog_GetDistributedXid(
 	slotno = SimpleLruReadPage_ReadOnly(DistributedLogCtl, page, localXid);
 	ptr = (DistributedLogEntry *) DistributedLogCtl->shared->page_buffer[slotno];
 	ptr += entryno;
-	*distribTimeStamp = ptr->distribTimeStamp;
 	*distribXid = ptr->distribXid;
 	LWLockRelease(DistributedLogControlLock);
 }
@@ -476,7 +462,6 @@ DistributedLog_GetDistributedXid(
 bool
 DistributedLog_CommittedCheck(
 	TransactionId 						localXid,
-	DistributedTransactionTimeStamp		*distribTimeStamp,
 	DistributedTransactionId 			*distribXid)
 {
 	int			page = TransactionIdToPage(localXid);
@@ -495,7 +480,6 @@ DistributedLog_CommittedCheck(
 
 	if (TransactionIdPrecedes(localXid, oldestXmin))
 	{
-		*distribTimeStamp = 0;	// Set it to something.
 		*distribXid = 0;
 		return false;
 	}
@@ -504,31 +488,19 @@ DistributedLog_CommittedCheck(
 	slotno = SimpleLruReadPage_ReadOnly(DistributedLogCtl, page, localXid);
 	ptr = (DistributedLogEntry *) DistributedLogCtl->shared->page_buffer[slotno];
 	ptr += entryno;
-	*distribTimeStamp = ptr->distribTimeStamp;
 	*distribXid = ptr->distribXid;
 	ptr = NULL;
 	LWLockRelease(DistributedLogControlLock);
 	LWLockRelease(DistributedLogTruncateLock);
 
-	if (*distribTimeStamp != 0 && *distribXid != 0)
+	if (*distribXid != 0)
 	{
 		return true;
 	}
-	else if (*distribTimeStamp == 0 && *distribXid == 0)
+	else
 	{
 		// Not found.
 		return false;
-	}
-	else
-	{
-		if (*distribTimeStamp == 0)
-			elog(ERROR, "Found zero timestamp for local xid = %u in distributed log (distributed xid = %u, page = %d, entryno = %d)",
-			     localXid, *distribXid, page, entryno);
-
-		elog(ERROR, "Found zero distributed xid for local xid = %u in distributed log (dtx start time = %u, page = %d, entryno = %d)",
-			     localXid, *distribTimeStamp, page, entryno);
-
-		return false;	// We'll never reach here.
 	}
 }
 
@@ -539,7 +511,6 @@ DistributedLog_CommittedCheck(
 bool
 DistributedLog_ScanForPrevCommitted(
 	TransactionId 						*indexXid,
-	DistributedTransactionTimeStamp 	*distribTimeStamp,
 	DistributedTransactionId 			*distribXid)
 {
 	TransactionId highXid;
@@ -548,7 +519,6 @@ DistributedLog_ScanForPrevCommitted(
 	int slotno;
 	TransactionId xid;
 
-	*distribTimeStamp = 0;	// Set it to something.
 	*distribXid = 0;
 
 	if ((*indexXid) == InvalidTransactionId)
@@ -578,7 +548,6 @@ DistributedLog_ScanForPrevCommitted(
 			LWLockRelease(DistributedLogControlLock);
 
 			*indexXid = InvalidTransactionId;
-			*distribTimeStamp = 0;	// Set it to something.
 			*distribXid = 0;
 			return false;
 		}
@@ -593,10 +562,9 @@ DistributedLog_ScanForPrevCommitted(
 			ptr = (DistributedLogEntry *) DistributedLogCtl->shared->page_buffer[slotno];
 			ptr += entryno;
 
-			if (ptr->distribTimeStamp != 0 && ptr->distribXid != 0)
+			if (ptr->distribXid != 0)
 			{
 				*indexXid = xid;
-				*distribTimeStamp = ptr->distribTimeStamp;
 				*distribXid = ptr->distribXid;
 				LWLockRelease(DistributedLogControlLock);
 
@@ -609,7 +577,6 @@ DistributedLog_ScanForPrevCommitted(
 		if (lowXid == FirstNormalTransactionId)
 		{
 			*indexXid = InvalidTransactionId;
-			*distribTimeStamp = 0;	// Set it to something.
 			*distribXid = 0;
 			return false;
 		}

--- a/src/backend/catalog/cdb_schema.sql
+++ b/src/backend/catalog/cdb_schema.sql
@@ -27,7 +27,7 @@ GRANT SELECT ON pg_catalog.gp_pgdatabase TO PUBLIC;
 ------------------------------------------------------------------
 CREATE OR REPLACE VIEW pg_catalog.gp_distributed_xacts AS 
     SELECT *
-      FROM gp_distributed_xacts() AS L(distributed_xid xid, distributed_id text, state text, gp_session_id int, xmin_distributed_snapshot xid);
+      FROM gp_distributed_xacts() AS L(distributed_xid xid, state text, gp_session_id int, xmin_distributed_snapshot xid);
 
 GRANT SELECT ON pg_catalog.gp_distributed_xacts TO PUBLIC;
 
@@ -40,7 +40,7 @@ GRANT SELECT ON pg_catalog.gp_transaction_log TO PUBLIC;
 
 CREATE OR REPLACE VIEW pg_catalog.gp_distributed_log AS 
     SELECT *
-      FROM gp_distributed_log() AS L(segment_id smallint, dbid smallint, distributed_xid xid, distributed_id text, status text, local_transaction xid);
+      FROM gp_distributed_log() AS L(segment_id smallint, dbid smallint, distributed_xid xid, status text, local_transaction xid);
 
 GRANT SELECT ON pg_catalog.gp_distributed_log TO PUBLIC;
 

--- a/src/backend/cdb/cdbdistributedsnapshot.c
+++ b/src/backend/cdb/cdbdistributedsnapshot.c
@@ -98,27 +98,15 @@ DistributedSnapshotWithLocalMapping_CommittedTest(
 	}
 	else
 	{
-		DistributedTransactionTimeStamp checkDistribTimeStamp;
-
 		/*
 		 * Ok, now we must consult the distributed log.
 		 */
-		if (DistributedLog_CommittedCheck(localXid,
-										  &checkDistribTimeStamp,
-										  &distribXid))
+		if (DistributedLog_CommittedCheck(localXid, &distribXid))
 		{
 			/*
 			 * We found it in the distributed log.
 			 */
-			Assert(checkDistribTimeStamp != 0);
 			Assert(distribXid != InvalidDistributedTransactionId);
-
-			/*
-			 * Committed distributed transactions from other DTM starts are
-			 * weeded out.
-			 */
-			if (checkDistribTimeStamp != ds->distribTransactionTimeStamp)
-				return DISTRIBUTEDSNAPSHOT_COMMITTED_IGNORE;
 
 			/*
 			 * We have a distributed committed xid that corresponds to the
@@ -167,12 +155,12 @@ DistributedSnapshotWithLocalMapping_CommittedTest(
 
 	/*
 	 * Any xid >= xmax is in-progress, distributed xmax points to the
-	 * latestCompletedDxid + 1.
+	 * latestCompletedGxid + 1.
 	 */
 	if (distribXid >= ds->xmax)
 	{
 		elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-			 "distributedsnapshot committed but invisible: distribXid %d dxmax %d dxmin %d distribSnapshotId %d",
+			 "distributedsnapshot committed but invisible: distribXid "UINT64_FORMAT" dxmax "UINT64_FORMAT" dxmin "UINT64_FORMAT" distribSnapshotId %d",
 			 distribXid, ds->xmax, ds->xmin, ds->distribSnapshotId);
 
 		return DISTRIBUTEDSNAPSHOT_COMMITTED_INPROGRESS;
@@ -232,7 +220,6 @@ DistributedSnapshotWithLocalMapping_CommittedTest(
 void
 DistributedSnapshot_Reset(DistributedSnapshot *distributedSnapshot)
 {
-	distributedSnapshot->distribTransactionTimeStamp = 0;
 	distributedSnapshot->xminAllDistributedSnapshots = InvalidDistributedTransactionId;
 	distributedSnapshot->distribSnapshotId = 0;
 	distributedSnapshot->xmin = InvalidDistributedTransactionId;
@@ -271,7 +258,6 @@ DistributedSnapshot_Copy(DistributedSnapshot *target,
 		 source->count,
 		 source->inProgressXidArray);
 
-	target->distribTransactionTimeStamp = source->distribTransactionTimeStamp;
 	target->xminAllDistributedSnapshots = source->xminAllDistributedSnapshots;
 	target->distribSnapshotId = source->distribSnapshotId;
 	target->xmin = source->xmin;
@@ -300,8 +286,7 @@ DistributedSnapshot_Copy(DistributedSnapshot *target,
 int
 DistributedSnapshot_SerializeSize(DistributedSnapshot *ds)
 {
-	return sizeof(DistributedTransactionTimeStamp) +
-		sizeof(DistributedSnapshotId) +
+	return sizeof(DistributedSnapshotId) +
 	/* xminAllDistributedSnapshots, xmin, xmax */
 		3 * sizeof(DistributedTransactionId) +
 	/* count */
@@ -315,8 +300,6 @@ DistributedSnapshot_Serialize(DistributedSnapshot *ds, char *buf)
 {
 	char	   *p = buf;
 
-	memcpy(p, &ds->distribTransactionTimeStamp, sizeof(DistributedTransactionTimeStamp));
-	p += sizeof(DistributedTransactionTimeStamp);
 	memcpy(p, &ds->xminAllDistributedSnapshots, sizeof(DistributedTransactionId));
 	p += sizeof(DistributedTransactionId);
 	memcpy(p, &ds->distribSnapshotId, sizeof(DistributedSnapshotId));
@@ -341,8 +324,6 @@ DistributedSnapshot_Deserialize(const char *buf, DistributedSnapshot *ds)
 {
 	const char *p = buf;
 
-	memcpy(&ds->distribTransactionTimeStamp, p, sizeof(DistributedTransactionTimeStamp));
-	p += sizeof(DistributedTransactionTimeStamp);
 	memcpy(&ds->xminAllDistributedSnapshots, p, sizeof(DistributedTransactionId));
 	p += sizeof(DistributedTransactionId);
 	memcpy(&ds->distribSnapshotId, p, sizeof(DistributedSnapshotId));

--- a/src/backend/cdb/cdbdistributedxacts.c
+++ b/src/backend/cdb/cdbdistributedxacts.c
@@ -43,16 +43,14 @@ gp_distributed_xacts__(PG_FUNCTION_ARGS)
 
 		/* build tupdesc for result tuples */
 		/* this had better match gp_distributed_xacts view in system_views.sql */
-		tupdesc = CreateTemplateTupleDesc(5);
+		tupdesc = CreateTemplateTupleDesc(4);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "distributed_xid",
 						   XIDOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "distributed_id",
+		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "state",
 						   TEXTOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "state",
-						   TEXTOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "gp_session_id",
+		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "gp_session_id",
 						   INT4OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 5, "xmin_distributed_snapshot",
+		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "xmin_distributed_snapshot",
 						   XIDOID, -1, 0);
 
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
@@ -90,11 +88,10 @@ gp_distributed_xacts__(PG_FUNCTION_ARGS)
 		MemSet(nulls, false, sizeof(nulls));
 
 		values[0] = TransactionIdGetDatum(distributedXactStatus->gxid);
-		values[1] = CStringGetTextDatum(distributedXactStatus->gid);
-		values[2] = CStringGetTextDatum(DtxStateToString(distributedXactStatus->state));
+		values[1] = CStringGetTextDatum(DtxStateToString(distributedXactStatus->state));
 
-		values[3] = UInt32GetDatum(distributedXactStatus->sessionId);
-		values[4] = TransactionIdGetDatum(distributedXactStatus->xminDistributedSnapshot);
+		values[2] = UInt32GetDatum(distributedXactStatus->sessionId);
+		values[3] = TransactionIdGetDatum(distributedXactStatus->xminDistributedSnapshot);
 
 		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 		result = HeapTupleGetDatum(tuple);

--- a/src/backend/cdb/cdbdtxcontextinfo.c
+++ b/src/backend/cdb/cdbdtxcontextinfo.c
@@ -47,10 +47,7 @@ DtxContextInfo_CreateOnMaster(DtxContextInfo *dtxContextInfo, bool inCursor,
 
 	dtxContextInfo->distributedXid = getDistributedTransactionId();
 	if (dtxContextInfo->distributedXid != InvalidDistributedTransactionId)
-	{
-		dtxContextInfo->distributedTimeStamp = getDtmStartTime();
 		dtxContextInfo->curcid = curcid;
-	}
 
 	/*
 	 * When this is an extended query, all the dispatchs will go to
@@ -71,7 +68,7 @@ DtxContextInfo_CreateOnMaster(DtxContextInfo *dtxContextInfo, bool inCursor,
 	dtxContextInfo->nestingLevel = GetCurrentTransactionNestLevel();
 
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DtxContextInfo_CreateOnMaster: created dtxcontext with dxid %u nestingLevel %d segmateSync %u/%u (current/cached)",
+		 "DtxContextInfo_CreateOnMaster: created dtxcontext with dxid "UINT64_FORMAT" nestingLevel %d segmateSync %u/%u (current/cached)",
 		 dtxContextInfo->distributedXid, dtxContextInfo->nestingLevel,
 		 dtxContextInfo->segmateSync, syncCount);
 
@@ -94,12 +91,10 @@ DtxContextInfo_CreateOnMaster(DtxContextInfo *dtxContextInfo, bool inCursor,
 			memcpy(gid, "<empty>", 8);
 
 		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "DtxContextInfo_CreateOnMaster Gp_role is DISPATCH and have gid = %s, gxid = %u --> have distributed snapshot",
-			 gid,
-			 getDistributedTransactionId());
+			 "DtxContextInfo_CreateOnMaster Gp_role is DISPATCH and have gid = %s --> have distributed snapshot", gid);
 		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "DtxContextInfo_CreateOnMaster distributedXid = %u, "
-			 "distributedSnapshotHeader (xminAllDistributedSnapshots %u, xmin = %u, xmax = %u, count = %d)",
+			 "DtxContextInfo_CreateOnMaster distributedXid = "UINT64_FORMAT", "
+			 "distributedSnapshotHeader (xminAllDistributedSnapshots "UINT64_FORMAT", xmin = "UINT64_FORMAT", xmax = "UINT64_FORMAT", count = %d)",
 			 dtxContextInfo->distributedXid,
 			 ds->xminAllDistributedSnapshots,
 			 ds->xmin,
@@ -109,7 +104,7 @@ DtxContextInfo_CreateOnMaster(DtxContextInfo *dtxContextInfo, bool inCursor,
 		for (i = 0; i < ds->count; i++)
 		{
 			elog((Debug_print_full_dtm ? LOG : DEBUG5),
-				 "....    distributedSnapshotData->xip[%d] = %u",
+				 "....    distributedSnapshotData->xip[%d] = "UINT64_FORMAT,
 				 i, ds->inProgressXidArray[i]);
 		}
 		elog((Debug_print_full_dtm ? LOG : DEBUG5),
@@ -135,7 +130,6 @@ DtxContextInfo_SerializeSize(DtxContextInfo *dtxContextInfo)
 
 	if (dtxContextInfo->distributedXid != InvalidDistributedTransactionId)
 	{
-		size += sizeof(DistributedTransactionTimeStamp);
 		size += TMGIDSIZE;		/* distributedId */
 		size += sizeof(CommandId);	/* curcid */
 	}
@@ -171,8 +165,6 @@ DtxContextInfo_Serialize(char *buffer, DtxContextInfo *dtxContextInfo)
 	p += sizeof(DistributedTransactionId);
 	if (dtxContextInfo->distributedXid != InvalidDistributedTransactionId)
 	{
-		memcpy(p, &dtxContextInfo->distributedTimeStamp, sizeof(DistributedTransactionTimeStamp));
-		p += sizeof(DistributedTransactionTimeStamp);
 		memcpy(p, &dtxContextInfo->curcid, sizeof(CommandId));
 		p += sizeof(CommandId);
 	}
@@ -183,8 +175,8 @@ DtxContextInfo_Serialize(char *buffer, DtxContextInfo *dtxContextInfo)
 	}
 
 	elog((Debug_print_full_dtm ? LOG : DEBUG3),
-		 "DtxContextInfo_Serialize distributedTimeStamp %u, distributedXid = %u, curcid %d nestingLevel %d segmateSync %u",
-		 dtxContextInfo->distributedTimeStamp, dtxContextInfo->distributedXid,
+		 "DtxContextInfo_Serialize distributedXid = "UINT64_FORMAT", curcid %d nestingLevel %d segmateSync %u",
+		 dtxContextInfo->distributedXid,
 		 dtxContextInfo->curcid, dtxContextInfo->nestingLevel, dtxContextInfo->segmateSync);
 
 	memcpy(p, &dtxContextInfo->segmateSync, sizeof(uint32));
@@ -212,16 +204,15 @@ DtxContextInfo_Serialize(char *buffer, DtxContextInfo *dtxContextInfo)
 	if (DEBUG5 >= log_min_messages || Debug_print_full_dtm || Debug_print_snapshot_dtm)
 	{
 		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "DtxContextInfo_Serialize distributedTimeStamp %u, distributedXid = %u, "
+			 "DtxContextInfo_Serialize distributedXid = "UINT64_FORMAT", "
 			 "curcid %d",
-			 dtxContextInfo->distributedTimeStamp,
 			 dtxContextInfo->distributedXid,
 			 dtxContextInfo->curcid);
 
 		if (dtxContextInfo->haveDistributedSnapshot)
 		{
 			elog((Debug_print_full_dtm ? LOG : DEBUG5),
-				 "distributedSnapshotHeader (xminAllDistributedSnapshots %u, xmin = %u, xmax = %u, count = %d)",
+				 "distributedSnapshotHeader (xminAllDistributedSnapshots "UINT64_FORMAT", xmin = "UINT64_FORMAT", xmax = "UINT64_FORMAT", count = %d)",
 				 ds->xminAllDistributedSnapshots,
 				 ds->xmin,
 				 ds->xmax,
@@ -229,11 +220,11 @@ DtxContextInfo_Serialize(char *buffer, DtxContextInfo *dtxContextInfo)
 			for (i = 0; i < ds->count; i++)
 			{
 				elog((Debug_print_full_dtm ? LOG : DEBUG5),
-					 "....    inProgressXidArray[%d] = %u",
+					 "....    inProgressXidArray[%d] = "UINT64_FORMAT,
 					 i, ds->inProgressXidArray[i]);
 			}
 			elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-				 "[Distributed Snapshot #%u] *Serialize* currcid = %d (gxid = %u, '%s')",
+				 "[Distributed Snapshot #%u] *Serialize* currcid = %d (gxid = "UINT64_FORMAT", '%s')",
 				 ds->distribSnapshotId,
 				 dtxContextInfo->curcid,
 				 getDistributedTransactionId(),
@@ -247,7 +238,6 @@ DtxContextInfo_Serialize(char *buffer, DtxContextInfo *dtxContextInfo)
 void
 DtxContextInfo_Reset(DtxContextInfo *dtxContextInfo)
 {
-	dtxContextInfo->distributedTimeStamp = 0;
 	dtxContextInfo->distributedXid = InvalidDistributedTransactionId;
 
 	dtxContextInfo->curcid = 0;
@@ -268,7 +258,6 @@ DtxContextInfo_Copy(
 {
 	DtxContextInfo_Reset(target);
 
-	target->distributedTimeStamp = source->distributedTimeStamp;
 	target->distributedXid = source->distributedXid;
 	target->segmateSync = source->segmateSync;
 	target->nestingLevel = source->nestingLevel;
@@ -285,17 +274,15 @@ DtxContextInfo_Copy(
 	target->distributedTxnOptions = source->distributedTxnOptions;
 
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DtxContextInfo_Copy distributed {timestamp %u, xid %u}, "
+		 "DtxContextInfo_Copy distributed {xid "UINT64_FORMAT"}, "
 		 "command id %d",
-		 target->distributedTimeStamp,
 		 target->distributedXid,
 		 target->curcid);
 
 	if (target->haveDistributedSnapshot)
 		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "distributed snapshot {timestamp %u, xminAllDistributedSnapshots %u, snapshot id %d, "
-			 "xmin %u, count %d, xmax %u}",
-			 target->distributedSnapshot.distribTransactionTimeStamp,
+			 "distributed snapshot {xminAllDistributedSnapshots "UINT64_FORMAT", snapshot id %d, "
+			 "xmin "UINT64_FORMAT", count %d, xmax "UINT64_FORMAT"}",
 			 target->distributedSnapshot.xminAllDistributedSnapshots,
 			 target->distributedSnapshot.distribSnapshotId,
 			 target->distributedSnapshot.xmin,
@@ -327,8 +314,6 @@ DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 
 		if (dtxContextInfo->distributedXid != InvalidDistributedTransactionId)
 		{
-			memcpy(&dtxContextInfo->distributedTimeStamp, p, sizeof(DistributedTransactionTimeStamp));
-			p += sizeof(DistributedTransactionTimeStamp);
 			memcpy(&dtxContextInfo->curcid, p, sizeof(CommandId));
 			p += sizeof(CommandId);
 		}
@@ -349,8 +334,8 @@ DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 		p += sizeof(bool);
 
 		elog((Debug_print_full_dtm ? LOG : DEBUG3),
-			 "DtxContextInfo_Deserialize distributedTimeStamp %u, distributedXid = %u, curcid %d nestingLevel %d segmateSync %u as %s",
-			 dtxContextInfo->distributedTimeStamp, dtxContextInfo->distributedXid,
+			 "DtxContextInfo_Deserialize distributedXid = "UINT64_FORMAT", curcid %d nestingLevel %d segmateSync %u as %s",
+			 dtxContextInfo->distributedXid,
 			 dtxContextInfo->curcid, dtxContextInfo->nestingLevel,
 			 dtxContextInfo->segmateSync, (Gp_is_writer ? "WRITER" : "READER"));
 
@@ -370,14 +355,13 @@ DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 		if (DEBUG5 >= log_min_messages || Debug_print_full_dtm)
 		{
 			elog((Debug_print_full_dtm ? LOG : DEBUG5),
-				 "DtxContextInfo_Deserialize distributedTimeStamp %u, distributedXid = %u",
-				 dtxContextInfo->distributedTimeStamp,
+				 "DtxContextInfo_Deserialize distributedXid = "UINT64_FORMAT,
 				 dtxContextInfo->distributedXid);
 
 			if (dtxContextInfo->haveDistributedSnapshot)
 			{
 				elog((Debug_print_full_dtm ? LOG : DEBUG5),
-					 "distributedSnapshotHeader (xminAllDistributedSnapshots %u, xmin = %u, xmax = %u, count = %d)",
+					 "distributedSnapshotHeader (xminAllDistributedSnapshots "UINT64_FORMAT", xmin = "UINT64_FORMAT", xmax = "UINT64_FORMAT", count = %d)",
 					 ds->xminAllDistributedSnapshots,
 					 ds->xmin,
 					 ds->xmax,
@@ -386,12 +370,12 @@ DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 				for (i = 0; i < ds->count; i++)
 				{
 					elog((Debug_print_full_dtm ? LOG : DEBUG5),
-						 "....    inProgressXidArray[%d] = %u",
+						 "....    inProgressXidArray[%d] = "UINT64_FORMAT,
 						 i, ds->inProgressXidArray[i]);
 				}
 
 				elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-					 "[Distributed Snapshot #%u] *Deserialize* currcid = %d (gxid = %u, '%s')",
+					 "[Distributed Snapshot #%u] *Deserialize* currcid = %d (gxid = "UINT64_FORMAT", '%s')",
 					 ds->distribSnapshotId,
 					 dtxContextInfo->curcid,
 					 getDistributedTransactionId(),

--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -645,9 +645,7 @@ DtxRecoveryMain(Datum main_arg)
 	}
 
 	/* Fetch the gxid batch in advance. */
-	SpinLockAcquire(shmGxidGenLock);
 	bumpGxid();
-	SpinLockRelease(shmGxidGenLock);
 
 	/*
 	 * Normally we check with interval gp_dtx_recovery_interval, but sometimes
@@ -675,9 +673,7 @@ DtxRecoveryMain(Datum main_arg)
 
 		if (event & DTX_RECOVERY_EVENT_BUMP_GXID)
 		{
-			SpinLockAcquire(shmGxidGenLock);
 			bumpGxid();
-			SpinLockRelease(shmGxidGenLock);
 			ResetDtxRecoveryEvent(DTX_RECOVERY_EVENT_BUMP_GXID);
 		}
 

--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -43,9 +43,11 @@ static int frequent_check_times;
 volatile bool *shmDtmStarted = NULL;
 volatile bool *shmCleanupBackends = NULL;
 volatile pid_t *shmDtxRecoveryPid = NULL;
+volatile DtxRecoveryEvent *shmDtxRecoveryEvents = NULL;
+slock_t *shmDtxRecoveryEventLock;
 
 /* transactions need recover */
-TMGXACT_LOG *shmCommittedGxactArray;
+DistributedTransactionId *shmCommittedGxidArray;
 volatile int *shmNumCommittedGxacts;
 
 static volatile sig_atomic_t got_SIGHUP = false;
@@ -184,17 +186,18 @@ recoverInDoubtTransactions(void)
 
 	for (i = 0; i < *shmNumCommittedGxacts; i++)
 	{
-		TMGXACT_LOG *gxact_log = &shmCommittedGxactArray[i];
+		DistributedTransactionId gxid = shmCommittedGxidArray[i];
+		char gid[TMGIDSIZE];
 
-		Assert(gxact_log->gxid != InvalidDistributedTransactionId);
+		Assert(gxid != InvalidDistributedTransactionId);
+		dtxFormGid(gid, gxid);
 
 		elog(DTM_DEBUG5,
-			 "Recovering committed distributed transaction gid = %s",
-			 gxact_log->gid);
+			 "Recovering committed distributed transaction gid = %s", gid);
 
-		doNotifyCommittedInDoubt(gxact_log->gid);
+		doNotifyCommittedInDoubt(gid);
 
-		RecordDistributedForgetCommitted(gxact_log);
+		RecordDistributedForgetCommitted(gxid);
 	}
 
 	*shmNumCommittedGxacts = 0;
@@ -392,7 +395,6 @@ abortOrphanedTransactions(HTAB *htab)
 {
 	HASH_SEQ_STATUS status;
 	InDoubtDtx *entry = NULL;
-	DistributedTransactionTimeStamp	distribTimeStamp;
 	DistributedTransactionId	gxid;
 
 	if (htab == NULL)
@@ -404,9 +406,9 @@ abortOrphanedTransactions(HTAB *htab)
 	{
 		elog(DTM_DEBUG3, "Finding orphaned transactions with gid = %s", entry->gid);
 
-		dtxCrackOpenGid(entry->gid, &distribTimeStamp, &gxid);
+		dtxDeformGid(entry->gid, &gxid);
 
-		if (!IsDtxInProgress(distribTimeStamp, gxid))
+		if (!IsDtxInProgress(gxid))
 		{
 			elog(LOG, "Aborting orphaned transactions with gid = %s", entry->gid);
 			doAbortInDoubt(entry->gid);
@@ -432,28 +434,20 @@ redoDtxCheckPoint(TMGXACT_CHECKPOINT *gxact_checkpoint)
 	elog(DTM_DEBUG5, "redoDtxCheckPoint has committedCount = %d", committedCount);
 
 	for (i = 0; i < committedCount; i++)
-		redoDistributedCommitRecord(&gxact_checkpoint->committedGxactArray[i]);
+		redoDistributedCommitRecord(gxact_checkpoint->committedGxidArray[i]);
 }
 
 /*
  * Redo transaction commit log record.
  */
 void
-redoDistributedCommitRecord(TMGXACT_LOG *gxact_log)
+redoDistributedCommitRecord(DistributedTransactionId gxid)
 {
 	int			i;
 
-	/*
-	 * The length check here requires the identifer have a trailing NUL
-	 * character.
-	 */
-	if (strlen(gxact_log->gid) >= TMGIDSIZE)
-		elog(PANIC, "Distribute transaction identifier too long (%d)",
-			 (int) strlen(gxact_log->gid));
-
 	for (i = 0; i < *shmNumCommittedGxacts; i++)
 	{
-		if (strcmp(gxact_log->gid, shmCommittedGxactArray[i].gid) == 0)
+		if (gxid == shmCommittedGxidArray[i])
 			return;
 	}
 
@@ -477,22 +471,22 @@ redoDistributedCommitRecord(TMGXACT_LOG *gxact_log)
 			initStringInfo(&gxact_array);
 			for (int j = 0; j < *shmNumCommittedGxacts; j++)
 			{
-				appendStringInfo(&gxact_array, "shmCommittedGxactArray[%d]: %s\n",
-					j, shmCommittedGxactArray[j].gid);
+				appendStringInfo(&gxact_array, "shmCommittedGxactArray[%d]: "UINT64_FORMAT"\n",
+					j, shmCommittedGxidArray[j]);
 			}
 			ereport(FATAL,
 					(errmsg("the limit of %d distributed transactions has been reached "\
-							"while adding gid = %s. Committed gid array length: %d, dump:\n%s",
-							max_tm_gxacts, gxact_log->gid, *shmNumCommittedGxacts, gxact_array.data),
+							"while adding gid = "UINT64_FORMAT". Committed gid array length: %d, dump:\n%s",
+							max_tm_gxacts, gxid, *shmNumCommittedGxacts, gxact_array.data),
 					 errdetail("It should not happen. Temporarily increase "
 							   "max_connections (need postmaster reboot) on "
 							   "the postgres (master or standby) to work "
 							   "around this issue and then report a bug")));
 		}
 
-		shmCommittedGxactArray[(*shmNumCommittedGxacts)++] = *gxact_log;
+		shmCommittedGxidArray[(*shmNumCommittedGxacts)++] = gxid;
 		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "Crash recovery redo added committed distributed transaction gid = %s", gxact_log->gid);
+			 "Crash recovery redo added committed distributed transaction gid = "UINT64_FORMAT, gxid);
 	}
 }
 
@@ -500,34 +494,34 @@ redoDistributedCommitRecord(TMGXACT_LOG *gxact_log)
  * Redo transaction forget commit log record.
  */
 void
-redoDistributedForgetCommitRecord(TMGXACT_LOG *gxact_log)
+redoDistributedForgetCommitRecord(DistributedTransactionId gxid)
 {
 	int			i;
 
 	for (i = 0; i < *shmNumCommittedGxacts; i++)
 	{
-		if (strcmp(gxact_log->gid, shmCommittedGxactArray[i].gid) == 0)
+		if (gxid == shmCommittedGxidArray[i])
 		{
 			/* found an active global transaction */
 			elog((Debug_print_full_dtm ? INFO : DEBUG5),
-				 "Crash recovery redo removed committed distributed transaction gid = %s for forget",
-				 gxact_log->gid);
+				 "Crash recovery redo removed committed distributed transaction gid = "UINT64_FORMAT" for forget",
+				 gxid);
 
 			/*
-			 * there's no concurrent access to shmCommittedGxactArray during
+			 * there's no concurrent access to shmCommittedGxidArray during
 			 * recovery
 			 */
 			(*shmNumCommittedGxacts)--;
 			if (i != *shmNumCommittedGxacts)
-				shmCommittedGxactArray[i] = shmCommittedGxactArray[*shmNumCommittedGxacts];
+				shmCommittedGxidArray[i] = shmCommittedGxidArray[*shmNumCommittedGxacts];
 
 			return;
 		}
 	}
 
 	elog((Debug_print_full_dtm ? WARNING : DEBUG5),
-		 "Crash recovery redo did not find committed distributed transaction gid = %s for forget",
-		 gxact_log->gid);
+		 "Crash recovery redo did not find committed distributed transaction gid = "UINT64_FORMAT" for forget",
+		 gxid);
 }
 
 bool
@@ -589,6 +583,30 @@ DtxRecoveryPID(void)
 	return *shmDtxRecoveryPid;
 }
 
+void
+SetDtxRecoveryEvent(DtxRecoveryEvent event, bool locked)
+{
+	if (!locked)
+		SpinLockAcquire(shmDtxRecoveryEventLock);
+	*shmDtxRecoveryEvents |= event;
+	if (!locked)
+		SpinLockRelease(shmDtxRecoveryEventLock);
+}
+
+DtxRecoveryEvent
+GetDtxRecoveryEvent(void)
+{
+	return *shmDtxRecoveryEvents;
+}
+
+static void
+ResetDtxRecoveryEvent(DtxRecoveryEvent event)
+{
+	SpinLockAcquire(shmDtxRecoveryEventLock);
+	*shmDtxRecoveryEvents &= ~event;
+	SpinLockRelease(shmDtxRecoveryEventLock);
+}
+
 /*
  * DtxRecoveryMain
  */
@@ -626,6 +644,11 @@ DtxRecoveryMain(Datum main_arg)
 		set_ps_display("", false);
 	}
 
+	/* Fetch the gxid batch in advance. */
+	SpinLockAcquire(shmGxidGenLock);
+	bumpGxid();
+	SpinLockRelease(shmGxidGenLock);
+
 	/*
 	 * Normally we check with interval gp_dtx_recovery_interval, but sometimes
 	 * we want to be more frequent in a period, e.g. just after master panic.
@@ -638,6 +661,7 @@ DtxRecoveryMain(Datum main_arg)
 	while (true)
 	{
 		int rc;
+		DtxRecoveryEvent event;
 
 		CHECK_FOR_INTERRUPTS();
 
@@ -647,8 +671,26 @@ DtxRecoveryMain(Datum main_arg)
 			ProcessConfigFile(PGC_SIGHUP);
 		}
 
-		/* Find orphaned prepared transactions and abort them. */
-		AbortOrphanedPreparedTransactions();
+		event = GetDtxRecoveryEvent();
+
+		if (event & DTX_RECOVERY_EVENT_BUMP_GXID)
+		{
+			SpinLockAcquire(shmGxidGenLock);
+			bumpGxid();
+			SpinLockRelease(shmGxidGenLock);
+			ResetDtxRecoveryEvent(DTX_RECOVERY_EVENT_BUMP_GXID);
+		}
+
+		if (event & DTX_RECOVERY_EVENT_ABORT_PREPARED)
+		{
+			/*
+			 * We do not reset the event so far, but maybe do this later when
+			 * we know there isn't distributed transaction to abort in normal
+			 * cases so that it could respond promptly for gxid bumping given
+			 * the abort operation might be time-consuming.
+			 */
+			AbortOrphanedPreparedTransactions();
+		}
 
 		/* GPDB_12_MERGE_FIXME: Create a new WaitEventIPC member for this? */
 		rc = WaitLatch(&MyProc->procLatch,

--- a/src/backend/cdb/cdblocaldistribxact.c
+++ b/src/backend/cdb/cdblocaldistribxact.c
@@ -79,7 +79,7 @@ LocalDistribXact_ChangeState(int pgprocno,
 		case LOCALDISTRIBXACT_STATE_PREPARED:
 			if (oldState != LOCALDISTRIBXACT_STATE_ACTIVE)
 				elog(PANIC,
-					 "Expected distributed transaction xid = %u to local element to be in state \"Active\" and "
+					 "Expected distributed transaction xid = "UINT64_FORMAT" to local element to be in state \"Active\" and "
 					 "found state \"%s\"",
 					 distribXid,
 					 LocalDistribXactStateToString(oldState));
@@ -88,7 +88,7 @@ LocalDistribXact_ChangeState(int pgprocno,
 		case LOCALDISTRIBXACT_STATE_COMMITTED:
 			if (oldState != LOCALDISTRIBXACT_STATE_ACTIVE)
 				elog(PANIC,
-					 "Expected distributed transaction xid = %u to local element to be in state \"Active\" or \"Commit Delivery\" and "
+					 "Expected distributed transaction xid = "UINT64_FORMAT" to local element to be in state \"Active\" or \"Commit Delivery\" and "
 					 "found state \"%s\"",
 					 distribXid,
 					 LocalDistribXactStateToString(oldState));
@@ -98,7 +98,7 @@ LocalDistribXact_ChangeState(int pgprocno,
 			if (oldState != LOCALDISTRIBXACT_STATE_ACTIVE &&
 				oldState != LOCALDISTRIBXACT_STATE_ABORTED)
 				elog(PANIC,
-					 "Expected distributed transaction xid = %u to local element to be in state \"Active\" or \"Abort Delivery\" and "
+					 "Expected distributed transaction xid = "UINT64_FORMAT" to local element to be in state \"Active\" or \"Abort Delivery\" and "
 					 "found state \"%s\"",
 					 distribXid,
 					 LocalDistribXactStateToString(oldState));
@@ -117,7 +117,7 @@ LocalDistribXact_ChangeState(int pgprocno,
 	proc->localDistribXactData.state = newState;
 
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "Moved distributed transaction xid = %u (local xid = %u) from \"%s\" to \"%s\"",
+		 "Moved distributed transaction xid = "UINT64_FORMAT" (local xid = %u) from \"%s\" to \"%s\"",
 		 distribXid,
 		 pgxact->xid,
 		 LocalDistribXactStateToString(oldState),
@@ -138,8 +138,7 @@ LocalDistribXact_DisplayString(int pgprocno)
 		snprintf(
 				 LocalDistribDisplayBuffer,
 				 MAX_LOCAL_DISTRIB_DISPLAY_BUFFER,
-				 "distributed transaction {timestamp %u, xid %u} for local xid %u",
-				 proc->localDistribXactData.distribTimeStamp,
+				 "distributed transaction {gxid "UINT64_FORMAT" for local xid %u",
 				 proc->localDistribXactData.distribXid,
 				 pgxact->xid);
 

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -51,6 +51,7 @@
 #include "cdb/cdbllize.h"
 #include "utils/faultinjector.h"
 #include "utils/guc.h"
+#include "utils/fmgrprotos.h"
 #include "utils/fmgroids.h"
 #include "utils/session_state.h"
 #include "utils/sharedsnapshot.h"
@@ -59,38 +60,37 @@
 
 typedef struct TmControlBlock
 {
-	DistributedTransactionTimeStamp	distribTimeStamp;
-	DistributedTransactionId	seqno;
 	bool						DtmStarted;
 	bool						CleanupBackends;
 	pid_t						DtxRecoveryPid;
+	DtxRecoveryEvent			DtxRecoveryEvents;
+	slock_t						DtxRecoveryEventLock;
 	uint32						NextSnapshotId;
 	int							num_committed_xacts;
 	slock_t						gxidGenLock;
 
-	/* Array [0..max_tm_gxacts-1] of TMGXACT_LOG ptrs is appended starting here */
-	TMGXACT_LOG  			    committed_gxact_array[1];
+	/* Array [0..max_tm_gxacts-1] of DistributedTransactionId ptrs is appended starting here */
+	DistributedTransactionId committed_gxid_array[FLEXIBLE_ARRAY_MEMBER];
 }	TmControlBlock;
 
 
 #define TMCONTROLBLOCK_BYTES(num_gxacts) \
-	(offsetof(TmControlBlock, committed_gxact_array) + sizeof(TMGXACT_LOG) * (num_gxacts))
+	(offsetof(TmControlBlock, committed_gxid_array) + sizeof(DistributedTransactionId) * (num_gxacts))
 
 extern bool Test_print_direct_dispatch_info;
 
 #define DTX_PHASE2_SLEEP_TIME_BETWEEN_RETRIES_MSECS 100
-
-volatile DistributedTransactionTimeStamp *shmDistribTimeStamp;
-volatile DistributedTransactionId *shmGIDSeq;
 
 uint32 *shmNextSnapshotId;
 slock_t *shmGxidGenLock;
 
 int	max_tm_gxacts = 100;
 
+int gp_gxid_prefetch_num;
+#define GXID_PRETCH_THRESHOLD (gp_gxid_prefetch_num>>1)
 
-#define TM_ERRDETAIL (errdetail("gid=%u-%.10u, state=%s", \
-		getDistributedTransactionTimestamp(), getDistributedTransactionId(),\
+#define TM_ERRDETAIL (errdetail("gid=" UINT64_FORMAT ", state=%s", \
+		getDistributedTransactionId(),\
 		DtxStateToString(MyTmGxactLocal ? MyTmGxactLocal->state : 0)))
 /* here are some flag options relationed to the txnOptions field of
  * PQsendGpQuery
@@ -170,12 +170,6 @@ isDtxContext(void)
  * VISIBLE FUNCTIONS
  */
 
-DistributedTransactionTimeStamp
-getDtmStartTime(void)
-{
-	return *shmDistribTimeStamp;
-}
-
 DistributedTransactionId
 getDistributedTransactionId(void)
 {
@@ -183,15 +177,6 @@ getDistributedTransactionId(void)
 		return MyTmGxact->gxid;
 	else
 		return InvalidDistributedTransactionId;
-}
-
-DistributedTransactionTimeStamp
-getDistributedTransactionTimestamp(void)
-{
-	if (isDtxContext())
-		return MyTmGxact->distribTimeStamp;
-	else
-		return 0;
 }
 
 bool
@@ -205,7 +190,7 @@ getDistributedTransactionIdentifier(char *id)
 		 * The length check here requires the identifer have a trailing
 		 * NUL character.
 		 */
-		dtxFormGID(id, MyTmGxact->distribTimeStamp, MyTmGxact->gxid);
+		dtxFormGid(id, MyTmGxact->gxid);
 		return true;
 	}
 
@@ -233,41 +218,86 @@ isCurrentDtxActivated(void)
 	return MyTmGxactLocal->state != DTX_STATE_NONE;
 }
 
+void
+bumpGxid()
+{
+	DistributedTransactionId nextLimit;
+	uint32 nextCount;
+
+	/* Note this function needs shmGxidGenLock to be locked in advance. */
+
+	nextCount = ShmemVariableCache->GxidCount + gp_gxid_prefetch_num;
+	nextLimit = ShmemVariableCache->nextGxid + nextCount;
+	if (nextLimit >= LastDistributedTransactionId)
+		ereport(PANIC,
+			(errmsg("reached the limit of "UINT64_FORMAT" global transactions",
+					LastDistributedTransactionId)));
+	/*
+	 * Should not hold shmGxidGenLock during bumping since there might be still
+	 * gxid count for use at this moment and bumping gxid might be
+	 * time-consuming in wal code.
+	 */
+	SpinLockRelease(shmGxidGenLock);
+
+	/*
+	 * Real work should be done by one caller one time.
+	 */
+	LWLockAcquire(GxidBumpLock, LW_EXCLUSIVE);
+
+	/*
+	 * If bumping already finishes skip bumping.
+	 *
+	 * Assume atomic access of ShmemVariableCache->GxidCount.  so there is no
+	 * need of GxidGenLock locking here.
+	 */
+	if (ShmemVariableCache->GxidCount > GXID_PRETCH_THRESHOLD)
+	{
+		LWLockRelease(GxidBumpLock);
+		return;
+	}
+
+	XLogPutNextGxid(nextLimit);
+
+	SpinLockAcquire(shmGxidGenLock);
+	ShmemVariableCache->GxidCount += gp_gxid_prefetch_num;
+	SpinLockRelease(shmGxidGenLock);
+
+	LWLockRelease(GxidBumpLock);
+}
+
 static void
 currentDtxActivate(void)
 {
-	/*
-	 * Bump 'shmGIDSeq' and assign it to 'MyTmGxact->gxid', this needs to be atomic.
-	 * Otherwise, another transaction might start and commit in between, which will
-	 * bump 'ShmemVariableCache->latestCompletedDxid'.  If someone else take a
-	 * snapshot now, it will consider this transaction has finished: it's not
-	 * in-progress (MyTmGxact->gxid is not set) and its transaction precedes the xmax.
-	 *
-	 * For example:
-	 * tx1: insert into t values(1), (2);
-	 * tx2: insert into t values(3), (4);
-	 * tx3: select * from t;
-	 *
-	 * It happens in the following order:
-	 * 1. tx1 generates a distributed transaction-id X1
-	 * 2. tx2 generates a distributed transaction-id X2 (X1 < X2)
-	 * 3. tx2 finished
-	 * 4. tx3 takes a distributed snapshot
-	 * 5. tx1 set 'TMGXACT->gxid'
-	 * 6. tx1 finish 'commit prepared' on segment 0 but not on segment 1 yet.
-	 * 7. tx3 will see the change of tx1 on segment 0 but not on segment 1, that's
-	 * because tx1 is considered finished according to the snapshot.
-	 */
+	bool signal_dtx_recovery;
+
+	if (ShmemVariableCache->GxidCount <= GXID_PRETCH_THRESHOLD)
+	{
+		signal_dtx_recovery = false;
+
+		SpinLockAcquire(shmDtxRecoveryEventLock);
+		/* avoid re-enter. */
+		if ((GetDtxRecoveryEvent() & DTX_RECOVERY_EVENT_BUMP_GXID) == 0)
+		{
+			/* wake up dtx recovery to prefetch */
+			SetDtxRecoveryEvent(DTX_RECOVERY_EVENT_BUMP_GXID, true);
+			signal_dtx_recovery = true;
+		}
+		SpinLockRelease(shmDtxRecoveryEventLock);
+
+		if (signal_dtx_recovery)
+			SendPostmasterSignal(PMSIGNAL_WAKEN_DTX_RECOVERY);
+	}
+
 	SpinLockAcquire(shmGxidGenLock);
-	MyTmGxact->gxid = ++(*shmGIDSeq);
+
+	if (unlikely(ShmemVariableCache->GxidCount == 0))
+		bumpGxid();
+
+	MyTmGxact->gxid = ShmemVariableCache->nextGxid++;
+	ShmemVariableCache->GxidCount--;
+
 	SpinLockRelease(shmGxidGenLock);
 
-	if (MyTmGxact->gxid == LastDistributedTransactionId)
-		ereport(PANIC,
-				(errmsg("reached the limit of %u global transactions per start",
-						LastDistributedTransactionId)));
-
-	MyTmGxact->distribTimeStamp = getDtmStartTime();
 	MyTmGxact->sessionId = gp_session_id;
 	setCurrentDtxState(DTX_STATE_ACTIVE_DISTRIBUTED);
 	GxactLockTableInsert(MyTmGxact->gxid);
@@ -392,7 +422,7 @@ doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType)
 														 mppTxnOptions(true),
 														 "doDispatchSubtransactionInternalCmd");
 
-	dtxFormGID(gid, getDistributedTransactionTimestamp(), getDistributedTransactionId());
+	dtxFormGid(gid, getDistributedTransactionId());
 	succeeded = doDispatchDtxProtocolCommand(cmdType,
 											 gid,
 											 /* raiseError */ true,
@@ -463,16 +493,11 @@ doPrepareTransaction(void)
 static void
 doInsertForgetCommitted(void)
 {
-	TMGXACT_LOG gxact_log;
-
 	elog(DTM_DEBUG5, "doInsertForgetCommitted entering in state = %s", DtxStateToString(MyTmGxactLocal->state));
 
 	setCurrentDtxState(DTX_STATE_INSERTING_FORGET_COMMITTED);
 
-	dtxFormGID(gxact_log.gid, getDistributedTransactionTimestamp(), getDistributedTransactionId());
-	gxact_log.gxid = getDistributedTransactionId();
-
-	RecordDistributedForgetCommitted(&gxact_log);
+	RecordDistributedForgetCommitted(getDistributedTransactionId());
 
 	setCurrentDtxState(DTX_STATE_INSERTED_FORGET_COMMITTED);
 	MyTmGxact->includeInCkpt = false;
@@ -690,6 +715,7 @@ retryAbortPrepared(void)
 	if (!succeeded)
 	{
 		ResetAllGangs();
+		SetDtxRecoveryEvent(DTX_RECOVERY_EVENT_ABORT_PREPARED, false);
 		SendPostmasterSignal(PMSIGNAL_WAKEN_DTX_RECOVERY);
 		ereport(WARNING,
 				(errmsg("unable to complete 'Abort' broadcast. The dtx recovery"
@@ -827,7 +853,7 @@ prepareDtxTransaction(void)
 	{
 		Assert(MyTmGxactLocal->state == DTX_STATE_NONE);
 		Assert(Gp_role != GP_ROLE_DISPATCH || MyTmGxact->gxid == InvalidDistributedTransactionId);
-		resetGxact();
+		resetTmGxact();
 		return;
 	}
 
@@ -854,7 +880,6 @@ prepareDtxTransaction(void)
 		 DtxStateToString(MyTmGxactLocal->state));
 
 	Assert(MyTmGxactLocal->state == DTX_STATE_ACTIVE_DISTRIBUTED);
-	Assert(MyTmGxact->gxid > FirstDistributedTransactionId);
 
 	doPrepareTransaction();
 }
@@ -1044,32 +1069,22 @@ tmShmemInit(void)
 	if (!shared)
 		elog(FATAL, "could not initialize transaction manager share memory");
 
-	shmDistribTimeStamp = &shared->distribTimeStamp;
-	shmGIDSeq = &shared->seqno;
 	/* Only initialize this if we are the creator of the shared memory */
 	if (!found)
 	{
-		time_t		t = time(NULL);
-
-		if (t == (time_t) -1)
-		{
-			elog(PANIC, "cannot generate global transaction id");
-		}
-
-		*shmDistribTimeStamp = (DistributedTransactionTimeStamp) t;
-		elog(DEBUG1, "DTM start timestamp %u", *shmDistribTimeStamp);
-
-		*shmGIDSeq = FirstDistributedTransactionId;
-		ShmemVariableCache->latestCompletedDxid = InvalidDistributedTransactionId;
+		ShmemVariableCache->latestCompletedGxid = InvalidDistributedTransactionId;
+		SpinLockInit(&shared->DtxRecoveryEventLock);
 		SpinLockInit(&shared->gxidGenLock);
 	}
 	shmDtmStarted = &shared->DtmStarted;
 	shmCleanupBackends = &shared->CleanupBackends;
 	shmDtxRecoveryPid = &shared->DtxRecoveryPid;
+	shmDtxRecoveryEvents = &shared->DtxRecoveryEvents;
+	shmDtxRecoveryEventLock = &shared->DtxRecoveryEventLock;
 	shmNextSnapshotId = &shared->NextSnapshotId;
-	shmNumCommittedGxacts = &shared->num_committed_xacts;
 	shmGxidGenLock = &shared->gxidGenLock;
-	shmCommittedGxactArray = &shared->committed_gxact_array[0];
+	shmNumCommittedGxacts = &shared->num_committed_xacts;
+	shmCommittedGxidArray = &shared->committed_gxid_array[0];
 
 	if (!IsUnderPostmaster)
 		/* Initialize locks and shared memory area */
@@ -1078,6 +1093,7 @@ tmShmemInit(void)
 		*shmDtmStarted = false;
 		*shmCleanupBackends = false;
 		*shmDtxRecoveryPid = 0;
+		*shmDtxRecoveryEvents = DTX_RECOVERY_EVENT_ABORT_PREPARED;
 		*shmNumCommittedGxacts = 0;
 	}
 }
@@ -1180,7 +1196,7 @@ currentDtxDispatchProtocolCommand(DtxProtocolCommand dtxProtocolCommand, bool ra
 {
 	char gid[TMGIDSIZE];
 
-	dtxFormGID(gid, getDistributedTransactionTimestamp(), getDistributedTransactionId());
+	dtxFormGid(gid, getDistributedTransactionId());
 	return doDispatchDtxProtocolCommand(dtxProtocolCommand, gid, raiseError,
 										MyTmGxactLocal->dtxSegments, NULL, 0);
 }
@@ -1402,10 +1418,9 @@ dispatchDtxCommand(const char *cmd)
 
 /* reset global transaction context */
 void
-resetGxact(void)
+resetTmGxact(void)
 {
 	Assert(MyTmGxact->gxid == InvalidDistributedTransactionId);
-	MyTmGxact->distribTimeStamp = 0;
 	MyTmGxact->xminDistributedSnapshot = InvalidDistributedTransactionId;
 	MyTmGxact->includeInCkpt = false;
 	MyTmGxact->sessionId = 0;
@@ -1681,15 +1696,15 @@ setupQEDtxContext(DtxContextInfo *dtxContextInfo)
 			 IsoLevelAsUpperString(mppTxOptions_IsoLevel(txnOptions)), (isMppTxOptions_ReadOnly(txnOptions) ? "true" : "false"),
 			 (haveDistributedSnapshot ? "true" : "false"));
 		elog(DTM_DEBUG5,
-			 "setupQEDtxContext inputs (part 2): distributedXid = %u, isSharedLocalSnapshotSlotPresent = %s.",
+			 "setupQEDtxContext inputs (part 2): distributedXid = "UINT64_FORMAT", isSharedLocalSnapshotSlotPresent = %s.",
 			 dtxContextInfo->distributedXid,
 			 (isSharedLocalSnapshotSlotPresent ? "true" : "false"));
 
 		if (haveDistributedSnapshot)
 		{
 			elog(DTM_DEBUG5,
-				 "setupQEDtxContext inputs (part 2a): distributedXid = %u, "
-				 "distributedSnapshotData (xmin = %u, xmax = %u, xcnt = %u), distributedCommandId = %d",
+				 "setupQEDtxContext inputs (part 2a): distributedXid = "UINT64_FORMAT", "
+				 "distributedSnapshotData (xmin = "UINT64_FORMAT", xmax = "UINT64_FORMAT", xcnt = %u), distributedCommandId = %d",
 				 dtxContextInfo->distributedXid,
 				 distributedSnapshot->xmin, distributedSnapshot->xmax,
 				 distributedSnapshot->count,
@@ -1702,7 +1717,7 @@ setupQEDtxContext(DtxContextInfo *dtxContextInfo)
 				LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_SHARED);
 				elog(DTM_DEBUG5,
 					 "setupQEDtxContext inputs (part 2b):  shared local snapshot xid = " UINT64_FORMAT " "
-					 "(xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = %u/%u",
+					 "(xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = "UINT64_FORMAT"/%u",
 					 U64FromFullTransactionId(SharedLocalSnapshotSlot->fullXid),
 					 SharedLocalSnapshotSlot->snapshot.xmin,
 					 SharedLocalSnapshotSlot->snapshot.xmax,
@@ -1895,7 +1910,7 @@ setupQEDtxContext(DtxContextInfo *dtxContextInfo)
 
 	if (haveDistributedSnapshot)
 	{
-		elog((Debug_print_snapshot_dtm ? LOG : DEBUG5), "[Distributed Snapshot #%u] *Set QE* currcid = %d (gxid = %u, '%s')",
+		elog((Debug_print_snapshot_dtm ? LOG : DEBUG5), "[Distributed Snapshot #%u] *Set QE* currcid = %d (gxid = "UINT64_FORMAT", '%s')",
 			 dtxContextInfo->distributedSnapshot.distribSnapshotId,
 			 dtxContextInfo->curcid,
 			 getDistributedTransactionId(),
@@ -1924,7 +1939,7 @@ finishDistributedTransactionContext(char *debugCaller, bool aborted)
 
 	gxid = getDistributedTransactionId();
 	elog(DTM_DEBUG5,
-		 "finishDistributedTransactionContext called to change DistributedTransactionContext from %s to %s (caller = %s, gxid = %u)",
+		 "finishDistributedTransactionContext called to change DistributedTransactionContext from %s to %s (caller = %s, gxid = "UINT64_FORMAT")",
 		 DtxContextToString(DistributedTransactionContext),
 		 DtxContextToString(DTX_CONTEXT_LOCAL_ONLY),
 		 debugCaller,
@@ -2026,7 +2041,6 @@ sendWaitGxidsToQD(List *waitGxids)
 static void
 performDtxProtocolCommitOnePhase(const char *gid)
 {
-	DistributedTransactionTimeStamp distribTimeStamp;
 	DistributedTransactionId gxid;
 	List *waitGxids = list_copy(MyTmGxactLocal->waitGxids);
 
@@ -2035,9 +2049,8 @@ performDtxProtocolCommitOnePhase(const char *gid)
 	elog(DTM_DEBUG5,
 		 "performDtxProtocolCommitOnePhase going to call CommitTransaction for distributed transaction %s", gid);
 
-	dtxCrackOpenGid(gid, &distribTimeStamp, &gxid);
+	dtxDeformGid(gid, &gxid);
 	Assert(gxid == getDistributedTransactionId());
-	Assert(distribTimeStamp == getDistributedTransactionTimestamp());
 	MyTmGxactLocal->isOnePhaseCommit = true;
 
 	StartTransactionCommand();
@@ -2399,4 +2412,20 @@ CurrentDtxIsRollingback(void)
 			MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED ||
 			MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_PREPARED ||
 			MyTmGxactLocal->state == DTX_STATE_RETRY_ABORT_PREPARED);
+}
+
+Datum
+gp_get_next_gxid(PG_FUNCTION_ARGS)
+{
+	DistributedTransactionId next_gxid;
+
+	if (!superuser())
+		ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						(errmsg("Superuser only to execute it"))));
+
+	SpinLockAcquire(shmGxidGenLock);
+	next_gxid = ShmemVariableCache->nextGxid;
+	SpinLockRelease(shmGxidGenLock);
+
+	PG_RETURN_UINT64(next_gxid);
 }

--- a/src/backend/cdb/cdbtmutils.c
+++ b/src/backend/cdb/cdbtmutils.c
@@ -28,15 +28,14 @@
  * transaction id.
  */
 void
-dtxCrackOpenGid(
+dtxDeformGid(
 				const char *gid,
-				DistributedTransactionTimeStamp *distribTimeStamp,
 				DistributedTransactionId *distribXid)
 {
 	int			itemsScanned;
 
-	itemsScanned = sscanf(gid, "%u-%u", distribTimeStamp, distribXid);
-	if (itemsScanned != 2)
+	itemsScanned = sscanf(gid, UINT64_FORMAT, distribXid);
+	if (itemsScanned != 1)
 	{
 		/*
 		 * Returning without an error here allows tests inheritied from
@@ -47,17 +46,17 @@ dtxCrackOpenGid(
 		 * allow non-Greenplum GIDs only in utility mode.
 		 */
 		if (Gp_role == GP_ROLE_UTILITY)
-			*distribTimeStamp = *distribXid = 0;
+			*distribXid = 0;
 		else
 			elog(ERROR, "Bad distributed transaction identifier \"%s\"", gid);
 	}
 }
 
 void
-dtxFormGID(char *gid, DistributedTransactionTimeStamp tstamp, DistributedTransactionId gxid)
+dtxFormGid(char *gid, DistributedTransactionId gxid)
 {
-	sprintf(gid, "%u-%.10u", tstamp, gxid);
-	/* gxid is unsigned int32 and its max string length is 10 */
+	sprintf(gid, UINT64_FORMAT, gxid);
+	/* gxid is unsigned int64 */
 	Assert(strlen(gid) < TMGIDSIZE);
 }
 

--- a/src/backend/cdb/test/cdbdistributedsnapshot_test.c
+++ b/src/backend/cdb/test/cdbdistributedsnapshot_test.c
@@ -14,7 +14,6 @@ static void
 test__DistributedSnapshotWithLocalMapping_CommittedTest(void **state)
 {
 	DistributedSnapshotCommitted retval;
-	DistributedTransactionTimeStamp timeStamp = time(NULL);
 	DistributedSnapshotWithLocalMapping dslm;
 	DistributedSnapshot *ds = &dslm.ds;
 
@@ -30,7 +29,6 @@ test__DistributedSnapshotWithLocalMapping_CommittedTest(void **state)
 		ds->inProgressXidArray =
 			(DistributedTransactionId*)malloc(SIZE_OF_IN_PROGRESS_ARRAY);
 		ds->distribSnapshotId = 12345;
-		ds->distribTransactionTimeStamp = timeStamp;
 	}
 
 	/*
@@ -38,29 +36,20 @@ test__DistributedSnapshotWithLocalMapping_CommittedTest(void **state)
 	 * the testing keep it extremely simple distribXid == 10 * localXid.
 	 */
 	{
-		expect_any_count(DistributedLog_CommittedCheck, distribTimeStamp, -1);
 		expect_any_count(DistributedLog_CommittedCheck, distribXid, -1);
 		will_return_count(DistributedLog_CommittedCheck, true, -1);
 
 		expect_value(DistributedLog_CommittedCheck, localXid, 10);
 		will_assign_value(DistributedLog_CommittedCheck, distribXid, 10 * 10);
-		will_assign_value(DistributedLog_CommittedCheck,
-						  distribTimeStamp, timeStamp);
 
 		expect_value(DistributedLog_CommittedCheck, localXid, 20);
 		will_assign_value(DistributedLog_CommittedCheck, distribXid, 10 * 20);
-		will_assign_value(DistributedLog_CommittedCheck,
-						  distribTimeStamp, timeStamp);
 
 		expect_value(DistributedLog_CommittedCheck, localXid, 5);
 		will_assign_value(DistributedLog_CommittedCheck, distribXid, 10 * 5);
-		will_assign_value(DistributedLog_CommittedCheck,
-						  distribTimeStamp, timeStamp);
 
 		expect_value(DistributedLog_CommittedCheck, localXid, 15);
 		will_assign_value(DistributedLog_CommittedCheck, distribXid, 10 * 15);
-		will_assign_value(DistributedLog_CommittedCheck,
-						  distribTimeStamp, timeStamp);
 	}
 
 	/* Empty in-progress array test */

--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -21,6 +21,7 @@
 #include "storage/spin.h"
 #include "executor/instrument.h"
 #include "utils/memutils.h"
+#include "utils/timestamp.h"
 #include "miscadmin.h"
 #include "storage/shmem.h"
 #include "cdb/cdbdtxcontextinfo.h"
@@ -500,10 +501,5 @@ instrShmemRecycleCallback(ResourceReleasePhase phase, bool isCommit, bool isTopL
 
 static void gp_gettmid(int32* tmid)
 {
-	if (QEDtxContextInfo.distributedSnapshot.distribTransactionTimeStamp > 0)
-		/* On QE */
-		*tmid = (int32)QEDtxContextInfo.distributedSnapshot.distribTransactionTimeStamp;
-	else
-		/* On QD */
-		*tmid = (int32)getDtmStartTime();
+	*tmid = (int32) PgStartTime;
 }

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -734,7 +734,7 @@ ExecDelete(ModifyTableState *mtstate,
 		   bool *tupleDeleted,
 		   TupleTableSlot **epqreturnslot)
 {
-	PlanGenerator planGen = estate->es_plannedstmt->planGen;
+	/* PlanGenerator planGen = estate->es_plannedstmt->planGen; */
 	ResultRelInfo *resultRelInfo;
 	Relation	resultRelationDesc;
 	TM_Result	result;

--- a/src/backend/replication/logical/decode.c
+++ b/src/backend/replication/logical/decode.c
@@ -202,6 +202,7 @@ DecodeXLogOp(LogicalDecodingContext *ctx, XLogRecordBuffer *buf)
 			break;
 		case XLOG_NOOP:
 		case XLOG_NEXTOID:
+		case XLOG_NEXTGXID:
 		case XLOG_SWITCH:
 		case XLOG_BACKUP_END:
 		case XLOG_PARAMETER_CHANGE:

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -378,13 +378,14 @@ ProcArrayRemove(PGPROC *proc, TransactionId latestXid)
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
 		/*
-		 * Remeber that the distributed xid is just a plain counter, so we just use the `<` for
+		 * Remember that the distributed xid is just a plain counter, so we just use the `<` for
 		 * the comparison of gxid
 		 */
 		DistributedTransactionId gxid = allTmGxact[proc->pgprocno].gxid;
+
 		if (InvalidDistributedTransactionId != gxid &&
-			ShmemVariableCache->latestCompletedDxid < gxid)
-			ShmemVariableCache->latestCompletedDxid = gxid;
+			ShmemVariableCache->latestCompletedGxid < gxid)
+			ShmemVariableCache->latestCompletedGxid = gxid;
 	}
 
 	for (index = 0; index < arrayP->numProcs; index++)
@@ -409,25 +410,24 @@ ProcArrayRemove(PGPROC *proc, TransactionId latestXid)
 
 
 void
-ProcArrayEndGxact(TMGXACT *gxact)
+ProcArrayEndGxact(TMGXACT *tmGxact)
 {
-	DistributedTransactionId gxid = gxact->gxid;
+	DistributedTransactionId gxid = tmGxact->gxid;
 
 	AssertImply(Gp_role == GP_ROLE_DISPATCH && gxid != InvalidDistributedTransactionId,
 				LWLockHeldByMe(ProcArrayLock));
-	gxact->gxid = InvalidDistributedTransactionId;
-	gxact->distribTimeStamp = 0;
-	gxact->xminDistributedSnapshot = InvalidDistributedTransactionId;
-	gxact->includeInCkpt = false;
-	gxact->sessionId = 0;
+	tmGxact->gxid = InvalidDistributedTransactionId;
+	tmGxact->xminDistributedSnapshot = InvalidDistributedTransactionId;
+	tmGxact->includeInCkpt = false;
+	tmGxact->sessionId = 0;
 
 	/*
 	 * Remeber that the distributed xid is just a plain counter, so we just use the `<` for
 	 * the comparison of gxid
 	 */
 	if (InvalidDistributedTransactionId != gxid &&
-		ShmemVariableCache->latestCompletedDxid < gxid)
-		ShmemVariableCache->latestCompletedDxid = gxid;
+		ShmemVariableCache->latestCompletedGxid < gxid)
+		ShmemVariableCache->latestCompletedGxid = gxid;
 }
 
 /*
@@ -453,7 +453,7 @@ void
 ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid)
 {
 	PGXACT	   *pgxact = &allPgXact[proc->pgprocno];
-	TMGXACT	   *gxact = &allTmGxact[proc->pgprocno];
+	TMGXACT	   *tmGxact = &allTmGxact[proc->pgprocno];
 
 #ifdef FAULT_INJECTOR
 	FaultInjector_InjectFaultIfSet("before_xact_end_procarray",
@@ -461,7 +461,7 @@ ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid)
 			MyProcPort ? MyProcPort->database_name : "",  // databaseName
 			""); // tableName
 #endif
-	if (TransactionIdIsValid(latestXid) || TransactionIdIsValid(gxact->gxid))
+	if (TransactionIdIsValid(latestXid) || TransactionIdIsValid(tmGxact->gxid))
 	{
 		/*
 		 * We must lock ProcArrayLock while clearing our advertised XID, so
@@ -470,7 +470,7 @@ ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid)
 		 * src/backend/access/transam/README.
 		 */
 		Assert(TransactionIdIsValid(allPgXact[proc->pgprocno].xid) ||
-			   TransactionIdIsValid(gxact->gxid) ||
+			   TransactionIdIsValid(tmGxact->gxid) ||
 			   (IsBootstrapProcessingMode() && latestXid == BootstrapTransactionId));
 
 		/*
@@ -483,8 +483,8 @@ ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid)
 			if (TransactionIdIsValid(latestXid))
 				ProcArrayEndTransactionInternal(proc, pgxact, latestXid);
 
-			if (TransactionIdIsValid(gxact->gxid))
-				ProcArrayEndGxact(gxact);
+			if (TransactionIdIsValid(tmGxact->gxid))
+				ProcArrayEndGxact(tmGxact);
 
 			LWLockRelease(ProcArrayLock);
 		}
@@ -497,7 +497,7 @@ ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid)
 	 * anyone else's calculation of a snapshot.  We might change their
 	 * estimate of global xmin, but that's OK.
 	 *
-	 * NB: this may reset the pgxact and gxact twice (not including the xid
+	 * NB: this may reset the pgxact and tmGxact twice (not including the xid
 	 * and gxid), it should be no harm to the correctness, just an easy way to
 	 * handle the cases like: there's a valid distributed XID but no local XID.
 	 */
@@ -514,7 +514,7 @@ ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid)
 	Assert(pgxact->nxids == 0);
 	Assert(pgxact->overflowed == false);
 
-	resetGxact();
+	resetTmGxact();
 }
 
 /*
@@ -630,13 +630,13 @@ ProcArrayGroupClearXid(PGPROC *proc, TransactionId latestXid)
 	{
 		PGPROC	   *proc = &allProcs[nextidx];
 		PGXACT	   *pgxact = &allPgXact[nextidx];
-		TMGXACT	   *gxact = &allTmGxact[nextidx];
+		TMGXACT	   *tmGxact = &allTmGxact[nextidx];
 
 		if (TransactionIdIsValid(proc->procArrayGroupMemberXid))
 			ProcArrayEndTransactionInternal(proc, pgxact, proc->procArrayGroupMemberXid);
 
-		if (TransactionIdIsValid(gxact->gxid))
-			ProcArrayEndGxact(gxact);
+		if (TransactionIdIsValid(tmGxact->gxid))
+			ProcArrayEndGxact(tmGxact);
 
 		/* Move to next proc in list. */
 		nextidx = pg_atomic_read_u32(&proc->procArrayGroupNext);
@@ -674,7 +674,7 @@ ProcArrayGroupClearXid(PGPROC *proc, TransactionId latestXid)
  *
  * This is used after successfully preparing a 2-phase transaction.  We are
  * not actually reporting the transaction's XID as no longer running --- it
- * will still appear as running because the 2PC's gxact is in the ProcArray
+ * will still appear as running because the 2PC's tmGxact is in the ProcArray
  * too.  We just have to clear out our own PGXACT.
  */
 void
@@ -685,7 +685,7 @@ ProcArrayClearTransaction(PGPROC *proc)
 	/*
 	 * We can skip locking ProcArrayLock here, because this action does not
 	 * actually change anyone's view of the set of running XIDs: our entry is
-	 * duplicate with the gxact that has already been inserted into the
+	 * duplicate with the tmGxact that has already been inserted into the
 	 * ProcArray.
 	 */
 	pgxact->xid = InvalidTransactionId;
@@ -1615,7 +1615,9 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 	SharedLocalSnapshotSlot->ready = true;
 
 	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-			(errmsg("updateSharedLocalSnapshot for DistributedTransactionContext = '%s' setting shared local snapshot xid = " UINT64_FORMAT " (xmin: %u xmax: %u xcnt: %u) curcid: %d, distributedXid = %u",
+			(errmsg("updateSharedLocalSnapshot for DistributedTransactionContext = '%s' "
+					"setting shared local snapshot xid = " UINT64_FORMAT " "
+					"(xmin: %d xmax: %d xcnt: %u) curcid: %d, distributedXid = "UINT64_FORMAT,
 					DtxContextToString(distributedTransactionContext),
 					U64FromFullTransactionId(SharedLocalSnapshotSlot->fullXid),
 					SharedLocalSnapshotSlot->snapshot.xmin,
@@ -1625,7 +1627,7 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 					SharedLocalSnapshotSlot->distributedXid)));
 
 	ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-			(errmsg("[Distributed Snapshot #%u] *Writer Set Shared* gxid %u, (gxid = %u, slot #%d, '%s', '%s')",
+			(errmsg("[Distributed Snapshot #%u] *Writer Set Shared* gxid "UINT64_FORMAT", (gxid = "UINT64_FORMAT", slot #%d, '%s', '%s')",
 					QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
 					SharedLocalSnapshotSlot->distributedXid,
 					getDistributedTransactionId(),
@@ -1712,7 +1714,7 @@ readerFillLocalSnapshot(Snapshot snapshot, DtxContext distributedTransactionCont
 	}
 
 	ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-			(errmsg("[Distributed Snapshot #%u] *Start Reader Match* gxid = %u and currcid %d (%s)",
+			(errmsg("[Distributed Snapshot #%u] *Start Reader Match* gxid = "UINT64_FORMAT" and currcid %d (%s)",
 					QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
 					QEDtxContextInfo.distributedXid,
 					QEDtxContextInfo.curcid,
@@ -1745,7 +1747,7 @@ readerFillLocalSnapshot(Snapshot snapshot, DtxContext distributedTransactionCont
 		{
 			if (QEDtxContextInfo.distributedXid != SharedLocalSnapshotSlot->distributedXid)
 				elog(ERROR, "transaction ID doesn't match between the reader gang "
-							"and the writer gang, expect %d but having %d",
+							"and the writer gang, expect "UINT64_FORMAT" but having "UINT64_FORMAT,
 							QEDtxContextInfo.distributedXid, SharedLocalSnapshotSlot->distributedXid);
 			copyLocalSnapshot(snapshot);
 			SetSharedTransactionId_reader(SharedLocalSnapshotSlot->fullXid, snapshot->curcid, distributedTransactionContext);
@@ -1760,8 +1762,8 @@ readerFillLocalSnapshot(Snapshot snapshot, DtxContext distributedTransactionCont
 			ereport(ERROR,
 					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 					 errmsg("GetSnapshotData timed out waiting for Writer to set the shared snapshot."),
-					 errdetail("We are waiting for the shared snapshot to have XID: %d but the value "
-							   "is currently: %d."
+					 errdetail("We are waiting for the shared snapshot to have XID: "UINT64_FORMAT" but the value "
+							   "is currently: "UINT64_FORMAT"."
 							   " waiting for syncount to be %d but is currently %d.  ready=%d."
 							   "DistributedTransactionContext = %s. "
 							   " Our slotindex is: %d \n"
@@ -1779,7 +1781,7 @@ readerFillLocalSnapshot(Snapshot snapshot, DtxContext distributedTransactionCont
 			 * Every second issue warning.
 			 */
 			ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-					(errmsg("[Distributed Snapshot #%u] *No Match* gxid %u = %u and segmateSync %d = %d (%s)",
+					(errmsg("[Distributed Snapshot #%u] *No Match* gxid "UINT64_FORMAT" = "UINT64_FORMAT" and segmateSync %d = %d (%s)",
 							QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
 							QEDtxContextInfo.distributedXid,
 							SharedLocalSnapshotSlot->distributedXid,
@@ -1789,8 +1791,8 @@ readerFillLocalSnapshot(Snapshot snapshot, DtxContext distributedTransactionCont
 
 			ereport(LOG,
 					(errmsg("GetSnapshotData did not find shared local snapshot information. "
-							"We are waiting for the shared snapshot to have XID: %d/%u but the value "
-							"is currently: %d/%u, ready=%d."
+							"We are waiting for the shared snapshot to have XID: "UINT64_FORMAT"/%u but the value "
+							"is currently: "UINT64_FORMAT"/%u, ready=%d."
 							" Our slotindex is: %d \n"
 							"DistributedTransactionContext = %s.",
 							QEDtxContextInfo.distributedXid, QEDtxContextInfo.segmateSync,
@@ -1841,16 +1843,15 @@ getAllDistributedXactStatus(TMGALLXACTSTATUS **allDistributedXactStatus)
 		{
 			/*
 			 * This function is only used by view gp_distributed_xacts. We do
-			 * not need to return a strictly correct gxact array. So no
-			 * 'volatile' is used for 'gxact'.
+			 * not need to return a strictly correct tmGxact array. So no
+			 * 'volatile' is used for 'tmGxact'.
 			 */
-			TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[i]];
+			TMGXACT *tmGxact = &allTmGxact[arrayP->pgprocnos[i]];
 
-			all->statusArray[i].gxid = gxact->gxid;
-			dtxFormGID(all->statusArray[i].gid, gxact->distribTimeStamp, gxact->gxid);
+			all->statusArray[i].gxid = tmGxact->gxid;
 			all->statusArray[i].state = 0; /* deprecate this field */
-			all->statusArray[i].sessionId = gxact->sessionId;
-			all->statusArray[i].xminDistributedSnapshot = gxact->xminDistributedSnapshot;
+			all->statusArray[i].sessionId = tmGxact->sessionId;
+			all->statusArray[i].xminDistributedSnapshot = tmGxact->xminDistributedSnapshot;
 		}
 
 		all->count = count;
@@ -1877,7 +1878,7 @@ void
 getDtxCheckPointInfo(char **result, int *result_size)
 {
 	TMGXACT_CHECKPOINT *gxact_checkpoint;
-	TMGXACT_LOG *gxact_log_array;
+	DistributedTransactionId *gxid_array;
 	int			i;
 	int			actual;
 	ProcArrayStruct *arrayP = procArray;
@@ -1892,11 +1893,11 @@ getDtxCheckPointInfo(char **result, int *result_size)
 	}
 
 	gxact_checkpoint = palloc(TMGXACT_CHECKPOINT_BYTES(arrayP->numProcs + *shmNumCommittedGxacts));
-	gxact_log_array = &gxact_checkpoint->committedGxactArray[0];
+	gxid_array = &gxact_checkpoint->committedGxidArray[0];
 
 	actual = 0;
 	for (; actual < *shmNumCommittedGxacts; actual++)
-		gxact_log_array[actual] = shmCommittedGxactArray[actual];
+		gxid_array[actual] = shmCommittedGxidArray[actual];
 
 	SIMPLE_FAULT_INJECTOR("checkpoint_dtx_info");
 
@@ -1917,18 +1918,15 @@ getDtxCheckPointInfo(char **result, int *result_size)
 
 	for (i = 0; i < arrayP->numProcs; i++)
 	{
-		TMGXACT_LOG *gxact_log;
-		TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[i]];
+		TMGXACT *tmGxact = &allTmGxact[arrayP->pgprocnos[i]];
 
-		if (!gxact->includeInCkpt)
+		if (!tmGxact->includeInCkpt)
 			continue;
 
-		gxact_log = &gxact_log_array[actual];
-		dtxFormGID(gxact_log->gid, gxact->distribTimeStamp, gxact->gxid);
-		gxact_log->gxid = gxact->gxid;
+		gxid_array[actual] = tmGxact->gxid;
 
 		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "Add DTM checkpoint entry gid = %s.", gxact_log->gid);
+			 "Add DTM checkpoint entry gid = "UINT64_FORMAT".", tmGxact->gxid);
 
 		actual++;
 	}
@@ -1980,7 +1978,7 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 	if (*shmNumCommittedGxacts != 0)
 		elog(ERROR, "Create distributed snapshot before DTM recovery finish");
 
-	xmin = xmax = ShmemVariableCache->latestCompletedDxid + 1;
+	xmin = xmax = ShmemVariableCache->latestCompletedGxid + 1;
 
 	/*
 	 * initialize for calculation with xmax, the calculation for this is on
@@ -2031,7 +2029,7 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 		ds->inProgressXidArray[count++] = gxid;
 
 		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "CreateDistributedSnapshot added inProgressDistributedXid = %u to snapshot",
+			 "CreateDistributedSnapshot added inProgressDistributedXid = "UINT64_FORMAT" to snapshot",
 			 gxid);
 	}
 
@@ -2049,7 +2047,6 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 	 * Copy the information we just captured under lock and then sorted into
 	 * the distributed snapshot.
 	 */
-	ds->distribTransactionTimeStamp = getDtmStartTime();
 	ds->xminAllDistributedSnapshots = globalXminDistributedSnapshots;
 	ds->distribSnapshotId = distribSnapshotId;
 	ds->xmin = xmin;
@@ -2060,10 +2057,10 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 		MyTmGxact->xminDistributedSnapshot = xmin;
 
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "CreateDistributedSnapshot distributed snapshot has xmin = %u, count = %u, xmax = %u.",
+		 "CreateDistributedSnapshot distributed snapshot has xmin = "UINT64_FORMAT", count = %u, xmax = "UINT64_FORMAT".",
 		 xmin, count, xmax);
 	elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-		 "[Distributed Snapshot #%u] *Create* (gxid = %u')",
+		 "[Distributed Snapshot #%u] *Create* (gxid = "UINT64_FORMAT"')",
 		 distribSnapshotId,
 		 MyTmGxact->gxid);
 
@@ -2461,7 +2458,6 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	{
 		if (snapshot->haveDistribSnapshot)
 			globalxmin = DistributedLog_AdvanceOldestXmin(globalxmin,
-														  ds->distribTransactionTimeStamp,
 														  ds->xminAllDistributedSnapshots);
 		else if (!gp_maintenance_mode)
 			globalxmin = DistributedLog_GetOldestXmin(globalxmin);
@@ -3154,7 +3150,7 @@ UpdateSerializableCommandId(CommandId curcid)
 		if (SharedLocalSnapshotSlot->distributedXid != QEDtxContextInfo.distributedXid)
 		{
 			ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-					(errmsg("[Distributed Snapshot #%u] *Can't Update Serializable Command Id* QDxid = %u (gxid = %u, '%s')",
+					(errmsg("[Distributed Snapshot #%u] *Can't Update Serializable Command Id* QDxid = "UINT64_FORMAT" (gxid = "UINT64_FORMAT", '%s')",
 							QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
 							SharedLocalSnapshotSlot->distributedXid,
 							getDistributedTransactionId(),
@@ -3164,7 +3160,9 @@ UpdateSerializableCommandId(CommandId curcid)
 		}
 
 		ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-				(errmsg("[Distributed Snapshot #%u] *Update Serializable Command Id* segment currcid = %d, TransactionSnapshot currcid = %d, Shared currcid = %d (gxid = %u, '%s')",
+				(errmsg("[Distributed Snapshot #%u] *Update Serializable Command "
+						"Id* segment currcid = %d, TransactionSnapshot currcid "
+						"= %d, Shared currcid = %d (gxid = "UINT64_FORMAT", '%s')",
 						QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
 						QEDtxContextInfo.curcid,
 						curcid,
@@ -4871,9 +4869,9 @@ ListAllGxid(void)
 
 	for (index = 0; index < arrayP->numProcs; index++)
 	{
-		volatile TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[index]];
+		volatile TMGXACT *tmGxact = &allTmGxact[arrayP->pgprocnos[index]];
 
-		gxid = gxact->gxid;
+		gxid = tmGxact->gxid;
 		if (gxid == InvalidDistributedTransactionId)
 			continue;
 		gxids = lappend_int(gxids, gxid);
@@ -4888,23 +4886,20 @@ ListAllGxid(void)
  * This function returns true if the gid is an ongoing dtx transaction.
  */
 bool
-IsDtxInProgress(DistributedTransactionTimeStamp distribTimeStamp, DistributedTransactionId gxid)
+IsDtxInProgress(DistributedTransactionId gxid)
 {
 	int i;
 	bool retval;
 	ProcArrayStruct *arrayP = procArray;
-
-	if (*shmDistribTimeStamp != distribTimeStamp)
-		return false;
 
 	retval = false;
 	LWLockAcquire(ProcArrayLock, LW_SHARED);
 
 	for (i = 0; i < arrayP->numProcs; i++)
 	{
-		volatile TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[i]];
+		volatile TMGXACT *tmGxact = &allTmGxact[arrayP->pgprocnos[i]];
 
-		if (gxact->gxid == gxid)
+		if (tmGxact->gxid == gxid)
 		{
 			retval = true;
 			break;
@@ -4932,8 +4927,8 @@ GetPidByGxid(DistributedTransactionId gxid)
 	for (i = 0; i < arrayP->numProcs; i++)
 	{
 		volatile PGPROC *proc = &allProcs[arrayP->pgprocnos[i]];
-		volatile TMGXACT *gxact = &allTmGxact[arrayP->pgprocnos[i]];
-		if (gxact->gxid == gxid)
+		volatile TMGXACT *tmGxact = &allTmGxact[arrayP->pgprocnos[i]];
+		if (tmGxact->gxid == gxid)
 		{
 			pid = proc->pid;
 			break;
@@ -4949,7 +4944,6 @@ DistributedTransactionId
 LocalXidGetDistributedXid(TransactionId xid)
 {
 	int index;
-	DistributedTransactionTimeStamp tstamp;
 	DistributedTransactionId gxid = InvalidDistributedTransactionId;
 	ProcArrayStruct *arrayP = procArray;
 
@@ -4959,10 +4953,10 @@ LocalXidGetDistributedXid(TransactionId xid)
 	{
 		int		 pgprocno = arrayP->pgprocnos[index];
 		volatile PGXACT *pgxact = &allPgXact[pgprocno];
-		volatile TMGXACT *gxact = &allTmGxact[pgprocno];
+		volatile TMGXACT *tmGxact = &allTmGxact[pgprocno];
 		if (xid == pgxact->xid)
 		{
-			gxid = gxact->gxid;
+			gxid = tmGxact->gxid;
 			break;
 		}
 	}
@@ -4971,9 +4965,7 @@ LocalXidGetDistributedXid(TransactionId xid)
 	/* The transaction has already committed on segment */
 	if (gxid == InvalidDistributedTransactionId)
 	{
-		DistributedLog_GetDistributedXid(xid, &tstamp, &gxid);
-		AssertImply(gxid != InvalidDistributedTransactionId,
-					tstamp == MyTmGxact->distribTimeStamp);
+		DistributedLog_GetDistributedXid(xid, &gxid);
 	}
 
 	return gxid;

--- a/src/backend/storage/ipc/test/procarray_test.c
+++ b/src/backend/storage/ipc/test/procarray_test.c
@@ -10,7 +10,6 @@
 #define MAX_PROCS 100
 VariableCacheData vcdata;
 uint32 nextSnapshotId;
-DistributedTransactionTimeStamp distribTimeStamp;
 int num_committed_xacts;
 
 static void
@@ -18,11 +17,9 @@ setup(void)
 {
 	ShmemVariableCache = &vcdata;
 	shmNextSnapshotId = &nextSnapshotId;
-	shmDistribTimeStamp = &distribTimeStamp;
 	shmNumCommittedGxacts = &num_committed_xacts;
 
 	/* Some imaginary LWLockId number */
-	*shmDistribTimeStamp = time(NULL);
 	*shmNumCommittedGxacts = 0;
 
 	allTmGxact = malloc(sizeof(TMGXACT)*MAX_PROCS);
@@ -51,9 +48,8 @@ test__CreateDistributedSnapshot(void **state)
 	expect_value_count(LWLockHeldByMe, l, ProcArrayLock, -1);
 	will_return_count(LWLockHeldByMe, true, -1);
 #endif
-	will_return_count(getDtmStartTime, 0, -1);
 
-	ShmemVariableCache->latestCompletedDxid = 24;
+	ShmemVariableCache->latestCompletedGxid = 24;
 
 	/* This is going to act as our gxact */
 	allTmGxact[procArray->pgprocnos[0]].gxid = 20;

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -3925,7 +3925,7 @@ GetLockStatusData(void)
 	for (i = 0; i < ProcGlobal->allProcCount; ++i)
 	{
 		PGPROC	   *proc = &ProcGlobal->allProcs[i];
-		TMGXACT	   *gxact = &ProcGlobal->allTmGxact[i];
+		TMGXACT	   *tmGxact = &ProcGlobal->allTmGxact[i];
 		uint32		f;
 
 		LWLockAcquire(&proc->backendLock, LW_SHARED);
@@ -3961,7 +3961,7 @@ GetLockStatusData(void)
 			instance->mppSessionId = proc->mppSessionId;
 			instance->mppIsWriter = proc->mppIsWriter;
 			instance->distribXid = (Gp_role == GP_ROLE_DISPATCH)?
-								   gxact->gxid :
+								   tmGxact->gxid :
 								   proc->localDistribXactData.distribXid;
 			instance->holdTillEndXact = (holdTillEndXactBits > 0);
 			el++;
@@ -3995,7 +3995,7 @@ GetLockStatusData(void)
 			instance->mppSessionId = proc->mppSessionId;
 			instance->mppIsWriter = proc->mppIsWriter;
 			instance->distribXid = (Gp_role == GP_ROLE_DISPATCH)?
-								   gxact->gxid :
+								   tmGxact->gxid :
 								   proc->localDistribXactData.distribXid;
 			instance->holdTillEndXact = false;
 			el++;
@@ -4037,7 +4037,7 @@ GetLockStatusData(void)
 		PGPROC	   *proc = proclock->tag.myProc;
 		LOCK	   *lock = proclock->tag.myLock;
 		LockInstanceData *instance = &data->locks[el];
-		TMGXACT	   *gxact = &ProcGlobal->allTmGxact[proc->pgprocno];
+		TMGXACT	   *tmGxact = &ProcGlobal->allTmGxact[proc->pgprocno];
 
 		memcpy(&instance->locktag, &lock->tag, sizeof(LOCKTAG));
 		instance->holdMask = proclock->holdMask;
@@ -4054,7 +4054,7 @@ GetLockStatusData(void)
 		instance->mppSessionId = proc->mppSessionId;
 		instance->mppIsWriter = proc->mppIsWriter;
 		instance->distribXid = (Gp_role == GP_ROLE_DISPATCH)?
-							   gxact->gxid :
+							   tmGxact->gxid :
 							   proc->localDistribXactData.distribXid;
 		instance->holdTillEndXact = proclock->tag.myLock->holdTillEndXact;
 		el++;

--- a/src/backend/storage/lmgr/lwlocknames.txt
+++ b/src/backend/storage/lmgr/lwlocknames.txt
@@ -64,3 +64,4 @@ DistributedLogTruncateLock			54
 TwophaseCommitLock				55
 ShareInputScanLock				56
 FTSReplicationStatusLock			57
+GxidBumpLock						58

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -579,7 +579,7 @@ InitProcess(void)
 
 	/* Init gxact */
 	MyTmGxact->gxid = InvalidDistributedTransactionId;
-	resetGxact();
+	resetTmGxact();
 
 	/*
 	 * Arrange to clean up at backend exit.

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5321,6 +5321,18 @@ PostgresMain(int argc, char *argv[],
 					if (TempDtxContextInfo.distributedXid != InvalidDistributedTransactionId &&
 						!IS_QUERY_DISPATCHER()) /* On segments only */
 					{
+						/*
+						 * In theory we do not need to track nextGxid on
+						 * segments since we generate gxid on the coordinator,
+						 * but we still do this due to:
+						 * 1. For possible debuggging purpose.
+						 * 2. pg_resetwal on the coordinator needs this value
+						 *    on all the segments for nextGxid guessing.
+						 *    Normally we do not need to use pg_resetwal since
+						 *    there is coordinator failover but pg_resetwal
+						 *    is still possibly useful in some scenarios.
+						 * 3. The related code change on segments are lightweight.
+						 */
 						SpinLockAcquire(shmGxidGenLock);
 						if (TempDtxContextInfo.distributedXid > ShmemVariableCache->nextGxid)
 							ShmemVariableCache->nextGxid = TempDtxContextInfo.distributedXid;

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3124,7 +3124,7 @@ log_line_prefix(StringInfo buf, ErrorData *edata)
 					if (localXid != InvalidTransactionId)
 					{
 						if (distribXid >= FirstDistributedTransactionId)
-							appendStringInfo(buf, "dx%u, ", distribXid);
+							appendStringInfo(buf, "dx"UINT64_FORMAT", ", distribXid);
 
 						appendStringInfo(buf, "x%u", localXid);
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3042,6 +3042,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		NULL, NULL, NULL
 	},
 	{
+		{"gp_gxid_prefetch_num", PGC_POSTMASTER, WAL,
+			gettext_noop("how many gxid is prefetched in each bumping batch."),
+			NULL,
+			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
+		},
+		&gp_gxid_prefetch_num,
+		8192, 512, INT_MAX,
+		NULL, NULL, NULL
+	},
+	{
 		{"gp_dbid", PGC_POSTMASTER, PRESET_OPTIONS,
 			gettext_noop("The dbid used by this server."),
 			NULL,

--- a/src/backend/utils/misc/ps_status.c
+++ b/src/backend/utils/misc/ps_status.c
@@ -369,7 +369,8 @@ set_ps_display(const char *activity, bool force)
 
 	/* Add client session's global id. */
 	if (gp_session_id > 0 && ep - cp > 0 &&
-		strstr(ps_buffer, "bgworker") == NULL) /* ugly hack for fts, dtx recovery */
+		strstr(ps_buffer, "dtx recovery process") == NULL &&
+		strstr(ps_buffer, "ftsprobe process") == NULL)
 	{
 		cp += snprintf(cp, ep - cp, "con%d ", gp_session_id);
 

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -342,7 +342,7 @@ SharedSnapshotDump(void)
 
 		if (testSlot->slotid != -1)
 		{
-			appendStringInfo(&str, "(SLOT index: %d slotid: %d QDxid: %u pid: %u)",
+			appendStringInfo(&str, "(SLOT index: %d slotid: %d QDxid: "UINT64_FORMAT" pid: %u)",
 							 testSlot->slotindex, testSlot->slotid, testSlot->distributedXid,
 							 testSlot->writer_proc ? testSlot->writer_proc->pid : 0);
 		}
@@ -798,8 +798,8 @@ LogDistributedSnapshotInfo(Snapshot snapshot, const char *prefix)
 	DistributedSnapshot *ds = &mapping->ds;
 
 	appendStringInfo(&buf, "%s Distributed snapshot info: "
-			 "xminAllDistributedSnapshots=%d, distribSnapshotId=%d"
-			 ", xmin=%d, xmax=%d, count=%d",
+			 "xminAllDistributedSnapshots="UINT64_FORMAT", distribSnapshotId=%d"
+			 ", xmin="UINT64_FORMAT", xmax="UINT64_FORMAT", count=%d",
 			 prefix,
 			 ds->xminAllDistributedSnapshots,
 			 ds->distribSnapshotId,
@@ -813,12 +813,12 @@ LogDistributedSnapshotInfo(Snapshot snapshot, const char *prefix)
 	{
 		if (no != 0)
 		{
-			appendStringInfo(&buf, ", (dx%d)",
+			appendStringInfo(&buf, ", (dx"UINT64_FORMAT")",
 					 ds->inProgressXidArray[no]);
 		}
 		else
 		{
-			appendStringInfo(&buf, " (dx%d)",
+			appendStringInfo(&buf, " (dx"UINT64_FORMAT")",
 					 ds->inProgressXidArray[no]);
 		}
 	}

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -368,7 +368,7 @@ GetTransactionSnapshot(void)
 	if (IsolationUsesXactSnapshot())
 	{
 		elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-			 "[Distributed Snapshot #%u] *Serializable* (gxid = %u, '%s')",
+			 "[Distributed Snapshot #%u] *Serializable* (gxid = "UINT64_FORMAT", '%s')",
 			 CurrentSnapshot->distribSnapshotWithLocalMapping.ds.distribSnapshotId,
 			 getDistributedTransactionId(),
 			 DtxContextToString(DistributedTransactionContext));
@@ -388,7 +388,7 @@ GetTransactionSnapshot(void)
 	CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData, DistributedTransactionContext);
 
 	elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-		 "[Distributed Snapshot #%u] (gxid = %u, '%s')",
+		 "[Distributed Snapshot #%u] (gxid = "UINT64_FORMAT", '%s')",
 		 CurrentSnapshot->distribSnapshotWithLocalMapping.ds.distribSnapshotId,
 		 getDistributedTransactionId(),
 		 DtxContextToString(DistributedTransactionContext));

--- a/src/backend/utils/time/visibility_summary.c
+++ b/src/backend/utils/time/visibility_summary.c
@@ -223,7 +223,6 @@ static char *
 GetTupleVisibilityDistribId(TransactionId xid,
 							TupleTransactionStatus status)
 {
-	DistributedTransactionTimeStamp distribTimeStamp;
 	DistributedTransactionId distribXid;
 
 	switch (status)
@@ -239,14 +238,12 @@ GetTupleVisibilityDistribId(TransactionId xid,
 		case TupleTransactionStatus_HintCommitted:
 		case TupleTransactionStatus_CLogCommitted:
 			if ((!IS_QUERY_DISPATCHER()) &&
-				DistributedLog_CommittedCheck(xid,
-											  &distribTimeStamp,
-											  &distribXid))
+				DistributedLog_CommittedCheck(xid, &distribXid))
 			{
 				char	   *distribId;
 
 				distribId = palloc(TMGIDSIZE);
-				dtxFormGID(distribId, distribTimeStamp, distribXid);
+				dtxFormGid(distribId, distribXid);
 				return distribId;
 			}
 			else

--- a/src/bin/pg_controldata/pg_controldata.c
+++ b/src/bin/pg_controldata/pg_controldata.c
@@ -267,6 +267,8 @@ main(int argc, char *argv[])
 	printf(_("Latest checkpoint's NextXID:          %u:%u\n"),
 		   EpochFromFullTransactionId(ControlFile->checkPointCopy.nextFullXid),
 		   XidFromFullTransactionId(ControlFile->checkPointCopy.nextFullXid));
+	printf(_("Latest checkpoint's NextGxid:         "UINT64_FORMAT"\n"),
+		   ControlFile->checkPointCopy.nextGxid);
 	printf(_("Latest checkpoint's NextOID:          %u\n"),
 		   ControlFile->checkPointCopy.nextOid);
 	printf(_("Latest checkpoint's NextRelfilenode:  %u\n"),

--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -37,7 +37,6 @@
  */
 typedef struct DistributedLogEntry
 {
-	DistributedTransactionTimeStamp distribTimeStamp;
 	DistributedTransactionId distribXid;
 
 } DistributedLogEntry;
@@ -46,19 +45,15 @@ typedef struct DistributedLogEntry
 #define NUM_DISTRIBUTEDLOG_BUFFERS	8
 
 extern void DistributedLog_SetCommittedTree(TransactionId xid, int nxids, TransactionId *xids,
-								DistributedTransactionTimeStamp	distribTimeStamp,
 								DistributedTransactionId distribXid,
 								bool isRedo);
 extern bool DistributedLog_CommittedCheck(
 							  TransactionId localXid,
-							  DistributedTransactionTimeStamp *dtxStartTime,
 							  DistributedTransactionId *distribXid);
 extern bool DistributedLog_ScanForPrevCommitted(
 									TransactionId *indexXid,
-									DistributedTransactionTimeStamp *distribTimeStamp,
 									DistributedTransactionId *distribXid);
 extern TransactionId DistributedLog_AdvanceOldestXmin(TransactionId oldestInProgressLocalXid,
-								 DistributedTransactionTimeStamp distribTimeStamp,
 								 DistributedTransactionId oldestDistribXid);
 extern TransactionId DistributedLog_GetOldestXmin(TransactionId oldestLocalXmin);
 
@@ -84,7 +79,6 @@ extern void DistributedLog_desc(StringInfo buf, XLogReaderState *record);
 extern const char *DistributedLog_identify(uint8 info);
 extern void DistributedLog_GetDistributedXid(
 				TransactionId 						localXid,
-				DistributedTransactionTimeStamp		*distribTimeStamp,
 				DistributedTransactionId 			*distribXid);
 
 #endif							/* DISTRIBUTEDLOG_H */

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -152,8 +152,17 @@ typedef struct VariableCacheData
 	 */
 	TransactionId latestCompletedXid;	/* newest XID that has committed or
 										 * aborted */
-	TransactionId latestCompletedDxid;	/* newest distributed XID that has
+	TransactionId latestCompletedGxid;	/* newest distributed XID that has
 										   committed or aborted */
+
+	/*
+	 * The two variables are protected by shmGxidGenLock.  Note nextGxid won't
+	 * be accurate after crash recovery.  When crash recovery happens, we bump
+	 * them to the next batch on the coordinator, while on the primary, it is
+	 * not accurate until the next query with an assigned gxid is dispatched.
+	 */
+	DistributedTransactionId nextGxid;	/* next full XID to assign */
+	uint32		GxidCount;		/* Gxids available before must do XLOG work */
 
 	/*
 	 * These fields are protected by CLogTruncationLock

--- a/src/include/access/twophase_xlog.h
+++ b/src/include/access/twophase_xlog.h
@@ -14,10 +14,6 @@
 #ifndef TWOPHASE_XLOG_H
 #define TWOPHASE_XLOG_H
 
-/* GPDB-specific: GIDSIZE is defined in twophase.c in Postgres */
-
-#define GIDSIZE 200
-
 /* GPDB-specific: TwoPhaseFileHeader is defined in twophase.c in Postgres */
 /*
  * Header for a 2PC state file

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -236,8 +236,7 @@ typedef struct xl_xact_xinfo
 
 typedef struct xl_xact_distrib
 {
-	TimestampTz distrib_timestamp;
-	TransactionId distrib_xid;
+	DistributedTransactionId distrib_xid;
 } xl_xact_distrib;
 
 typedef struct xl_xact_dbinfo
@@ -354,7 +353,6 @@ typedef struct xl_xact_parsed_commit
 	XLogRecPtr	origin_lsn;
 	TimestampTz origin_timestamp;
 
-	DistributedTransactionTimeStamp distribTimeStamp;
 	DistributedTransactionId        distribXid;
 } xl_xact_parsed_commit;
 
@@ -390,7 +388,7 @@ typedef struct xl_xact_parsed_abort
  */
 typedef struct xl_xact_distributed_forget
 {
-	TMGXACT_LOG gxact_log;
+	DistributedTransactionId gxid;
 } xl_xact_distributed_forget;
 
 /* ----------------
@@ -475,7 +473,7 @@ extern void UnregisterXactCallbackOnce(XactCallback callback, void *arg);
 extern void RegisterSubXactCallback(SubXactCallback callback, void *arg);
 extern void UnregisterSubXactCallback(SubXactCallback callback, void *arg);
 
-extern void RecordDistributedForgetCommitted(struct TMGXACT_LOG *gxact_log);
+extern void RecordDistributedForgetCommitted(DistributedTransactionId gxid);
 
 extern int	xactGetCommittedChildren(TransactionId **ptr);
 

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -314,6 +314,7 @@ extern void CreateCheckPoint(int flags);
 extern bool CreateRestartPoint(int flags);
 extern void XLogPutNextOid(Oid nextOid);
 extern void XLogPutNextRelfilenode(Oid nextRelfilenode);
+extern void XLogPutNextGxid(DistributedTransactionId nextGxid);
 extern XLogRecPtr XLogRestorePoint(const char *rpName);
 extern void UpdateFullPageWrites(void);
 extern void GetFullPageWriteInfo(XLogRecPtr *RedoRecPtr_p, bool *doPageWrites_p);

--- a/src/include/c.h
+++ b/src/include/c.h
@@ -520,19 +520,18 @@ typedef TransactionId MultiXactId;
 
 typedef uint32 MultiXactOffset;
 
-typedef uint32 DistributedTransactionTimeStamp;
-
 typedef int32 DistributedSnapshotId;
 
-typedef uint32 DistributedTransactionId;
+typedef uint64 DistributedTransactionId;
 #define InvalidDistributedTransactionId	((DistributedTransactionId) 0)
 #define FirstDistributedTransactionId	((DistributedTransactionId) 1)
-#define LastDistributedTransactionId	((DistributedTransactionId) 0xffffffff)
+#define LastDistributedTransactionId	((DistributedTransactionId) 0xffffFFFFffffFFFF)
 
 /*
- * A 10 digit timestamp, a dash, a 10 digit distributed transaction id, and NUL.
+ * max(LastDistributedTransactionId) is 20-bytes, and then plus NULL.
+ * FIXME: Use hex later to save a bit memory.
  */
-#define TMGIDSIZE 22
+#define TMGIDSIZE 21
 
 typedef uint32 CommandId;
 

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302012031
+#define CATALOG_VERSION_NO	302012071
 
 #endif

--- a/src/include/catalog/pg_control.h
+++ b/src/include/catalog/pg_control.h
@@ -46,6 +46,7 @@ typedef struct CheckPoint
 								 * timeline (equals ThisTimeLineID otherwise) */
 	bool		fullPageWrites; /* current full_page_writes */
 	FullTransactionId nextFullXid;	/* next free full transaction ID */
+	DistributedTransactionId nextGxid;	/* next free gxid */
 	Oid			nextOid;		/* next free OID */
 	Oid			nextRelfilenode;	/* next free Relfilenode */
 	MultiXactId nextMulti;		/* next free MultiXactId */
@@ -85,6 +86,7 @@ typedef struct CheckPoint
 #define XLOG_FPI_FOR_HINT				0xA0
 #define XLOG_FPI						0xB0
 #define XLOG_NEXTRELFILENODE			0xC0
+#define XLOG_NEXTGXID					0xD0
 
 
 /*

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -10977,7 +10977,7 @@
    proname => 'gp_execution_dbid', proisstrict => 'f', provolatile => 'v', proparallel => 'u', prorettype => 'int4', proargtypes => '', prosrc => 'gp_execution_dbid' },
 
 { oid => 7000, descr => 'Get the next available distributed transaction id',
-   proname => 'gp_get_next_gxid', provolatile => 'v', prorettype => 'int8', proargtypes => '', prosrc => 'gp_get_next_gxid' },
+   proname => 'gp_get_next_gxid', provolatile => 'v', proparallel => 'u', prorettype => 'int8', proargtypes => '', prosrc => 'gp_get_next_gxid' },
 
 { oid => 7169, descr => 'show append only table tuple distribution across segment databases',
    proname => 'get_ao_distribution', prorows => '1000', proisstrict => 'f', proretset => 't', provolatile => 'v', proparallel => 'u', prorettype => 'record', proargtypes => 'regclass', proallargtypes => '{regclass,int4,int8}', proargmodes => '{i,o,o}', proargnames => '{rel,segmentid,tupcount}', prosrc => 'get_ao_distribution', prodataaccess => 'r' },

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -10976,6 +10976,9 @@
 { oid => 6068, descr => 'dbid executing function',
    proname => 'gp_execution_dbid', proisstrict => 'f', provolatile => 'v', proparallel => 'u', prorettype => 'int4', proargtypes => '', prosrc => 'gp_execution_dbid' },
 
+{ oid => 7000, descr => 'Get the next available distributed transaction id',
+   proname => 'gp_get_next_gxid', provolatile => 'v', prorettype => 'int8', proargtypes => '', prosrc => 'gp_get_next_gxid' },
+
 { oid => 7169, descr => 'show append only table tuple distribution across segment databases',
    proname => 'get_ao_distribution', prorows => '1000', proisstrict => 'f', proretset => 't', provolatile => 'v', proparallel => 'u', prorettype => 'record', proargtypes => 'regclass', proallargtypes => '{regclass,int4,int8}', proargmodes => '{i,o,o}', proargnames => '{rel,segmentid,tupcount}', prosrc => 'get_ao_distribution', prodataaccess => 'r' },
 

--- a/src/include/cdb/cdbdistributedsnapshot.h
+++ b/src/include/cdb/cdbdistributedsnapshot.h
@@ -17,16 +17,10 @@
 /* This is a shipped header, do not include other files under "cdb" */
 #include "c.h"     /* DistributedTransactionId */
 
-#define DistributedSnapshot_StaticInit {0,0,0,0,0,0,0}
+#define DistributedSnapshot_StaticInit {0,0,0,0,0,0}
 
 typedef struct DistributedSnapshot
 {
-	/*
-	 * The unique timestamp for this start of the DTM.  It applies to all of
-	 * the distributed transactions in this snapshot.
-	 */
-	DistributedTransactionTimeStamp	distribTransactionTimeStamp;
-
 	/*
 	 * The lowest distributed transaction being used for distributed snapshots.
 	 */

--- a/src/include/cdb/cdbdtxcontextinfo.h
+++ b/src/include/cdb/cdbdtxcontextinfo.h
@@ -16,12 +16,10 @@
 
 #include "utils/snapshot.h"
 
-#define DtxContextInfo_StaticInit {0,InvalidDistributedTransactionId,false,false,DistributedSnapshot_StaticInit,0,0,0}
+#define DtxContextInfo_StaticInit {InvalidDistributedTransactionId,false,false,DistributedSnapshot_StaticInit,0,0,0,0}
 
 typedef struct DtxContextInfo
 {
-	DistributedTransactionTimeStamp	distributedTimeStamp;
-	
 	DistributedTransactionId 		distributedXid;
 	
 	bool							haveDistributedSnapshot;

--- a/src/include/cdb/cdblocaldistribxact.h
+++ b/src/include/cdb/cdblocaldistribxact.h
@@ -35,9 +35,8 @@ typedef struct LocalDistribXactData
 	LocalDistribXactState		state;
 
 	/*
-	 * Distributed xid and the master's restart timestamp.
+	 * Distributed xid.
 	 */
-	DistributedTransactionTimeStamp	distribTimeStamp;
 	DistributedTransactionId 		distribXid;
 
 } LocalDistribXactData;

--- a/src/include/cdb/cdbpublic.h
+++ b/src/include/cdb/cdbpublic.h
@@ -25,25 +25,15 @@
 
 #include "c.h"         /* DistributedTransactionId */
 
-/* Things defined in this header */
-typedef struct TMGXACT_LOG           TMGXACT_LOG;
-
-/* From "cdb/cdbtm.h" */
-struct TMGXACT_LOG
-{
-	char						gid[TMGIDSIZE];
-	DistributedTransactionId	gxid;
-};
-
 typedef struct TMGXACT_CHECKPOINT
 {
 	int						committedCount;
-    /* Array [0..committedCount-1] of TMGXACT_LOG structs begins here */
-	TMGXACT_LOG				committedGxactArray[1];
+	/* Array [0..committedCount-1] of DistributedTransactionId begins here */
+	DistributedTransactionId committedGxidArray[1];
 }	TMGXACT_CHECKPOINT;
 
 #define TMGXACT_CHECKPOINT_BYTES(committedCount) \
-	(offsetof(TMGXACT_CHECKPOINT, committedGxactArray) + sizeof(TMGXACT_LOG) * (committedCount))
+	(offsetof(TMGXACT_CHECKPOINT, committedGxidArray) + sizeof(DistributedTransactionId) * (committedCount))
 
 #endif
 

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -13,6 +13,9 @@
 #include "cdb/cdblocaldistribxact.h"
 #include "cdb/cdbdtxcontextinfo.h"
 #include "cdb/cdbpublic.h"
+#ifndef FRONTEND
+#include "storage/s_lock.h"
+#endif
 #include "nodes/plannodes.h"
 
 struct Gang;
@@ -193,13 +196,11 @@ typedef enum
 typedef struct TMGXACT_UTILITY_MODE_REDO
 {
 	bool		committed;
-	TMGXACT_LOG	gxact_log;
+	DistributedTransactionId gxid;
 }	TMGXACT_UTILITY_MODE_REDO;
 
 typedef struct TMGXACT
 {
-	DistributedTransactionTimeStamp	distribTimeStamp;
-
 	/*
 	 * Like PGPROC->xid to local transaction, gxid is set if distributed
 	 * transaction needs two-phase, and it's reset when distributed
@@ -239,7 +240,6 @@ typedef struct TMGXACTLOCAL
 typedef struct TMGXACTSTATUS
 {
 	DistributedTransactionId	gxid;
-	char						gid[TMGIDSIZE];
  	DtxState					state;
 	int							sessionId;
 	DistributedTransactionId	xminDistributedSnapshot;
@@ -253,11 +253,17 @@ typedef struct TMGALLXACTSTATUS
 	TMGXACTSTATUS		*statusArray;
 } TMGALLXACTSTATUS;
 
+typedef enum
+{
+	DTX_RECOVERY_EVENT_ABORT_PREPARED	= 1 << 0,
+	DTX_RECOVERY_EVENT_BUMP_GXID			= 1 << 1
+} DtxRecoveryEvent;
 
 #define DTM_DEBUG3 (Debug_print_full_dtm ? LOG : DEBUG3)
 #define DTM_DEBUG5 (Debug_print_full_dtm ? LOG : DEBUG5)
 
 extern int max_tm_gxacts;
+extern int gp_gxid_prefetch_num;
 
 extern DtxContext DistributedTransactionContext;
 
@@ -265,27 +271,25 @@ extern DtxContext DistributedTransactionContext;
 extern volatile bool *shmDtmStarted;
 extern volatile bool *shmCleanupBackends;
 extern volatile pid_t *shmDtxRecoveryPid;
-extern volatile DistributedTransactionTimeStamp *shmDistribTimeStamp;
-extern volatile DistributedTransactionId *shmGIDSeq;
+extern volatile DtxRecoveryEvent *shmDtxRecoveryEvents;
 extern uint32 *shmNextSnapshotId;
-extern TMGXACT_LOG *shmCommittedGxactArray;
+#ifndef FRONTEND
+extern slock_t *shmDtxRecoveryEventLock;
+extern slock_t *shmGxidGenLock;
+#endif
+extern DistributedTransactionId *shmCommittedGxidArray;
 extern volatile int *shmNumCommittedGxacts;
 
 extern char *DtxStateToString(DtxState state);
 extern char *DtxProtocolCommandToString(DtxProtocolCommand command);
 extern char *DtxContextToString(DtxContext context);
-extern DistributedTransactionTimeStamp getDtmStartTime(void);
-extern void dtxCrackOpenGid(const char	*gid,
-							DistributedTransactionTimeStamp	*distribTimeStamp,
+extern void dtxDeformGid(const char	*gid,
 							DistributedTransactionId		*distribXid);
-extern void dtxFormGID(char *gid,
-					   DistributedTransactionTimeStamp tstamp,
-					   DistributedTransactionId gxid);
+extern void dtxFormGid(char *gid, DistributedTransactionId gxid);
 extern DistributedTransactionId getDistributedTransactionId(void);
-extern DistributedTransactionTimeStamp getDistributedTransactionTimestamp(void);
 extern bool getDistributedTransactionIdentifier(char *id);
 
-extern void resetGxact(void);
+extern void resetTmGxact(void);
 extern void	prepareDtxTransaction(void);
 extern bool isPreparedDtxTransaction(void);
 extern bool notifyCommittedDtxTransactionIsNeeded(void);
@@ -296,11 +300,12 @@ extern void insertingDistributedCommitted(void);
 extern void insertedDistributedCommitted(void);
 
 extern void redoDtxCheckPoint(TMGXACT_CHECKPOINT *gxact_checkpoint);
-extern void redoDistributedCommitRecord(TMGXACT_LOG *gxact_log);
-extern void redoDistributedForgetCommitRecord(TMGXACT_LOG *gxact_log);
+extern void redoDistributedCommitRecord(DistributedTransactionId gxid);
+extern void redoDistributedForgetCommitRecord(DistributedTransactionId gxid);
 
 extern void setupDtxTransaction(void);
 extern DtxState getCurrentDtxState(void);
+extern void bumpGxid(void);
 extern bool isCurrentDtxActivated(void);
 
 extern void sendDtxExplicitBegin(void);
@@ -342,6 +347,8 @@ extern void addToGxactDtxSegments(struct Gang* gp);
 extern bool CurrentDtxIsRollingback(void);
 
 extern pid_t DtxRecoveryPID(void);
+extern DtxRecoveryEvent GetDtxRecoveryEvent(void);
+extern void SetDtxRecoveryEvent(DtxRecoveryEvent event, bool locked);
 extern void DtxRecoveryMain(Datum main_arg);
 extern bool DtxRecoveryStartRule(Datum main_arg);
 

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -348,7 +348,7 @@ extern bool CurrentDtxIsRollingback(void);
 
 extern pid_t DtxRecoveryPID(void);
 extern DtxRecoveryEvent GetDtxRecoveryEvent(void);
-extern void SetDtxRecoveryEvent(DtxRecoveryEvent event, bool locked);
+extern void SetDtxRecoveryEvent(DtxRecoveryEvent event);
 extern void DtxRecoveryMain(Datum main_arg);
 extern bool DtxRecoveryStartRule(Datum main_arg);
 

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -138,7 +138,7 @@ extern void getDtxCheckPointInfo(char **result, int *result_size);
 
 extern List *ListAllGxid(void);
 extern int GetPidByGxid(DistributedTransactionId gxid);
-extern bool IsDtxInProgress(DistributedTransactionTimeStamp distribTimeStamp, DistributedTransactionId gxid);
+extern bool IsDtxInProgress(DistributedTransactionId gxid);
 
 extern void ProcArraySetReplicationSlotXmin(TransactionId xmin,
 											TransactionId catalog_xmin, bool already_locked);

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -203,6 +203,7 @@
 		"gp_gang_creation_retry_count",
 		"gp_gang_creation_retry_timer",
 		"gp_global_deadlock_detector_period",
+		"gp_gxid_prefetch_num",
 		"gp_heap_require_relhasoids_match",
 		"gp_instrument_shmem_size",
 		"gp_interconnect_cache_future_packets",

--- a/src/test/isolation2/expected/check_gxid.out
+++ b/src/test/isolation2/expected/check_gxid.out
@@ -1,0 +1,57 @@
+select gp_segment_id, gp_get_next_gxid() < (select gp_get_next_gxid()) from gp_dist_random('gp_id');
+ gp_segment_id | ?column? 
+---------------+----------
+ 1             | t        
+ 2             | t        
+ 0             | t        
+(3 rows)
+-- start_ignore
+select gp_segment_id,gp_get_next_gxid() on_seg, (select gp_get_next_gxid() on_cor) from gp_dist_random('gp_id');
+ gp_segment_id | on_seg | on_cor 
+---------------+--------+--------
+ 0             | 53830  | 53831  
+ 1             | 53830  | 53831  
+ 2             | 53830  | 53831  
+(3 rows)
+-- end_ignore
+
+-- trigger master panic and wait until master down before running any new query.
+1&: SELECT wait_till_master_shutsdown();  <waiting ...>
+2: SELECT gp_inject_fault('before_read_command', 'panic', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: SELECT 1;
+PANIC:  fault triggered, fault name:'before_read_command' fault type:'panic'
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+1<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+-- wait until master is up for querying.
+3: SELECT 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+
+3: select gp_segment_id, gp_get_next_gxid() < (select gp_get_next_gxid()) from gp_dist_random('gp_id');
+ gp_segment_id | ?column? 
+---------------+----------
+ 2             | t        
+ 0             | t        
+ 1             | t        
+(3 rows)
+-- start_ignore
+3: select gp_segment_id,gp_get_next_gxid() on_seg, (select gp_get_next_gxid() on_cor) from gp_dist_random('gp_id');
+ gp_segment_id | on_seg | on_cor 
+---------------+--------+--------
+ 0             | 53830  | 61997  
+ 1             | 53830  | 61997  
+ 2             | 53830  | 61997  
+(3 rows)
+-- end_ignore

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -7,9 +7,6 @@
 -- s/\s+\(.*\.[ch]:\d+\)/ (SOMEFILE:SOMEFUNC)/
 -- m/(PANIC):.*unable to complete*/
 --
--- m/^DETAIL:.*gid=.*/
--- s/gid=\d+-\d+/gid DUMMY/
---
 -- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/
 -- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
 --
@@ -24,13 +21,6 @@ select pg_reload_conf();
 ----------------
  t              
 (1 row)
-
--- This function is used to loop until master shutsdown, to make sure
--- next command executed is only after restart and doesn't go through
--- while PANIC is still being processed by master, as master continues
--- to accept connections for a while despite undergoing PANIC.
-CREATE OR REPLACE FUNCTION wait_till_master_shutsdown() RETURNS void AS $$ DECLARE i int; /* in func */ BEGIN i := 0; /* in func */ while i < 120 loop i := i + 1; /* in func */ PERFORM pg_sleep(.5); /* in func */ end loop; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
-CREATE
 
 1:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
  role | preferred_role | content | mode | status 
@@ -65,8 +55,8 @@ CREATE
 3&: SELECT wait_till_master_shutsdown();  <waiting ...>
 -- Start transaction which should hit PANIC as COMMIT PREPARED will fail to one segment
 1: CREATE TABLE commit_phase1_panic(a int, b int);
-PANIC:  unable to complete 'Commit Prepared' broadcast (cdbtm.c:661)
-DETAIL:  gid=1561100299-0000000009, state=Retry Commit Prepared
+PANIC:  unable to complete 'Commit Prepared' broadcast (cdbtm.c:604)
+DETAIL:  gid=1630210, state=Retry Commit Prepared
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -125,3 +125,10 @@ CREATE
 
 create or replace function validate_tablespace_symlink(datadir text, tablespacedir text, dbid int, tablespace_oid oid) returns boolean as $$ import os return os.readlink('%s/pg_tblspc/%d' % (datadir, tablespace_oid)) == ('%s/%d' % (tablespacedir, dbid)) $$ language plpython3u;
 CREATE
+
+-- This function is used to loop until master shutsdown, to make sure
+-- next command executed is only after restart and doesn't go through
+-- while PANIC is still being processed by master, as master continues
+-- to accept connections for a while despite undergoing PANIC.
+CREATE OR REPLACE FUNCTION wait_till_master_shutsdown() RETURNS void AS $$ DECLARE i int; /* in func */ BEGIN i := 0; /* in func */ while i < 120 loop i := i + 1; /* in func */ PERFORM pg_sleep(.5); /* in func */ end loop; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
+CREATE

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,3 +1,6 @@
+# test if gxid is valid or not on the cluster before running the tests
+test: check_gxid
+
 test: autovacuum-analyze
 test: lockmodes
 # Put test prepare_limit near to test lockmodes since both of them reboot the
@@ -247,3 +250,6 @@ test: concurrent_drop_truncate_tablespace
 
 # Test for distributed commit array overflow during replay on standby 
 test: standby_replay_dtx_info 
+
+# test if gxid is valid or not on the cluster after running the tests
+test: check_gxid

--- a/src/test/isolation2/sql/check_gxid.sql
+++ b/src/test/isolation2/sql/check_gxid.sql
@@ -1,0 +1,18 @@
+select gp_segment_id, gp_get_next_gxid() < (select gp_get_next_gxid()) from gp_dist_random('gp_id');
+-- start_ignore
+select gp_segment_id,gp_get_next_gxid() on_seg, (select gp_get_next_gxid() on_cor) from gp_dist_random('gp_id');
+-- end_ignore
+
+-- trigger master panic and wait until master down before running any new query.
+1&: SELECT wait_till_master_shutsdown();
+2: SELECT gp_inject_fault('before_read_command', 'panic', 1);
+2: SELECT 1;
+1<:
+
+-- wait until master is up for querying.
+3: SELECT 1;
+
+3: select gp_segment_id, gp_get_next_gxid() < (select gp_get_next_gxid()) from gp_dist_random('gp_id');
+-- start_ignore
+3: select gp_segment_id,gp_get_next_gxid() on_seg, (select gp_get_next_gxid() on_cor) from gp_dist_random('gp_id');
+-- end_ignore

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -7,9 +7,6 @@
 -- s/\s+\(.*\.[ch]:\d+\)/ (SOMEFILE:SOMEFUNC)/
 -- m/(PANIC):.*unable to complete*/
 --
--- m/^DETAIL:.*gid=.*/
--- s/gid=\d+-\d+/gid DUMMY/
---
 -- m/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/
 -- s/^ERROR:  Error on receive from seg0.*: server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/
 --
@@ -19,24 +16,6 @@
 -- 2pc retry PANIC (do not finish earlier before PANIC happens).
 alter system set dtx_phase2_retry_second to 5;
 select pg_reload_conf();
-
--- This function is used to loop until master shutsdown, to make sure
--- next command executed is only after restart and doesn't go through
--- while PANIC is still being processed by master, as master continues
--- to accept connections for a while despite undergoing PANIC.
-CREATE OR REPLACE FUNCTION wait_till_master_shutsdown()
-RETURNS void AS
-$$
-  DECLARE
-    i int; /* in func */
-  BEGIN
-    i := 0; /* in func */
-    while i < 120 loop
-      i := i + 1; /* in func */
-      PERFORM pg_sleep(.5); /* in func */
-    end loop; /* in func */
-  END; /* in func */
-$$ LANGUAGE plpgsql;
 
 1:SELECT role, preferred_role, content, mode, status FROM gp_segment_configuration;
 -- Scenario 1: Test to fail broadcasting of COMMIT PREPARED to one

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -369,3 +369,21 @@ create or replace function validate_tablespace_symlink(datadir text, tablespaced
     import os
     return os.readlink('%s/pg_tblspc/%d' % (datadir, tablespace_oid)) == ('%s/%d' % (tablespacedir, dbid))
 $$ language plpython3u;
+
+-- This function is used to loop until master shutsdown, to make sure
+-- next command executed is only after restart and doesn't go through
+-- while PANIC is still being processed by master, as master continues
+-- to accept connections for a while despite undergoing PANIC.
+CREATE OR REPLACE FUNCTION wait_till_master_shutsdown()
+RETURNS void AS
+$$
+  DECLARE
+    i int; /* in func */
+  BEGIN
+    i := 0; /* in func */
+    while i < 120 loop
+      i := i + 1; /* in func */
+      PERFORM pg_sleep(.5); /* in func */
+    end loop; /* in func */
+  END; /* in func */
+$$ LANGUAGE plpgsql;

--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -10,9 +10,6 @@
 -- m/(ERROR|WARNING|CONTEXT|NOTICE):.*The previous session was reset because its gang was disconnected/
 -- s/session id \=\s*\d+/session id \= DUMMY/gm
 --
--- m/^DETAIL:.*gid=.*/
--- s/gid=\d+-\d+/gid DUMMY/
---
 -- end_matchsubs
 --
 --
@@ -100,7 +97,7 @@ SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "commit_prepared";
 COMMIT;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561094833-0000002743, state=Retry Commit Prepared
+DETAIL:  gid=66802167, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 SELECT * FROM distxact1_3;
  a  
@@ -139,7 +136,7 @@ SET debug_dtm_action_target = "protocol";
 SET debug_dtm_action_protocol = "abort_prepared";
 COMMIT;
 WARNING:  the distributed transaction broadcast failed to one or more segments
-DETAIL:  gid=1561094833-0000003185, state=Notifying Abort Prepared
+DETAIL:  gid=66802193, state=Notifying Abort Prepared
 ERROR:  Raise an error as directed by Debug_abort_after_distributed_prepared
 SELECT * FROM distxact1_4;
  a 
@@ -367,7 +364,7 @@ DROP TABLE
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561094833-0000003786, state=Retry Commit Prepared
+DETAIL:  gid=66802449, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 result: INSERT 0 2
 --

--- a/src/test/regress/expected/dtm_retry.out
+++ b/src/test/regress/expected/dtm_retry.out
@@ -1,7 +1,3 @@
--- start_matchsubs
--- m/^DETAIL:.*gid=.*/
--- s/gid=\d+-\d+/gid DUMMY/
--- end_matchsubs
 -- Check if retry logic handles errors correctly.  The retry logic had
 -- a bug where error state wasn't cleaned up correctly during retries,
 -- leading to PANIC due to ERRORDATA_STACK_SIZE exeeded.
@@ -27,34 +23,34 @@ create table dtm_retry_table (a int) distributed by (a);
 -- one succeeds.
 end;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000000397, state=Retry Commit Prepared
+DETAIL:  gid=66803951, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 2
-DETAIL:  gid=1561095062-0000000397, state=Retry Commit Prepared
+DETAIL:  gid=66803951, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 3
-DETAIL:  gid=1561095062-0000000397, state=Retry Commit Prepared
+DETAIL:  gid=66803951, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 4
-DETAIL:  gid=1561095062-0000000397, state=Retry Commit Prepared
+DETAIL:  gid=66803951, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 5
-DETAIL:  gid=1561095062-0000000397, state=Retry Commit Prepared
+DETAIL:  gid=66803951, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 6
-DETAIL:  gid=1561095062-0000000397, state=Retry Commit Prepared
+DETAIL:  gid=66803951, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 7
-DETAIL:  gid=1561095062-0000000397, state=Retry Commit Prepared
+DETAIL:  gid=66803951, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 8
-DETAIL:  gid=1561095062-0000000397, state=Retry Commit Prepared
+DETAIL:  gid=66803951, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 9
-DETAIL:  gid=1561095062-0000000397, state=Retry Commit Prepared
+DETAIL:  gid=66803951, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 10
-DETAIL:  gid=1561095062-0000000397, state=Retry Commit Prepared
+DETAIL:  gid=66803951, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 -- Reset all faults.
 select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
@@ -100,7 +96,7 @@ truncate table dtm_retry_table;
 -- abort_some_prepared message succeeds.
 end;
 WARNING:  the distributed transaction broadcast failed to one or more segments
-DETAIL:  gid=1561095062-0000000402, state=Notifying Abort (Some Prepared)
+DETAIL:  gid=66803953, state=Notifying Abort (Some Prepared)
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
@@ -159,7 +155,7 @@ truncate table dtm_retry_table;
 -- abort_prepared message succeeds.
 end;
 WARNING:  the distributed transaction broadcast failed to one or more segments
-DETAIL:  gid=1561095062-0000000407, state=Notifying Abort Prepared
+DETAIL:  gid=66803954, state=Notifying Abort Prepared
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.
 NOTICE:  Releasing segworker groups to retry broadcast.

--- a/src/test/regress/expected/not_out_of_shmem_exit_slots.out
+++ b/src/test/regress/expected/not_out_of_shmem_exit_slots.out
@@ -11,9 +11,6 @@
 -- start_matchsubs
 -- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected/
 -- s/session id \=\s*\d+/session id \= DUMMY/gm
---
--- m/^DETAIL:.*gid=.*/
--- s/gid=\d+-\d+/gid DUMMY/
 -- end_matchsubs
 CREATE TABLE foo(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -28,7 +25,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014049, state=Retry Commit Prepared
+DETAIL:  gid=66810156, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 142)
 -- 2
@@ -41,7 +38,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014088, state=Retry Commit Prepared
+DETAIL:  gid=66810165, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 143)
 -- 3
@@ -54,7 +51,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014112, state=Retry Commit Prepared
+DETAIL:  gid=66810177, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 144)
 -- 4
@@ -67,7 +64,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014133, state=Retry Commit Prepared
+DETAIL:  gid=66810180, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 145)
 -- 5
@@ -80,7 +77,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014160, state=Retry Commit Prepared
+DETAIL:  gid=66810194, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 146)
 -- 6
@@ -93,7 +90,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014195, state=Retry Commit Prepared
+DETAIL:  gid=66810207, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 147)
 -- 7
@@ -106,7 +103,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014230, state=Retry Commit Prepared
+DETAIL:  gid=66810215, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 148)
 -- 8
@@ -119,7 +116,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014313, state=Retry Commit Prepared
+DETAIL:  gid=66810228, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 149)
 -- 9
@@ -132,7 +129,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014356, state=Retry Commit Prepared
+DETAIL:  gid=66810237, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 150)
 -- 10
@@ -145,7 +142,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014367, state=Retry Commit Prepared
+DETAIL:  gid=66810244, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 151)
 -- 11
@@ -158,7 +155,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014373, state=Retry Commit Prepared
+DETAIL:  gid=66810251, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 152)
 -- 12
@@ -171,7 +168,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014383, state=Retry Commit Prepared
+DETAIL:  gid=66810257, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 153)
 -- 13
@@ -184,7 +181,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014389, state=Retry Commit Prepared
+DETAIL:  gid=66810264, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 154)
 -- 14
@@ -197,7 +194,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014398, state=Retry Commit Prepared
+DETAIL:  gid=66810270, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 155)
 -- 15
@@ -210,7 +207,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014406, state=Retry Commit Prepared
+DETAIL:  gid=66810273, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 156)
 -- 16
@@ -223,7 +220,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014421, state=Retry Commit Prepared
+DETAIL:  gid=66810276, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 157)
 -- 17
@@ -236,7 +233,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014434, state=Retry Commit Prepared
+DETAIL:  gid=66810281, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 158)
 -- 18
@@ -249,7 +246,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014446, state=Retry Commit Prepared
+DETAIL:  gid=66810287, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 159)
 -- 19
@@ -262,7 +259,7 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014494, state=Retry Commit Prepared
+DETAIL:  gid=66810293, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 160)
 -- 20
@@ -275,6 +272,6 @@ SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1561095062-0000014522, state=Retry Commit Prepared
+DETAIL:  gid=66810299, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 161)

--- a/src/test/regress/expected/udf_exception_blocks.out
+++ b/src/test/regress/expected/udf_exception_blocks.out
@@ -678,8 +678,6 @@ SELECT count(*) FROM test_truncate_tab;
 -- m/ /
 -- m/transaction \d+/
 -- s/transaction \d+/transaction /
--- m/transaction -\d+/
--- s/transaction -\d+/transaction/
 -- end_matchsubs
 CREATE OR REPLACE FUNCTION test_excep (arg INTEGER) RETURNS INTEGER
 AS $$
@@ -758,8 +756,8 @@ DROP TABLE IF EXISTS employees;
 NOTICE:  table "employees" does not exist, skipping
 select test_protocol_allseg(1, 2,'f');
 NOTICE:  catching the exception ...2
-ERROR:  transaction 1518031192-0000000602 at level 1 already processed (current level 1) (cdbtm.c:3456)  (seg1 127.0.1.1:25433 pid=24105)
-CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 8 during exception cleanup
+ERROR:  transaction 41615890 at level 1 already processed (current level 1) (cdbtm.c:2299)  (seg2 192.168.235.128:7004 pid=654) (cdbtm.c:2299)
+CONTEXT:  PL/pgSQL function test_protocol_allseg(integer,integer,character) line 9 during exception cleanup
 select * from employees;
 ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;
@@ -870,8 +868,8 @@ SET debug_dtm_action_nestinglevel=0;
 DROP TABLE IF EXISTS employees;
 select test_protocol_allseg(1, 2,'f');
 NOTICE:  catching the exception ...2
-ERROR:  transaction 1518031192-0000000650 at level 1 already processed (current level 1) (cdbtm.c:3456)  (seg0 127.0.1.1:25432 pid=24104)
-CONTEXT:  PL/pgSQL function "test_protocol_allseg" line 8 during exception cleanup
+ERROR:  transaction 41615928 at level 1 already processed (current level 1) (cdbtm.c:2299)  (seg1 192.168.235.128:7003 pid=648) (cdbtm.c:2299)
+CONTEXT:  PL/pgSQL function test_protocol_allseg(integer,integer,character) line 9 during exception cleanup
 select * from employees;
 ERROR:  relation "employees" does not exist
 LINE 1: select * from employees;

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -124,4 +124,7 @@ s/nodename nor servname provided, or not known/Name or service not known/
 m/ERROR:  could not devise a query plan for the given query \(.*\)/
 s/ERROR:  could not devise a query plan for the given query \(.*\)/ERROR:  could not devise a query plan for the given query/
 
+m/^DETAIL:.*gid=.*/
+s/gid=\d+/gid DUMMY/
+
 -- end_matchsubs

--- a/src/test/regress/input/gp_tablespace_with_faults.source
+++ b/src/test/regress/input/gp_tablespace_with_faults.source
@@ -1,8 +1,4 @@
 -- CREATE TABLESPACE
--- start_matchsubs
--- m/^DETAIL:.*gid=.*/
--- s/gid=\d+-\d+/gid DUMMY/
--- end_matchsubs
 --
 -- We need to update the restart point on the mirrors
 -- so downstream tests do not attempt to replay records

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -1,8 +1,4 @@
 -- CREATE TABLESPACE
--- start_matchsubs
--- m/^DETAIL:.*gid=.*/
--- s/gid=\d+-\d+/gid DUMMY/
--- end_matchsubs
 --
 -- We need to update the restart point on the mirrors
 -- so downstream tests do not attempt to replay records
@@ -867,7 +863,7 @@ select gp_inject_fault(:'fault_name', :'fault_type', dbid) from gp_segment_confi
 
 DROP TABLESPACE my_tablespace_for_testing;
 WARNING:  the distributed transaction 'Commit Prepared' broadcast failed to one or more segments. Retrying ... try 1
-DETAIL:  gid=1564560606-0000000899, state=Retry Commit Prepared
+DETAIL:  gid=41608220, state=Retry Commit Prepared
 NOTICE:  Releasing segworker group to retry broadcast.
 select wait_for_primaries_to_restart();
  wait_for_primaries_to_restart 

--- a/src/test/regress/sql/distributed_transactions.sql
+++ b/src/test/regress/sql/distributed_transactions.sql
@@ -10,9 +10,6 @@
 -- m/(ERROR|WARNING|CONTEXT|NOTICE):.*The previous session was reset because its gang was disconnected/
 -- s/session id \=\s*\d+/session id \= DUMMY/gm
 --
--- m/^DETAIL:.*gid=.*/
--- s/gid=\d+-\d+/gid DUMMY/
---
 -- end_matchsubs
 --
 --

--- a/src/test/regress/sql/dtm_retry.sql
+++ b/src/test/regress/sql/dtm_retry.sql
@@ -1,7 +1,3 @@
--- start_matchsubs
--- m/^DETAIL:.*gid=.*/
--- s/gid=\d+-\d+/gid DUMMY/
--- end_matchsubs
 -- Check if retry logic handles errors correctly.  The retry logic had
 -- a bug where error state wasn't cleaned up correctly during retries,
 -- leading to PANIC due to ERRORDATA_STACK_SIZE exeeded.

--- a/src/test/regress/sql/not_out_of_shmem_exit_slots.sql
+++ b/src/test/regress/sql/not_out_of_shmem_exit_slots.sql
@@ -12,9 +12,6 @@
 -- start_matchsubs
 -- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected/
 -- s/session id \=\s*\d+/session id \= DUMMY/gm
---
--- m/^DETAIL:.*gid=.*/
--- s/gid=\d+-\d+/gid DUMMY/
 -- end_matchsubs
 
 CREATE TABLE foo(a int, b int);

--- a/src/test/regress/sql/udf_exception_blocks.sql
+++ b/src/test/regress/sql/udf_exception_blocks.sql
@@ -526,8 +526,6 @@ SELECT count(*) FROM test_truncate_tab;
 -- m/ /
 -- m/transaction \d+/
 -- s/transaction \d+/transaction /
--- m/transaction -\d+/
--- s/transaction -\d+/transaction/
 -- end_matchsubs
 CREATE OR REPLACE FUNCTION test_excep (arg INTEGER) RETURNS INTEGER
 AS $$


### PR DESCRIPTION
Previously we use dtm_start_timestamp + 32bit_gxid as gid. That normally works
fine but it has the issue of potential wraparound of 32bit gxid, which is not
rare in real production environment. This will be more and more an issue when
gpdb OLTP performance is better and better. There was a patch trying to resolve
the issue.

	https://github.com/greenplum-db/gpdb/pull/10177

The patch handles wraparound, still keeping 32bit gxid, and for 64bit gxid
idea, there were some concerns in the patch,

1. DistributedSnapshot double size: i.e. DistributedSnapshot->inProgressXidArray.
   Actually we could optimize use relative values (i.e. use 'gxid - base_gxid'
   as 32bit for most cases).

2. distributed log size: we do not need timestamp in it so the distributed
   entry size is same as before. We could further optimize similar to 1
   also so we could use even less memory compared with before?

This patch is master only. It introduces catalog change...

The implementation would be mostly straightforward, but there are still several
blocking issues.

On master, ShmemVariableCache->nextGxid is used to store the nextGxid for use.

For normal reboot on master it could work fine since we could save
ShmemVariableCache->nextGxid during shutdown checkpoint, but for abnormal
reboot or standby promote, we need to find the correct
ShmemVariableCache->nextGxid.

One possible solution is to follow the oid solution (use a oid batch and write
xlog in each batch), but that seems to be costly (need to flush xlog for our
case when exhausting each gxid number batch).

Another solution (in this patch) is:

- Always update ShmemVariableCache->nextGxid in checkpoint and one phase
  commit/prepare (during both commit and redo code)

- in dtx recovery, for the scenarios, it previously terminate all backends in
  such case, now it dispatches a udf to collect the max nextGxid on all segments
  and compare with ShmemVariableCache->nextGxid to get the max nextGxid.
  Need to write the code very carefully when handling those orphaned segment
  processes on segments.

TODO:
  Coding to complete it. some FIXME/TODO. More testing and add tests.
  Quick perf testing to see if there is obvious regression.

Notes:
1. Use PgStartTime in gp_gettmid() - this seems to be more correct?
   No need to dispatch dtm timestamp now.
2. Removed distributed timestamp.
3. below UDF definitions are modified.
   gp_distributed_log
   gp_distributed_xacts

FIXME (maybe in the future):
1. TMGIDSIZE could be smaller when use hex characters.
2. DistributedSnapshot->inProgressXidArray use relative values in most cases.
3. distributed log: optimize to use 32bit relative gxid value?