### PR TITLE
Improve the internal implementation of ereport() and mainly elog()

### DIFF
--- a/contrib/adminpack/adminpack.c
+++ b/contrib/adminpack/adminpack.c
@@ -192,7 +192,7 @@ pg_file_write_internal(text *file, text *data, bool replace)
 
 		if (stat(filename, &fst) >= 0)
 			ereport(ERROR,
-					(ERRCODE_DUPLICATE_FILE,
+					(errcode(ERRCODE_DUPLICATE_FILE),
 					 errmsg("file \"%s\" exists", filename)));
 
 		f = AllocateFile(filename, "wb");
@@ -324,7 +324,7 @@ pg_file_rename_internal(text *file1, text *file2, text *file3)
 	if (rc >= 0 || errno != ENOENT)
 	{
 		ereport(ERROR,
-				(ERRCODE_DUPLICATE_FILE,
+				(errcode(ERRCODE_DUPLICATE_FILE),
 				 errmsg("cannot rename to target file \"%s\"",
 						fn3 ? fn3 : fn2)));
 	}
@@ -355,7 +355,7 @@ pg_file_rename_internal(text *file1, text *file2, text *file3)
 			else
 			{
 				ereport(ERROR,
-						(ERRCODE_UNDEFINED_FILE,
+						(errcode(ERRCODE_UNDEFINED_FILE),
 						 errmsg("renaming \"%s\" to \"%s\" was reverted",
 								fn2, fn3)));
 			}

--- a/contrib/extprotocol/gpextprotocol.c
+++ b/contrib/extprotocol/gpextprotocol.c
@@ -53,7 +53,7 @@ static void check_ext_options(const FunctionCallInfo fcinfo)
 			char *value = defGetString(def);
 
 			if (key && strcasestr(key, "database") && !strcasestr(value, "greenplum")) {
-					ereport(ERROR, (0, errmsg("This is greenplum.")));
+					ereport(ERROR, errmsg("This is greenplum."));
 			}
         }
 }

--- a/gpcontrib/gp_exttable_fdw/extaccess.c
+++ b/gpcontrib/gp_exttable_fdw/extaccess.c
@@ -1007,7 +1007,7 @@ externalgettup_custom(FileScanDesc scan)
 		 * EOF. This is an error.
 		 */
 		ereport(WARNING,
-				(ERRCODE_DATA_EXCEPTION,
+				(errcode(ERRCODE_DATA_EXCEPTION),
 				 errmsg("unexpected end of file")));
 	}
 

--- a/gpcontrib/gpcloud/src/gpcloud.cpp
+++ b/gpcontrib/gpcloud/src/gpcloud.cpp
@@ -161,9 +161,9 @@ static void parseFormatOpts(FunctionCallInfo fcinfo) {
                 eolString[0] = '\n';
                 eolString[1] = '\0';
             } else {  // should never come here
-                ereport(ERROR, (0, errmsg("invalid value for NEWLINE (%s), "
-                                          "valid options are: 'LF', 'CRLF', 'CR'",
-                                          newline_str)));
+	      ereport(ERROR, errmsg("invalid value for NEWLINE (%s), "
+				    "valid options are: 'LF', 'CRLF', 'CR'",
+				    newline_str));
             }
         }
     }
@@ -296,10 +296,10 @@ Datum s3_import(PG_FUNCTION_ARGS) {
 
         resHandle->gpreader = reader_init(url_with_options);
         if (!resHandle->gpreader) {
-            ereport(ERROR, (0, errmsg("Failed to init gpcloud extension (segid = %d, "
-                                      "segnum = %d), please check your "
-                                      "configurations and network connection: %s",
-                                      s3ext_segid, s3ext_segnum, s3extErrorMessage.c_str())));
+            ereport(ERROR, errmsg("Failed to init gpcloud extension (segid = %d, "
+				  "segnum = %d), please check your "
+				  "configurations and network connection: %s",
+				  s3ext_segid, s3ext_segnum, s3extErrorMessage.c_str()));
         }
 
         EXTPROTOCOL_SET_USER_CTX(fcinfo, resHandle);
@@ -310,7 +310,7 @@ Datum s3_import(PG_FUNCTION_ARGS) {
 
     if (!reader_transfer_data(resHandle->gpreader, data_buf, data_len)) {
         ereport(ERROR,
-                (0, errmsg("s3_import: could not read data: %s", s3extErrorMessage.c_str())));
+                errmsg("s3_import: could not read data: %s", s3extErrorMessage.c_str()));
     }
     PG_RETURN_INT32(data_len);
 }
@@ -351,10 +351,10 @@ Datum s3_export(PG_FUNCTION_ARGS) {
 
         resHandle->gpwriter = writer_init(url_with_options, format);
         if (!resHandle->gpwriter) {
-            ereport(ERROR, (0, errmsg("Failed to init gpcloud extension (segid = %d, "
-                                      "segnum = %d), please check your "
-                                      "configurations and network connection: %s",
-                                      s3ext_segid, s3ext_segnum, s3extErrorMessage.c_str())));
+	  ereport(ERROR, errmsg("Failed to init gpcloud extension (segid = %d, "
+				"segnum = %d), please check your "
+				"configurations and network connection: %s",
+				s3ext_segid, s3ext_segnum, s3extErrorMessage.c_str()));
         }
 
         EXTPROTOCOL_SET_USER_CTX(fcinfo, resHandle);
@@ -365,7 +365,7 @@ Datum s3_export(PG_FUNCTION_ARGS) {
 
     if (!writer_transfer_data(resHandle->gpwriter, data_buf, data_len)) {
         ereport(ERROR,
-                (0, errmsg("s3_export: could not write data: %s", s3extErrorMessage.c_str())));
+                errmsg("s3_export: could not write data: %s", s3extErrorMessage.c_str()));
     }
 
     PG_RETURN_INT32(data_len);

--- a/gpcontrib/orafce/sqlscan.c
+++ b/gpcontrib/orafce/sqlscan.c
@@ -1,6 +1,6 @@
-#line 1 "sqlscan.c"
+#line 2 "sqlscan.c"
 
-#line 3 "sqlscan.c"
+#line 4 "sqlscan.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1004,7 +1004,7 @@ static unsigned char unescape_single_char(unsigned char c);
 #define _pg_mbstrlen_with_len(buf,loc) 	pg_mbstrlen_with_len(buf,loc)
 #endif
 
-#line 1007 "sqlscan.c"
+#line 1008 "sqlscan.c"
 #define YY_NO_INPUT 1
 /*
  * OK, here is a short description of lex/flex rules behavior.
@@ -1132,7 +1132,7 @@ static unsigned char unescape_single_char(unsigned char c);
  * Note that xcstart must appear before operator, as explained above!
  *  Also whitespace (comment) must appear before operator.
  */
-#line 1135 "sqlscan.c"
+#line 1136 "sqlscan.c"
 
 #define INITIAL 0
 #define xb 1
@@ -1357,7 +1357,7 @@ YY_DECL
 #line 308 "sqlscan.l"
 
 
-#line 1360 "sqlscan.c"
+#line 1361 "sqlscan.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -2176,7 +2176,7 @@ YY_RULE_SETUP
 #line 862 "sqlscan.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 2179 "sqlscan.c"
+#line 2180 "sqlscan.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -3165,7 +3165,7 @@ lexer_errposition(void)
 	pos = _pg_mbstrlen_with_len(scanbuf, orafce_sql_yylval.val.lloc) + 1;
 	/* And pass it to the ereport mechanism */
 
-#if PG_VERSION_NUM >= 130000
+#if PG_VERSION_NUM >= 120000
 
 	errposition(pos);
 

--- a/gpcontrib/orafce/sqlscan.l
+++ b/gpcontrib/orafce/sqlscan.l
@@ -880,7 +880,7 @@ lexer_errposition(void)
 	pos = _pg_mbstrlen_with_len(scanbuf, orafce_sql_yylval.val.lloc) + 1;
 	/* And pass it to the ereport mechanism */
 
-#if PG_VERSION_NUM >= 130000
+#if PG_VERSION_NUM >= 120000
 
 	errposition(pos);
 

--- a/gpcontrib/orafce/utility.c
+++ b/gpcontrib/orafce/utility.c
@@ -44,7 +44,7 @@ dbms_utility_format_call_stack(char mode)
 	StringInfo   sinfo;
 
 
-#if PG_VERSION_NUM >= 130000
+#if PG_VERSION_NUM >= 120000
 
 	errstart(ERROR, TEXTDOMAIN);
 

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -409,7 +409,7 @@ errcontext_appendonly_insert_block(AppendOnlyInsertDesc aoInsertDesc)
  *
  * Add an errdetail() line showing the Append-Only Storage block header for the block being inserted.
  */
-static int
+static void
 errdetail_appendonly_insert_block_header(AppendOnlyInsertDesc aoInsertDesc)
 {
 	uint8	   *header;
@@ -420,7 +420,7 @@ errdetail_appendonly_insert_block_header(AppendOnlyInsertDesc aoInsertDesc)
 
 	usingChecksum = aoInsertDesc->usingChecksum;
 
-	return errdetail_appendonly_storage_content_header(header, usingChecksum, aoInsertDesc->storageWrite.formatVersion);
+	errdetail_appendonly_storage_content_header(header, usingChecksum, aoInsertDesc->storageWrite.formatVersion);
 }
 
 /*

--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -101,7 +101,7 @@ _bitmap_get_metapage_data(Relation rel, Buffer metabuf)
 	if (metapage->bm_version != BITMAP_VERSION)
 	{
 		ereport(ERROR,
-				(ERRCODE_INTERNAL_ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
 				 errmsg("the disk format for \"%s\" is not valid for this version of Greenplum Database",
 						RelationGetRelationName(rel)),
 				 errhint("Use REINDEX to update this index.")));

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1214,7 +1214,7 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 
 			if (!is_file_exists(extssl_cer_full))
 				ereport(ERROR,
-						(errcode(errcode_for_file_access()),
+						(errcode_for_file_access(),
 						 errmsg("could not open certificate file \"%s\": %m",
 								extssl_cer_full)));
 
@@ -1235,7 +1235,7 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 
 			if (!is_file_exists(extssl_key_full))
 				ereport(ERROR,
-						(errcode(errcode_for_file_access()),
+						(errcode_for_file_access(),
 						 errmsg("could not open private key file \"%s\": %m",
 								extssl_key_full)));
 
@@ -1250,7 +1250,7 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 
 			if (!is_file_exists(extssl_cas_full))
 				ereport(ERROR,
-						(errcode(errcode_for_file_access()),
+						(errcode_for_file_access(),
 						 errmsg("could not open private key file \"%s\": %m",
 								extssl_cas_full)));
 

--- a/src/backend/access/transam/test/varsup_test.c
+++ b/src/backend/access/transam/test/varsup_test.c
@@ -7,11 +7,14 @@
 #include "postgres.h"
 
 #undef ereport
-#define ereport(elevel, rest) ereport_mock(elevel, rest)
+#define ereport(elevel, ...) \
+	do { \
+	__VA_ARGS__, ereport_mock(elevel); \
+	} while(0)
 
 static int expected_elevel;
 
-static void ereport_mock(int elevel, int dummy pg_attribute_unused(),...)
+static void ereport_mock(int elevel)
 {
 	assert_int_equal(elevel, expected_elevel);
 	

--- a/src/backend/cdb/cdbappendonlystorageformat.c
+++ b/src/backend/cdb/cdbappendonlystorageformat.c
@@ -700,7 +700,7 @@ AppendOnlyStorageFormat_BlockHeaderStr(
  *
  * Add an errdetail() line showing the Append-Only Storage block header.
  */
-int
+void
 errdetail_appendonly_storage_smallcontent_header(
 												 uint8 *headerPtr,
 												 bool usingChecksums,
@@ -716,8 +716,6 @@ errdetail_appendonly_storage_smallcontent_header(
 	errdetail("%s", str);
 
 	pfree(str);
-
-	return 0;
 }
 
 /*
@@ -725,7 +723,7 @@ errdetail_appendonly_storage_smallcontent_header(
  *
  * Add an errdetail() line showing the Append-Only Storage block header.
  */
-int
+void
 errdetail_appendonly_storage_largecontent_header(
 												 uint8 *headerPtr,
 												 bool usingChecksums,
@@ -740,8 +738,6 @@ errdetail_appendonly_storage_largecontent_header(
 	errdetail("%s", str);
 
 	pfree(str);
-
-	return 0;
 }
 
 
@@ -750,7 +746,7 @@ errdetail_appendonly_storage_largecontent_header(
  *
  * Add an errdetail() line showing the Append-Only Storage block header.
  */
-int
+void
 errdetail_appendonly_storage_nonbulkdensecontent_header(
 														uint8 *headerPtr,
 														bool usingChecksums,
@@ -766,8 +762,6 @@ errdetail_appendonly_storage_nonbulkdensecontent_header(
 	errdetail("%s", str);
 
 	pfree(str);
-
-	return 0;
 }
 
 /*
@@ -775,7 +769,7 @@ errdetail_appendonly_storage_nonbulkdensecontent_header(
  *
  * Add an errdetail() line showing the Append-Only Storage block header.
  */
-int
+void
 errdetail_appendonly_storage_bulkdensecontent_header(
 													 uint8 *headerPtr,
 													 bool usingChecksums,
@@ -791,8 +785,6 @@ errdetail_appendonly_storage_bulkdensecontent_header(
 	errdetail("%s", str);
 
 	pfree(str);
-
-	return 0;
 }
 
 /*
@@ -800,7 +792,7 @@ errdetail_appendonly_storage_bulkdensecontent_header(
  *
  * Add an errdetail() line showing the Append-Only Storage content (Small, Large, Dense) header.
  */
-int
+void
 errdetail_appendonly_storage_content_header(
 											uint8 *header,
 											bool usingChecksum,
@@ -815,21 +807,25 @@ errdetail_appendonly_storage_content_header(
 	switch (aoHeaderKind)
 	{
 		case AoHeaderKind_SmallContent:
-			return errdetail_appendonly_storage_smallcontent_header(header, usingChecksum, version);
+			errdetail_appendonly_storage_smallcontent_header(header, usingChecksum, version);
+			break;
 
 		case AoHeaderKind_LargeContent:
-			return errdetail_appendonly_storage_largecontent_header(header, usingChecksum, version);
+			errdetail_appendonly_storage_largecontent_header(header, usingChecksum, version);
+			break;
 
 		case AoHeaderKind_NonBulkDenseContent:
-			return errdetail_appendonly_storage_nonbulkdensecontent_header(header, usingChecksum, version);
+			errdetail_appendonly_storage_nonbulkdensecontent_header(header, usingChecksum, version);
+			break;
 
 		case AoHeaderKind_BulkDenseContent:
-			return errdetail_appendonly_storage_bulkdensecontent_header(header, usingChecksum, version);
+			errdetail_appendonly_storage_bulkdensecontent_header(header, usingChecksum, version);
+			break;
 
 		default:
-			return errdetail(
-							 "Append-Only storage header kind %d unknown",
-							 aoHeaderKind);
+			errdetail(
+				"Append-Only storage header kind %d unknown",
+				aoHeaderKind);
 	}
 }
 

--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -670,7 +670,7 @@ errcontext_appendonly_write_storage_block(AppendOnlyStorageWrite *storageWrite)
  *
  * Add an errdetail() line showing the Append-Only Storage header being written.
  */
-static int
+static void
 errdetail_appendonly_write_storage_block_header(AppendOnlyStorageWrite *storageWrite)
 {
 	uint8	   *header;
@@ -681,8 +681,8 @@ errdetail_appendonly_write_storage_block_header(AppendOnlyStorageWrite *storageW
 	checksum = storageWrite->storageAttributes.checksum;
 	version = storageWrite->formatVersion;
 
-	return errdetail_appendonly_storage_smallcontent_header(header, checksum,
-															version);
+	errdetail_appendonly_storage_smallcontent_header(header, checksum,
+													 version);
 }
 
 /*----------------------------------------------------------------

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -146,9 +146,12 @@ cdbdisp_getDispatchResults(struct CdbDispatcherState *ds, ErrorData **qeError)
 		 * likely to output the errors on NULL return, add an error message to
 		 * aid debugging.
 		 */
-		if (errstart(ERROR, __FILE__, __LINE__, PG_FUNCNAME_MACRO, TEXTDOMAIN))
-			*qeError = errfinish_and_return(errcode(ERRCODE_INTERNAL_ERROR),
-											errmsg("no dispatcher state"));
+		if (errstart(ERROR, TEXTDOMAIN))
+		{
+			errcode(ERRCODE_INTERNAL_ERROR);
+			errmsg("no dispatcher state");
+			*qeError = errfinish_and_return(__FILE__, __LINE__, PG_FUNCNAME_MACRO);
+		}
 		else
 			pg_unreachable();
 

--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -472,9 +472,12 @@ cdbdisp_dumpDispatchResult(CdbDispatchResult *dispatchResult)
 	if (dispatchResult->error_message &&
 		dispatchResult->error_message->len > 0)
 	{
-		if (errstart(ERROR, __FILE__, __LINE__, PG_FUNCNAME_MACRO, TEXTDOMAIN))
-			errdata = errfinish_and_return(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
-											errmsg("%s", dispatchResult->error_message->data));
+		if (errstart(ERROR, TEXTDOMAIN))
+		{
+			errcode(ERRCODE_GP_INTERCONNECTION_ERROR);
+			errmsg("%s", dispatchResult->error_message->data);
+			errdata = errfinish_and_return(__FILE__, __LINE__, PG_FUNCNAME_MACRO);
+		}
 		else
 			pg_unreachable();
 
@@ -547,7 +550,7 @@ cdbdisp_get_PQerror(PGresult *pgresult)
 	 * command failed. And if a QE disconnected with FATAL, or PANICed,
 	 * we don't want to do the same in the QD. So, always an ERROR.
 	 */
-	if (!errstart(ERROR, filename, lineno, funcname, TEXTDOMAIN))
+	if (!errstart(ERROR, TEXTDOMAIN))
 		pg_unreachable(); /* unexpected path. */
 
 	fld = PQresultErrorField(pgresult, PG_DIAG_SQLSTATE);
@@ -578,7 +581,7 @@ cdbdisp_get_PQerror(PGresult *pgresult)
 		errcontext("%s", fld);
 
 	oldcontext = MemoryContextSwitchTo(TopTransactionContext);
-	ErrorData *edata = errfinish_and_return(0);
+	ErrorData *edata = errfinish_and_return(filename, lineno, funcname);
 	MemoryContextSwitchTo(oldcontext);
 	return edata;
 }

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -950,21 +950,21 @@ UpdateChangedParamSet(PlanState *node, Bitmapset *newchg)
  * normal non-error case: computing character indexes would be much more
  * expensive than storing token offsets.)
  */
-int
+void
 executor_errposition(EState *estate, int location)
 {
 	int			pos;
 
 	/* No-op if location was not provided */
 	if (location < 0)
-		return 0;
+		return;
 	/* Can't do anything if source text is not available */
 	if (estate == NULL || estate->es_sourceText == NULL)
-		return 0;
+		return;
 	/* Convert offset to character number */
 	pos = pg_mbstrlen_with_len(estate->es_sourceText, location) + 1;
 	/* And pass it to the ereport mechanism */
-	return errposition(pos);
+	errposition(pos);
 }
 
 /*

--- a/src/backend/fts/test/Makefile
+++ b/src/backend/fts/test/Makefile
@@ -27,6 +27,5 @@ ftsprobe.t: \
     $(MOCK_DIR)/backend/libpq/fe-connect_mock.o \
     $(MOCK_DIR)/backend/access/transam/xact_mock.o \
     $(MOCK_DIR)/backend/utils/time/snapmgr_mock.o \
-    $(MOCK_DIR)/backend/utils/error/elog_mock.o \
     $(MOCK_DIR)/backend/access/hash/hash_mock.o \
     $(MOCK_DIR)/backend/utils/fmgr/fmgr_mock.o

--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -73,18 +73,24 @@ CGPOptimizer::GPOPTOptimizedPlan(
 		if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL,
 						  gpdxl::ExmiQuery2DXLNotNullViolation))
 		{
-			errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
-			errfinish(errcode(ERRCODE_NOT_NULL_VIOLATION),
-					  errmsg("%s", serialized_error_msg));
+			if (errstart(ERROR, TEXTDOMAIN))
+			{
+				errcode(ERRCODE_NOT_NULL_VIOLATION);
+				errmsg("%s", serialized_error_msg);
+				errfinish(ex.Filename(), ex.Line(), NULL);
+			}
 		}
 
 		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL, gpdxl::ExmiOptimizerError) ||
 				 gpopt_context.m_should_error_out)
 		{
 			Assert(NULL != serialized_error_msg);
-			errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
-			errfinish(errcode(ERRCODE_INTERNAL_ERROR),
-					  errmsg("%s", serialized_error_msg));
+			if (errstart(ERROR, TEXTDOMAIN))
+			{
+				errcode(ERRCODE_INTERNAL_ERROR);
+				errmsg("%s", serialized_error_msg);
+				errfinish(ex.Filename(), ex.Line(), NULL);
+			}
 		}
 		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaGPDB, gpdxl::ExmiGPDBError))
 		{
@@ -93,18 +99,23 @@ CGPOptimizer::GPOPTOptimizedPlan(
 		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL,
 							   gpdxl::ExmiNoAvailableMemory))
 		{
-			errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
-			errfinish(errcode(ERRCODE_INTERNAL_ERROR),
-					  errmsg("no available memory to allocate string buffer"));
+			if (errstart(ERROR, TEXTDOMAIN))
+			{
+				errcode(ERRCODE_INTERNAL_ERROR);
+				errmsg("no available memory to allocate string buffer");
+				errfinish(ex.Filename(), ex.Line(), NULL);
+			}
 		}
 		else if (GPOS_MATCH_EX(ex, gpdxl::ExmaDXL,
 							   gpdxl::ExmiInvalidComparisonTypeCode))
 		{
-			errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
-			errfinish(
-				errcode(ERRCODE_INTERNAL_ERROR),
+			if (errstart(ERROR, TEXTDOMAIN))
+			{
+				errcode(ERRCODE_INTERNAL_ERROR);
 				errmsg(
-					"invalid comparison type code. Valid values are Eq, NEq, LT, LEq, GT, GEq."));
+					"invalid comparison type code. Valid values are Eq, NEq, LT, LEq, GT, GEq.");
+				errfinish(ex.Filename(), ex.Line(), NULL);
+			}
 		}
 
 		// Failed to produce a plan, but it wasn't an error that should
@@ -114,13 +125,15 @@ CGPOptimizer::GPOPTOptimizedPlan(
 
 		if (optimizer_trace_fallback)
 		{
-			errstart(INFO, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
-			errfinish(
-				errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			if (errstart(INFO, TEXTDOMAIN))
+			{
+				errcode(ERRCODE_FEATURE_NOT_SUPPORTED);
 				errmsg(
-					"GPORCA failed to produce a plan, falling back to planner"),
-				serialized_error_msg ? errdetail("%s", serialized_error_msg)
-									 : 0);
+					"GPORCA failed to produce a plan, falling back to planner");
+				if (serialized_error_msg)
+					errdetail("%s", serialized_error_msg);
+				errfinish(ex.Filename(), ex.Line(), NULL);
+			}
 		}
 
 		*had_unexpected_failure = gpopt_context.m_is_unexpected_failure;
@@ -150,9 +163,12 @@ CGPOptimizer::SerializeDXLPlan(Query *query)
 	}
 	GPOS_CATCH_EX(ex);
 	{
-		errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
-		errfinish(errcode(ERRCODE_INTERNAL_ERROR),
-				  errmsg("optimizer failed to produce plan"));
+		if (errstart(ERROR, TEXTDOMAIN))
+		{
+			errcode(ERRCODE_INTERNAL_ERROR);
+			errmsg("optimizer failed to produce plan");
+			errfinish(ex.Filename(), ex.Line(), NULL);
+		}
 	}
 	GPOS_CATCH_END;
 	return NULL;

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1648,9 +1648,14 @@ gpdb::GpdbEreportImpl(int xerrcode, int severitylevel, const char *xerrmsg,
 		// expanded version of ereport(). It will be caught by the
 		// GP_WRAP_END, and propagated up as a C++ exception, to be
 		// re-thrown as a Postgres error once we leave the C++ land.
-		if (errstart(severitylevel, filename, lineno, funcname, TEXTDOMAIN))
-			errfinish(errcode(xerrcode), errmsg("%s", xerrmsg),
-					  xerrhint ? errhint("%s", xerrhint) : 0);
+		if (errstart(severitylevel, TEXTDOMAIN))
+		{
+			errcode(xerrcode);
+			errmsg("%s", xerrmsg);
+			if (xerrhint)
+				errhint("%s", xerrhint);
+			errfinish(filename, lineno, funcname);
+		}
 	}
 	GP_WRAP_END;
 }

--- a/src/backend/libpq/test/pqcomm_test.c
+++ b/src/backend/libpq/test/pqcomm_test.c
@@ -117,9 +117,6 @@ test__internal_flush_failedSendEPIPE(void **state)
 
 	/* In that case, we expect ereport(COMERROR, ...) to be called */
 	expect_value(errstart, elevel, COMMERROR);
-	expect_any(errstart, filename);
-	expect_any(errstart, lineno);
-	expect_any(errstart, funcname);
 	expect_any(errstart, domain);
 	will_return(errstart, false);
 

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -1289,15 +1289,15 @@ coerce_to_specific_type(ParseState *pstate, Node *node,
  * XXX possibly this is more generally useful than coercion errors;
  * if so, should rename and place with parser_errposition.
  */
-int
+void
 parser_coercion_errposition(ParseState *pstate,
 							int coerce_location,
 							Node *input_expr)
 {
 	if (coerce_location >= 0)
-		return parser_errposition(pstate, coerce_location);
+		parser_errposition(pstate, coerce_location);
 	else
-		return parser_errposition(pstate, exprLocation(input_expr));
+		parser_errposition(pstate, exprLocation(input_expr));
 }
 
 

--- a/src/backend/parser/parse_node.c
+++ b/src/backend/parser/parse_node.c
@@ -107,21 +107,21 @@ free_parsestate(ParseState *pstate)
  * normal non-error case: computing character indexes would be much more
  * expensive than storing token offsets.)
  */
-int
+void
 parser_errposition(ParseState *pstate, int location)
 {
 	int			pos;
 
 	/* No-op if location was not provided */
 	if (location < 0)
-		return 0;
+		return;
 	/* Can't do anything if source text is not available */
 	if (pstate == NULL || pstate->p_sourcetext == NULL)
-		return 0;
+		return;
 	/* Convert offset to character number */
 	pos = pg_mbstrlen_with_len(pstate->p_sourcetext, location) + 1;
 	/* And pass it to the ereport mechanism */
-	return errposition(pos);
+	errposition(pos);
 }
 
 

--- a/src/backend/parser/scan.l
+++ b/src/backend/parser/scan.l
@@ -1101,18 +1101,18 @@ other			.
  * (essentially, scan.l and gram.y), since it requires the yyscanner struct
  * to still be available.
  */
-int
+void
 scanner_errposition(int location, core_yyscan_t yyscanner)
 {
 	int			pos;
 
 	if (location < 0)
-		return 0;				/* no-op if location is unknown */
+		return;				/* no-op if location is unknown */
 
 	/* Convert byte offset to character number */
 	pos = pg_mbstrlen_with_len(yyextra->scanbuf, location) + 1;
 	/* And pass it to the ereport mechanism */
-	return errposition(pos);
+	errposition(pos);
 }
 
 /*

--- a/src/backend/replication/test/gp_replication_test.c
+++ b/src/backend/replication/test/gp_replication_test.c
@@ -39,9 +39,6 @@ static void
 expect_ereport()
 {
 	expect_any(errstart, elevel);
-	expect_any(errstart, filename);
-	expect_any(errstart, lineno);
-	expect_any(errstart, funcname);
 	expect_any(errstart, domain);
 
 	will_be_called(errstart);

--- a/src/backend/storage/ipc/dsm_impl.c
+++ b/src/backend/storage/ipc/dsm_impl.c
@@ -92,7 +92,7 @@ static bool dsm_impl_mmap(dsm_op op, dsm_handle handle, Size request_size,
 						  void **impl_private, void **mapped_address,
 						  Size *mapped_size, int elevel);
 #endif
-static int	errcode_for_dynamic_shared_memory(void);
+static void errcode_for_dynamic_shared_memory(void);
 
 const struct config_enum_entry dynamic_shared_memory_options[] = {
 #ifdef USE_DSM_POSIX
@@ -1021,11 +1021,11 @@ dsm_impl_unpin_segment(dsm_handle handle, void **impl_private)
 	}
 }
 
-static int
+static void
 errcode_for_dynamic_shared_memory(void)
 {
 	if (errno == EFBIG || errno == ENOMEM)
-		return errcode(ERRCODE_OUT_OF_MEMORY);
+		errcode(ERRCODE_OUT_OF_MEMORY);
 	else
-		return errcode_for_file_access();
+		errcode_for_file_access();
 }

--- a/src/backend/storage/page/bufpage.c
+++ b/src/backend/storage/page/bufpage.c
@@ -148,7 +148,7 @@ PageIsVerified(Page page, BlockNumber blkno)
 	if (checksum_failure)
 	{
 		ereport(WARNING,
-				(ERRCODE_DATA_CORRUPTED,
+				(errcode(ERRCODE_DATA_CORRUPTED),
 				 errmsg("page verification failed, calculated checksum %u but expected %u",
 						checksum, p->pd_checksum)));
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4537,15 +4537,15 @@ process_postgres_switches(int argc, char *argv[], GucContext ctx,
 		/* spell the error message a bit differently depending on context */
 		if (IsUnderPostmaster)
 			ereport(FATAL,
-					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("invalid command-line argument for server process: %s", argv[optind]),
-					 errhint("Try \"%s --help\" for more information.", progname)));
+					errcode(ERRCODE_SYNTAX_ERROR),
+					errmsg("invalid command-line argument for server process: %s", argv[optind]),
+					errhint("Try \"%s --help\" for more information.", progname));
 		else
 			ereport(FATAL,
-					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("%s: invalid command-line argument: %s",
-							progname, argv[optind]),
-					 errhint("Try \"%s --help\" for more information.", progname)));
+					errcode(ERRCODE_SYNTAX_ERROR),
+					errmsg("%s: invalid command-line argument: %s",
+						   progname, argv[optind]),
+					errhint("Try \"%s --help\" for more information.", progname));
 	}
 
 	/*

--- a/src/backend/utils/adt/genfile.c
+++ b/src/backend/utils/adt/genfile.c
@@ -569,7 +569,7 @@ pg_file_write(PG_FUNCTION_ARGS)
 
 		if (stat(filename, &fst) >= 0)
 			ereport(ERROR,
-					(ERRCODE_DUPLICATE_FILE,
+					(errcode(ERRCODE_DUPLICATE_FILE),
 					 errmsg("file \"%s\" exists", filename)));
 
 		f = fopen(filename, "wb");
@@ -640,7 +640,7 @@ pg_file_rename(PG_FUNCTION_ARGS)
 	if (rc >= 0 || errno != ENOENT)
 	{
 		ereport(ERROR,
-				(ERRCODE_DUPLICATE_FILE,
+				(errcode(ERRCODE_DUPLICATE_FILE),
 				 errmsg("cannot rename to target file \"%s\"",
 						fn3 ? fn3 : fn2)));
 	}
@@ -671,7 +671,7 @@ pg_file_rename(PG_FUNCTION_ARGS)
 			else
 			{
 				ereport(ERROR,
-						(ERRCODE_UNDEFINED_FILE,
+						(errcode(ERRCODE_UNDEFINED_FILE),
 						 errmsg("renaming \"%s\" to \"%s\" was reverted",
 								fn2, fn3)));
 			}

--- a/src/backend/utils/adt/json.c
+++ b/src/backend/utils/adt/json.c
@@ -1316,8 +1316,10 @@ report_json_context(JsonLexContext *lex)
 	prefix = (context_start > line_start) ? "..." : "";
 	suffix = (lex->token_type != JSON_TOKEN_END && context_end - lex->input < lex->input_length && *context_end != '\n' && *context_end != '\r') ? "..." : "";
 
-	return errcontext("JSON data, line %d: %s%s%s",
-					  line_number, prefix, ctxt, suffix);
+	errcontext("JSON data, line %d: %s%s%s",
+			   line_number, prefix, ctxt, suffix);
+
+	return 0;
 }
 
 /*

--- a/src/backend/utils/error/assert.c
+++ b/src/backend/utils/error/assert.c
@@ -34,25 +34,21 @@ ExceptionalCondition(const char *conditionName,
 					 int lineNumber)
 {
     /* CDB: Try to tell the QD or client what happened. */
-    if (errstart(FATAL, fileName, lineNumber, NULL,TEXTDOMAIN))
-    {
-		if (!PointerIsValid(conditionName)
-			|| !PointerIsValid(fileName)
-			|| !PointerIsValid(errorType))
-			errfinish(errcode(ERRCODE_INTERNAL_ERROR),
-					  errFatalReturn(gp_reraise_signal),
-					  errmsg("TRAP: ExceptionalCondition: bad arguments"));
-		else
-			errfinish(errcode(ERRCODE_INTERNAL_ERROR),
-					  errFatalReturn(gp_reraise_signal),
-					  errmsg("Unexpected internal error"),
-					  errdetail("%s(\"%s\", File: \"%s\", Line: %d)\n",
-								errorType, conditionName, fileName, lineNumber)
-				);
+	if (!PointerIsValid(conditionName)
+		|| !PointerIsValid(fileName)
+		|| !PointerIsValid(errorType))
+		ereport(FATAL,
+				errFatalReturn(gp_reraise_signal),
+				errmsg("TRAP: ExceptionalCondition: bad arguments"));
+	else
+		ereport(FATAL,
+				errFatalReturn(gp_reraise_signal),
+				errmsg("Unexpected internal error"),
+				errdetail("%s(\"%s\", File: \"%s\", Line: %d)\n",
+						  errorType, conditionName, fileName, lineNumber));
 				
-		/* Usually this shouldn't be needed, but make sure the msg went out */
-		fflush(stderr);
-	}
+	/* Usually this shouldn't be needed, but make sure the msg went out */
+	fflush(stderr);
 
 #ifdef SLEEP_ON_ASSERT
 

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -1331,16 +1331,6 @@ errcontext_msg(const char *fmt,...)
  * translate it.  Instead, each errcontext_msg() call should be preceded by
  * a set_errcontext_domain() call to specify the domain.  This is usually
  * done transparently by the errcontext() macro.
- *
- * Although errcontext is primarily meant for use at call sites distant from
- * the original ereport call, there are a few places that invoke errcontext
- * within ereport.  The expansion of errcontext as a comma expression calling
- * set_errcontext_domain then errcontext_msg is problematic in this case,
- * because the intended comma expression becomes two arguments to errfinish,
- * which the compiler is at liberty to evaluate in either order.  But in
- * such a case, the set_errcontext_domain calls must be selecting the same
- * TEXTDOMAIN value that the errstart call did, so order does not matter
- * so long as errstart initializes context_domain along with domain.
  */
 int
 set_errcontext_domain(const char *domain)

--- a/src/backend/utils/fmgr/test/dfmgr_test.c
+++ b/src/backend/utils/fmgr/test/dfmgr_test.c
@@ -36,24 +36,22 @@ static char expectedErrorMsg[ERROR_MESSAGE_MAX_LEN];
 
 static MemoryContext testMemoryContext = NULL;
 
-static int
-errfinish_impl(int dummy pg_attribute_unused(),...)
+static void
+errfinish_impl(const char *filename, int lineno, const char *funcname)
 {
 	/* We only throw error if the error message matches our expectation */
 	if (0 == strcmp(lastErrorMsg, expectedErrorMsg))
 	{
 		PG_RE_THROW();
 	}
-	return 0;
 }
 
-static int
+static void
 errmsg_impl(const char *fmt, ...)
 {
-	return 0;
 }
 
-static int
+static void
 errdetail_internal_impl(const char* fmt, ...)
 {
     StringInfoData	buf;
@@ -65,16 +63,12 @@ errdetail_internal_impl(const char* fmt, ...)
 	strncpy(lastErrorMsg, buf.data, sizeof(lastErrorMsg) / sizeof(lastErrorMsg[0]));
 
 	pfree(buf.data);
-	return 0;
 }
 
 #include "../dfmgr.c"
 
 #define EXPECT_EREPORT(LOG_LEVEL)     \
 	expect_any(errstart, elevel); \
-	expect_any(errstart, filename); \
-	expect_any(errstart, lineno); \
-	expect_any(errstart, funcname); \
 	expect_any(errstart, domain); \
 	if (LOG_LEVEL < ERROR) \
 	{ \

--- a/src/backend/utils/init/test/postinit_test.c
+++ b/src/backend/utils/init/test/postinit_test.c
@@ -9,26 +9,15 @@
 #undef PG_RE_THROW
 #define PG_RE_THROW() siglongjmp(*PG_exception_stack, 1)
 
-#define errfinish errfinish_impl
-
-static int
-errfinish_impl(int dummy pg_attribute_unused(),...)
+static void
+_errfinish_impl()
 {
 	PG_RE_THROW();
 }
 
 static void expect_ereport(int expect_elevel)
 {
-	expect_any(errmsg, fmt);
-	will_be_called(errmsg);
-
-	expect_any(errcode, sqlerrcode);
-	will_be_called(errcode);
-
 	expect_value(errstart, elevel, expect_elevel);
-	expect_any(errstart, filename);
-	expect_any(errstart, lineno);
-	expect_any(errstart, funcname);
 	expect_any(errstart, domain);
 	if (expect_elevel < ERROR)
 	{
@@ -36,7 +25,7 @@ static void expect_ereport(int expect_elevel)
 	}
     else
     {
-		will_return(errstart, true);
+		will_return_with_sideeffect(errstart, false, &_errfinish_impl, NULL);
     }
 }
 

--- a/src/backend/utils/mmgr/test/redzone_handler_test.c
+++ b/src/backend/utils/mmgr/test/redzone_handler_test.c
@@ -7,9 +7,6 @@
 
 #define EXPECT_EREPORT(LOG_LEVEL)     \
 	expect_any(errstart, elevel); \
-	expect_any(errstart, filename); \
-	expect_any(errstart, lineno); \
-	expect_any(errstart, funcname); \
 	expect_any(errstart, domain); \
 	if (LOG_LEVEL < ERROR) \
 	{ \

--- a/src/backend/utils/mmgr/test/runaway_cleaner_test.c
+++ b/src/backend/utils/mmgr/test/runaway_cleaner_test.c
@@ -5,27 +5,8 @@
 
 #include "../runaway_cleaner.c"
 
-#define EXPECT_ELOG(LOG_LEVEL)     \
-    will_be_called(elog_start); \
-	expect_any(elog_start, filename); \
-	expect_any(elog_start, lineno); \
-	expect_any(elog_start, funcname); \
-	if (LOG_LEVEL < ERROR) \
-	{ \
-    	will_be_called(elog_finish); \
-	} \
-    else \
-    { \
-    	will_be_called_with_sideeffect(elog_finish, &_ExceptionalCondition, NULL);\
-    } \
-	expect_value(elog_finish, elevel, LOG_LEVEL); \
-	expect_any(elog_finish, fmt); \
-
 #define EXPECT_EREPORT(LOG_LEVEL)     \
 	expect_any(errstart, elevel); \
-	expect_any(errstart, filename); \
-	expect_any(errstart, lineno); \
-	expect_any(errstart, funcname); \
 	expect_any(errstart, domain); \
 	if (LOG_LEVEL < ERROR) \
 	{ \
@@ -33,8 +14,8 @@
 	} \
     else \
     { \
-    	will_return_with_sideeffect(errstart, false, &_ExceptionalCondition, NULL);\
-    } \
+    	will_return_with_sideeffect(errstart, false, &_ExceptionalCondition, NULL); \
+    }
 
 #define CHECK_FOR_RUNAWAY_CLEANUP_MEMORY_LOGGING() \
 	will_be_called(write_stderr); \

--- a/src/backend/utils/test/session_state_test.c
+++ b/src/backend/utils/test/session_state_test.c
@@ -20,9 +20,6 @@
 
 #define EXPECT_EREPORT(LOG_LEVEL)     \
 	expect_any(errstart, elevel); \
-	expect_any(errstart, filename); \
-	expect_any(errstart, lineno); \
-	expect_any(errstart, funcname); \
 	expect_any(errstart, domain); \
 	if (LOG_LEVEL < ERROR) \
 	{ \

--- a/src/include/cdb/cdbappendonlystorageformat.h
+++ b/src/include/cdb/cdbappendonlystorageformat.h
@@ -162,32 +162,32 @@ extern char *AppendOnlyStorageFormat_BlockHeaderStr(
 	bool			usingChecksums,
 	int				version);
 
-extern int errdetail_appendonly_storage_content_header(
+extern void errdetail_appendonly_storage_content_header(
 	uint8	*headerPtr,
 	bool	usingChecksums,
 	int		version);
 
-extern int errdetail_appendonly_storage_smallcontent_header(
+extern void errdetail_appendonly_storage_smallcontent_header(
 	uint8	*headerPtr,
 	bool	usingChecksums,
 	int		version);
 
-extern int errdetail_appendonly_storage_largecontent_header(
+extern void errdetail_appendonly_storage_largecontent_header(
 	uint8	*headerPtr,
 	bool	usingChecksums,
 	int		version);
 
-extern int errdetail_appendonly_storage_densecontent_header(
+extern void errdetail_appendonly_storage_densecontent_header(
 	uint8	*headerPtr,
 	bool	usingChecksums,
 	int		version);
 
-extern int errdetail_appendonly_storage_nonbulkdensecontent_header(
+extern void errdetail_appendonly_storage_nonbulkdensecontent_header(
 	uint8	*headerPtr,
 	bool	usingChecksums,
 	int		version);
 
-extern int errdetail_appendonly_storage_bulkdensecontent_header(
+extern void errdetail_appendonly_storage_bulkdensecontent_header(
 	uint8	*headerPtr,
 	bool	usingChecksums,
 	int		version);

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -591,7 +591,7 @@ exec_rt_fetch(Index rti, EState *estate)
 
 extern Relation ExecGetRangeTableRelation(EState *estate, Index rti);
 
-extern int	executor_errposition(EState *estate, int location);
+extern void executor_errposition(EState *estate, int location);
 
 extern void RegisterExprContextCallback(ExprContext *econtext,
 										ExprContextCallbackFunction function,

--- a/src/include/parser/parse_coerce.h
+++ b/src/include/parser/parse_coerce.h
@@ -65,7 +65,7 @@ extern Node *coerce_to_specific_type_typmod(ParseState *pstate, Node *node,
 											Oid targetTypeId, int32 targetTypmod,
 											const char *constructName);
 
-extern int	parser_coercion_errposition(ParseState *pstate,
+extern void parser_coercion_errposition(ParseState *pstate,
 										int coerce_location,
 										Node *input_expr);
 

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -280,7 +280,7 @@ typedef struct ParseCallbackState
 extern ParseState *make_parsestate(ParseState *parentParseState);
 extern void free_parsestate(ParseState *pstate);
 extern struct HTAB *parser_get_namecache(ParseState *pstate);
-extern int	parser_errposition(ParseState *pstate, int location);
+extern void	parser_errposition(ParseState *pstate, int location);
 
 extern void setup_parser_errposition_callback(ParseCallbackState *pcbstate,
 											  ParseState *pstate, int location);

--- a/src/include/parser/scanner.h
+++ b/src/include/parser/scanner.h
@@ -127,7 +127,8 @@ extern core_yyscan_t scanner_init(const char *str,
 extern void scanner_finish(core_yyscan_t yyscanner);
 extern int	core_yylex(core_YYSTYPE *lvalp, YYLTYPE *llocp,
 					   core_yyscan_t yyscanner);
-extern int	scanner_errposition(int location, core_yyscan_t yyscanner);
+
+extern void	scanner_errposition(int location, core_yyscan_t yyscanner);
 extern void scanner_yyerror(const char *message, core_yyscan_t yyscanner) pg_attribute_noreturn();
 
 #endif							/* SCANNER_H */

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -151,15 +151,18 @@ void elog_internalerror(const char *filename, int lineno, const char *funcname)
 /*----------
  * New-style error reporting API: to be used in this way:
  *		ereport(ERROR,
- *				(errcode(ERRCODE_UNDEFINED_CURSOR),
- *				 errmsg("portal \"%s\" not found", stmt->portalname),
- *				 ... other errxxx() fields as needed ...));
+ *				errcode(ERRCODE_UNDEFINED_CURSOR),
+ *				errmsg("portal \"%s\" not found", stmt->portalname),
+ *				... other errxxx() fields as needed ...);
  *
  * The error level is required, and so is a primary error message (errmsg
  * or errmsg_internal).  All else is optional.  errcode() defaults to
  * ERRCODE_INTERNAL_ERROR if elevel is ERROR or more, ERRCODE_WARNING
  * if elevel is WARNING, or ERRCODE_SUCCESSFUL_COMPLETION if elevel is
  * NOTICE or below.
+ *
+ * Before Postgres v12, extra parentheses were required around the
+ * list of auxiliary function calls; that's now optional.
  *
  * ereport_domain() allows a message domain to be specified, for modules that
  * wish to use a different message catalog from the backend's.  To avoid having
@@ -178,28 +181,28 @@ void elog_internalerror(const char *filename, int lineno, const char *funcname)
  *----------
  */
 #ifdef HAVE__BUILTIN_CONSTANT_P
-#define ereport_domain(elevel, domain, rest)	\
+#define ereport_domain(elevel, domain, ...)	\
 	do { \
 		pg_prevent_errno_in_scope(); \
 		if (errstart(elevel, __FILE__, __LINE__, PG_FUNCNAME_MACRO, domain)) \
-			errfinish rest; \
+			__VA_ARGS__, errfinish(0); \
 		if (__builtin_constant_p(elevel) && (elevel) >= ERROR) \
 			pg_unreachable(); \
 	} while(0)
 #else							/* !HAVE__BUILTIN_CONSTANT_P */
-#define ereport_domain(elevel, domain, rest)	\
+#define ereport_domain(elevel, domain, ...)	\
 	do { \
 		const int elevel_ = (elevel); \
 		pg_prevent_errno_in_scope(); \
 		if (errstart(elevel_, __FILE__, __LINE__, PG_FUNCNAME_MACRO, domain)) \
-			errfinish rest; \
+			__VA_ARGS__, errfinish(0); \
 		if (elevel_ >= ERROR) \
 			pg_unreachable(); \
 	} while(0)
 #endif							/* HAVE__BUILTIN_CONSTANT_P */
 
-#define ereport(elevel, rest)	\
-	ereport_domain(elevel, TEXTDOMAIN, rest)
+#define ereport(elevel, ...)	\
+	ereport_domain(elevel, TEXTDOMAIN, __VA_ARGS__)
 
 #define TEXTDOMAIN NULL
 

--- a/src/pl/plpgsql/src/pl_scanner.c
+++ b/src/pl/plpgsql/src/pl_scanner.c
@@ -471,20 +471,20 @@ plpgsql_peek2(int *tok1_p, int *tok2_p, int *tok1_loc, int *tok2_loc)
  * parsing of a plpgsql function, since it requires the scanorig string
  * to still be available.
  */
-int
+void
 plpgsql_scanner_errposition(int location)
 {
 	int			pos;
 
 	if (location < 0 || scanorig == NULL)
-		return 0;				/* no-op if location is unknown */
+		return;					/* no-op if location is unknown */
 
 	/* Convert byte offset to character number */
 	pos = pg_mbstrlen_with_len(scanorig, location) + 1;
 	/* And pass it to the ereport mechanism */
 	(void) internalerrposition(pos);
 	/* Also pass the function body string */
-	return internalerrquery(scanorig);
+	internalerrquery(scanorig);
 }
 
 /*

--- a/src/pl/plpgsql/src/plpgsql.h
+++ b/src/pl/plpgsql/src/plpgsql.h
@@ -1306,7 +1306,7 @@ extern void plpgsql_append_source_text(StringInfo buf,
 extern int	plpgsql_peek(void);
 extern void plpgsql_peek2(int *tok1_p, int *tok2_p, int *tok1_loc,
 						  int *tok2_loc);
-extern int	plpgsql_scanner_errposition(int location);
+extern void plpgsql_scanner_errposition(int location);
 extern void plpgsql_yyerror(const char *message) pg_attribute_noreturn();
 extern int	plpgsql_location_to_lineno(int location);
 extern int	plpgsql_latest_lineno(void);


### PR DESCRIPTION
As discussed in PR https://github.com/greenplum-db/gpdb/pull/10894 to reduce logging overhead due to elog() in code, this PR is cherry-picking couple of commits from upstream. To make it work, adjusts some GPDB specific functions which make use of error-reporting routines in dispatcher and other places. GPDB specific changes are in separate commits so should be easy to review.

2 commits just fixing the missing errcode() calls in ereport() will be backported to GPDB6.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
