### PR TITLE
Add pipeline_target to jinjia context

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -169,7 +169,8 @@ def create_pipeline(args):
         'os_types': args.os_types,
         'test_sections': args.test_sections,
         'pipeline_configuration': args.pipeline_configuration,
-        'test_trigger': test_trigger
+        'test_trigger': test_trigger,
+        'pipeline_target': args.pipeline_target
     }
 
     pipeline_yml = render_template(args.template_filename, context)

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -1229,7 +1229,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb6-centos6-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos6]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb_binary_swap.yml
@@ -1256,7 +1256,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb6-centos6-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos6]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1278,7 +1278,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb6-centos6-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos6]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1300,7 +1300,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb6-centos6-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos6]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1322,7 +1322,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb6-centos6-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos6]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1345,7 +1345,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb6-centos7-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos7]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1367,7 +1367,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb6-centos7-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos7]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1389,7 +1389,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb6-centos7-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos7]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1411,7 +1411,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb6-centos7-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos7]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1435,7 +1435,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb6-oracle7-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-oracle7]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1457,7 +1457,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb6-oracle7-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-oracle7]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1481,7 +1481,7 @@ jobs:
           trigger: [[ test_trigger ]]
         - get: gpdb6-ubuntu18.04-test
     - task: ic_gpdb
-      {% if pipeline_configuration == "prod" %}
+      {% if pipeline_target == "prod" %}
       tags: [icw-ubuntu18.04]
       {% endif %}
       file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1503,7 +1503,7 @@ jobs:
           trigger: [[ test_trigger ]]
         - get: gpdb6-ubuntu18.04-test
     - task: ic_gpdb
-      {% if pipeline_configuration == "prod" %}
+      {% if pipeline_target == "prod" %}
       tags: [icw-ubuntu18.04]
       {% endif %}
       file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1525,7 +1525,7 @@ jobs:
           trigger: [[ test_trigger ]]
         - get: gpdb6-ubuntu18.04-test
     - task: ic_gpdb
-      {% if pipeline_configuration == "prod" %}
+      {% if pipeline_target == "prod" %}
       tags: [icw-ubuntu18.04]
       {% endif %}
       file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1547,7 +1547,7 @@ jobs:
           trigger: [[ test_trigger ]]
         - get: gpdb6-ubuntu18.04-test
     - task: ic_gpdb
-      {% if pipeline_configuration == "prod" %}
+      {% if pipeline_target == "prod" %}
       tags: [icw-ubuntu18.04]
       {% endif %}
       file: gpdb_src/concourse/tasks/ic_gpdb.yml


### PR DESCRIPTION
   This context variable works for tagging concourse external
   workers depend on different concourse env

   This commit for gpdb6

Authored-by: Tingfang Bao <baotingfang@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
