### PR TITLE
Remove duplicate definition of data_directory

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -202,8 +202,6 @@ int			gp_connection_send_timeout;
 
 bool create_restartpoint_on_ckpt_record_replay = false;
 
-char	   *data_directory;
-
 /*
  * This variable is a dummy that doesn't do anything, except in some
  * cases provide the value for SHOW to display.  The real state is elsewhere

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -380,7 +380,6 @@ extern int Debug_dtm_action_protocol;
 extern int Debug_dtm_action_segment;
 extern int Debug_dtm_action_nestinglevel;
 
-extern char *data_directory;
 extern PGDLLIMPORT char *ConfigFileName;
 extern char *HbaFileName;
 extern char *IdentFileName;


### PR DESCRIPTION
Compiling with gcc 10 on Debian testing fails with the following error:

```
/usr/bin/ld: utils/misc/guc_gp.o:(.bss+0x308): multiple definition of
`data_directory'; utils/misc/guc.o:(.bss+0x70): first defined here
```