### PR TITLE
[6X Backport] Allow distribution spec match when hash spec uses gp_segment_id

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecHashed.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecHashed.h
@@ -72,6 +72,8 @@ private:
 	BOOL FMatchHashedDistribution(
 		const CDistributionSpecHashed *pdshashed) const;
 
+	BOOL FDistributionSpecHashedOnlyOnGpSegmentId() const;
+
 	// private copy ctor
 	CDistributionSpecHashed(const CDistributionSpecHashed &);
 

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -749,22 +749,22 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 (3 rows)
 
 explain (costs off) select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_via_segid t1, t_test_dd_via_segid t2 where t1.gp_segment_id=t2.id;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Join
-         Hash Cond: (t2.id = t1.gp_segment_id)
-         ->  Seq Scan on t_test_dd_via_segid t2
+         Hash Cond: (t1.gp_segment_id = t2.id)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: t1.gp_segment_id
+               ->  Seq Scan on t_test_dd_via_segid t1
          ->  Hash
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: t1.gp_segment_id
-                     ->  Seq Scan on t_test_dd_via_segid t1
+               ->  Seq Scan on t_test_dd_via_segid t2
  Optimizer: Postgres query optimizer
 (9 rows)
 
 select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_via_segid t1, t_test_dd_via_segid t2 where t1.gp_segment_id=t2.id;
-INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
  gp_segment_id | gp_segment_id | id | id 
 ---------------+---------------+----+----
              1 |             1 |  1 |  1
@@ -773,22 +773,22 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 (3 rows)
 
 explain (costs off) select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
-                       QUERY PLAN                        
----------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: gp_segment_id
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Merge Key: gp_segment_id
-         ->  Sort
-               Sort Key: gp_segment_id
-               ->  Partial HashAggregate
-                     Group Key: gp_segment_id
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  HashAggregate
+         Group Key: t_test_dd_via_segid.gp_segment_id
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: t_test_dd_via_segid.gp_segment_id
+               ->  HashAggregate
+                     Group Key: t_test_dd_via_segid.gp_segment_id
                      ->  Seq Scan on t_test_dd_via_segid
  Optimizer: Postgres query optimizer
-(10 rows)
+(9 rows)
 
 select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
  gp_segment_id | count 
 ---------------+-------
              0 |     3

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -748,6 +748,54 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
              1 |  1
 (3 rows)
 
+explain (costs off) select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_via_segid t1, t_test_dd_via_segid t2 where t1.gp_segment_id=t2.id;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t2.id = t1.gp_segment_id)
+         ->  Seq Scan on t_test_dd_via_segid t2
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: t1.gp_segment_id
+                     ->  Seq Scan on t_test_dd_via_segid t1
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_via_segid t1, t_test_dd_via_segid t2 where t1.gp_segment_id=t2.id;
+INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | gp_segment_id | id | id 
+---------------+---------------+----+----
+             1 |             1 |  1 |  1
+             2 |             0 |  5 |  2
+             2 |             0 |  6 |  2
+(3 rows)
+
+explain (costs off) select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Finalize GroupAggregate
+   Group Key: gp_segment_id
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: gp_segment_id
+         ->  Sort
+               Sort Key: gp_segment_id
+               ->  Partial HashAggregate
+                     Group Key: gp_segment_id
+                     ->  Seq Scan on t_test_dd_via_segid
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | count 
+---------------+-------
+             0 |     3
+             1 |     1
+             2 |     2
+(3 rows)
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -776,10 +776,10 @@ INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 2
 explain (costs off) select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_via_segid t1, t_test_dd_via_segid t2 where t1.gp_segment_id=t2.id;
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Join
          Hash Cond: (t_test_dd_via_segid.gp_segment_id = t_test_dd_via_segid_1.id)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: t_test_dd_via_segid.gp_segment_id
                ->  Seq Scan on t_test_dd_via_segid
          ->  Hash
@@ -788,8 +788,8 @@ explain (costs off) select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_
 (9 rows)
 
 select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_via_segid t1, t_test_dd_via_segid t2 where t1.gp_segment_id=t2.id;
-INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
  gp_segment_id | gp_segment_id | id | id 
 ---------------+---------------+----+----
              1 |             1 |  1 |  1

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -773,6 +773,51 @@ INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 2
              2 |  6
 (3 rows)
 
+explain (costs off) select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_via_segid t1, t_test_dd_via_segid t2 where t1.gp_segment_id=t2.id;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t_test_dd_via_segid.gp_segment_id = t_test_dd_via_segid_1.id)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: t_test_dd_via_segid.gp_segment_id
+               ->  Seq Scan on t_test_dd_via_segid
+         ->  Hash
+               ->  Seq Scan on t_test_dd_via_segid t_test_dd_via_segid_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_via_segid t1, t_test_dd_via_segid t2 where t1.gp_segment_id=t2.id;
+INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | gp_segment_id | id | id 
+---------------+---------------+----+----
+             1 |             1 |  1 |  1
+             2 |             0 |  5 |  2
+             2 |             0 |  6 |  2
+(3 rows)
+
+explain (costs off) select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: gp_segment_id
+         ->  Sort
+               Sort Key: gp_segment_id
+               ->  Seq Scan on t_test_dd_via_segid
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | count 
+---------------+-------
+             0 |     3
+             1 |     1
+             2 |     2
+(3 rows)
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;

--- a/src/test/regress/sql/direct_dispatch.sql
+++ b/src/test/regress/sql/direct_dispatch.sql
@@ -308,6 +308,12 @@ select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_se
 explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2 or gp_segment_id=3;
 select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2 or gp_segment_id=3;
 
+explain (costs off) select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_via_segid t1, t_test_dd_via_segid t2 where t1.gp_segment_id=t2.id;
+select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_via_segid t1, t_test_dd_via_segid t2 where t1.gp_segment_id=t2.id;
+
+explain (costs off) select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
+select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 


### PR DESCRIPTION
Clean cherry-pick except answer files: https://github.com/greenplum-db/gpdb/commit/399d7d0157c7ce86a590d415243d234bcad99c3d (will before commit)
ICW passed: [CI Link](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-6X-avoid-redistribute-on-group-by-gp-segment-id/resources/gpdb_src)

---

This allows Orca to perform a GROUP BY over gp_segment_id without
requiring a redistribute motion.

```
EXPLAIN (COSTS OFF) SELECT count(*), gp_segment_id FROM motiondata
ROUP BY gp_segment_id;
                QUERY PLAN
------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  GroupAggregate
         Group Key: gp_segment_id
         ->  Sort
               Sort Key: gp_segment_id
               ->  Seq Scan on motiondata
 Optimizer: Pivotal Optimizer (GPORCA)
(7 rows)
```

(cherry picked from commit 9ea2a96)