### PR TITLE
Add pipeline_target to jinjia context

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -171,7 +171,8 @@ def create_pipeline(args):
         'os_types': args.os_types,
         'test_sections': args.test_sections,
         'pipeline_configuration': args.pipeline_configuration,
-        'test_trigger': test_trigger
+        'test_trigger': test_trigger,
+        "pipeline_target": args.pipeline_target
     }
 
     pipeline_yml = render_template(args.template_filename, context)

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -871,7 +871,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb7-centos7-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos7]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -893,7 +893,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb7-centos7-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos7]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -920,7 +920,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb7-centos7-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos7]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -942,7 +942,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb7-centos7-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos7]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -964,7 +964,7 @@ jobs:
         trigger: [[ test_trigger ]]
       - get: gpdb7-centos7-test
   - task: ic_gpdb
-    {% if pipeline_configuration == "prod" %}
+    {% if pipeline_target == "prod" %}
     tags: [icw-centos7]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -987,7 +987,7 @@ jobs:
           trigger: [[ test_trigger ]]
         - get: gpdb7-ubuntu18.04-test
     - task: ic_gpdb
-      {% if pipeline_configuration == "prod" %}
+      {% if pipeline_target == "prod" %}
       tags: [icw-ubuntu18.04]
       {% endif %}
       file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1009,7 +1009,7 @@ jobs:
           trigger: [[ test_trigger ]]
         - get: gpdb7-ubuntu18.04-test
     - task: ic_gpdb
-      {% if pipeline_configuration == "prod" %}
+      {% if pipeline_target == "prod" %}
       tags: [icw-ubuntu18.04]
       {% endif %}
       file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1031,7 +1031,7 @@ jobs:
           trigger: [[ test_trigger ]]
         - get: gpdb7-ubuntu18.04-test
     - task: ic_gpdb
-      {% if pipeline_configuration == "prod" %}
+      {% if pipeline_target == "prod" %}
       tags: [icw-ubuntu18.04]
       {% endif %}
       file: gpdb_src/concourse/tasks/ic_gpdb.yml
@@ -1053,7 +1053,7 @@ jobs:
           trigger: [[ test_trigger ]]
         - get: gpdb7-ubuntu18.04-test
     - task: ic_gpdb
-      {% if pipeline_configuration == "prod" %}
+      {% if pipeline_target == "prod" %}
       tags: [icw-ubuntu18.04]
       {% endif %}
       file: gpdb_src/concourse/tasks/ic_gpdb.yml


### PR DESCRIPTION
  This context variable works for tagging concourse external
  workers depend on different concourse env

Authored-by: Tingfang Bao <baotingfang@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
