### PR TITLE
pg_upgrade: fix check_heterogeneous_partition message

### DIFF
--- a/contrib/pg_upgrade/greenplum/check_gp.c
+++ b/contrib/pg_upgrade/greenplum/check_gp.c
@@ -580,8 +580,9 @@ check_heterogeneous_partition(void)
 			   "| Your installation contains heterogenous partitioned tables\n"
 			   "| where the root partition does not match one or more child\n"
 			   "| partitions' on disk representation. In order to make the\n"
-			   "| tables homogeneous, CREATE TABLE AS must be performed on\n"
-			   "| the tables so that they can be be dropped before upgrade.\n"
+			   "| tables homogenous, create a new partition table with the same\n"
+			   "| schema as the old partition table, insert the old data into\n"
+			   "| the new table, and drop the old table.\n"
 			   "| A list of the problem tables is in the file:\n" "| \t%s\n\n",
 			   output_path);
 	}

--- a/contrib/pg_upgrade/test/integration/output/partitioned_heap_table_with_differently_aligned_dropped_columns.source
+++ b/contrib/pg_upgrade/test/integration/output/partitioned_heap_table_with_differently_aligned_dropped_columns.source
@@ -31,8 +31,9 @@ Checking for heterogeneous partitioned tables               fatal
 | Your installation contains heterogenous partitioned tables
 | where the root partition does not match one or more child
 | partitions' on disk representation. In order to make the
-| tables homogeneous, CREATE TABLE AS must be performed on
-| the tables so that they can be be dropped before upgrade.
+| tables homogenous, create a new partition table with the same
+| schema as the old partition table, insert the old data into
+| the new table, and drop the old table.
 | A list of the problem tables is in the file:
 | 	heterogeneous_partitioned_tables.txt
 

--- a/contrib/pg_upgrade/test/integration/output/partitioned_heap_table_with_differently_aligned_varlen_dropped_columns.source
+++ b/contrib/pg_upgrade/test/integration/output/partitioned_heap_table_with_differently_aligned_varlen_dropped_columns.source
@@ -29,8 +29,9 @@ Checking for heterogeneous partitioned tables               fatal
 | Your installation contains heterogenous partitioned tables
 | where the root partition does not match one or more child
 | partitions' on disk representation. In order to make the
-| tables homogeneous, CREATE TABLE AS must be performed on
-| the tables so that they can be be dropped before upgrade.
+| tables homogenous, create a new partition table with the same
+| schema as the old partition table, insert the old data into
+| the new table, and drop the old table.
 | A list of the problem tables is in the file:
 | 	heterogeneous_partitioned_tables.txt
 

--- a/contrib/pg_upgrade/test/integration/output/partitioned_heap_table_with_differently_sized_dropped_columns.source
+++ b/contrib/pg_upgrade/test/integration/output/partitioned_heap_table_with_differently_sized_dropped_columns.source
@@ -24,8 +24,9 @@ Checking for heterogeneous partitioned tables               fatal
 | Your installation contains heterogenous partitioned tables
 | where the root partition does not match one or more child
 | partitions' on disk representation. In order to make the
-| tables homogeneous, CREATE TABLE AS must be performed on
-| the tables so that they can be be dropped before upgrade.
+| tables homogenous, create a new partition table with the same
+| schema as the old partition table, insert the old data into
+| the new table, and drop the old table.
 | A list of the problem tables is in the file:
 | 	heterogeneous_partitioned_tables.txt
 


### PR DESCRIPTION
The suggestion in the existing error text is incorrect, as CREATE TABLE AS on
a partition table will end up creating a non-partitioned table.  This commit
updates the message to be more precise in addressing the error.

Co-authored-by: Jamie McAtamney <jmcatamney@vmware.com>