### PR TITLE
Revert the default wal segment file size to 64M on Greenplum

### DIFF
--- a/src/include/pg_config_manual.h
+++ b/src/include/pg_config_manual.h
@@ -16,8 +16,9 @@
 /*
  * This is the default value for wal_segment_size to be used when initdb is run
  * without the --wal-segsize option.  It must be a valid segment size.
+ * gpdb: Greenplum uses 64M wal segment file size by default.
  */
-#define DEFAULT_XLOG_SEG_SIZE	(16*1024*1024)
+#define DEFAULT_XLOG_SEG_SIZE	(64*1024*1024)
 
 /*
  * Maximum length for identifiers (e.g. table names, column names,


### PR DESCRIPTION
It was modified to 16M (that's upstream default setting) during PG12 merge when
resolving code merge conflict without explanation. It looks like the change was
not intentional. Why the value was 64M on Greenplum is not clear just from
commit history (e.g. merge repo commit 8b1be90e989268a), but I assume we had
done some perf testing with the value, also the below related upstream patch
explains this a bit, especially the second reason, assuming it means calling
issue_xlog_fsync() less, is quite reasonable. Note with the below upstream
patch there isn't configure option so directly modifying the definition, else I
have to modify all code/scripts which calls initdb - that is bug prone and hard
to maintain.

commit fc49e24fa69a15efacd5b8958115ed9c43c48f9a
Author: Andres Freund <andres@anarazel.de>
Date:   Tue Sep 19 22:03:48 2017 -0700

    Make WAL segment size configurable at initdb time.

    For performance reasons a larger segment size than the default 16MB
    can be useful. A larger segment size has two main benefits: Firstly,
    in setups using archiving, it makes it easier to write scripts that
    can keep up with higher amounts of WAL, secondly, the WAL has to be
    written and synced to disk less frequently.

    But at the same time large segment size are disadvantageous for
    smaller databases. So far the segment size had to be configured at
    compile time, often making it unrealistic to choose one fitting to a
    particularly load. Therefore change it to a initdb time setting.

    This includes a breaking changes to the xlogreader.h API, which now
    requires the current segment size to be configured.  For that and
    similar reasons a number of binaries had to be taught how to recognize
    the current segment size.