### PR TITLE
cdbdisp_buildUtilityQueryParams: Replace NULL debug_query_string with empty string

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -435,7 +435,8 @@ CdbDispatchUtilityStatement(struct Node *stmt,
 
 	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
 		   "CdbDispatchUtilityStatement: %s (needTwoPhase = %s)",
-		   debug_query_string, (needTwoPhase ? "true" : "false"));
+		   (PointerIsValid(debug_query_string) ? debug_query_string : "\"\""),
+		   (needTwoPhase ? "true" : "false"));
 
 	pQueryParms = cdbdisp_buildUtilityQueryParms(stmt, flags, oid_assignments);
 
@@ -590,7 +591,7 @@ cdbdisp_buildUtilityQueryParms(struct Node *stmt,
 	}
 
 	pQueryParms = palloc0(sizeof(*pQueryParms));
-	pQueryParms->strCommand = debug_query_string;
+	pQueryParms->strCommand = PointerIsValid(debug_query_string) ? debug_query_string : "";
 	pQueryParms->serializedPlantree = serializedPlantree;
 	pQueryParms->serializedPlantreelen = serializedPlantree_len;
 	pQueryParms->serializedQueryDispatchDesc = serializedQueryDispatchDesc;
@@ -1303,7 +1304,8 @@ CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags)
 
 	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
 		   "CdbDispatchCopyStart: %s (needTwoPhase = %s)",
-		   debug_query_string, (needTwoPhase ? "true" : "false"));
+		   (PointerIsValid(debug_query_string) ? debug_query_string : "\"\""),
+		   (needTwoPhase ? "true" : "false"));
 
 	pQueryParms = cdbdisp_buildUtilityQueryParms(stmt, flags, NULL);
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -16,7 +16,7 @@ include $(top_builddir)/src/Makefile.global
 # removed "subscription" test from below list.
 SUBDIRS = perl regress isolation modules authentication recovery
 
-SUBDIRS += fsync walrep heap_checksum isolation2
+SUBDIRS += fsync walrep heap_checksum isolation2 fdw
 
 # Test suites that are not safe by default but can be run if selected
 # by the user via the whitespace-separated list in variable

--- a/src/test/fdw/Makefile
+++ b/src/test/fdw/Makefile
@@ -1,0 +1,30 @@
+SUBDIRS = extension
+
+PROGRAM = extended_protocol_commit_test
+
+OBJS = extended_protocol_commit_test.o
+
+REGRESS = extended_protocol_commit_test
+
+
+subdir = src/test/isolation2
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
+NO_PGXS = 1
+include $(top_srcdir)/src/makefiles/pgxs.mk
+include $(top_srcdir)/src/Makefile.shlib
+
+ifeq ($(PORTNAME), win32)
+LDLIBS += -lws2_32
+endif
+override CPPFLAGS := -I$(srcdir) -I$(libpq_srcdir) -I$(srcdir)/../regress $(CPPFLAGS)
+override LDLIBS := $(libpq_pgport) $(LDLIBS)
+
+
+installcheck: install
+
+extended_protocol_commit_test: extended_protocol_commit_test.c
+	$(CC) $(CPPFLAGS) -I$(top_builddir)/src/interfaces/libpq -L$(top_builddir)/src/interfaces/libpq -o $@ $< -lpq
+
+
+$(call recurse,all clean installcheck)

--- a/src/test/fdw/expected/extended_protocol_commit_test.out
+++ b/src/test/fdw/expected/extended_protocol_commit_test.out
@@ -1,0 +1,2 @@
+\! ./extended_protocol_commit_test;
+extended_protocol_commit_test passed

--- a/src/test/fdw/extended_protocol_commit_test.c
+++ b/src/test/fdw/extended_protocol_commit_test.c
@@ -1,0 +1,113 @@
+/*
+ * extended_protocol_commit_test.c
+ *
+ * This program is to test whether exetend-queries properly work with FOREIGN
+ * TABLEs at transaction commit.
+ *
+ * See https://github.com/greenplum-db/gpdb/issues/10918
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include "libpq-fe.h"
+
+
+static void
+exit_nicely(PGconn *conn)
+{
+	PQfinish(conn);
+	exit(1);
+}
+
+int
+main(int argc, char **argv)
+{
+	const char *conninfo;
+	PGconn	   *conn;
+	PGresult   *res;
+
+	/*
+	 * If the user supplies a parameter on the command line, use it as the
+	 * conninfo string; otherwise default to setting dbname=postgres and using
+	 * environment variables or defaults for all other connection parameters.
+	 */
+	if (argc > 1)
+		conninfo = argv[1];
+	else
+		conninfo = "dbname = postgres";
+
+	/* Connect to the database */
+	conn = PQconnectdb(conninfo);
+	if (PQstatus(conn) != CONNECTION_OK)
+	{
+		printf("%s:%d: Connection to database failed: %s", __FILE__, __LINE__, PQerrorMessage(conn));
+		exit_nicely(conn);
+	}
+
+	/* Prepare objects for the test */
+	res = PQexec(conn, "SET client_min_messages = ERROR;");
+	if (PQresultStatus(res) != PGRES_COMMAND_OK)
+	{
+		printf("%s:%d: Execution failed: %s", __FILE__, __LINE__, PQresultErrorMessage(res));
+		exit_nicely(conn);
+	}
+	PQclear(res);
+	res = PQexec(conn, "DROP EXTENSION IF EXISTS extended_protocol_commit_test_fdw CASCADE;");
+	if (PQresultStatus(res) != PGRES_COMMAND_OK)
+	{
+		printf("%s:%d: Execution failed: %s", __FILE__, __LINE__, PQresultErrorMessage(res));
+		exit_nicely(conn);
+	}
+	PQclear(res);
+	res = PQexec(conn, "CREATE EXTENSION extended_protocol_commit_test_fdw;");
+	if (PQresultStatus(res) != PGRES_COMMAND_OK)
+	{
+		printf("%s:%d: Execution failed: %s", __FILE__, __LINE__, PQresultErrorMessage(res));
+		exit_nicely(conn);
+	}
+	PQclear(res);
+	res = PQexec(conn, "CREATE SERVER extended_protocol_commit_test_server FOREIGN DATA WRAPPER extended_protocol_commit_test_fdw;");
+	if (PQresultStatus(res) != PGRES_COMMAND_OK)
+	{
+		printf("%s:%d: Execution failed: %s", __FILE__, __LINE__, PQresultErrorMessage(res));
+		exit_nicely(conn);
+	}
+	PQclear(res);
+	res = PQexec(conn, "CREATE FOREIGN TABLE extended_protocol_commit_test_table(i INT, t TEXT) SERVER extended_protocol_commit_test_server;");
+	if (PQresultStatus(res) != PGRES_COMMAND_OK)
+	{
+		printf("%s:%d: Execution failed: %s", __FILE__, __LINE__, PQresultErrorMessage(res));
+		exit_nicely(conn);
+	}
+	PQclear(res);
+	res = PQexec(conn, "SELECT * FROM extended_protocol_commit_test_table;");
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+	{
+		printf("%s:%d: Execution failed: %s", __FILE__, __LINE__, PQresultErrorMessage(res));
+		exit_nicely(conn);
+	}
+	PQclear(res);
+
+	/* The test itself */
+	res = PQprepare(conn, "extend_query_cursor", "SELECT i, t FROM extended_protocol_commit_test_table;", 0, NULL);
+	if (PQresultStatus(res) != PGRES_COMMAND_OK)
+	{
+		printf("%s:%d: Execution failed: %s", __FILE__, __LINE__, PQresultErrorMessage(res));
+		exit_nicely(conn);
+	}
+	PQclear(res);
+	res = PQexecPrepared(conn, "extend_query_cursor", 0, NULL, NULL, NULL, 0);
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+	{
+		printf("%s:%d: Execution failed: %s", __FILE__, __LINE__, PQresultErrorMessage(res));
+		exit_nicely(conn);
+	}
+	PQclear(res);
+
+	printf("extended_protocol_commit_test passed\n");
+
+	PQfinish(conn);
+	return 0;
+}

--- a/src/test/fdw/extension/Makefile
+++ b/src/test/fdw/extension/Makefile
@@ -1,0 +1,16 @@
+EXTENSION = extended_protocol_commit_test_fdw
+DATA = extended_protocol_commit_test_fdw--1.0.sql
+
+MODULE_big = extended_protocol_commit_test_fdw
+
+OBJS = extended_protocol_commit_test_fdw.o
+
+
+subdir = src/test/fdw/extension
+top_builddir = ../../../..
+include $(top_builddir)/src/Makefile.global
+NO_PGXS = 1
+include $(top_srcdir)/src/makefiles/pgxs.mk
+
+
+installcheck: install

--- a/src/test/fdw/extension/extended_protocol_commit_test_fdw--1.0.sql
+++ b/src/test/fdw/extension/extended_protocol_commit_test_fdw--1.0.sql
@@ -1,0 +1,9 @@
+\echo use "create extension" to load this file. \quit
+
+CREATE FUNCTION extended_protocol_commit_test_fdw_handler()
+RETURNS fdw_handler
+AS '$libdir/extended_protocol_commit_test_fdw', 'extended_protocol_commit_test_fdw_handler'
+LANGUAGE C STRICT;
+
+CREATE FOREIGN DATA WRAPPER extended_protocol_commit_test_fdw
+  HANDLER extended_protocol_commit_test_fdw_handler;

--- a/src/test/fdw/extension/extended_protocol_commit_test_fdw.c
+++ b/src/test/fdw/extension/extended_protocol_commit_test_fdw.c
@@ -1,0 +1,157 @@
+/*
+ * src/test/fdw/extended_protocol_commit_test_fdw.c
+ *
+ *
+ * extended_protocol_commit_test_fdw.c
+ *
+ *		A foreign data wrapper for testing of its interaction with FDW.
+ */
+
+#include "postgres.h"
+
+#include "executor/spi.h"
+#include "foreign/fdwapi.h"
+#include "optimizer/pathnode.h"
+#include "optimizer/planmain.h"
+#include "optimizer/restrictinfo.h"
+
+#ifdef PG_MODULE_MAGIC
+PG_MODULE_MAGIC;
+#endif
+
+
+#define TEST_TABLE_NAME "extended_protocol_commit_test_table_for_create_drop"
+
+
+/*
+ * Execute the given query via SPI
+ */
+static void
+test_execute_spi_expression(const char *query)
+{
+	int			r;
+
+	if (SPI_connect() != SPI_OK_CONNECT)
+		elog(ERROR, "Failed to connect to SPI");
+	PG_TRY();
+	{
+		r = SPI_execute(query, false, 0);
+		if (r < 0)
+			elog(ERROR, "Failed to execute '%s' via SPI: %s [%d]", query, SPI_result_code_string(r), r);
+	}
+	PG_CATCH();
+	{
+		SPI_finish();
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+	SPI_finish();
+}
+
+static void
+test_create_table_via_spi(void)
+{
+	StringInfo	query;
+
+	query = makeStringInfo();
+	appendStringInfo(query, "CREATE TABLE %s(i INT, t TEXT) DISTRIBUTED RANDOMLY;", TEST_TABLE_NAME);
+
+	test_execute_spi_expression(query->data);
+
+	pfree(query->data);
+	pfree(query);
+}
+
+static void
+test_drop_table_via_spi(void)
+{
+	StringInfo	query;
+
+	query = makeStringInfo();
+	appendStringInfo(query, "DROP TABLE %s;", TEST_TABLE_NAME);
+
+	test_execute_spi_expression(query->data);
+
+	pfree(query->data);
+	pfree(query);
+}
+
+static void
+extended_protocol_commit_test_fdw_GetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
+{
+	test_create_table_via_spi();
+
+	baserel->rows = 1;
+	baserel->fdw_private = NULL;
+}
+
+static void
+extended_protocol_commit_test_fdw_GetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
+{
+	add_path(baserel, (Path *) create_foreignscan_path(
+													   root,
+													   baserel,
+													   NULL,
+													   0,
+													   0,
+													   0,
+													   NIL,
+													   NULL,
+													   NULL,
+													   NIL
+													   ));
+}
+
+static ForeignScan *
+extended_protocol_commit_test_fdw_GetForeignPlan(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid, ForeignPath *best_path, List *tlist, List *scan_clauses, Plan *outer_plan)
+{
+	return make_foreignscan(
+							tlist,
+							extract_actual_clauses(scan_clauses, false),
+							baserel->relid,
+							NIL,
+							NULL,
+							NIL,
+							NIL,
+							NULL
+		);
+}
+
+static void
+extended_protocol_commit_test_fdw_BeginForeignScan(ForeignScanState *node, int eflags)
+{
+}
+
+static TupleTableSlot *
+extended_protocol_commit_test_fdw_IterateForeignScan(ForeignScanState *node)
+{
+	return ExecClearTuple(node->ss.ss_ScanTupleSlot);
+}
+
+static void
+extended_protocol_commit_test_fdw_ReScanForeignScan(ForeignScanState *node)
+{
+}
+
+static void
+extended_protocol_commit_test_fdw_EndForeignScan(ForeignScanState *node)
+{
+	test_drop_table_via_spi();
+}
+
+PG_FUNCTION_INFO_V1(extended_protocol_commit_test_fdw_handler);
+Datum
+extended_protocol_commit_test_fdw_handler(PG_FUNCTION_ARGS)
+{
+	FdwRoutine *result = makeNode(FdwRoutine);
+
+	result->GetForeignRelSize = extended_protocol_commit_test_fdw_GetForeignRelSize;
+	result->GetForeignPaths = extended_protocol_commit_test_fdw_GetForeignPaths;
+	result->GetForeignPlan = extended_protocol_commit_test_fdw_GetForeignPlan;
+	result->BeginForeignScan = extended_protocol_commit_test_fdw_BeginForeignScan;
+	result->IterateForeignScan = extended_protocol_commit_test_fdw_IterateForeignScan;
+	result->ReScanForeignScan = extended_protocol_commit_test_fdw_ReScanForeignScan;
+	result->EndForeignScan = extended_protocol_commit_test_fdw_EndForeignScan;
+
+	PG_RETURN_POINTER(result);
+}

--- a/src/test/fdw/extension/extended_protocol_commit_test_fdw.control
+++ b/src/test/fdw/extension/extended_protocol_commit_test_fdw.control
@@ -1,0 +1,3 @@
+comment = 'Extended protocol commit test foreign data wrapper'
+default_version = '1.0'
+relocatable = true

--- a/src/test/fdw/sql/extended_protocol_commit_test.sql
+++ b/src/test/fdw/sql/extended_protocol_commit_test.sql
@@ -1,0 +1,1 @@
+\! ./extended_protocol_commit_test;


### PR DESCRIPTION
Closes https://github.com/greenplum-db/gpdb/issues/10918.

`debug_query_string` global variable is used by `cdbdisp_buildUtilityQueryParams()` to pass the original query to segments executing utility queries.

There is a case when `debug_query_string` is `NULL` (see the linked issue).

Handle this case by checking `NULL`ness of the variable and changing it to empty string if necessary.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
