### PR TITLE
Fix parsing bug for ROLLUP/GROUPING SETS with nested RowExpr

### DIFF
--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -3562,9 +3562,9 @@ transformRowExprToList(ParseState *pstate, RowExpr *rowexpr,
 
 		if (IsA(node, RowExpr))
 		{
-			groupsets =
+			grping_set =
 				transformRowExprToGroupClauses(pstate, (RowExpr *)node,
-											   groupsets, targetList);
+											   grping_set, targetList);
 		}
 
 		else

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -2909,6 +2909,29 @@ View definition:
    FROM sale
   GROUP BY GROUPING SETS ((sale.vn), (sale.cn), (), ((sale.cn), (sale.vn)));
 
+-- A RowExpr that is immediately inside a grouping extension clause is treated
+-- as a single grouping set. Any RowExpr that is nested inside another RowExpr
+-- will be flattened.
+create view rollup_nested_rowexpr_view as
+select cn, vn, pn, dt, count(distinct dt) from sale group by rollup(cn, (vn, (pn, dt)));
+\d+ rollup_nested_rowexpr_view
+       View "public.rollup_nested_rowexpr_view"
+ Column |  Type   | Modifiers | Storage | Description 
+--------+---------+-----------+---------+-------------
+ cn     | integer |           | plain   | 
+ vn     | integer |           | plain   | 
+ pn     | integer |           | plain   | 
+ dt     | date    |           | plain   | 
+ count  | bigint  |           | plain   | 
+View definition:
+ SELECT sale.cn,
+    sale.vn,
+    sale.pn,
+    sale.dt,
+    count(DISTINCT sale.dt) AS count
+   FROM sale
+  GROUP BY ROLLUP (sale.cn, (sale.vn, sale.pn, sale.dt));
+
 -- GROUP_ID function --
 select pn, sum(qty), group_id() from sale group by rollup(pn);
  pn  | sum  | ?column? 

--- a/src/test/regress/sql/olap_group.sql
+++ b/src/test/regress/sql/olap_group.sql
@@ -341,6 +341,12 @@ create view rollup_view as select cn,vn,pn,grouping(cn,vn,pn) from sale group by
 \d+ rollup_view;
 create view gs_view as select cn,vn,grouping(vn,cn) from sale group by grouping sets ((vn), (cn), (), (cn,vn));
 \d+ gs_view;
+-- A RowExpr that is immediately inside a grouping extension clause is treated
+-- as a single grouping set. Any RowExpr that is nested inside another RowExpr
+-- will be flattened.
+create view rollup_nested_rowexpr_view as
+select cn, vn, pn, dt, count(distinct dt) from sale group by rollup(cn, (vn, (pn, dt)));
+\d+ rollup_nested_rowexpr_view
 
 -- GROUP_ID function --
 


### PR DESCRIPTION
When transforming RowExprs inside of a GroupingClause such as ROLLUP
or GROUPING SETS, we intend to only consider a RowExpr as a separate
grouping set if it is immediately inside of the GroupingClause. A
RowExpr that is nested inside of another RowExpr will be flattened.
For example, the following queries should all be equivalent:

SELECT a, b, c, d, SUM(v) FROM gstest GROUP BY ROLLUP(a, (b, (c, d)));

SELECT a, b, c, d, SUM(v) FROM gstest GROUP BY ROLLUP(a, (b, c, d));

SELECT a, b, c, d, SUM(v) FROM gstest GROUP BY GROUPING SETS ((a, b, c, d), (a), ());

SELECT a, b, c, d, SUM(v) FROM gstest GROUP BY GROUPING SETS ((a, (b, c), d), (a), ());

SELECT a, b, c, d, SUM(v) FROM gstest GROUP BY (a, b, c, d)
UNION ALL
SELECT a, NULL, NULL, NULL, SUM(v) FROM gstest GROUP BY (a)
UNION ALL
SELECT NULL, NULL, NULL, NULL, SUM(v) FROM gstest;

The above expected behavior was not guaranteed due to probably a typo
that has been existed prehistorically, this patch fixes it.

Fixes greenplum-db#10925.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
