### PR TITLE
Update python configure macros

### DIFF
--- a/config/programs.m4
+++ b/config/programs.m4
@@ -1,6 +1,24 @@
 # config/programs.m4
 
 
+# PGAC_PATH_PROGS
+# ---------------
+# This wrapper for AC_PATH_PROGS behaves like that macro except when
+# VARIABLE is already set; in that case we just accept the value verbatim.
+# (AC_PATH_PROGS would accept it only if it looks like an absolute path.)
+# A desirable future improvement would be to convert a non-absolute-path
+# input into absolute form.
+AC_DEFUN([PGAC_PATH_PROGS],
+[if test -z "$$1"; then
+  AC_PATH_PROGS($@)
+else
+  # Report the value of $1 in configure's output in all cases.
+  AC_MSG_CHECKING([for $1])
+  AC_MSG_RESULT([$$1])
+fi
+])
+
+
 # PGAC_PATH_BISON
 # ---------------
 # Look for Bison, set the output variable BISON to its path if found.

--- a/configure
+++ b/configure
@@ -9561,8 +9561,11 @@ fi
 fi
 
 if test "$with_python" = yes; then
-  # Extract the first word of "python", so it can be a program name with args.
-set dummy python; ac_word=$2
+  if test -z "$PYTHON"; then
+  for ac_prog in python python2
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
 if ${ac_cv_path_PYTHON+:} false; then :
@@ -9601,10 +9604,29 @@ $as_echo "no" >&6; }
 fi
 
 
+  test -n "$PYTHON" && break
+done
+
+else
+  # Report the value of PYTHON in configure's output in all cases.
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for PYTHON" >&5
+$as_echo_n "checking for PYTHON... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON" >&5
+$as_echo "$PYTHON" >&6; }
+fi
+
 if test x"$PYTHON" = x""; then
   as_fn_error $? "Python not found" "$LINENO" 5
 fi
 
+
+python_fullversion=`${PYTHON} -c "import sys; print(sys.version)" | sed q`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: using python $python_fullversion" >&5
+$as_echo "$as_me: using python $python_fullversion" >&6;}
+# python_fullversion is typically n.n.n plus some trailing junk
+python_majorversion=`echo "$python_fullversion" | sed 's/^\([0-9]*\).*/\1/'`
+python_minorversion=`echo "$python_fullversion" | sed 's/^[0-9]*\.\([0-9]*\).*/\1/'`
+python_version=`echo "$python_fullversion" | sed 's/^\([0-9]*\.[0-9]*\).*/\1/'`
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Python distutils module" >&5
 $as_echo_n "checking for Python distutils module... " >&6; }
@@ -9619,8 +9641,6 @@ $as_echo "no" >&6; }
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking Python configuration directory" >&5
 $as_echo_n "checking Python configuration directory... " >&6; }
-python_majorversion=`${PYTHON} -c "import sys; print(sys.version[0])"`
-python_version=`${PYTHON} -c "import sys; print(sys.version[:3])"`
 python_configdir=`${PYTHON} -c "import distutils.sysconfig; print(' '.join(filter(None,distutils.sysconfig.get_config_vars('LIBPL'))))"`
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $python_configdir" >&5
 $as_echo "$python_configdir" >&6; }


### PR DESCRIPTION
Some platforms do not have unversioned "python" available but do have
versioned "python2". Configure should look for either "python" or
"python2" when run with the option "--with-python".

These changes were manually copied from the Postgres build system but
omitted searching for "python3" since Greenplum does not have support
for Python 3 yet.