### PR TITLE
Get rid of Insist() interface by replacing its usage either by elog(ERROR) or Assert()

### DIFF
--- a/gpcontrib/quicklz/quicklz_compression.c
+++ b/gpcontrib/quicklz/quicklz_compression.c
@@ -71,24 +71,16 @@ static size_t
 quicklz_compressor(int level, const void *source, char *destination,
 				   size_t size, void *state)
 {
-	if (level == 1)
-	{
-		return qlz_compress(source, destination, size,
-							 (qlz_state_compress *)state);
-	}
-	Insist(false);
+	return qlz_compress(source, destination, size,
+						(qlz_state_compress *)state);
 }
 
 static size_t
 quicklz_decompressor(int level, const char *source, void *destination,
 					 void *state)
 {
-	if (level == 1)
-	{
-		return qlz_decompress(source, destination,
-							   (qlz_state_decompress *)state);
-	}
-	Insist(false);
+	return qlz_decompress(source, destination,
+						  (qlz_state_decompress *)state);
 }
 
 /* ---------------------------------------------------------------------
@@ -116,23 +108,17 @@ quicklz_constructor(PG_FUNCTION_ARGS)
 
 	cs->opaque = (void *)state;
 
-	Insist(PointerIsValid(sa->comptype));
-	Insist(strcmp(sa->comptype, "quicklz") == 0);
-	Insist(sa->complevel == 1);
+	Assert(PointerIsValid(sa->comptype));
+	Assert(strcmp(sa->comptype, "quicklz") == 0);
 
 	state->level = sa->complevel;
 	state->compress = compress;
-	if (sa->complevel == 1)
-	{
-		state->compress_fn = quicklz_compressor;
-		state->decompress_fn = quicklz_decompressor;
-		if (compress)
-			scratchlen = sizeof(qlz_state_compress);
-		else
-			scratchlen = sizeof(qlz_state_decompress);
-	}
+	state->compress_fn = quicklz_compressor;
+	state->decompress_fn = quicklz_decompressor;
+	if (compress)
+		scratchlen = sizeof(qlz_state_compress);
 	else
-		Insist(false); /* shouldn't get here but code defensively */
+		scratchlen = sizeof(qlz_state_decompress);
 
 	state->scratch = palloc0(scratchlen);
 

--- a/gpcontrib/quicklz/quicklz_compression.c
+++ b/gpcontrib/quicklz/quicklz_compression.c
@@ -180,7 +180,7 @@ quicklz_compress(PG_FUNCTION_ARGS)
 	CompressionState *cs 	= (CompressionState *)PG_GETARG_POINTER(5);
 	quicklz_state *state	= (quicklz_state *)cs->opaque;
 
-	Insist(dst_sz >= quicklz_desired_sz(src_sz));
+	Assert(dst_sz >= quicklz_desired_sz(src_sz));
 
 	*dst_used = state->compress_fn(state->level, src, dst, (size_t)src_sz,
 								   state->scratch);
@@ -199,7 +199,7 @@ quicklz_decompress(PG_FUNCTION_ARGS)
 	CompressionState *cs 	= (CompressionState *)PG_GETARG_POINTER(5);
 	quicklz_state *state	= (quicklz_state *)cs->opaque;
 
-	Insist(src_sz > 0 && dst_sz > 0);
+	Assert(src_sz > 0 && dst_sz > 0);
 	*dst_used = state->decompress_fn(state->level, src, dst, state->scratch);
 
 	PG_RETURN_VOID();

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -1311,7 +1311,7 @@ validateColumnStorageEncodingClauses(List *aocoColumnEncoding,
 	{
 		ColumnReferenceStorageDirective *c = lfirst(lc);
 
-		Insist(IsA(c, ColumnReferenceStorageDirective));
+		Assert(IsA(c, ColumnReferenceStorageDirective));
 
 		if (c->deflt)
 			continue;
@@ -1532,7 +1532,7 @@ transformAttributeEncoding(List *columns,
 	foreach(lc, stenc)
 	{
 		ColumnReferenceStorageDirective *c = lfirst(lc);
-		Insist(IsA(c, ColumnReferenceStorageDirective));
+		Assert(IsA(c, ColumnReferenceStorageDirective));
 
 		if (c->deflt)
 		{

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1197,7 +1197,7 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	 */
 	if (IS_GPFDISTS_URI(url))
 	{
-		Insist(PointerIsValid(DataDir));
+		Assert(PointerIsValid(DataDir));
 		elog(LOG,"trying to load certificates from %s", DataDir);
 
 		/* curl will save its last error in curlErrorBuffer */

--- a/src/backend/access/index/genam.c
+++ b/src/backend/access/index/genam.c
@@ -388,11 +388,6 @@ systable_beginscan(Relation heapRelation,
 	{
 		int			i;
 
-		if (!IsBootstrapProcessingMode())
-		{
-			Insist(RelationGetRelid(heapRelation) == irel->rd_index->indrelid);
-		}
-
 		/* Change attribute numbers to be index column numbers. */
 		for (i = 0; i < nkeys; i++)
 		{

--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -46,7 +46,7 @@ add_attribute_encoding_entry(Oid relid, AttrNumber attnum, Datum attoptions)
 	bool nulls[Natts_pg_attribute_encoding];
 	HeapTuple tuple;
 	
-	Insist(attnum != InvalidAttrNumber);
+	Assert(attnum != InvalidAttrNumber);
 
 	rel = heap_open(AttributeEncodingRelationId, RowExclusiveLock);
 
@@ -86,7 +86,7 @@ get_funcs_for_compression(char *compresstype)
 	{
 		func = GetCompressionImplementation(compresstype);
 
-		Insist(PointerIsValid(func));
+		Assert(PointerIsValid(func));
 	}
 	return func;
 }
@@ -126,11 +126,11 @@ get_rel_attoptions(Oid relid, AttrNumber max_attno)
 		Datum attoptions;
 		bool isnull;
 
-		Insist(attnum > 0 && attnum <= max_attno);
+		Assert(attnum > 0 && attnum <= max_attno);
 
 		attoptions = heap_getattr(tuple, Anum_pg_attribute_encoding_attoptions,
 								  RelationGetDescr(pgae), &isnull);
-		Insist(!isnull);
+		Assert(!isnull);
 
 		dats[attnum - 1] = datumCopy(attoptions,
 									 attform->attbyval,
@@ -232,7 +232,7 @@ AddRelationAttributeEncodings(Relation rel, List *attr_encodings)
 		List *encoding;
 		AttrNumber attnum;
 
-		Insist(IsA(c, ColumnReferenceStorageDirective));
+		Assert(IsA(c, ColumnReferenceStorageDirective));
 
 		attnum = get_attnum(relid, c->column);
 

--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -317,7 +317,7 @@ zlib_compress(PG_FUNCTION_ARGS)
 
 			default:
 				/* shouldn't get here */
-				Insist(false);
+				elog(ERROR, "zlib compression failed with error %d", last_error);
 				break;
 		}
 	}
@@ -376,7 +376,7 @@ zlib_decompress(PG_FUNCTION_ARGS)
 
 			default:
 				/* shouldn't get here */
-				Insist(false);
+				elog(ERROR, "zlib decompression failed with error %d", last_error);
 				break;
 		}
 	}

--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -160,23 +160,23 @@ GetCompressionImplementation(char *comptype)
 
 	ctup = (Form_pg_compression)GETSTRUCT(tuple);
 
-	Insist(OidIsValid(ctup->compconstructor));
+	Assert(OidIsValid(ctup->compconstructor));
 	fmgr_info(ctup->compconstructor, &finfo);
 	funcs[COMPRESSION_CONSTRUCTOR] = finfo.fn_addr;
 
-	Insist(OidIsValid(ctup->compdestructor));
+	Assert(OidIsValid(ctup->compdestructor));
 	fmgr_info(ctup->compdestructor, &finfo);
 	funcs[COMPRESSION_DESTRUCTOR] = finfo.fn_addr;
 
-	Insist(OidIsValid(ctup->compcompressor));
+	Assert(OidIsValid(ctup->compcompressor));
 	fmgr_info(ctup->compcompressor, &finfo);
 	funcs[COMPRESSION_COMPRESS] = finfo.fn_addr;
 
-	Insist(OidIsValid(ctup->compdecompressor));
+	Assert(OidIsValid(ctup->compdecompressor));
 	fmgr_info(ctup->compdecompressor, &finfo);
 	funcs[COMPRESSION_DECOMPRESS] = finfo.fn_addr;
 
-	Insist(OidIsValid(ctup->compvalidator));
+	Assert(OidIsValid(ctup->compvalidator));
 	fmgr_info(ctup->compvalidator, &finfo);
 	funcs[COMPRESSION_VALIDATOR] = finfo.fn_addr;
 
@@ -249,7 +249,7 @@ zlib_constructor(PG_FUNCTION_ARGS)
 	cs->opaque = (void *) state;
 	cs->desired_sz = NULL;
 
-	Insist(PointerIsValid(sa->comptype));
+	Assert(PointerIsValid(sa->comptype));
 
 	if (sa->complevel == 0)
 		sa->complevel = 1;
@@ -338,7 +338,7 @@ zlib_decompress(PG_FUNCTION_ARGS)
 	int				last_error;
 	unsigned long amount_available_used = dst_sz;
 
-	Insist(src_sz > 0 && dst_sz > 0);
+	Assert(src_sz > 0 && dst_sz > 0);
 
 
 	last_error = state->decompress_fn(dst, &amount_available_used,

--- a/src/backend/catalog/pg_proc_callback.c
+++ b/src/backend/catalog/pg_proc_callback.c
@@ -45,7 +45,7 @@ deleteProcCallbacks(Oid profnoid)
 	SysScanDesc scan;
 	HeapTuple	tup;
 
-	Insist(OidIsValid(profnoid));
+	Assert(OidIsValid(profnoid));
 
 	/*
 	 * This is equivalent to:
@@ -91,8 +91,8 @@ addProcCallback(Oid profnoid, Oid procallback, char promethod)
 	Datum		values[Natts_pg_proc_callback];
 	HeapTuple   tup;
 	
-	Insist(OidIsValid(profnoid));
-	Insist(OidIsValid(procallback));
+	Assert(OidIsValid(profnoid));
+	Assert(OidIsValid(procallback));
 
 	/* open pg_proc_callback */
 	rel = table_open(ProcCallbackRelationId, RowExclusiveLock);
@@ -131,7 +131,7 @@ lookupProcCallback(Oid profnoid, char promethod)
 	HeapTuple	tup;
 	Oid         result;
 
-	Insist(OidIsValid(profnoid));
+	Assert(OidIsValid(profnoid));
 
 	/* open pg_proc_callback */
 	rel = heap_open(ProcCallbackRelationId, AccessShareLock);

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -1549,9 +1549,7 @@ motion_sanity_check(PlannerInfo *root, Plan *plan)
 	elog(DEBUG5, "Motion Deadlock Sanity Check");
 
 	if (motion_sanity_walker((Node *) plan, &sanity_result))
-	{
-		Insist(0);
-	}
+		elog(ERROR, "motion sanity walker returned true");
 
 	if (sanity_result.flags & SANITY_DEADLOCK)
 		elog(ERROR, "Post-planning sanity check detected motion deadlock.");

--- a/src/backend/cdb/cdbpathtoplan.c
+++ b/src/backend/cdb/cdbpathtoplan.c
@@ -81,7 +81,7 @@ cdbpathtoplan_create_flow(PlannerInfo *root,
 		flow = makeFlow(FLOW_SINGLETON, 1);
 	}
 	else
-		Insist(0);
+		elog(ERROR, "incorrect locus type %d to create flow", locus.locustype);
 
 	flow->locustype = locus.locustype;
 	return flow;

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -343,8 +343,6 @@ addOneOption(StringInfo string, struct config_generic *guc)
 				}
 				break;
 			}
-		default:
-			Insist(false);
 	}
 }
 

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -709,7 +709,7 @@ CopyToDispatchFlush(CopyState cstate)
 			(void) pq_putmessage('d', fe_msgbuf->data, fe_msgbuf->len);
 			break;
 		case COPY_CALLBACK:
-			Insist(false); /* internal error */
+			elog(ERROR, "unexpected destination COPY_CALLBACK to flush data");
 			break;
 	}
 

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -308,7 +308,7 @@ cdbexplain_localExecStats(struct PlanState *planstate,
 
 	Assert(Gp_role != GP_ROLE_EXECUTE);
 
-	Insist(planstate && planstate->instrument && showstatctx);
+	Assert(planstate && planstate->instrument && showstatctx);
 
 	memset(&ctx, 0, sizeof(ctx));
 
@@ -610,7 +610,7 @@ cdbexplain_recvExecStats(struct PlanState *planstate,
 										"the correct %s software version.",
 										PACKAGE_NAME)));
 
-			Insist(ctx.nStatInst == hdr->nInst);
+			Assert(ctx.nStatInst == hdr->nInst);
 		}
 
 		/* Save lowest and highest segment id for which we have stats. */
@@ -630,7 +630,7 @@ cdbexplain_recvExecStats(struct PlanState *planstate,
 	planstate_walk_node(planstate, cdbexplain_recvStatWalker, &ctx);
 
 	/* Make sure we visited the right number of PlanState nodes. */
-	Insist(ctx.iStatInst == ctx.nStatInst);
+	Assert(ctx.iStatInst == ctx.nStatInst);
 
 	/* Transfer per-slice stats from message headers to the SliceSummary. */
 	for (imsgptr = 0; imsgptr < ctx.nmsgptr; imsgptr++)
@@ -735,7 +735,7 @@ cdbexplain_depositSliceStats(CdbExplain_StatHdr *hdr,
 	CdbExplain_SliceWorker *ssw;
 	int			iworker;
 
-	Insist(sliceIndex >= 0 &&
+	Assert(sliceIndex >= 0 &&
 		   sliceIndex < showstatctx->nslice);
 
 	/* Kludge:	QD can have more than one 'Slice 0' if plan is non-parallel. */
@@ -767,8 +767,8 @@ cdbexplain_depositSliceStats(CdbExplain_StatHdr *hdr,
 	/* Save a copy of this SliceWorker instance in the worker array. */
 	iworker = hdr->segindex - ss->segindex0;
 	ssw = &ss->workers[iworker];
-	Insist(iworker >= 0 && iworker < ss->nworker);
-	Insist(ssw->peakmemused == 0);	/* each worker should be seen just once */
+	Assert(iworker >= 0 && iworker < ss->nworker);
+	Assert(ssw->peakmemused == 0);	/* each worker should be seen just once */
 	*ssw = hdr->worker;
 
 	/* Rollup of per-worker stats into SliceSummary */
@@ -799,7 +799,7 @@ cdbexplain_collectStatsFromNode(PlanState *planstate, CdbExplain_SendStatCtx *ct
 	CdbExplain_StatInst *si = &ctx->hdr.inst[0];
 	Instrumentation *instr = planstate->instrument;
 
-	Insist(instr);
+	Assert(instr);
 
 	/* We have to finalize statistics, since ExecutorEnd hasn't been called. */
 	InstrEndLoop(instr);
@@ -921,7 +921,7 @@ cdbexplain_depStatAcc_saveText(CdbExplain_DepStatAcc *acc,
 		int			notelen = rsi->enotes - rsi->bnotes;
 		const char *notes = (const char *) rsh + rsh->bnotes + rsi->bnotes;
 
-		Insist(rsh->bnotes + rsi->enotes < rsh->enotes &&
+		Assert(rsh->bnotes + rsi->enotes < rsh->enotes &&
 			   notes[notelen] == '\0');
 
 		/* Append to extratextbuf. */
@@ -977,7 +977,7 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 	int			imsgptr;
 	int			nInst;
 
-	Insist(instr &&
+	Assert(instr &&
 		   ctx->iStatInst < ctx->nStatInst);
 
 	/* Allocate NodeSummary block. */
@@ -1017,7 +1017,7 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 		rsh = ctx->msgptrs[imsgptr];
 		rsi = &rsh->inst[ctx->iStatInst];
 
-		Insist(rsi->pstype == planstate->type &&
+		Assert(rsi->pstype == planstate->type &&
 			   ns->segindex0 <= rsh->segindex &&
 			   rsh->segindex < ns->segindex0 + ns->ninst);
 

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -1161,7 +1161,7 @@ validate_describe_callback(List *describeQualName,
 		int   len   = ARR_DIMS(parameterModes)[0];
 		char *modes = ARR_DATA_PTR(parameterModes);
 		
-		Insist(ARR_NDIM(parameterModes) == 1);
+		Assert(ARR_NDIM(parameterModes) == 1);
 		for (i = 0; i < len; i++)
 		{
 			switch (modes[i])

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17039,7 +17039,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 			relationRelation = table_open(RelationRelationId, RowExclusiveLock);
 			tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(tarrelid));
 
-			Insist(HeapTupleIsValid(tuple));
+			Assert(HeapTupleIsValid(tuple));
 			newOptsTuple = heap_modify_tuple(tuple, RelationGetDescr(relationRelation),
 											 repl_val, repl_null, repl_repl);
 

--- a/src/backend/executor/execCurrent.c
+++ b/src/backend/executor/execCurrent.c
@@ -436,7 +436,8 @@ getCurrentOf(CurrentOfExpr *cexpr,
 		 * tuple yielded by the top node in the plan.
 		 */
 		slot = queryDesc->planstate->ps_ResultTupleSlot;
-		Insist(!TupIsNull(slot));
+		if (TupIsNull(slot))
+			elog(ERROR, "TupleTableslot is empty");
 		Assert(queryDesc->estate->es_junkFilter);
 
 		/* extract gp_segment_id metadata */

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4067,10 +4067,10 @@ AdjustReplicatedTableCounts(EState *estate)
 		else if (containReplicatedTable)
 		{
 			/*
-			 * If one is replicated table, assert that other
-			 * tables are also replicated table.
+			 * If one is replicated table, error if other tables are not
+			 * replicated table.
  			 */
-			Insist(0);
+			elog(ERROR, "mix of replicated and non-replicated tables in result_relation is not supported");
 		}
 	}
 

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -781,7 +781,7 @@ ExecInitHashJoin(HashJoin *node, EState *estate, int eflags)
 	if (node->hashqualclauses != NIL)
 	{
 		/* CDB: This must be an IS NOT DISTINCT join!  */
-		Insist(isNotDistinctJoin(node->hashqualclauses));
+		Assert(isNotDistinctJoin(node->hashqualclauses));
 		hjstate->hj_nonequijoin = true;
 	}
 	else

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -680,7 +680,7 @@ ExecInitMotion(Motion *node, EState *estate, int eflags)
 	/* QE must fill in map from motionID to MotionState node. */
 	else
 	{
-		Insist(Gp_role == GP_ROLE_EXECUTE);
+		Assert(Gp_role == GP_ROLE_EXECUTE);
 
 		if (LocallyExecutingSliceIndex(estate) == recvSlice->sliceIndex)
 		{

--- a/src/backend/executor/nodeTableFunction.c
+++ b/src/backend/executor/nodeTableFunction.c
@@ -149,8 +149,8 @@ TableFunctionNext(TableFunctionState *node)
 			Datum		values[MaxTupleAttributeNumber];
 			bool		nulls[MaxTupleAttributeNumber];
 
-			Insist(!returns_set);  /* checked above */
-			Insist(resultdesc->natts <= MaxTupleAttributeNumber);
+			Assert(!returns_set);  /* checked above */
+			Assert(resultdesc->natts <= MaxTupleAttributeNumber);
 			for (i = 0; i < resultdesc->natts; i++)
 				nulls[i] = true;
 
@@ -483,7 +483,7 @@ AnyTable_GetTupleDesc(AnyTable t)
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("invalid null value for anytable type")));
 	}
-	Insist(t->junkfilter && IsA(t->junkfilter, JunkFilter));
+	Assert(t->junkfilter && IsA(t->junkfilter, JunkFilter));
 
 	/* Return the projected tuple descriptor */
 	return t->junkfilter->jf_cleanTupType;

--- a/src/backend/optimizer/path/joinrels.c
+++ b/src/backend/optimizer/path/joinrels.c
@@ -680,7 +680,7 @@ make_join_rel(PlannerInfo *root, RelOptInfo *rel1, RelOptInfo *rel2)
 	/* This is a convenient place to check for query cancel. */
 	CHECK_FOR_INTERRUPTS();
 
-    Insist(rel1 &&
+    Assert(rel1 &&
            rel2 &&
            rel1->cheapest_total_path &&
            rel2->cheapest_total_path);

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -306,7 +306,7 @@ query_planner(PlannerInfo *root,
 	if (!final_rel || !final_rel->cheapest_total_path ||
 		final_rel->cheapest_total_path->param_info != NULL)
 		elog(ERROR, "failed to construct the join relation");
-	Insist(final_rel->cheapest_startup_path);
+	Assert(final_rel->cheapest_startup_path);
 
 	return final_rel;
 }

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -2081,7 +2081,8 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 		 * which might be optimal in some cases?
 		 */
 		add_motion = true;
-        Insist(subpath);
+		if (subpath == NULL)
+			elog(ERROR, "could not create motion path");
 	}
 	else
 		locus = subpath->locus;

--- a/src/backend/optimizer/util/walkers.c
+++ b/src/backend/optimizer/util/walkers.c
@@ -601,7 +601,7 @@ Plan *plan_tree_base_subplan_get_plan(plan_tree_base_prefix *base, SubPlan *subp
 		rootdata.glob = (PlannerGlobal*)base->node;
 		return planner_subplan_get_plan(&rootdata, subplan);
 	}
-	Insist(false);
+	Assert(false);
 	return NULL;
 }
 

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1391,7 +1391,7 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 	 * possible due to grammar restrictions on where a SCATTER clause is
 	 * allowed.
 	 */
-	Insist(!(stmt->scatterClause && stmt->intoClause));
+	Assert(!(stmt->scatterClause && stmt->intoClause));
 	qry->scatterClause = transformScatterClause(pstate,
 												stmt->scatterClause,
 												&qry->targetList);

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -19292,7 +19292,7 @@ mergeTableFuncParameters(List *func_args, List *columns)
 
 			/* Output modes */
 			case FUNC_PARAM_TABLE:
-				Insist(false);  /* not feasible */
+				elog(ERROR, "TABLE arguments aren't allowed in TABLE functions"); /* not feasible */
 				break;
 			case FUNC_PARAM_OUT:
 				ereport(ERROR,

--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -1143,7 +1143,7 @@ split_encoding_clauses(List *encs, List **non_def,
 	{
 		ColumnReferenceStorageDirective *c = lfirst(lc);
 
-		Insist(IsA(c, ColumnReferenceStorageDirective));
+		Assert(IsA(c, ColumnReferenceStorageDirective));
 
 		if (c->deflt)
 		{

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1667,7 +1667,7 @@ addRangeTableEntryForFunction(ParseState *pstate,
 			Datum     d;
 			int       i;
 
-			Insist(TypeSupportsDescribe(funcrettype));
+			Assert(TypeSupportsDescribe(funcrettype));
 
 			funcDescribe = lookupProcCallback(func->funcid, PROMETHOD_DESCRIBE);
 			if (OidIsValid(funcDescribe))

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -1636,8 +1636,8 @@ expandRecordVariable(ParseState *pstate, Var *var, int levelsup)
 			}
 			break;
 		case RTE_VOID:
-	            Insist(0);
-        	    break;
+			elog(ERROR, "unexpected RTE type RTE_VOID");
+			break;
 	}
 
 	/*

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -4867,7 +4867,9 @@ TypeNameGetStorageDirective(TypeName *typname)
 							   RelationGetDescr(rel),
 							   &isnull);
 
-		Insist(!isnull);
+		if (isnull)
+			elog(ERROR, "null typoptions attribute encountered for pg_type_encoding for typid %d",
+				 typid);
 
 		out = untransformRelOptions(options);
 	}

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -284,33 +284,6 @@ err_gettext(const char *str)
 #endif
 }
 
-
-/*
- * elog_internalerror -- report an internal error
- *
- * GPDB only
- *
- * Does not return; exits via longjmp to PG_CATCH error handler.
- */
-void
-elog_internalerror(const char *filename, int lineno, const char *funcname)
-{
-	/*
-	 * TODO  Why isn't this a FATAL error?
-	 *
-	 * Also, why aren't we allowing for a specific err message to be passed in?
-	 */
-    if (errstart(ERROR, TEXTDOMAIN))
-    {
-		errcode(ERRCODE_INTERNAL_ERROR);
-		errmsg("Unexpected internal error");
-        errfinish(filename, lineno, funcname);
-    }
-    /* not reached */
-    abort();
-}                               /* elog_internalerror */
-
-
 /*
  * errstart --- begin an error-reporting cycle
  *

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4981,9 +4981,6 @@ DispatchSyncPGVariable(struct config_generic * gconfig)
 			}
 			break;
 		}
-		default:
-			Insist(false);
-
 	}
 
 	CdbDispatchSetCommand(buffer.data, false);

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -98,39 +98,6 @@ extern pthread_t main_tid;
 #endif 
 
 /*
- * Insist(assertion)
- *
- * Returns true if assertion is true; else issues a generic internal
- * error message and exits to the closest enclosing PG_TRY block via
- * plain old ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), ...)).
- *
- ** Use instead of Assert() for internal errors that should always be checked
- *  even in release builds; and to suppress warnings (such as uninitialized
- *  variables) along paths that should never be executed (eg. switch defaults).
- ** Use instead of ExceptionalCondition() for internal errors that are not
- *  so severe as to necessitate aborting the process, where ordinary error
- *  handling should suffice.
- ** Use when elog()/ereport() is just not worth it because no user would
- *  ever see the nice customized message that you would otherwise code up
- *  for that weird case that should never happen.
- */
-/*
- * TODO  Why aren't we passing the text of the assertion to elog_internalerror?
- * How is anybody supposed to know what was wrong?
- */
-#define Insist(assertion) \
-	do {				  \
-		if (!(assertion))										   \
-			elog_internalerror(__FILE__, __LINE__, PG_FUNCNAME_MACRO);	\
-	} while(0)
-
-#ifdef _MSC_VER
-__declspec(noreturn)
-#endif
-void elog_internalerror(const char *filename, int lineno, const char *funcname)
-						pg_attribute_noreturn();
-
-/*
  * Provide a way to prevent "errno" from being accidentally used inside an
  * elog() or ereport() invocation.  Since we know that some operating systems
  * define errno as something involving a function call, we'll put a local


### PR DESCRIPTION
    Remove Insist() interface
    
    Sometime in history Insist() error reporting function wrapper was
    added in gpdb. It was miss used in some occasions inplace of simple
    assert like in heap_insert(), Insist(RelationIsHeap(relation)); This
    should just be assert as adds per tuple cost in production.
    
    Plus, the interface never emitted proper error message for non-assert
    enabled builds. Hence, best to remove this interface and remove
    confusion.
    
    Should be using Assert(), elog() or ereport() which covers for all the
    usecases present.
    
    Discussion:
    https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/BH1IXU6vnEw/m/56vxCQsMBAAJ

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
