### PR TITLE
Reduce the overhead of logging that are related to Debug_print_full_dtm and Debug_print_snapshot_dtm.

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -336,15 +336,15 @@ DistributedLog_SetCommittedWithinAPage(
 
 	if (isRedo)
 	{
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "DistributedLog_SetCommitted check if page %d is present",
-			 page);
+		elogif(Debug_print_full_dtm, LOG,
+			   "DistributedLog_SetCommitted check if page %d is present",
+			   page);
 		if (!SimpleLruDoesPhysicalPageExist(DistributedLogCtl, page))
 		{
 			DistributedLog_ZeroPage(page, /* writeXLog */ false);
-			elog((Debug_print_full_dtm ? LOG : DEBUG5),
-				 "DistributedLog_SetCommitted zeroed page %d",
-				 page);
+			elogif(Debug_print_full_dtm, LOG,
+				   "DistributedLog_SetCommitted zeroed page %d",
+				   page);
 		}
 	}
 
@@ -382,10 +382,10 @@ DistributedLog_SetCommittedWithinAPage(
 			DistributedLogCtl->shared->page_dirty[slotno] = true;
 		}
 
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "DistributedLog_SetCommitted with local xid = %d (page = %d, entryno = %d) and distributed transaction xid = %u (timestamp = %u) status = %s",
-			 localXid[i], page, entryno, distribXid, distribTimeStamp,
-			 (alreadyThere ? "already there" : "set"));
+		elogif(Debug_print_full_dtm, LOG,
+			   "DistributedLog_SetCommitted with local xid = %d (page = %d, entryno = %d) and distributed transaction xid = %u (timestamp = %u) status = %s",
+			   localXid[i], page, entryno, distribXid, distribTimeStamp,
+			   (alreadyThere ? "already there" : "set"));
 	}
 
 	LWLockRelease(DistributedLogControlLock);
@@ -716,9 +716,9 @@ DistributedLog_ZeroPage(int page, bool writeXlog)
 
 	Assert(!IS_QUERY_DISPATCHER());
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DistributedLog_ZeroPage zero page %d",
-		 page);
+	elogif(Debug_print_full_dtm, LOG,
+		   "DistributedLog_ZeroPage zero page %d",
+		   page);
 	slotno = SimpleLruZeroPage(DistributedLogCtl, page);
 
 	if (writeXlog)
@@ -751,9 +751,9 @@ DistributedLog_Startup(TransactionId oldestActiveXid,
 
 	LWLockAcquire(DistributedLogControlLock, LW_EXCLUSIVE);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DistributedLog_Startup startPage %d, endPage %d",
-		 startPage, endPage);
+	elogif(Debug_print_full_dtm, LOG,
+		   "DistributedLog_Startup startPage %d, endPage %d",
+		   startPage, endPage);
 
 	/*
 	 * Initialize our idea of the latest page number.
@@ -841,8 +841,7 @@ DistributedLog_Shutdown(void)
 	if (IS_QUERY_DISPATCHER())
 		return;
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DistributedLog_Shutdown");
+	elogif(Debug_print_full_dtm, LOG, "DistributedLog_Shutdown");
 
 	/* Flush dirty DistributedLog pages to disk */
 	SimpleLruFlush(DistributedLogCtl, false);
@@ -857,8 +856,7 @@ DistributedLog_CheckPoint(void)
 	if (IS_QUERY_DISPATCHER())
 		return;
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DistributedLog_CheckPoint");
+	elogif(Debug_print_full_dtm, LOG, "DistributedLog_CheckPoint");
 
 	/* Flush dirty DistributedLog pages to disk */
 	SimpleLruFlush(DistributedLogCtl, true);
@@ -891,9 +889,7 @@ DistributedLog_Extend(TransactionId newestXact)
 
 	page = TransactionIdToPage(newestXact);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DistributedLog_Extend page %d",
-		 page);
+	elogif(Debug_print_full_dtm, LOG, "DistributedLog_Extend page %d", page);
 
 	LWLockAcquire(DistributedLogControlLock, LW_EXCLUSIVE);
 
@@ -902,9 +898,9 @@ DistributedLog_Extend(TransactionId newestXact)
 
 	LWLockRelease(DistributedLogControlLock);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DistributedLog_Extend with newest local xid = %d to page = %d",
-		 newestXact, page);
+	elogif(Debug_print_full_dtm, LOG,
+		   "DistributedLog_Extend with newest local xid = %d to page = %d",
+		   newestXact, page);
 }
 
 
@@ -945,9 +941,9 @@ DistributedLog_Truncate(TransactionId oldestXmin)
 	 */
 	cutoffPage = TransactionIdToPage(oldestXmin);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DistributedLog_Truncate with oldest local xid = %d to cutoff page = %d",
-		 oldestXmin, cutoffPage);
+	elogif(Debug_print_full_dtm, LOG,
+		   "DistributedLog_Truncate with oldest local xid = %d to cutoff page = %d",
+		   oldestXmin, cutoffPage);
 
 	/* Check to see if there's any files that could be removed */
 	if (!SlruScanDirectory(DistributedLogCtl, SlruScanDirCbReportPresence, &cutoffPage))
@@ -1047,9 +1043,9 @@ DistributedLog_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 
 		memcpy(&page, XLogRecGetData(record), sizeof(int));
 
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "Redo DISTRIBUTEDLOG_ZEROPAGE page %d",
-			 page);
+		elogif(Debug_print_full_dtm, LOG,
+			   "Redo DISTRIBUTEDLOG_ZEROPAGE page %d",
+			   page);
 
 		LWLockAcquire(DistributedLogControlLock, LW_EXCLUSIVE);
 
@@ -1059,9 +1055,9 @@ DistributedLog_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 
 		LWLockRelease(DistributedLogControlLock);
 
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "DistributedLog_redo zero page = %d",
-			 page);
+		elogif(Debug_print_full_dtm, LOG,
+			   "DistributedLog_redo zero page = %d",
+			   page);
 	}
 	else if (info == DISTRIBUTEDLOG_TRUNCATE)
 	{
@@ -1069,9 +1065,9 @@ DistributedLog_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 
 		memcpy(&page, XLogRecGetData(record), sizeof(int));
 
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "Redo DISTRIBUTEDLOG_TRUNCATE page %d",
-			 page);
+		elogif(Debug_print_full_dtm, LOG,
+			   "Redo DISTRIBUTEDLOG_TRUNCATE page %d",
+			   page);
 
 		/*
 		 * During XLOG replay, latest_page_number isn't set up yet; insert
@@ -1081,9 +1077,9 @@ DistributedLog_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 
 		SimpleLruTruncate(DistributedLogCtl, page);
 
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "DistributedLog_redo truncate to cutoff page = %d",
-			 page);
+		elogif(Debug_print_full_dtm, LOG,
+			   "DistributedLog_redo truncate to cutoff page = %d",
+			   page);
 	}
 	else
 		elog(PANIC, "DistributedLog_redo: unknown op code %u", info);

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -590,8 +590,8 @@ MarkAsPrepared(GlobalTransaction gxact)
 	gxact->valid = true;
 	LWLockRelease(TwoPhaseStateLock);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),"MarkAsPrepared marking GXACT gid = %s as valid (prepared)",
-		 gxact->gid);
+	elogif(Debug_print_full_dtm, LOG, "MarkAsPrepared marking GXACT gid = %s as valid (prepared)",
+		   gxact->gid);
 
 	LocalDistribXact_ChangeState(gxact->pgprocno,
 								 LOCALDISTRIBXACT_STATE_PREPARED);
@@ -612,7 +612,7 @@ LockGXact(const char *gid, Oid user, bool raiseErrorIfNotFound)
 {
 	int			i;
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),"LockGXact called to lock identifier = %s.",gid);
+	elogif(Debug_print_full_dtm, LOG, "LockGXact called to lock identifier = %s.", gid);
 	/* on first call, register the exit hook */
 	if (!twophaseExitRegistered)
 	{
@@ -627,7 +627,7 @@ LockGXact(const char *gid, Oid user, bool raiseErrorIfNotFound)
 		GlobalTransaction gxact = TwoPhaseState->prepXacts[i];
 		PGPROC	   *proc = &ProcGlobal->allProcs[gxact->pgprocno];
 
-		elog((Debug_print_full_dtm ? LOG : DEBUG5), "LockGXact checking identifier = %s.",gxact->gid);
+		elogif(Debug_print_full_dtm, LOG, "LockGXact checking identifier = %s.", gxact->gid);
 
 		/* Ignore not-yet-valid GIDs */
 		if (!gxact->valid)
@@ -1391,8 +1391,8 @@ FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFo
 	xid = pgxact->xid;
 	tfXLogRecPtr = gxact->prepare_begin_lsn;
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "FinishPreparedTransaction(): got xid %d for gid '%s'", xid, gid);
+	elogif(Debug_print_full_dtm, LOG,
+		   "FinishPreparedTransaction(): got xid %d for gid '%s'", xid, gid);
 
     /* get the two phase information from the xlog */
 	/*

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -623,9 +623,8 @@ AssignTransactionId(TransactionState s)
 	 * the Xid as "running".  See GetNewTransactionId.
 	 */
 	s->transactionId = GetNewTransactionId(isSubXact);
-	ereportif(Debug_print_full_dtm, LOG,
-			  (errmsg("AssignTransactionId(): assigned xid %u",
-					  s->transactionId)));
+	elogif(Debug_print_full_dtm, LOG,
+		   "AssignTransactionId(): assigned xid %u", s->transactionId);
 
 	if (isSubXact)
 	{
@@ -949,8 +948,8 @@ bool IsCurrentTransactionIdForReader(TransactionId xid)
 		 */
 		if (TransactionIdEquals(xid, writer_xid))
 		{
-			ereportif(Debug_print_full_dtm, LOG,
-					  (errmsg("reader encountered writer's top xid %u", xid)));
+			elogif(Debug_print_full_dtm, LOG,
+				   "reader encountered writer's top xid %u", xid);
 			isCurrent = true;
 		}
 		else
@@ -999,8 +998,8 @@ bool IsCurrentTransactionIdForReader(TransactionId xid)
 		}
 	}
 
-	ereportif(isCurrent && Debug_print_full_dtm, LOG,
-			  (errmsg("reader encountered writer's subxact ID %u", xid)));
+	elogif(isCurrent && Debug_print_full_dtm, LOG,
+		   "reader encountered writer's subxact ID %u", xid);
 
 	return isCurrent;
 }
@@ -1034,9 +1033,9 @@ TransactionIdIsCurrentTransactionId(TransactionId xid)
 	{
 		isCurrentTransactionId = IsCurrentTransactionIdForReader(xid);
 
-		ereportif(Debug_print_full_dtm, LOG,
-				  (errmsg("qExec Reader xid = %u, is current = %s",
-						  xid, (isCurrentTransactionId ? "true" : "false"))));
+		elogif(Debug_print_full_dtm, LOG,
+			   "qExec Reader xid = %u, is current = %s",
+			   xid, (isCurrentTransactionId ? "true" : "false"));
 
 		return isCurrentTransactionId;
 	}
@@ -2186,11 +2185,11 @@ SetSharedTransactionId_writer(DtxContext distributedTransactionContext)
 		   distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER ||
 		   distributedTransactionContext == DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT);
 
-	ereportif(Debug_print_full_dtm, LOG,
-			  (errmsg("%s setting shared xid %u -> %u",
-					  DtxContextToString(distributedTransactionContext),
-					  SharedLocalSnapshotSlot->xid,
-					  TopTransactionStateData.transactionId)));
+	elogif(Debug_print_full_dtm, LOG,
+		   "%s setting shared xid %u -> %u",
+		   DtxContextToString(distributedTransactionContext),
+		   SharedLocalSnapshotSlot->xid,
+		   TopTransactionStateData.transactionId);
 	SharedLocalSnapshotSlot->xid = TopTransactionStateData.transactionId;
 }
 
@@ -2209,12 +2208,12 @@ SetSharedTransactionId_reader(TransactionId xid, CommandId cid, DtxContext distr
 	 */
 	TopTransactionStateData.transactionId = xid;
 	currentCommandId = cid;
-	ereportif(Debug_print_full_dtm, LOG,
-			  (errmsg("qExec READER setting local xid=%u, cid=%u "
-					  "(distributedXid %u/%u)",
-					  TopTransactionStateData.transactionId, currentCommandId,
-					  QEDtxContextInfo.distributedXid,
-					  QEDtxContextInfo.segmateSync)));
+	elogif(Debug_print_full_dtm, LOG,
+		   "qExec READER setting local xid=%u, cid=%u "
+		   "(distributedXid %u/%u)",
+		   TopTransactionStateData.transactionId, currentCommandId,
+		   QEDtxContextInfo.distributedXid,
+		   QEDtxContextInfo.segmateSync);
 }
 
 /*
@@ -2359,11 +2358,11 @@ StartTransaction(void)
 			if (SharedLocalSnapshotSlot != NULL)
 			{
 				LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_EXCLUSIVE);
-				ereportif(Debug_print_full_dtm, LOG,
-						  (errmsg("setting shared snapshot startTimestamp = "
-								  INT64_FORMAT "[old=" INT64_FORMAT "])",
-								  stmtStartTimestamp,
-								  SharedLocalSnapshotSlot->startTimestamp)));
+				elogif(Debug_print_full_dtm, LOG,
+					   "setting shared snapshot startTimestamp = "
+					   INT64_FORMAT "[old=" INT64_FORMAT "])",
+					   stmtStartTimestamp,
+					   SharedLocalSnapshotSlot->startTimestamp);
 				SharedLocalSnapshotSlot->startTimestamp = stmtStartTimestamp;
 				LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 			}
@@ -2436,19 +2435,18 @@ StartTransaction(void)
 				SharedLocalSnapshotSlot->writer_proc = MyProc;
 				SharedLocalSnapshotSlot->writer_xact = MyPgXact;
 
-				ereportif(Debug_print_full_dtm, LOG,
-						  (errmsg(
-							  "qExec writer setting distributedXid: %d "
-							  "sharedQDxid %d (shared xid %u -> %u) ready %s"
-							  " (shared timeStamp = " INT64_FORMAT " -> "
-							  INT64_FORMAT ")",
-							  QEDtxContextInfo.distributedXid,
-							  SharedLocalSnapshotSlot->QDxid,
-							  SharedLocalSnapshotSlot->xid,
-							  s->transactionId,
-							  SharedLocalSnapshotSlot->ready ? "true" : "false",
-							  SharedLocalSnapshotSlot->startTimestamp,
-							  xactStartTimestamp)));
+				elogif(Debug_print_full_dtm, LOG,
+					   "qExec writer setting distributedXid: %d "
+					   "sharedQDxid %d (shared xid %u -> %u) ready %s"
+					   " (shared timeStamp = " INT64_FORMAT " -> "
+					   INT64_FORMAT ")",
+					   QEDtxContextInfo.distributedXid,
+					   SharedLocalSnapshotSlot->QDxid,
+					   SharedLocalSnapshotSlot->xid,
+					   s->transactionId,
+					   SharedLocalSnapshotSlot->ready ? "true" : "false",
+					   SharedLocalSnapshotSlot->startTimestamp,
+					   xactStartTimestamp);
 				LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 			}
 		}
@@ -2502,15 +2500,14 @@ StartTransaction(void)
 			break;
 	}
 
-	ereportif(Debug_print_snapshot_dtm, LOG,
-			  (errmsg("[Distributed Snapshot #%u] *StartTransaction* "
-					  "(gxid = %u, xid = %u, '%s')",
-					  (!FirstSnapshotSet ? 0 :
-					   GetTransactionSnapshot()->
-					   distribSnapshotWithLocalMapping.ds.distribSnapshotId),
-					  getDistributedTransactionId(),
-					  s->transactionId,
-					  DtxContextToString(DistributedTransactionContext))));
+	elogif(Debug_print_snapshot_dtm, LOG,
+		   "[Distributed Snapshot #%u] *StartTransaction* "
+		   "(gxid = %u, xid = %u, '%s')",
+		   (!FirstSnapshotSet ? 0 :
+			GetTransactionSnapshot()->distribSnapshotWithLocalMapping.ds.distribSnapshotId),
+		   getDistributedTransactionId(),
+		   s->transactionId,
+		   DtxContextToString(DistributedTransactionContext));
 
 	/*
 	 * Assign a new LocalTransactionId, and combine it with the backendId to
@@ -2592,12 +2589,12 @@ StartTransaction(void)
 	initialize_wal_bytes_written();
 	ShowTransactionState("StartTransaction");
 
-	ereportif(Debug_print_full_dtm, LOG,
-			  (errmsg("StartTransaction in DTX Context = '%s', "
-					  "isolation level %s, read-only = %d, %s",
-					  DtxContextToString(DistributedTransactionContext),
-					  IsoLevelAsUpperString(XactIsoLevel), XactReadOnly,
-					  LocalDistribXact_DisplayString(MyProc->pgprocno))));
+	elogif(Debug_print_full_dtm, LOG,
+		   "StartTransaction in DTX Context = '%s', "
+		   "isolation level %s, read-only = %d, %s",
+		   DtxContextToString(DistributedTransactionContext),
+		   IsoLevelAsUpperString(XactIsoLevel), XactReadOnly,
+		   LocalDistribXact_DisplayString(MyProc->pgprocno));
 }
 
 /*
@@ -3551,12 +3548,12 @@ StartTransactionCommand(void)
 
 				LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 
-				ereportif(Debug_print_full_dtm, LOG,
-						  (errmsg("qExec WRITER updating shared xid: %u -> %u "
-								  "(StartTransactionCommand) timestamp: "
-								  INT64_FORMAT " -> " INT64_FORMAT ")",
-								  oldXid, s->transactionId,
-								  oldStartTimestamp, xactStartTimestamp)));
+				elogif(Debug_print_full_dtm, LOG,
+					   "qExec WRITER updating shared xid: %u -> %u "
+					   "(StartTransactionCommand) timestamp: "
+					   INT64_FORMAT " -> " INT64_FORMAT ")",
+					   oldXid, s->transactionId,
+					   oldStartTimestamp, xactStartTimestamp);
 			}
 			break;
 
@@ -5317,8 +5314,8 @@ ExecutorMarkTransactionDoesWrites(void)
 	// UNDONE: Verify we are in transaction...
 	if (!TopTransactionStateData.executorSaysXactDoesWrites)
 	{
-		ereportif(Debug_print_full_dtm, LOG,
-				  (errmsg("ExecutorMarkTransactionDoesWrites called")));
+		elogif(Debug_print_full_dtm, LOG,
+			   "ExecutorMarkTransactionDoesWrites called");
 		TopTransactionStateData.executorSaysXactDoesWrites = true;
 	}
 }

--- a/src/backend/cdb/cdbdistributedsnapshot.c
+++ b/src/backend/cdb/cdbdistributedsnapshot.c
@@ -176,9 +176,9 @@ DistributedSnapshotWithLocalMapping_CommittedTest(
 	 */
 	if (distribXid >= ds->xmax)
 	{
-		elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-			 "distributedsnapshot committed but invisible: distribXid %d dxmax %d dxmin %d distribSnapshotId %d",
-			 distribXid, ds->xmax, ds->xmin, ds->distribSnapshotId);
+		elogif(Debug_print_snapshot_dtm, LOG,
+			   "distributedsnapshot committed but invisible: distribXid %d dxmax %d dxmin %d distribSnapshotId %d",
+			   distribXid, ds->xmax, ds->xmin, ds->distribSnapshotId);
 
 		return DISTRIBUTEDSNAPSHOT_COMMITTED_INPROGRESS;
 	}
@@ -260,14 +260,14 @@ DistributedSnapshot_Copy(DistributedSnapshot *target,
 {
 	DistributedSnapshot_Reset(target);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DistributedSnapshot_Copy target maxCount %d, inProgressXidArray %p, and "
-		 "source maxCount %d, count %d, inProgressXidArray %p",
-		 target->maxCount,
-		 target->inProgressXidArray,
-		 source->maxCount,
-		 source->count,
-		 source->inProgressXidArray);
+	elogif(Debug_print_full_dtm, LOG,
+		   "DistributedSnapshot_Copy target maxCount %d, inProgressXidArray %p, and "
+		   "source maxCount %d, count %d, inProgressXidArray %p",
+		   target->maxCount,
+		   target->inProgressXidArray,
+		   source->maxCount,
+		   source->count,
+		   source->inProgressXidArray);
 
 	/*
 	 * If we have allocated space for the in-progress distributed

--- a/src/backend/cdb/cdbdtxcontextinfo.c
+++ b/src/backend/cdb/cdbdtxcontextinfo.c
@@ -73,10 +73,10 @@ DtxContextInfo_CreateOnMaster(DtxContextInfo *dtxContextInfo, bool inCursor,
 	dtxContextInfo->cursorContext = inCursor;
 	dtxContextInfo->nestingLevel = GetCurrentTransactionNestLevel();
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DtxContextInfo_CreateOnMaster: created dtxcontext with dxid %u nestingLevel %d segmateSync %u/%u (current/cached)",
-		 dtxContextInfo->distributedXid, dtxContextInfo->nestingLevel,
-		 dtxContextInfo->segmateSync, syncCount);
+	elogif(Debug_print_full_dtm, LOG,
+		   "DtxContextInfo_CreateOnMaster: created dtxcontext with dxid %u nestingLevel %d segmateSync %u/%u (current/cached)",
+		   dtxContextInfo->distributedXid, dtxContextInfo->nestingLevel,
+		   dtxContextInfo->segmateSync, syncCount);
 
 	dtxContextInfo->haveDistributedSnapshot = false;
 	if (snapshot && snapshot->haveDistribSnapshot)
@@ -157,8 +157,8 @@ DtxContextInfo_SerializeSize(DtxContextInfo *dtxContextInfo)
 
 	size += sizeof(int);		/* distributedTxnOptions */
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DtxContextInfo_SerializeSize is returning size = %d", size);
+	elogif(Debug_print_full_dtm, LOG,
+		   "DtxContextInfo_SerializeSize is returning size = %d", size);
 
 	return size;
 }
@@ -187,14 +187,14 @@ DtxContextInfo_Serialize(char *buffer, DtxContextInfo *dtxContextInfo)
 	}
 	else
 	{
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "DtxContextInfo_Serialize only copied InvalidDistributedTransactionId");
+		elogif(Debug_print_full_dtm, LOG,
+			   "DtxContextInfo_Serialize only copied InvalidDistributedTransactionId");
 	}
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG3),
-		 "DtxContextInfo_Serialize distributedTimeStamp %u, distributedXid = %u, curcid %d nestingLevel %d segmateSync %u",
-		 dtxContextInfo->distributedTimeStamp, dtxContextInfo->distributedXid,
-		 dtxContextInfo->curcid, dtxContextInfo->nestingLevel, dtxContextInfo->segmateSync);
+	elogif(Debug_print_full_dtm, LOG,
+		   "DtxContextInfo_Serialize distributedTimeStamp %u, distributedXid = %u, curcid %d nestingLevel %d segmateSync %u",
+		   dtxContextInfo->distributedTimeStamp, dtxContextInfo->distributedXid,
+		   dtxContextInfo->curcid, dtxContextInfo->nestingLevel, dtxContextInfo->segmateSync);
 
 	memcpy(p, &dtxContextInfo->segmateSync, sizeof(uint32));
 	p += sizeof(uint32);
@@ -302,24 +302,24 @@ DtxContextInfo_Copy(
 
 	target->distributedTxnOptions = source->distributedTxnOptions;
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DtxContextInfo_Copy distributed {timestamp %u, xid %u}, id = %s, "
-		 "command id %d",
-		 target->distributedTimeStamp,
-		 target->distributedXid,
-		 target->distributedId,
-		 target->curcid);
+	elogif(Debug_print_full_dtm, LOG,
+		   "DtxContextInfo_Copy distributed {timestamp %u, xid %u}, id = %s, "
+		   "command id %d",
+		   target->distributedTimeStamp,
+		   target->distributedXid,
+		   target->distributedId,
+		   target->curcid);
 
 	if (target->haveDistributedSnapshot)
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "distributed snapshot {timestamp %u, xminAllDistributedSnapshots %u, snapshot id %d, "
-			 "xmin %u, count %d, xmax %u}",
-			 target->distributedSnapshot.distribTransactionTimeStamp,
-			 target->distributedSnapshot.xminAllDistributedSnapshots,
-			 target->distributedSnapshot.distribSnapshotId,
-			 target->distributedSnapshot.xmin,
-			 target->distributedSnapshot.count,
-			 target->distributedSnapshot.xmax);
+		elogif(Debug_print_full_dtm, LOG,
+			   "distributed snapshot {timestamp %u, xminAllDistributedSnapshots %u, snapshot id %d, "
+			   "xmin %u, count %d, xmax %u}",
+			   target->distributedSnapshot.distribTransactionTimeStamp,
+			   target->distributedSnapshot.xminAllDistributedSnapshots,
+			   target->distributedSnapshot.distribSnapshotId,
+			   target->distributedSnapshot.xmin,
+			   target->distributedSnapshot.count,
+			   target->distributedSnapshot.xmax);
 
 }
 
@@ -337,9 +337,9 @@ DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 	{
 		const char *p = serializedDtxContextInfo;
 
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "DtxContextInfo_Deserialize serializedDtxContextInfolen = %d.",
-			 serializedDtxContextInfolen);
+		elogif(Debug_print_full_dtm, LOG,
+			   "DtxContextInfo_Deserialize serializedDtxContextInfolen = %d.",
+			   serializedDtxContextInfolen);
 
 		memcpy(&dtxContextInfo->distributedXid, p, sizeof(DistributedTransactionId));
 		p += sizeof(DistributedTransactionId);
@@ -358,8 +358,8 @@ DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 		}
 		else
 		{
-			elog((Debug_print_full_dtm ? LOG : DEBUG5),
-				 "DtxContextInfo_Deserialize distributedXid was InvalidDistributedTransactionId");
+			elogif(Debug_print_full_dtm, LOG,
+				   "DtxContextInfo_Deserialize distributedXid was InvalidDistributedTransactionId");
 		}
 
 		memcpy(&dtxContextInfo->segmateSync, p, sizeof(uint32));
@@ -372,11 +372,11 @@ DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 		memcpy(&dtxContextInfo->cursorContext, p, sizeof(bool));
 		p += sizeof(bool);
 
-		elog((Debug_print_full_dtm ? LOG : DEBUG3),
-			 "DtxContextInfo_Deserialize distributedTimeStamp %u, distributedXid = %u, curcid %d nestingLevel %d segmateSync %u as %s",
-			 dtxContextInfo->distributedTimeStamp, dtxContextInfo->distributedXid,
-			 dtxContextInfo->curcid, dtxContextInfo->nestingLevel,
-			 dtxContextInfo->segmateSync, (Gp_is_writer ? "WRITER" : "READER"));
+		elogif(Debug_print_full_dtm, LOG,
+			   "DtxContextInfo_Deserialize distributedTimeStamp %u, distributedXid = %u, curcid %d nestingLevel %d segmateSync %u as %s",
+			   dtxContextInfo->distributedTimeStamp, dtxContextInfo->distributedXid,
+			   dtxContextInfo->curcid, dtxContextInfo->nestingLevel,
+			   dtxContextInfo->segmateSync, (Gp_is_writer ? "WRITER" : "READER"));
 
 		if (dtxContextInfo->haveDistributedSnapshot)
 		{
@@ -384,8 +384,8 @@ DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 		}
 		else
 		{
-			elog((Debug_print_full_dtm ? LOG : DEBUG5),
-				 "DtxContextInfo_Deserialize no distributed snapshot");
+			elogif(Debug_print_full_dtm, LOG,
+				   "DtxContextInfo_Deserialize no distributed snapshot");
 		}
 
 		memcpy(&dtxContextInfo->distributedTxnOptions, p, sizeof(int));
@@ -417,12 +417,12 @@ DtxContextInfo_Deserialize(const char *serializedDtxContextInfo,
 						 i, ds->inProgressXidArray[i]);
 				}
 
-				elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-					 "[Distributed Snapshot #%u] *Deserialize* currcid = %d (gxid = %u, '%s')",
-					 ds->distribSnapshotId,
-					 dtxContextInfo->curcid,
-					 getDistributedTransactionId(),
-					 DtxContextToString(DistributedTransactionContext));
+				elogif(Debug_print_snapshot_dtm, LOG,
+					   "[Distributed Snapshot #%u] *Deserialize* currcid = %d (gxid = %u, '%s')",
+					   ds->distribSnapshotId,
+					   dtxContextInfo->curcid,
+					   getDistributedTransactionId(),
+					   DtxContextToString(DistributedTransactionContext));
 			}
 
 			elog((Debug_print_full_dtm ? LOG : DEBUG5),

--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -111,7 +111,8 @@ GetRedoFileName(char *path)
 {
 	snprintf(path, MAXPGPATH,
 			 "%s/" UTILITYMODEDTMREDO_DIR "/" UTILITYMODEDTMREDO_FILE, DataDir);
-	elog(DTM_DEBUG3, "Returning save DTM redo file path = %s", path);
+	elogif(Debug_print_full_dtm, LOG,
+		   "Returning save DTM redo file path = %s", path);
 }
 
 /*
@@ -133,7 +134,8 @@ GetRedoFileName(char *path)
 static void
 recoverTM(void)
 {
-	elog(DTM_DEBUG3, "Starting to Recover DTM...");
+	elogif(Debug_print_full_dtm, LOG,
+		   "Starting to Recover DTM...");
 
 	/*
 	 * attempt to recover all in-doubt transactions.
@@ -159,7 +161,8 @@ recoverInDoubtTransactions(void)
 	int			i;
 	HTAB	   *htab;
 
-	elog(DTM_DEBUG3, "recover in-doubt distributed transactions");
+	elogif(Debug_print_full_dtm, LOG,
+		   "recover in-doubt distributed transactions");
 
 	ReplayRedoFromUtilityMode();
 
@@ -168,9 +171,9 @@ recoverInDoubtTransactions(void)
 	 * matched by a forget committed record, change its state indicating
 	 * committed notification needed.  Attempt a notification.
 	 */
-	elog(DTM_DEBUG5,
-		 "Going to retry commit notification for distributed transactions (count = %d)",
-		 *shmNumCommittedGxacts);
+	elogif(Debug_print_full_dtm, LOG,
+		   "Going to retry commit notification for distributed transactions (count = %d)",
+		   *shmNumCommittedGxacts);
 
 	for (i = 0; i < *shmNumCommittedGxacts; i++)
 	{
@@ -178,9 +181,9 @@ recoverInDoubtTransactions(void)
 
 		Assert(gxact_log->gxid != InvalidDistributedTransactionId);
 
-		elog(DTM_DEBUG5,
-			 "Recovering committed distributed transaction gid = %s",
-			 gxact_log->gid);
+		elogif(Debug_print_full_dtm, LOG,
+			   "Recovering committed distributed transaction gid = %s",
+			   gxact_log->gid);
 
 		doNotifyCommittedInDoubt(gxact_log->gid);
 
@@ -349,7 +352,8 @@ abortRMInDoubtTransactions(HTAB *htab)
 
 	while ((entry = (InDoubtDtx *) hash_seq_search(&status)) != NULL)
 	{
-		elog(DTM_DEBUG3, "Aborting in-doubt transaction with gid = %s", entry->gid);
+		elogif(Debug_print_full_dtm, LOG,
+			   "Aborting in-doubt transaction with gid = %s", entry->gid);
 
 		doAbortInDoubt(entry->gid);
 	}
@@ -383,10 +387,11 @@ UtilityModeSaveRedo(bool committed, TMGXACT_LOG *gxact_log)
 	utilityModeRedo.committed = committed;
 	memcpy(&utilityModeRedo.gxact_log, gxact_log, sizeof(TMGXACT_LOG));
 
-	elog(DTM_DEBUG5, "Writing {committed = %s, gid = %s, gxid = %u} to DTM redo file",
-		 (utilityModeRedo.committed ? "true" : "false"),
-		 utilityModeRedo.gxact_log.gid,
-		 utilityModeRedo.gxact_log.gxid);
+	elogif(Debug_print_full_dtm, LOG,
+		   "Writing {committed = %s, gid = %s, gxid = %u} to DTM redo file",
+		   (utilityModeRedo.committed ? "true" : "false"),
+		   utilityModeRedo.gxact_log.gid,
+		   utilityModeRedo.gxact_log.gxid);
 
 	write_len = write(redoFileFD, &utilityModeRedo, sizeof(TMGXACT_UTILITY_MODE_REDO));
 	if (write_len != sizeof(TMGXACT_UTILITY_MODE_REDO))
@@ -414,13 +419,13 @@ ReplayRedoFromUtilityMode(void)
 	if (fd < 0)
 	{
 		/* UNDONE: Distinquish "not found" from other errors. */
-		elog(DTM_DEBUG3, "Could not open DTM redo file %s for reading",
-			 path);
+		elogif(Debug_print_full_dtm, LOG,
+			   "Could not open DTM redo file %s for reading", path);
 		return;
 	}
 
-	elog(DTM_DEBUG3, "Succesfully opened DTM redo file %s for reading",
-		 path);
+	elogif(Debug_print_full_dtm, LOG,
+		   "Succesfully opened DTM redo file %s for reading", path);
 
 	while (true)
 	{
@@ -440,10 +445,11 @@ ReplayRedoFromUtilityMode(void)
 					 errmsg("error reading DTM redo file: %m")));
 		}
 
-		elog(DTM_DEBUG5, "Read {committed = %s, gid = %s, gxid = %u} from DTM redo file",
-			 (utilityModeRedo.committed ? "true" : "false"),
-			 utilityModeRedo.gxact_log.gid,
-			 utilityModeRedo.gxact_log.gxid);
+		elogif(Debug_print_full_dtm, LOG,
+			   "Read {committed = %s, gid = %s, gxid = %u} from DTM redo file",
+			   (utilityModeRedo.committed ? "true" : "false"),
+			   utilityModeRedo.gxact_log.gid,
+			   utilityModeRedo.gxact_log.gxid);
 		if (utilityModeRedo.committed)
 			redoDistributedCommitRecord(&utilityModeRedo.gxact_log);
 		else
@@ -452,8 +458,8 @@ ReplayRedoFromUtilityMode(void)
 		entries++;
 	}
 
-	elog(DTM_DEBUG5, "Processed %d entries from DTM redo file",
-		 entries);
+	elogif(Debug_print_full_dtm, LOG,
+		   "Processed %d entries from DTM redo file", entries);
 	close(fd);
 }
 
@@ -465,8 +471,8 @@ RemoveRedoUtilityModeFile(void)
 
 	GetRedoFileName(path);
 	removed = (unlink(path) == 0);
-	elog(DTM_DEBUG5, "Removed DTM redo file %s (%s)",
-		 path, (removed ? "true" : "false"));
+	elogif(Debug_print_full_dtm, LOG,
+		   "Removed DTM redo file %s (%s)", path, (removed ? "true" : "false"));
 }
 
 void
@@ -474,11 +480,12 @@ UtilityModeCloseDtmRedoFile(void)
 {
 	if (Gp_role != GP_ROLE_UTILITY)
 	{
-		elog(DTM_DEBUG3, "Not in Utility Mode (role = %s)-- skipping closing DTM redo file",
-			 role_to_string(Gp_role));
+		elogif(Debug_print_full_dtm, LOG,
+			   "Not in Utility Mode (role = %s)-- skipping closing DTM redo file",
+			   role_to_string(Gp_role));
 		return;
 	}
-	elog(DTM_DEBUG3, "Closing DTM redo file");
+	elogif(Debug_print_full_dtm, LOG, "Closing DTM redo file");
 	close(redoFileFD);
 }
 
@@ -489,8 +496,9 @@ UtilityModeFindOrCreateDtmRedoFile(void)
 
 	if (Gp_role != GP_ROLE_UTILITY)
 	{
-		elog(DTM_DEBUG3, "Not in Utility Mode (role = %s) -- skipping finding or creating DTM redo file",
-			 role_to_string(Gp_role));
+		elogif(Debug_print_full_dtm, LOG,
+			   "Not in Utility Mode (role = %s) -- skipping finding or creating DTM redo file",
+			   role_to_string(Gp_role));
 		return;
 	}
 	GetRedoFileName(path);
@@ -502,8 +510,9 @@ UtilityModeFindOrCreateDtmRedoFile(void)
 				 errmsg("could not create save DTM redo file \"%s\"", path)));
 
 	redoFileOffset = lseek(redoFileFD, 0, SEEK_END);
-	elog(DTM_DEBUG3, "Succesfully opened DTM redo file %s (end offset %d)",
-		 path, redoFileOffset);
+	elogif(Debug_print_full_dtm, LOG,
+		   "Succesfully opened DTM redo file %s (end offset %d)",
+		   path, redoFileOffset);
 }
 
 /*
@@ -521,7 +530,8 @@ redoDtxCheckPoint(TMGXACT_CHECKPOINT *gxact_checkpoint)
 	 * in-memory if Dispatch.
 	 */
 	committedCount = gxact_checkpoint->committedCount;
-	elog(DTM_DEBUG5, "redoDtxCheckPoint has committedCount = %d", committedCount);
+	elogif(Debug_print_full_dtm, LOG,
+		   "redoDtxCheckPoint has committedCount = %d", committedCount);
 
 	for (i = 0; i < committedCount; i++)
 		redoDistributedCommitRecord(&gxact_checkpoint->committedGxactArray[i]);
@@ -545,7 +555,8 @@ redoDistributedCommitRecord(TMGXACT_LOG *gxact_log)
 
 	if (Gp_role == GP_ROLE_UTILITY)
 	{
-		elog(DTM_DEBUG3, "DB in Utility mode.  Save DTM distributed commit until later.");
+		elogif(Debug_print_full_dtm, LOG,
+			   "DB in Utility mode.  Save DTM distributed commit until later.");
 		UtilityModeSaveRedo(true, gxact_log);
 		return;
 	}
@@ -571,8 +582,8 @@ redoDistributedCommitRecord(TMGXACT_LOG *gxact_log)
 							   "around this issue and then report a bug")));
 
 		shmCommittedGxactArray[(*shmNumCommittedGxacts)++] = *gxact_log;
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "Crash recovery redo added committed distributed transaction gid = %s", gxact_log->gid);
+		elogif(Debug_print_full_dtm, LOG,
+			   "Crash recovery redo added committed distributed transaction gid = %s", gxact_log->gid);
 	}
 }
 
@@ -586,7 +597,8 @@ redoDistributedForgetCommitRecord(TMGXACT_LOG *gxact_log)
 
 	if (Gp_role == GP_ROLE_UTILITY)
 	{
-		elog(DTM_DEBUG3, "DB in Utility mode.  Save DTM disributed forget until later.");
+		elogif(Debug_print_full_dtm, LOG,
+			   "DB in Utility mode.  Save DTM disributed forget until later.");
 		UtilityModeSaveRedo(false, gxact_log);
 		return;
 	}
@@ -596,9 +608,9 @@ redoDistributedForgetCommitRecord(TMGXACT_LOG *gxact_log)
 		if (strcmp(gxact_log->gid, shmCommittedGxactArray[i].gid) == 0)
 		{
 			/* found an active global transaction */
-			elog((Debug_print_full_dtm ? INFO : DEBUG5),
-				 "Crash recovery redo removed committed distributed transaction gid = %s for forget",
-				 gxact_log->gid);
+			elogif(Debug_print_full_dtm, INFO,
+				   "Crash recovery redo removed committed distributed transaction gid = %s for forget",
+				   gxact_log->gid);
 
 			/*
 			 * there's no concurrent access to shmCommittedGxactArray during
@@ -612,9 +624,9 @@ redoDistributedForgetCommitRecord(TMGXACT_LOG *gxact_log)
 		}
 	}
 
-	elog((Debug_print_full_dtm ? WARNING : DEBUG5),
-		 "Crash recovery redo did not find committed distributed transaction gid = %s for forget",
-		 gxact_log->gid);
+	elogif(Debug_print_full_dtm, WARNING,
+		   "Crash recovery redo did not find committed distributed transaction gid = %s for forget",
+		   gxact_log->gid);
 }
 
 bool

--- a/src/backend/cdb/cdblocaldistribxact.c
+++ b/src/backend/cdb/cdblocaldistribxact.c
@@ -117,12 +117,12 @@ LocalDistribXact_ChangeState(int pgprocno,
 
 	proc->localDistribXactData.state = newState;
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "Moved distributed transaction xid = %u (local xid = %u) from \"%s\" to \"%s\"",
-		 distribXid,
-		 pgxact->xid,
-		 LocalDistribXactStateToString(oldState),
-		 LocalDistribXactStateToString(newState));
+	elogif(Debug_print_full_dtm, LOG,
+		   "Moved distributed transaction xid = %u (local xid = %u) from \"%s\" to \"%s\"",
+		   distribXid,
+		   pgxact->xid,
+		   LocalDistribXactStateToString(oldState),
+		   LocalDistribXactStateToString(newState));
 }
 
 #define MAX_LOCAL_DISTRIB_DISPLAY_BUFFER 100

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -291,14 +291,16 @@ notifyCommittedDtxTransactionIsNeeded(void)
 {
 	if (DistributedTransactionContext != DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE)
 	{
-		elog(DTM_DEBUG5, "notifyCommittedDtxTransaction nothing to do (DistributedTransactionContext = '%s')",
-			 DtxContextToString(DistributedTransactionContext));
+		elogif(Debug_print_full_dtm, LOG,
+			   "notifyCommittedDtxTransaction nothing to do (DistributedTransactionContext = '%s')",
+			   DtxContextToString(DistributedTransactionContext));
 		return false;
 	}
 
 	if (!isCurrentDtxActivated())
 	{
-		elog(DTM_DEBUG5, "notifyCommittedDtxTransaction nothing to do (two phase not activated)");
+		elogif(Debug_print_full_dtm, LOG,
+			   "notifyCommittedDtxTransaction nothing to do (two phase not activated)");
 		return false;
 	}
 
@@ -417,8 +419,9 @@ doPrepareTransaction(void)
 
 	CHECK_FOR_INTERRUPTS();
 
-	elog(DTM_DEBUG5, "doPrepareTransaction entering in state = %s",
-		 DtxStateToString(MyTmGxactLocal->state));
+	elogif(Debug_print_full_dtm, LOG,
+		   "doPrepareTransaction entering in state = %s",
+		   DtxStateToString(MyTmGxactLocal->state));
 
 	/*
 	 * Don't allow a cancel while we're dispatching our prepare (we wrap our
@@ -429,7 +432,9 @@ doPrepareTransaction(void)
 	Assert(MyTmGxactLocal->state == DTX_STATE_ACTIVE_DISTRIBUTED);
 	setCurrentDtxState(DTX_STATE_PREPARING);
 
-	elog(DTM_DEBUG5, "doPrepareTransaction moved to state = %s", DtxStateToString(MyTmGxactLocal->state));
+	elogif(Debug_print_full_dtm, LOG,
+		   "doPrepareTransaction moved to state = %s",
+		   DtxStateToString(MyTmGxactLocal->state));
 
 	Assert(MyTmGxactLocal->dtxSegments != NIL);
 	succeeded = currentDtxDispatchProtocolCommand(DTX_PROTOCOL_COMMAND_PREPARE, true);
@@ -442,23 +447,25 @@ doPrepareTransaction(void)
 
 	if (!succeeded)
 	{
-		elog(DTM_DEBUG5, "doPrepareTransaction error finds badPrimaryGangs = %s",
-			 (MyTmGxactLocal->badPrepareGangs ? "true" : "false"));
+		elogif(Debug_print_full_dtm, LOG,
+			   "doPrepareTransaction error finds badPrimaryGangs = %s",
+			   (MyTmGxactLocal->badPrepareGangs ? "true" : "false"));
 
 		ereport(ERROR,
 				(errmsg("The distributed transaction 'Prepare' broadcast failed to one or more segments"),
 				TM_ERRDETAIL));
 	}
-	ereport(DTM_DEBUG5,
-			(errmsg("The distributed transaction 'Prepare' broadcast succeeded to the segments"),
-			TM_ERRDETAIL));
+	ereportif(Debug_print_full_dtm, LOG,
+			  (errmsg("The distributed transaction 'Prepare' broadcast succeeded to the segments"),
+				  TM_ERRDETAIL));
 
 	Assert(MyTmGxactLocal->state == DTX_STATE_PREPARING);
 	setCurrentDtxState(DTX_STATE_PREPARED);
 
 	SIMPLE_FAULT_INJECTOR("dtm_broadcast_prepare");
 
-	elog(DTM_DEBUG5, "doPrepareTransaction leaving in state = %s", DtxStateToString(MyTmGxactLocal->state));
+	elogif(Debug_print_full_dtm, LOG,
+		   "doPrepareTransaction leaving in state = %s", DtxStateToString(MyTmGxactLocal->state));
 }
 
 /*
@@ -469,7 +476,8 @@ doInsertForgetCommitted(void)
 {
 	TMGXACT_LOG gxact_log;
 
-	elog(DTM_DEBUG5, "doInsertForgetCommitted entering in state = %s", DtxStateToString(MyTmGxactLocal->state));
+	elogif(Debug_print_full_dtm, LOG,
+		   "doInsertForgetCommitted entering in state = %s", DtxStateToString(MyTmGxactLocal->state));
 
 	setCurrentDtxState(DTX_STATE_INSERTING_FORGET_COMMITTED);
 
@@ -530,7 +538,8 @@ doNotifyingOnePhaseCommit(void)
 	if (MyTmGxactLocal->dtxSegments == NIL)
 		return;
 
-	elog(DTM_DEBUG5, "doNotifyingOnePhaseCommit entering in state = %s", DtxStateToString(MyTmGxactLocal->state));
+	elogif(Debug_print_full_dtm, LOG,
+		   "doNotifyingOnePhaseCommit entering in state = %s", DtxStateToString(MyTmGxactLocal->state));
 
 	Assert(MyTmGxactLocal->state == DTX_STATE_ONE_PHASE_COMMIT);
 	setCurrentDtxState(DTX_STATE_NOTIFYING_ONE_PHASE_COMMIT);
@@ -554,7 +563,8 @@ doNotifyingCommitPrepared(void)
 	volatile int savedInterruptHoldoffCount;
 	MemoryContext oldcontext = CurrentMemoryContext;;
 
-	elog(DTM_DEBUG5, "doNotifyingCommitPrepared entering in state = %s", DtxStateToString(MyTmGxactLocal->state));
+	elogif(Debug_print_full_dtm, LOG,
+		   "doNotifyingCommitPrepared entering in state = %s", DtxStateToString(MyTmGxactLocal->state));
 
 	Assert(MyTmGxactLocal->state == DTX_STATE_INSERTED_COMMITTED);
 	setCurrentDtxState(DTX_STATE_NOTIFYING_COMMIT_PREPARED);
@@ -582,10 +592,10 @@ doNotifyingCommitPrepared(void)
 	if (!succeeded)
 	{
 		Assert(MyTmGxactLocal->state == DTX_STATE_NOTIFYING_COMMIT_PREPARED);
-		ereport(DTM_DEBUG5,
-				(errmsg("marking retry needed for distributed transaction "
-						"'Commit Prepared' broadcast to the segments"),
-				TM_ERRDETAIL));
+		ereportif(Debug_print_full_dtm, LOG,
+				  (errmsg("marking retry needed for distributed transaction "
+						  "'Commit Prepared' broadcast to the segments"),
+					  TM_ERRDETAIL));
 
 		setCurrentDtxState(DTX_STATE_RETRY_COMMIT_PREPARED);
 		setDistributedTransactionContext(DTX_CONTEXT_QD_RETRY_PHASE_2);
@@ -642,9 +652,9 @@ doNotifyingCommitPrepared(void)
 				(errmsg("unable to complete 'Commit Prepared' broadcast"),
 				TM_ERRDETAIL));
 
-	ereport(DTM_DEBUG5,
-			(errmsg("the distributed transaction 'Commit Prepared' broadcast succeeded to all the segments"),
-			TM_ERRDETAIL));
+	ereportif(Debug_print_full_dtm, LOG,
+			  (errmsg("the distributed transaction 'Commit Prepared' broadcast succeeded to all the segments"),
+				  TM_ERRDETAIL));
 
 	SIMPLE_FAULT_INJECTOR("dtm_before_insert_forget_comitted");
 
@@ -715,9 +725,9 @@ retryAbortPrepared(void)
 				(errmsg("unable to complete 'Abort' broadcast"),
 				TM_ERRDETAIL));
 
-	ereport(DTM_DEBUG5,
-			(errmsg("The distributed transaction 'Abort' broadcast succeeded to all the segments"),
-			TM_ERRDETAIL));
+	ereportif(Debug_print_full_dtm, LOG,
+			  (errmsg("The distributed transaction 'Abort' broadcast succeeded to all the segments"),
+				  TM_ERRDETAIL));
 }
 
 
@@ -728,7 +738,8 @@ doNotifyingAbort(void)
 	volatile int savedInterruptHoldoffCount;
 	MemoryContext oldcontext = CurrentMemoryContext;
 
-	elog(DTM_DEBUG5, "doNotifyingAborted entering in state = %s", DtxStateToString(MyTmGxactLocal->state));
+	elogif(Debug_print_full_dtm, LOG,
+		   "doNotifyingAborted entering in state = %s", DtxStateToString(MyTmGxactLocal->state));
 
 	Assert(MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_NO_PREPARED ||
 			MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED ||
@@ -766,16 +777,16 @@ doNotifyingAbort(void)
 			}
 			else
 			{
-				ereport(DTM_DEBUG5,
-						(errmsg("The distributed transaction 'Abort' broadcast succeeded to all the segments"),
-						TM_ERRDETAIL));
+				ereportif(Debug_print_full_dtm, LOG,
+						  (errmsg("The distributed transaction 'Abort' broadcast succeeded to all the segments"),
+							  TM_ERRDETAIL));
 			}
 		}
 		else
 		{
-			ereport(DTM_DEBUG5,
-					(errmsg("The distributed transaction 'Abort' broadcast was omitted (segworker group already dead)"),
-					TM_ERRDETAIL));
+			ereportif(Debug_print_full_dtm, LOG,
+					  (errmsg("The distributed transaction 'Abort' broadcast was omitted (segworker group already dead)"),
+						  TM_ERRDETAIL));
 		}
 	}
 	else
@@ -848,8 +859,9 @@ prepareDtxTransaction(void)
 
 	if (DistributedTransactionContext != DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE)
 	{
-		elog(DTM_DEBUG5, "prepareDtxTransaction nothing to do (DistributedTransactionContext = '%s')",
-			 DtxContextToString(DistributedTransactionContext));
+		elogif(Debug_print_full_dtm, LOG,
+			   "prepareDtxTransaction nothing to do (DistributedTransactionContext = '%s')",
+			   DtxContextToString(DistributedTransactionContext));
 		Assert(Gp_role != GP_ROLE_DISPATCH || MyTmGxact->gxid == InvalidDistributedTransactionId);
 		return;
 	}
@@ -880,9 +892,9 @@ prepareDtxTransaction(void)
 		return;
 	}
 
-	elog(DTM_DEBUG5,
-		 "prepareDtxTransaction called with state = %s",
-		 DtxStateToString(MyTmGxactLocal->state));
+	elogif(Debug_print_full_dtm, LOG,
+		   "prepareDtxTransaction called with state = %s",
+		   DtxStateToString(MyTmGxactLocal->state));
 
 	Assert(MyTmGxactLocal->state == DTX_STATE_ACTIVE_DISTRIBUTED);
 	Assert(MyTmGxact->gxid > FirstDistributedTransactionId);
@@ -899,19 +911,21 @@ rollbackDtxTransaction(void)
 {
 	if (DistributedTransactionContext != DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE)
 	{
-		elog(DTM_DEBUG5, "rollbackDtxTransaction nothing to do (DistributedTransactionContext = '%s')",
-			 DtxContextToString(DistributedTransactionContext));
+		elogif(Debug_print_full_dtm, LOG,
+			   "rollbackDtxTransaction nothing to do (DistributedTransactionContext = '%s')",
+			   DtxContextToString(DistributedTransactionContext));
 		return;
 	}
 	if (!isCurrentDtxActivated())
 	{
-		elog(DTM_DEBUG5, "rollbackDtxTransaction nothing to do (two phase not activate)");
+		elogif(Debug_print_full_dtm, LOG,
+			   "rollbackDtxTransaction nothing to do (two phase not activate)");
 		return;
 	}
 
-	ereport(DTM_DEBUG5,
-			(errmsg("rollbackDtxTransaction called"),
-			TM_ERRDETAIL));
+	ereportif(Debug_print_full_dtm, LOG,
+			  (errmsg("rollbackDtxTransaction called"),
+				  TM_ERRDETAIL));
 
 	switch (MyTmGxactLocal->state)
 	{
@@ -977,8 +991,9 @@ rollbackDtxTransaction(void)
 		case DTX_STATE_INSERTED_FORGET_COMMITTED:
 		case DTX_STATE_RETRY_COMMIT_PREPARED:
 		case DTX_STATE_RETRY_ABORT_PREPARED:
-			elog(DTM_DEBUG5, "rollbackDtxTransaction dtx state \"%s\" not expected here",
-				 DtxStateToString(MyTmGxactLocal->state));
+			elogif(Debug_print_full_dtm, LOG,
+				   "rollbackDtxTransaction dtx state \"%s\" not expected here",
+				   DtxStateToString(MyTmGxactLocal->state));
 			clearAndResetGxact();
 			return;
 
@@ -1142,10 +1157,10 @@ mppTxnOptions(bool needDtx)
 {
 	int			options = 0;
 
-	elog(DTM_DEBUG5,
-		 "mppTxnOptions DefaultXactIsoLevel = %s, DefaultXactReadOnly = %s, XactIsoLevel = %s, XactReadOnly = %s.",
-		 IsoLevelAsUpperString(DefaultXactIsoLevel), (DefaultXactReadOnly ? "true" : "false"),
-		 IsoLevelAsUpperString(XactIsoLevel), (XactReadOnly ? "true" : "false"));
+	elogif(Debug_print_full_dtm, LOG,
+		   "mppTxnOptions DefaultXactIsoLevel = %s, DefaultXactReadOnly = %s, XactIsoLevel = %s, XactReadOnly = %s.",
+		   IsoLevelAsUpperString(DefaultXactIsoLevel), (DefaultXactReadOnly ? "true" : "false"),
+		   IsoLevelAsUpperString(XactIsoLevel), (XactReadOnly ? "true" : "false"));
 
 	if (needDtx)
 		options |= GP_OPT_NEED_DTX;
@@ -1165,11 +1180,11 @@ mppTxnOptions(bool needDtx)
 	if (isCurrentDtxActivated() && MyTmGxactLocal->explicitBeginRemembered)
 		options |= GP_OPT_EXPLICT_BEGIN;
 
-	elog(DTM_DEBUG5,
-		 "mppTxnOptions txnOptions = 0x%x, needDtx = %s, explicitBegin = %s, isoLevel = %s, readOnly = %s.",
-		 options,
-		 (isMppTxOptions_NeedDtx(options) ? "true" : "false"), (isMppTxOptions_ExplicitBegin(options) ? "true" : "false"),
-		 IsoLevelAsUpperString(mppTxOptions_IsoLevel(options)), (isMppTxOptions_ReadOnly(options) ? "true" : "false"));
+	elogif(Debug_print_full_dtm, LOG,
+		   "mppTxnOptions txnOptions = 0x%x, needDtx = %s, explicitBegin = %s, isoLevel = %s, readOnly = %s.",
+		   options,
+		   (isMppTxOptions_NeedDtx(options) ? "true" : "false"), (isMppTxOptions_ExplicitBegin(options) ? "true" : "false"),
+		   IsoLevelAsUpperString(mppTxOptions_IsoLevel(options)), (isMppTxOptions_ReadOnly(options) ? "true" : "false"));
 
 	return options;
 
@@ -1265,10 +1280,10 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 			 								dtxProtocolCommandStr,
 											segmentsToContentStr(dtxSegments));
 
-	ereport(DTM_DEBUG5,
-			(errmsg("dispatchDtxProtocolCommand: %d ('%s'), direct content #: %s",
-					dtxProtocolCommand, dtxProtocolCommandStr,
-					segmentsToContentStr(dtxSegments))));
+	ereportif(Debug_print_full_dtm, LOG,
+			  (errmsg("dispatchDtxProtocolCommand: %d ('%s'), direct content #: %s",
+					  dtxProtocolCommand, dtxProtocolCommandStr,
+					  segmentsToContentStr(dtxSegments))));
 
 	ErrorData *qeError;
 	results = CdbDispatchDtxProtocolCommand(dtxProtocolCommand,
@@ -1394,7 +1409,7 @@ dispatchDtxCommand(const char *cmd)
 
 	CdbPgResults cdb_pgresults = {NULL, 0};
 
-	elog(DTM_DEBUG5, "dispatchDtxCommand: '%s'", cmd);
+	elogif(Debug_print_full_dtm, LOG, "dispatchDtxCommand: '%s'", cmd);
 
 	if (currentGxactWriterGangLost())
 	{
@@ -1508,9 +1523,9 @@ clearAndResetGxact(void)
 void
 insertingDistributedCommitted(void)
 {
-	elog(DTM_DEBUG5,
-		 "insertingDistributedCommitted entering in state = %s",
-		 DtxStateToString(MyTmGxactLocal->state));
+	elogif(Debug_print_full_dtm, LOG,
+		   "insertingDistributedCommitted entering in state = %s",
+		   DtxStateToString(MyTmGxactLocal->state));
 
 	Assert(MyTmGxactLocal->state == DTX_STATE_PREPARED);
 	setCurrentDtxState(DTX_STATE_INSERTING_COMMITTED);
@@ -1522,9 +1537,9 @@ insertingDistributedCommitted(void)
 void
 insertedDistributedCommitted(void)
 {
-	ereport(DTM_DEBUG5,
-			(errmsg("entering insertedDistributedCommitted"),
-			TM_ERRDETAIL));
+	ereportif(Debug_print_full_dtm, LOG,
+			  (errmsg("entering insertedDistributedCommitted"),
+				  TM_ERRDETAIL));
 
 	Assert(MyTmGxactLocal->state == DTX_STATE_INSERTING_COMMITTED);
 	setCurrentDtxState(DTX_STATE_INSERTED_COMMITTED);
@@ -1699,8 +1714,9 @@ setupRegularDtxContext(void)
 			break;
 	}
 
-	elog(DTM_DEBUG5, "setupRegularDtxContext leaving with DistributedTransactionContext = '%s'.",
-		 DtxContextToString(DistributedTransactionContext));
+	elogif(Debug_print_full_dtm, LOG,
+		   "setupRegularDtxContext leaving with DistributedTransactionContext = '%s'.",
+		   DtxContextToString(DistributedTransactionContext));
 }
 
 /**
@@ -1816,15 +1832,15 @@ setupQEDtxContext(DtxContextInfo *dtxContextInfo)
 
 		default:
 			Assert(DistributedTransactionContext == DTX_CONTEXT_LOCAL_ONLY);
-			elog(DTM_DEBUG5,
-				 "setupQEDtxContext leaving context = 'Local Only' for Gp_role = %s", role_to_string(Gp_role));
+			elogif(Debug_print_full_dtm, LOG,
+				   "setupQEDtxContext leaving context = 'Local Only' for Gp_role = %s", role_to_string(Gp_role));
 			return;
 	}
 
-	elog(DTM_DEBUG5,
-		 "setupQEDtxContext intermediate result: isEntryDbSingleton = %s, isWriterQE = %s, isReaderQE = %s.",
-		 (isEntryDbSingleton ? "true" : "false"),
-		 (isWriterQE ? "true" : "false"), (isReaderQE ? "true" : "false"));
+	elogif(Debug_print_full_dtm, LOG,
+		   "setupQEDtxContext intermediate result: isEntryDbSingleton = %s, isWriterQE = %s, isReaderQE = %s.",
+		   (isEntryDbSingleton ? "true" : "false"),
+		   (isWriterQE ? "true" : "false"), (isReaderQE ? "true" : "false"));
 
 	/*
 	 * Copy to our QE global variable.
@@ -1856,8 +1872,8 @@ setupQEDtxContext(DtxContextInfo *dtxContextInfo)
 			{
 				if (!haveDistributedSnapshot)
 				{
-					elog(DTM_DEBUG5,
-						 "setupQEDtxContext Segment Writer is involved in a distributed transaction without a distributed snapshot...");
+					elogif(Debug_print_full_dtm, LOG,
+						   "setupQEDtxContext Segment Writer is involved in a distributed transaction without a distributed snapshot...");
 				}
 
 				if (IsTransactionOrTransactionBlock())
@@ -1954,16 +1970,18 @@ setupQEDtxContext(DtxContextInfo *dtxContextInfo)
 			break;
 	}
 
-	elog(DTM_DEBUG5, "setupQEDtxContext final result: DistributedTransactionContext = '%s'.",
-		 DtxContextToString(DistributedTransactionContext));
+	elogif(Debug_print_full_dtm, LOG,
+		   "setupQEDtxContext final result: DistributedTransactionContext = '%s'.",
+		   DtxContextToString(DistributedTransactionContext));
 
 	if (haveDistributedSnapshot)
 	{
-		elog((Debug_print_snapshot_dtm ? LOG : DEBUG5), "[Distributed Snapshot #%u] *Set QE* currcid = %d (gxid = %u, '%s')",
-			 dtxContextInfo->distributedSnapshot.distribSnapshotId,
-			 dtxContextInfo->curcid,
-			 getDistributedTransactionId(),
-			 DtxContextToString(DistributedTransactionContext));
+		elogif(Debug_print_snapshot_dtm, LOG,
+			   "[Distributed Snapshot #%u] *Set QE* currcid = %d (gxid = %u, '%s')",
+			   dtxContextInfo->distributedSnapshot.distribSnapshotId,
+			   dtxContextInfo->curcid,
+			   getDistributedTransactionId(),
+			   DtxContextToString(DistributedTransactionContext));
 	}
 
 }
@@ -1987,12 +2005,12 @@ finishDistributedTransactionContext(char *debugCaller, bool aborted)
 	}
 
 	gxid = getDistributedTransactionId();
-	elog(DTM_DEBUG5,
-		 "finishDistributedTransactionContext called to change DistributedTransactionContext from %s to %s (caller = %s, gxid = %u)",
-		 DtxContextToString(DistributedTransactionContext),
-		 DtxContextToString(DTX_CONTEXT_LOCAL_ONLY),
-		 debugCaller,
-		 gxid);
+	elogif(Debug_print_full_dtm, LOG,
+		   "finishDistributedTransactionContext called to change DistributedTransactionContext from %s to %s (caller = %s, gxid = %u)",
+		   DtxContextToString(DistributedTransactionContext),
+		   DtxContextToString(DTX_CONTEXT_LOCAL_ONLY),
+		   debugCaller,
+		   gxid);
 
 	setDistributedTransactionContext(DTX_CONTEXT_LOCAL_ONLY);
 
@@ -2007,16 +2025,16 @@ rememberDtxExplicitBegin(void)
 
 	if (!MyTmGxactLocal->explicitBeginRemembered)
 	{
-		ereport(DTM_DEBUG5,
-				(errmsg("rememberDtxExplicitBegin explicit BEGIN"),
-				TM_ERRDETAIL));
+		ereportif(Debug_print_full_dtm, LOG,
+				  (errmsg("rememberDtxExplicitBegin explicit BEGIN"),
+					  TM_ERRDETAIL));
 		MyTmGxactLocal->explicitBeginRemembered = true;
 	}
 	else
 	{
-		ereport(DTM_DEBUG5,
-				(errmsg("rememberDtxExplicitBegin already an explicit BEGIN"),
-				TM_ERRDETAIL));
+		ereportif(Debug_print_full_dtm, LOG,
+				  (errmsg("rememberDtxExplicitBegin already an explicit BEGIN"),
+					  TM_ERRDETAIL));
 	}
 }
 
@@ -2048,7 +2066,8 @@ performDtxProtocolPrepare(const char *gid)
 {
 	StartTransactionCommand();
 
-	elog(DTM_DEBUG5, "performDtxProtocolCommand going to call PrepareTransactionBlock for distributed transaction (id = '%s')", gid);
+	elogif(Debug_print_full_dtm, LOG,
+		   "performDtxProtocolCommand going to call PrepareTransactionBlock for distributed transaction (id = '%s')", gid);
 	if (!PrepareTransactionBlock((char *) gid))
 	{
 		elog(ERROR, "Prepare of distributed transaction %s failed", gid);
@@ -2061,7 +2080,8 @@ performDtxProtocolPrepare(const char *gid)
 	 */
 	CommitTransactionCommand();
 
-	elog(DTM_DEBUG5, "Prepare of distributed transaction succeeded (id = '%s')", gid);
+	elogif(Debug_print_full_dtm, LOG,
+		   "Prepare of distributed transaction succeeded (id = '%s')", gid);
 
 	setDistributedTransactionContext(DTX_CONTEXT_QE_PREPARED);
 }
@@ -2096,8 +2116,8 @@ performDtxProtocolCommitOnePhase(const char *gid)
 
 	SIMPLE_FAULT_INJECTOR("start_performDtxProtocolCommitOnePhase");
 
-	elog(DTM_DEBUG5,
-		 "performDtxProtocolCommitOnePhase going to call CommitTransaction for distributed transaction %s", gid);
+	elogif(Debug_print_full_dtm, LOG,
+		   "performDtxProtocolCommitOnePhase going to call CommitTransaction for distributed transaction %s", gid);
 
 	dtxCrackOpenGid(gid, &distribTimeStamp, &gxid);
 	Assert(gxid == getDistributedTransactionId());
@@ -2127,8 +2147,8 @@ performDtxProtocolCommitOnePhase(const char *gid)
 static void
 performDtxProtocolCommitPrepared(const char *gid, bool raiseErrorIfNotFound)
 {
-	elog(DTM_DEBUG5,
-		 "performDtxProtocolCommitPrepared going to call FinishPreparedTransaction for distributed transaction %s", gid);
+	elogif(Debug_print_full_dtm, LOG,
+		   "performDtxProtocolCommitPrepared going to call FinishPreparedTransaction for distributed transaction %s", gid);
 
 	List *waitGxids = list_copy(MyTmGxactLocal->waitGxids);
 
@@ -2165,7 +2185,8 @@ performDtxProtocolCommitPrepared(const char *gid, bool raiseErrorIfNotFound)
 static void
 performDtxProtocolAbortPrepared(const char *gid, bool raiseErrorIfNotFound)
 {
-	elog(DTM_DEBUG5, "performDtxProtocolAbortPrepared going to call FinishPreparedTransaction for distributed transaction %s", gid);
+	elogif(Debug_print_full_dtm, LOG,
+		   "performDtxProtocolAbortPrepared going to call FinishPreparedTransaction for distributed transaction %s", gid);
 
 	StartTransactionCommand();
 
@@ -2200,15 +2221,15 @@ performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 						  const char *gid,
 						  DtxContextInfo *contextInfo)
 {
-	elog(DTM_DEBUG5,
-		 "performDtxProtocolCommand called with DTX protocol = %s, segment distribute transaction context: '%s'",
-		 DtxProtocolCommandToString(dtxProtocolCommand), DtxContextToString(DistributedTransactionContext));
+	elogif(Debug_print_full_dtm, LOG,
+		   "performDtxProtocolCommand called with DTX protocol = %s, segment distribute transaction context: '%s'",
+		   DtxProtocolCommandToString(dtxProtocolCommand), DtxContextToString(DistributedTransactionContext));
 
 	switch (dtxProtocolCommand)
 	{
 		case DTX_PROTOCOL_COMMAND_ABORT_NO_PREPARED:
-			elog(DTM_DEBUG5,
-				 "performDtxProtocolCommand going to call AbortOutOfAnyTransaction for distributed transaction %s", gid);
+			elogif(Debug_print_full_dtm, LOG,
+				   "performDtxProtocolCommand going to call AbortOutOfAnyTransaction for distributed transaction %s", gid);
 			AbortOutOfAnyTransaction();
 			break;
 
@@ -2266,7 +2287,8 @@ performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 					 * call abort on us, even if we didn't finish the prepare yet,
 					 * if some other QE reported failure already.
 					 */
-					elog(DTM_DEBUG3, "Distributed transaction %s not found during abort", gid);
+					elogif(Debug_print_full_dtm, LOG,
+						   "Distributed transaction %s not found during abort", gid);
 					AbortOutOfAnyTransaction();
 					break;
 
@@ -2351,9 +2373,9 @@ performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 				default:
 					/* Lets flag this situation out, with explicit crash */
 					Assert(false);
-					elog(DTM_DEBUG5,
-						 " SUBTRANSACTION_BEGIN_INTERNAL distributed transaction context invalid: %d",
-						 (int) DistributedTransactionContext);
+					elogif(Debug_print_full_dtm, LOG,
+						   " SUBTRANSACTION_BEGIN_INTERNAL distributed transaction context invalid: %d",
+						   (int) DistributedTransactionContext);
 					break;
 			}
 
@@ -2395,7 +2417,8 @@ performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 				 (int) dtxProtocolCommand);
 			break;
 	}
-	elog(DTM_DEBUG5, "performDtxProtocolCommand successful return for distributed transaction %s", gid);
+	elogif(Debug_print_full_dtm, LOG,
+		   "performDtxProtocolCommand successful return for distributed transaction %s", gid);
 }
 
 void

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1280,10 +1280,10 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 			 								dtxProtocolCommandStr,
 											segmentsToContentStr(dtxSegments));
 
-	ereportif(Debug_print_full_dtm, LOG,
-			  (errmsg("dispatchDtxProtocolCommand: %d ('%s'), direct content #: %s",
-					  dtxProtocolCommand, dtxProtocolCommandStr,
-					  segmentsToContentStr(dtxSegments))));
+	elogif(Debug_print_full_dtm, LOG,
+		   "dispatchDtxProtocolCommand: %d ('%s'), direct content #: %s",
+		   dtxProtocolCommand, dtxProtocolCommandStr,
+		   segmentsToContentStr(dtxSegments));
 
 	ErrorData *qeError;
 	results = CdbDispatchDtxProtocolCommand(dtxProtocolCommand,
@@ -1751,23 +1751,23 @@ setupQEDtxContext(DtxContextInfo *dtxContextInfo)
 	haveDistributedSnapshot = dtxContextInfo->haveDistributedSnapshot;
 	isSharedLocalSnapshotSlotPresent = (SharedLocalSnapshotSlot != NULL);
 
-	if (DEBUG5 >= log_min_messages || Debug_print_full_dtm)
+	if (Debug_print_full_dtm)
 	{
-		elog(DTM_DEBUG5,
+		elog(LOG,
 			 "setupQEDtxContext inputs (part 1): Gp_role = %s, Gp_is_writer = %s, "
 			 "txnOptions = 0x%x, needDtx = %s, explicitBegin = %s, isoLevel = %s, readOnly = %s, haveDistributedSnapshot = %s.",
 			 role_to_string(Gp_role), (Gp_is_writer ? "true" : "false"), txnOptions,
 			 (needDtx ? "true" : "false"), (explicitBegin ? "true" : "false"),
 			 IsoLevelAsUpperString(mppTxOptions_IsoLevel(txnOptions)), (isMppTxOptions_ReadOnly(txnOptions) ? "true" : "false"),
 			 (haveDistributedSnapshot ? "true" : "false"));
-		elog(DTM_DEBUG5,
+		elog(LOG,
 			 "setupQEDtxContext inputs (part 2): distributedXid = %u, isSharedLocalSnapshotSlotPresent = %s.",
 			 dtxContextInfo->distributedXid,
 			 (isSharedLocalSnapshotSlotPresent ? "true" : "false"));
 
 		if (haveDistributedSnapshot)
 		{
-			elog(DTM_DEBUG5,
+			elog(LOG,
 				 "setupQEDtxContext inputs (part 2a): distributedXid = %u, "
 				 "distributedSnapshotData (xmin = %u, xmax = %u, xcnt = %u), distributedCommandId = %d",
 				 dtxContextInfo->distributedXid,
@@ -1777,21 +1777,18 @@ setupQEDtxContext(DtxContextInfo *dtxContextInfo)
 		}
 		if (isSharedLocalSnapshotSlotPresent)
 		{
-			if (DTM_DEBUG5 >= log_min_messages)
-			{
-				LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_SHARED);
-				elog(DTM_DEBUG5,
-					 "setupQEDtxContext inputs (part 2b):  shared local snapshot xid = %u "
-					 "(xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = %u/%u",
-					 SharedLocalSnapshotSlot->xid,
-					 SharedLocalSnapshotSlot->snapshot.xmin,
-					 SharedLocalSnapshotSlot->snapshot.xmax,
-					 SharedLocalSnapshotSlot->snapshot.xcnt,
-					 SharedLocalSnapshotSlot->snapshot.curcid,
-					 SharedLocalSnapshotSlot->QDxid,
-					 SharedLocalSnapshotSlot->segmateSync);
-				LWLockRelease(SharedLocalSnapshotSlot->slotLock);
-			}
+			LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_SHARED);
+			elog(LOG,
+				 "setupQEDtxContext inputs (part 2b):  shared local snapshot xid = %u "
+				 "(xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = %u/%u",
+				 SharedLocalSnapshotSlot->xid,
+				 SharedLocalSnapshotSlot->snapshot.xmin,
+				 SharedLocalSnapshotSlot->snapshot.xmax,
+				 SharedLocalSnapshotSlot->snapshot.xcnt,
+				 SharedLocalSnapshotSlot->snapshot.curcid,
+				 SharedLocalSnapshotSlot->QDxid,
+				 SharedLocalSnapshotSlot->segmateSync);
+			LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 		}
 	}
 

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -123,9 +123,9 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 		if (!GangOK(primaryGang) && badGangs != NULL)
 		{
 			*badGangs = true;
-			elog((Debug_print_full_dtm ? LOG : DEBUG5),
-				 "CdbDispatchDtxProtocolCommand: Bad gang from dispatch of %s for gid = %s",
-				 dtxProtocolCommandLoggingStr, gid);
+			elogif(Debug_print_full_dtm, LOG,
+				   "CdbDispatchDtxProtocolCommand: Bad gang from dispatch of %s for gid = %s",
+				   dtxProtocolCommandLoggingStr, gid);
 		}
 
 		cdbdisp_destroyDispatcherState(ds);
@@ -209,10 +209,10 @@ qdSerializeDtxContextInfo(int *size, bool wantSnapshot, bool inCursor,
 
 	DtxContextInfo_Serialize(serializedDtxContextInfo, pDtxContextInfo);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "qdSerializeDtxContextInfo (called by %s) returning a snapshot of %d bytes (ptr is %s)",
-		 debugCaller, *size,
-		 (serializedDtxContextInfo != NULL ? "Non-NULL" : "NULL"));
+	elogif(Debug_print_full_dtm, LOG,
+		   "qdSerializeDtxContextInfo (called by %s) returning a snapshot of %d bytes (ptr is %s)",
+		   debugCaller, *size,
+		   (serializedDtxContextInfo != NULL ? "Non-NULL" : "NULL"));
 	return serializedDtxContextInfo;
 }
 

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -362,7 +362,7 @@ CdbDispatchCommandToSegments(const char *strCommand,
 	if (needTwoPhase)
 		setupDtxTransaction();
 
-	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
+	elogif(Debug_print_full_dtm, LOG,
 		   "CdbDispatchCommand: %s (needTwoPhase = %s)",
 		   strCommand, (needTwoPhase ? "true" : "false"));
 
@@ -400,7 +400,7 @@ CdbDispatchUtilityStatement(struct Node *stmt,
 	if (needTwoPhase)
 		setupDtxTransaction();
 
-	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
+	elogif(Debug_print_full_dtm, LOG,
 		   "CdbDispatchUtilityStatement: %s (needTwoPhase = %s)",
 		   debug_query_string, (needTwoPhase ? "true" : "false"));
 
@@ -1425,7 +1425,7 @@ CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags)
 	if (needTwoPhase)
 		setupDtxTransaction();
 
-	elogif((Debug_print_full_dtm || log_min_messages <= DEBUG5), LOG,
+	elogif(Debug_print_full_dtm, LOG,
 		   "CdbDispatchCopyStart: %s (needTwoPhase = %s)",
 		   debug_query_string, (needTwoPhase ? "true" : "false"));
 

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -272,9 +272,8 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 	ListCell   *le;
 	ErrorData *qeError = NULL;
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "CdbDispatchSetCommand for command = '%s'",
-		 strCommand);
+	elogif(Debug_print_full_dtm, LOG,
+		   "CdbDispatchSetCommand for command = '%s'", strCommand);
 
 	pQueryParms = cdbdisp_buildCommandQueryParms(strCommand, DF_NONE);
 

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1198,9 +1198,9 @@ HasSerializableBackends(bool allDbs)
 		{
 			if (proc->serializableIsoLevel && proc != MyProc)
 			{
-				ereport((Debug_print_snapshot_dtm ? LOG : DEBUG3),
-						(errmsg("Found serializable transaction: database %d, pid %d, xid %d, xmin %d",
-								proc->databaseId, proc->pid, pgxact->xid, pgxact->xmin)));
+				ereportif(Debug_print_snapshot_dtm, LOG,
+						  (errmsg("Found serializable transaction: database %d, pid %d, xid %d, xmin %d",
+								  proc->databaseId, proc->pid, pgxact->xid, pgxact->xmin)));
 				result = true;
 			}
 		}
@@ -1451,13 +1451,13 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 
 	Assert(snapshot != NULL);
 
-	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-			(errmsg("updateSharedLocalSnapshot for DistributedTransactionContext = '%s' passed local snapshot (xmin: %u xmax: %u xcnt: %u) curcid: %d",
-					DtxContextToString(distributedTransactionContext),
-					snapshot->xmin,
-					snapshot->xmax,
-					snapshot->xcnt,
-					snapshot->curcid)));
+	ereportif(Debug_print_full_dtm, LOG,
+			  (errmsg("updateSharedLocalSnapshot for DistributedTransactionContext = '%s' passed local snapshot (xmin: %u xmax: %u xcnt: %u) curcid: %d",
+					  DtxContextToString(distributedTransactionContext),
+					  snapshot->xmin,
+					  snapshot->xmax,
+					  snapshot->xcnt,
+					  snapshot->curcid)));
 
 	LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_EXCLUSIVE);
 
@@ -1469,9 +1469,9 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 	{
 		Assert(snapshot->xip != NULL);
 
-		ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-				(errmsg("updateSharedLocalSnapshot count of in-doubt ids %u",
-						SharedLocalSnapshotSlot->snapshot.xcnt)));
+		ereportif(Debug_print_full_dtm, LOG,
+				  (errmsg("updateSharedLocalSnapshot count of in-doubt ids %u",
+						  SharedLocalSnapshotSlot->snapshot.xcnt)));
 
 		memcpy(SharedLocalSnapshotSlot->snapshot.xip, snapshot->xip, snapshot->xcnt * sizeof(TransactionId));
 	}
@@ -1485,9 +1485,9 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 
 	SharedLocalSnapshotSlot->snapshot.curcid = snapshot->curcid;
 
-	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-			(errmsg("updateSharedLocalSnapshot: combocidsize is now %d max %d segmateSync %d->%d",
-					combocidSize, MaxComboCids, SharedLocalSnapshotSlot->segmateSync, dtxContextInfo->segmateSync)));
+	ereportif(Debug_print_full_dtm, LOG,
+			  (errmsg("updateSharedLocalSnapshot: combocidsize is now %d max %d segmateSync %d->%d",
+					  combocidSize, MaxComboCids, SharedLocalSnapshotSlot->segmateSync, dtxContextInfo->segmateSync)));
 
 	SetSharedTransactionId_writer(distributedTransactionContext);
 	
@@ -1495,24 +1495,24 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 	SharedLocalSnapshotSlot->segmateSync = dtxContextInfo->segmateSync;
 	SharedLocalSnapshotSlot->ready = true;
 
-	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-			(errmsg("updateSharedLocalSnapshot for DistributedTransactionContext = '%s' setting shared local snapshot xid = %u (xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = %u",
-					DtxContextToString(distributedTransactionContext),
-					SharedLocalSnapshotSlot->xid,
-					SharedLocalSnapshotSlot->snapshot.xmin,
-					SharedLocalSnapshotSlot->snapshot.xmax,
-					SharedLocalSnapshotSlot->snapshot.xcnt,
-					SharedLocalSnapshotSlot->snapshot.curcid,
-					SharedLocalSnapshotSlot->QDxid)));
+	ereportif(Debug_print_full_dtm, LOG,
+			  (errmsg("updateSharedLocalSnapshot for DistributedTransactionContext = '%s' setting shared local snapshot xid = %u (xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = %u",
+					  DtxContextToString(distributedTransactionContext),
+					  SharedLocalSnapshotSlot->xid,
+					  SharedLocalSnapshotSlot->snapshot.xmin,
+					  SharedLocalSnapshotSlot->snapshot.xmax,
+					  SharedLocalSnapshotSlot->snapshot.xcnt,
+					  SharedLocalSnapshotSlot->snapshot.curcid,
+					  SharedLocalSnapshotSlot->QDxid)));
 
-	ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-			(errmsg("[Distributed Snapshot #%u] *Writer Set Shared* gxid %u, (gxid = %u, slot #%d, '%s', '%s')",
-					QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-					SharedLocalSnapshotSlot->QDxid,
-					getDistributedTransactionId(),
-					SharedLocalSnapshotSlot->slotid,
-					debugCaller,
-					DtxContextToString(distributedTransactionContext))));
+	ereportif(Debug_print_snapshot_dtm, LOG,
+			  (errmsg("[Distributed Snapshot #%u] *Writer Set Shared* gxid %u, (gxid = %u, slot #%d, '%s', '%s')",
+					  QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+					  SharedLocalSnapshotSlot->QDxid,
+					  getDistributedTransactionId(),
+					  SharedLocalSnapshotSlot->slotid,
+					  debugCaller,
+					  DtxContextToString(distributedTransactionContext))));
 	LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 }
 
@@ -1560,9 +1560,9 @@ GetDistributedSnapshotMaxCount(DtxContext distributedTransactionContext)
 static void
 FillInDistributedSnapshot(Snapshot snapshot, DtxContext distributedTransactionContext)
 {
-	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-			(errmsg("FillInDistributedSnapshot DTX Context = '%s'",
-					DtxContextToString(distributedTransactionContext))));
+	ereportif(Debug_print_full_dtm, LOG,
+			  (errmsg("FillInDistributedSnapshot DTX Context = '%s'",
+					  DtxContextToString(distributedTransactionContext))));
 
 	switch (distributedTransactionContext)
 	{
@@ -1760,8 +1760,8 @@ getDtxCheckPointInfo(char **result, int *result_size)
 		dtxFormGID(gxact_log->gid, gxact->distribTimeStamp, gxact->gxid);
 		gxact_log->gxid = gxact->gxid;
 
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "Add DTM checkpoint entry gid = %s.", gxact_log->gid);
+		elogif(Debug_print_full_dtm, LOG,
+			   "Add DTM checkpoint entry gid = %s.", gxact_log->gid);
 
 		actual++;
 	}
@@ -1773,8 +1773,8 @@ getDtxCheckPointInfo(char **result, int *result_size)
 	*result = (char *) gxact_checkpoint;
 	*result_size = TMGXACT_CHECKPOINT_BYTES(actual);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "Filled in DTM checkpoint information (count = %d).", actual);
+	elogif(Debug_print_full_dtm, LOG,
+		   "Filled in DTM checkpoint information (count = %d).", actual);
 }
 
 /*
@@ -1866,9 +1866,9 @@ CreateDistributedSnapshot(DistributedSnapshot *ds, DtxContext distributedTransac
 
 		ds->inProgressXidArray[count++] = gxid;
 
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "CreateDistributedSnapshot added inProgressDistributedXid = %u to snapshot",
-			 gxid);
+		elogif(Debug_print_full_dtm, LOG,
+			   "CreateDistributedSnapshot added inProgressDistributedXid = %u to snapshot",
+			   gxid);
 	}
 
 	distribSnapshotId = pg_atomic_add_fetch_u32((pg_atomic_uint32 *)shmNextSnapshotId, 1);
@@ -1905,14 +1905,14 @@ CreateDistributedSnapshot(DistributedSnapshot *ds, DtxContext distributedTransac
 	if (MyTmGxact->xminDistributedSnapshot == InvalidDistributedTransactionId)
 		MyTmGxact->xminDistributedSnapshot = xmin;
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "CreateDistributedSnapshot distributed snapshot has xmin = %u, count = %u, xmax = %u.",
-		 xmin, count, xmax);
-	elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-		 "[Distributed Snapshot #%u] *Create* (gxid = %u, '%s')",
-		 distribSnapshotId,
-		 MyTmGxact->gxid,
-		 DtxContextToString(distributedTransactionContext));
+	elogif(Debug_print_full_dtm, LOG,
+		   "CreateDistributedSnapshot distributed snapshot has xmin = %u, count = %u, xmax = %u.",
+		   xmin, count, xmax);
+	elogif(Debug_print_snapshot_dtm, LOG,
+		   "[Distributed Snapshot #%u] *Create* (gxid = %u, '%s')",
+		   distribSnapshotId,
+		   MyTmGxact->gxid,
+		   DtxContextToString(distributedTransactionContext));
 
 	return true;
 }
@@ -2036,10 +2036,10 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	/*
 	 * GP: Distributed snapshot.
 	 */
-	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-			(errmsg("GetSnapshotData maxCount %d, inProgressEntryArray %p",
-					snapshot->distribSnapshotWithLocalMapping.ds.maxCount,
-					snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray)));
+	ereportif(Debug_print_full_dtm, LOG,
+			  (errmsg("GetSnapshotData maxCount %d, inProgressEntryArray %p",
+					  snapshot->distribSnapshotWithLocalMapping.ds.maxCount,
+					  snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray)));
 
 	if (snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray == NULL)
 	{
@@ -2120,12 +2120,12 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 			return snapshot;
 		}
 
-		ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-				(errmsg("[Distributed Snapshot #%u] *Start Reader Match* gxid = %u and currcid %d (%s)",
-						QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-						QEDtxContextInfo.distributedXid,
-						QEDtxContextInfo.curcid,
-						DtxContextToString(distributedTransactionContext))));
+		ereportif(Debug_print_snapshot_dtm, LOG,
+				  (errmsg("[Distributed Snapshot #%u] *Start Reader Match* gxid = %u and currcid %d (%s)",
+						  QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+						  QEDtxContextInfo.distributedXid,
+						  QEDtxContextInfo.curcid,
+						  DtxContextToString(distributedTransactionContext))));
 
 		/*
 		 * This is the second phase of the handshake we started in
@@ -2187,21 +2187,21 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 
 				LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 
-				ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-						(errmsg("Reader qExec usedComboCids: %d shared %d segmateSync %d",
-								usedComboCids, comboCidCnt, segmateSync)));
+				ereportif(Debug_print_snapshot_dtm, LOG,
+						  (errmsg("Reader qExec usedComboCids: %d shared %d segmateSync %d",
+								  usedComboCids, comboCidCnt, segmateSync)));
 
 				SetSharedTransactionId_reader(SharedLocalSnapshotSlot->xid,
 											  SharedLocalSnapshotSlot->snapshot.curcid,
 											  distributedTransactionContext);
 
-				ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-						(errmsg("Reader qExec setting shared local snapshot to: xmin: %d xmax: %d curcid: %d",
-								snapshot->xmin, snapshot->xmax, snapshot->curcid)));
+				ereportif(Debug_print_snapshot_dtm, LOG,
+						  (errmsg("Reader qExec setting shared local snapshot to: xmin: %d xmax: %d curcid: %d",
+								  snapshot->xmin, snapshot->xmax, snapshot->curcid)));
 
-				ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-						(errmsg("GetSnapshotData(): READER currentcommandid %d curcid %d segmatesync %d",
-								GetCurrentCommandId(false), snapshot->curcid, segmateSync)));
+				ereportif(Debug_print_snapshot_dtm, LOG,
+						  (errmsg("GetSnapshotData(): READER currentcommandid %d curcid %d segmatesync %d",
+								  GetCurrentCommandId(false), snapshot->curcid, segmateSync)));
 
 				if (TransactionIdPrecedes(snapshot->xmin, TransactionXmin))
 					TransactionXmin = snapshot->xmin;
@@ -2249,13 +2249,13 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 					/*
 					 * Every second issue warning.
 					 */
-					ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-							(errmsg("[Distributed Snapshot #%u] *No Match* gxid %u = %u and currcid %d (%s)",
-									QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-									QEDtxContextInfo.distributedXid,
-									SharedLocalSnapshotSlot->QDxid,
-									QEDtxContextInfo.curcid,
-									DtxContextToString(distributedTransactionContext))));
+					ereportif(Debug_print_snapshot_dtm, LOG,
+							  (errmsg("[Distributed Snapshot #%u] *No Match* gxid %u = %u and currcid %d (%s)",
+									  QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+									  QEDtxContextInfo.distributedXid,
+									  SharedLocalSnapshotSlot->QDxid,
+									  QEDtxContextInfo.curcid,
+									  DtxContextToString(distributedTransactionContext))));
 
 
 					ereport(LOG,
@@ -2298,9 +2298,9 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	/* initialize xmin calculation with xmax */
 	globalxmin = xmin = xmax;
 
-	ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-			(errmsg("GetSnapshotData setting globalxmin and xmin to %u",
-					xmin)));
+	ereportif(Debug_print_full_dtm, LOG,
+			  (errmsg("GetSnapshotData setting globalxmin and xmin to %u",
+					  xmin)));
 
 	/*
 	 * Get the distributed snapshot if needed and copy it into the field 
@@ -2344,9 +2344,9 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 			&snapshot->distribSnapshotWithLocalMapping.ds,
 			distributedTransactionContext);
 
-		ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-				(errmsg("Got distributed snapshot from DistributedSnapshotWithLocalXids_Create = %s",
-						(snapshot->haveDistribSnapshot ? "true" : "false"))));
+		ereportif(Debug_print_full_dtm, LOG,
+				  (errmsg("Got distributed snapshot from DistributedSnapshotWithLocalXids_Create = %s",
+						  (snapshot->haveDistribSnapshot ? "true" : "false"))));
 
 		/* Nice that we may have collected it, but turn it off... */
 		if (Debug_disable_distributed_snapshot)
@@ -2505,9 +2505,9 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	{
 		MyProc->serializableIsoLevel = true;
 
-		ereport((Debug_print_snapshot_dtm ? LOG : DEBUG3),
-				(errmsg("Got serializable snapshot: database %d, pid %d, xid %d, xmin %d",
-						MyProc->databaseId, MyProc->pid, MyPgXact->xid, MyPgXact->xmin)));
+		ereportif(Debug_print_snapshot_dtm, LOG,
+				  (errmsg("Got serializable snapshot: database %d, pid %d, xid %d, xmin %d",
+						  MyProc->databaseId, MyProc->pid, MyPgXact->xid, MyPgXact->xmin)));
 	}
 
 	LWLockRelease(ProcArrayLock);
@@ -2609,9 +2609,9 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 			"GetSnapshotData");
 	}
 
-	ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-			(errmsg("GetSnapshotData(): WRITER currentcommandid %d curcid %d segmatesync %d",
-					GetCurrentCommandId(false), snapshot->curcid, QEDtxContextInfo.segmateSync)));
+	ereportif(Debug_print_snapshot_dtm, LOG,
+			  (errmsg("GetSnapshotData(): WRITER currentcommandid %d curcid %d segmatesync %d",
+					  GetCurrentCommandId(false), snapshot->curcid, QEDtxContextInfo.segmateSync)));
 
 	return snapshot;
 }
@@ -3147,28 +3147,28 @@ UpdateSerializableCommandId(CommandId curcid)
 
 		if (SharedLocalSnapshotSlot->QDxid != QEDtxContextInfo.distributedXid)
 		{
-			ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-					(errmsg("[Distributed Snapshot #%u] *Can't Update Serializable Command Id* QDxid = %u (gxid = %u, '%s')",
-							QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-							SharedLocalSnapshotSlot->QDxid,
-							getDistributedTransactionId(),
-							DtxContextToString(DistributedTransactionContext))));
+			ereportif(Debug_print_snapshot_dtm, LOG,
+					  (errmsg("[Distributed Snapshot #%u] *Can't Update Serializable Command Id* QDxid = %u (gxid = %u, '%s')",
+							  QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+							  SharedLocalSnapshotSlot->QDxid,
+							  getDistributedTransactionId(),
+							  DtxContextToString(DistributedTransactionContext))));
 			LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 			return;
 		}
 
-		ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-				(errmsg("[Distributed Snapshot #%u] *Update Serializable Command Id* segment currcid = %d, TransactionSnapshot currcid = %d, Shared currcid = %d (gxid = %u, '%s')",
-						QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-						QEDtxContextInfo.curcid,
-						curcid,
-						SharedLocalSnapshotSlot->snapshot.curcid,
-						getDistributedTransactionId(),
-						DtxContextToString(DistributedTransactionContext))));
+		ereportif(Debug_print_snapshot_dtm, LOG,
+				  (errmsg("[Distributed Snapshot #%u] *Update Serializable Command Id* segment currcid = %d, TransactionSnapshot currcid = %d, Shared currcid = %d (gxid = %u, '%s')",
+						  QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+						  QEDtxContextInfo.curcid,
+						  curcid,
+						  SharedLocalSnapshotSlot->snapshot.curcid,
+						  getDistributedTransactionId(),
+						  DtxContextToString(DistributedTransactionContext))));
 
-		ereport((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-				(errmsg("serializable writer updating combocid: used combocids %d shared %d",
-						usedComboCids, SharedLocalSnapshotSlot->combocidcnt)));
+		ereportif(Debug_print_snapshot_dtm, LOG,
+				  (errmsg("serializable writer updating combocid: used combocids %d shared %d",
+						  usedComboCids, SharedLocalSnapshotSlot->combocidcnt)));
 
 		combocidSize = ((usedComboCids < MaxComboCids) ? usedComboCids : MaxComboCids );
 

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1198,9 +1198,9 @@ HasSerializableBackends(bool allDbs)
 		{
 			if (proc->serializableIsoLevel && proc != MyProc)
 			{
-				ereportif(Debug_print_snapshot_dtm, LOG,
-						  (errmsg("Found serializable transaction: database %d, pid %d, xid %d, xmin %d",
-								  proc->databaseId, proc->pid, pgxact->xid, pgxact->xmin)));
+				elogif(Debug_print_snapshot_dtm, LOG,
+					   "Found serializable transaction: database %d, pid %d, xid %d, xmin %d",
+					   proc->databaseId, proc->pid, pgxact->xid, pgxact->xmin);
 				result = true;
 			}
 		}
@@ -1451,13 +1451,13 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 
 	Assert(snapshot != NULL);
 
-	ereportif(Debug_print_full_dtm, LOG,
-			  (errmsg("updateSharedLocalSnapshot for DistributedTransactionContext = '%s' passed local snapshot (xmin: %u xmax: %u xcnt: %u) curcid: %d",
-					  DtxContextToString(distributedTransactionContext),
-					  snapshot->xmin,
-					  snapshot->xmax,
-					  snapshot->xcnt,
-					  snapshot->curcid)));
+	elogif(Debug_print_full_dtm, LOG,
+		   "updateSharedLocalSnapshot for DistributedTransactionContext = '%s' passed local snapshot (xmin: %u xmax: %u xcnt: %u) curcid: %d",
+		   DtxContextToString(distributedTransactionContext),
+		   snapshot->xmin,
+		   snapshot->xmax,
+		   snapshot->xcnt,
+		   snapshot->curcid);
 
 	LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_EXCLUSIVE);
 
@@ -1469,9 +1469,9 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 	{
 		Assert(snapshot->xip != NULL);
 
-		ereportif(Debug_print_full_dtm, LOG,
-				  (errmsg("updateSharedLocalSnapshot count of in-doubt ids %u",
-						  SharedLocalSnapshotSlot->snapshot.xcnt)));
+		elogif(Debug_print_full_dtm, LOG,
+			   "updateSharedLocalSnapshot count of in-doubt ids %u",
+			   SharedLocalSnapshotSlot->snapshot.xcnt);
 
 		memcpy(SharedLocalSnapshotSlot->snapshot.xip, snapshot->xip, snapshot->xcnt * sizeof(TransactionId));
 	}
@@ -1485,9 +1485,9 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 
 	SharedLocalSnapshotSlot->snapshot.curcid = snapshot->curcid;
 
-	ereportif(Debug_print_full_dtm, LOG,
-			  (errmsg("updateSharedLocalSnapshot: combocidsize is now %d max %d segmateSync %d->%d",
-					  combocidSize, MaxComboCids, SharedLocalSnapshotSlot->segmateSync, dtxContextInfo->segmateSync)));
+	elogif(Debug_print_full_dtm, LOG,
+		   "updateSharedLocalSnapshot: combocidsize is now %d max %d segmateSync %d->%d",
+		   combocidSize, MaxComboCids, SharedLocalSnapshotSlot->segmateSync, dtxContextInfo->segmateSync);
 
 	SetSharedTransactionId_writer(distributedTransactionContext);
 	
@@ -1495,24 +1495,24 @@ updateSharedLocalSnapshot(DtxContextInfo *dtxContextInfo,
 	SharedLocalSnapshotSlot->segmateSync = dtxContextInfo->segmateSync;
 	SharedLocalSnapshotSlot->ready = true;
 
-	ereportif(Debug_print_full_dtm, LOG,
-			  (errmsg("updateSharedLocalSnapshot for DistributedTransactionContext = '%s' setting shared local snapshot xid = %u (xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = %u",
-					  DtxContextToString(distributedTransactionContext),
-					  SharedLocalSnapshotSlot->xid,
-					  SharedLocalSnapshotSlot->snapshot.xmin,
-					  SharedLocalSnapshotSlot->snapshot.xmax,
-					  SharedLocalSnapshotSlot->snapshot.xcnt,
-					  SharedLocalSnapshotSlot->snapshot.curcid,
-					  SharedLocalSnapshotSlot->QDxid)));
+	elogif(Debug_print_full_dtm, LOG,
+		   "updateSharedLocalSnapshot for DistributedTransactionContext = '%s' setting shared local snapshot xid = %u (xmin: %u xmax: %u xcnt: %u) curcid: %d, QDxid = %u",
+		   DtxContextToString(distributedTransactionContext),
+		   SharedLocalSnapshotSlot->xid,
+		   SharedLocalSnapshotSlot->snapshot.xmin,
+		   SharedLocalSnapshotSlot->snapshot.xmax,
+		   SharedLocalSnapshotSlot->snapshot.xcnt,
+		   SharedLocalSnapshotSlot->snapshot.curcid,
+		   SharedLocalSnapshotSlot->QDxid);
 
-	ereportif(Debug_print_snapshot_dtm, LOG,
-			  (errmsg("[Distributed Snapshot #%u] *Writer Set Shared* gxid %u, (gxid = %u, slot #%d, '%s', '%s')",
-					  QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-					  SharedLocalSnapshotSlot->QDxid,
-					  getDistributedTransactionId(),
-					  SharedLocalSnapshotSlot->slotid,
-					  debugCaller,
-					  DtxContextToString(distributedTransactionContext))));
+	elogif(Debug_print_snapshot_dtm, LOG,
+		   "[Distributed Snapshot #%u] *Writer Set Shared* gxid %u, (gxid = %u, slot #%d, '%s', '%s')",
+		   QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+		   SharedLocalSnapshotSlot->QDxid,
+		   getDistributedTransactionId(),
+		   SharedLocalSnapshotSlot->slotid,
+		   debugCaller,
+		   DtxContextToString(distributedTransactionContext));
 	LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 }
 
@@ -1560,9 +1560,9 @@ GetDistributedSnapshotMaxCount(DtxContext distributedTransactionContext)
 static void
 FillInDistributedSnapshot(Snapshot snapshot, DtxContext distributedTransactionContext)
 {
-	ereportif(Debug_print_full_dtm, LOG,
-			  (errmsg("FillInDistributedSnapshot DTX Context = '%s'",
-					  DtxContextToString(distributedTransactionContext))));
+	elogif(Debug_print_full_dtm, LOG,
+		   "FillInDistributedSnapshot DTX Context = '%s'",
+		   DtxContextToString(distributedTransactionContext));
 
 	switch (distributedTransactionContext)
 	{
@@ -2036,10 +2036,10 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	/*
 	 * GP: Distributed snapshot.
 	 */
-	ereportif(Debug_print_full_dtm, LOG,
-			  (errmsg("GetSnapshotData maxCount %d, inProgressEntryArray %p",
-					  snapshot->distribSnapshotWithLocalMapping.ds.maxCount,
-					  snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray)));
+	elogif(Debug_print_full_dtm, LOG,
+		   "GetSnapshotData maxCount %d, inProgressEntryArray %p",
+		   snapshot->distribSnapshotWithLocalMapping.ds.maxCount,
+		   snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray);
 
 	if (snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray == NULL)
 	{
@@ -2120,12 +2120,12 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 			return snapshot;
 		}
 
-		ereportif(Debug_print_snapshot_dtm, LOG,
-				  (errmsg("[Distributed Snapshot #%u] *Start Reader Match* gxid = %u and currcid %d (%s)",
-						  QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-						  QEDtxContextInfo.distributedXid,
-						  QEDtxContextInfo.curcid,
-						  DtxContextToString(distributedTransactionContext))));
+		elogif(Debug_print_snapshot_dtm, LOG,
+			   "[Distributed Snapshot #%u] *Start Reader Match* gxid = %u and currcid %d (%s)",
+			   QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+			   QEDtxContextInfo.distributedXid,
+			   QEDtxContextInfo.curcid,
+			   DtxContextToString(distributedTransactionContext));
 
 		/*
 		 * This is the second phase of the handshake we started in
@@ -2187,21 +2187,21 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 
 				LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 
-				ereportif(Debug_print_snapshot_dtm, LOG,
-						  (errmsg("Reader qExec usedComboCids: %d shared %d segmateSync %d",
-								  usedComboCids, comboCidCnt, segmateSync)));
+				elogif(Debug_print_snapshot_dtm, LOG,
+					   "Reader qExec usedComboCids: %d shared %d segmateSync %d",
+					   usedComboCids, comboCidCnt, segmateSync);
 
 				SetSharedTransactionId_reader(SharedLocalSnapshotSlot->xid,
 											  SharedLocalSnapshotSlot->snapshot.curcid,
 											  distributedTransactionContext);
 
-				ereportif(Debug_print_snapshot_dtm, LOG,
-						  (errmsg("Reader qExec setting shared local snapshot to: xmin: %d xmax: %d curcid: %d",
-								  snapshot->xmin, snapshot->xmax, snapshot->curcid)));
+				elogif(Debug_print_snapshot_dtm, LOG,
+					   "Reader qExec setting shared local snapshot to: xmin: %d xmax: %d curcid: %d",
+					   snapshot->xmin, snapshot->xmax, snapshot->curcid);
 
-				ereportif(Debug_print_snapshot_dtm, LOG,
-						  (errmsg("GetSnapshotData(): READER currentcommandid %d curcid %d segmatesync %d",
-								  GetCurrentCommandId(false), snapshot->curcid, segmateSync)));
+				elogif(Debug_print_snapshot_dtm, LOG,
+					   "GetSnapshotData(): READER currentcommandid %d curcid %d segmatesync %d",
+					   GetCurrentCommandId(false), snapshot->curcid, segmateSync);
 
 				if (TransactionIdPrecedes(snapshot->xmin, TransactionXmin))
 					TransactionXmin = snapshot->xmin;
@@ -2249,13 +2249,13 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 					/*
 					 * Every second issue warning.
 					 */
-					ereportif(Debug_print_snapshot_dtm, LOG,
-							  (errmsg("[Distributed Snapshot #%u] *No Match* gxid %u = %u and currcid %d (%s)",
-									  QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-									  QEDtxContextInfo.distributedXid,
-									  SharedLocalSnapshotSlot->QDxid,
-									  QEDtxContextInfo.curcid,
-									  DtxContextToString(distributedTransactionContext))));
+					elogif(Debug_print_snapshot_dtm, LOG,
+						   "[Distributed Snapshot #%u] *No Match* gxid %u = %u and currcid %d (%s)",
+						   QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+						   QEDtxContextInfo.distributedXid,
+						   SharedLocalSnapshotSlot->QDxid,
+						   QEDtxContextInfo.curcid,
+						   DtxContextToString(distributedTransactionContext));
 
 
 					ereport(LOG,
@@ -2298,9 +2298,8 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	/* initialize xmin calculation with xmax */
 	globalxmin = xmin = xmax;
 
-	ereportif(Debug_print_full_dtm, LOG,
-			  (errmsg("GetSnapshotData setting globalxmin and xmin to %u",
-					  xmin)));
+	elogif(Debug_print_full_dtm, LOG,
+		   "GetSnapshotData setting globalxmin and xmin to %u", xmin);
 
 	/*
 	 * Get the distributed snapshot if needed and copy it into the field 
@@ -2344,9 +2343,9 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 			&snapshot->distribSnapshotWithLocalMapping.ds,
 			distributedTransactionContext);
 
-		ereportif(Debug_print_full_dtm, LOG,
-				  (errmsg("Got distributed snapshot from DistributedSnapshotWithLocalXids_Create = %s",
-						  (snapshot->haveDistribSnapshot ? "true" : "false"))));
+		elogif(Debug_print_full_dtm, LOG,
+			   "Got distributed snapshot from DistributedSnapshotWithLocalXids_Create = %s",
+			   (snapshot->haveDistribSnapshot ? "true" : "false"));
 
 		/* Nice that we may have collected it, but turn it off... */
 		if (Debug_disable_distributed_snapshot)
@@ -2505,9 +2504,9 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	{
 		MyProc->serializableIsoLevel = true;
 
-		ereportif(Debug_print_snapshot_dtm, LOG,
-				  (errmsg("Got serializable snapshot: database %d, pid %d, xid %d, xmin %d",
-						  MyProc->databaseId, MyProc->pid, MyPgXact->xid, MyPgXact->xmin)));
+		elogif(Debug_print_snapshot_dtm, LOG,
+			   "Got serializable snapshot: database %d, pid %d, xid %d, xmin %d",
+			   MyProc->databaseId, MyProc->pid, MyPgXact->xid, MyPgXact->xmin);
 	}
 
 	LWLockRelease(ProcArrayLock);
@@ -2609,9 +2608,9 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 			"GetSnapshotData");
 	}
 
-	ereportif(Debug_print_snapshot_dtm, LOG,
-			  (errmsg("GetSnapshotData(): WRITER currentcommandid %d curcid %d segmatesync %d",
-					  GetCurrentCommandId(false), snapshot->curcid, QEDtxContextInfo.segmateSync)));
+	elogif(Debug_print_snapshot_dtm, LOG,
+		   "GetSnapshotData(): WRITER currentcommandid %d curcid %d segmatesync %d",
+		   GetCurrentCommandId(false), snapshot->curcid, QEDtxContextInfo.segmateSync);
 
 	return snapshot;
 }
@@ -3147,28 +3146,28 @@ UpdateSerializableCommandId(CommandId curcid)
 
 		if (SharedLocalSnapshotSlot->QDxid != QEDtxContextInfo.distributedXid)
 		{
-			ereportif(Debug_print_snapshot_dtm, LOG,
-					  (errmsg("[Distributed Snapshot #%u] *Can't Update Serializable Command Id* QDxid = %u (gxid = %u, '%s')",
-							  QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-							  SharedLocalSnapshotSlot->QDxid,
-							  getDistributedTransactionId(),
-							  DtxContextToString(DistributedTransactionContext))));
+			elogif(Debug_print_snapshot_dtm, LOG,
+				   "[Distributed Snapshot #%u] *Can't Update Serializable Command Id* QDxid = %u (gxid = %u, '%s')",
+				   QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+				   SharedLocalSnapshotSlot->QDxid,
+				   getDistributedTransactionId(),
+				   DtxContextToString(DistributedTransactionContext));
 			LWLockRelease(SharedLocalSnapshotSlot->slotLock);
 			return;
 		}
 
-		ereportif(Debug_print_snapshot_dtm, LOG,
-				  (errmsg("[Distributed Snapshot #%u] *Update Serializable Command Id* segment currcid = %d, TransactionSnapshot currcid = %d, Shared currcid = %d (gxid = %u, '%s')",
-						  QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
-						  QEDtxContextInfo.curcid,
-						  curcid,
-						  SharedLocalSnapshotSlot->snapshot.curcid,
-						  getDistributedTransactionId(),
-						  DtxContextToString(DistributedTransactionContext))));
+		elogif(Debug_print_snapshot_dtm, LOG,
+			   "[Distributed Snapshot #%u] *Update Serializable Command Id* segment currcid = %d, TransactionSnapshot currcid = %d, Shared currcid = %d (gxid = %u, '%s')",
+			   QEDtxContextInfo.distributedSnapshot.distribSnapshotId,
+			   QEDtxContextInfo.curcid,
+			   curcid,
+			   SharedLocalSnapshotSlot->snapshot.curcid,
+			   getDistributedTransactionId(),
+			   DtxContextToString(DistributedTransactionContext));
 
-		ereportif(Debug_print_snapshot_dtm, LOG,
-				  (errmsg("serializable writer updating combocid: used combocids %d shared %d",
-						  usedComboCids, SharedLocalSnapshotSlot->combocidcnt)));
+		elogif(Debug_print_snapshot_dtm, LOG,
+			   "serializable writer updating combocid: used combocids %d shared %d",
+			   usedComboCids, SharedLocalSnapshotSlot->combocidcnt);
 
 		combocidSize = ((usedComboCids < MaxComboCids) ? usedComboCids : MaxComboCids );
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1472,8 +1472,8 @@ exec_mpp_dtx_protocol_command(DtxProtocolCommand dtxProtocolCommand,
 	if (log_statement == LOGSTMT_ALL)
 		elog(LOG,"DTM protocol command '%s' for gid = %s", loggingStr, gid);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),"exec_mpp_dtx_protocol_command received the dtxProtocolCommand = %d (%s) gid = %s",
-		 dtxProtocolCommand, loggingStr, gid);
+	elogif(Debug_print_full_dtm, LOG, "exec_mpp_dtx_protocol_command received the dtxProtocolCommand = %d (%s) gid = %s",
+		   dtxProtocolCommand, loggingStr, gid);
 
 	set_ps_display(commandTag, false);
 
@@ -1497,8 +1497,8 @@ exec_mpp_dtx_protocol_command(DtxProtocolCommand dtxProtocolCommand,
 
 	performDtxProtocolCommand(dtxProtocolCommand, gid, contextInfo);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),"exec_mpp_dtx_protocol_command calling EndCommand for dtxProtocolCommand = %d (%s) gid = %s",
-		 dtxProtocolCommand, loggingStr, gid);
+	elogif(Debug_print_full_dtm, LOG, "exec_mpp_dtx_protocol_command calling EndCommand for dtxProtocolCommand = %d (%s) gid = %s",
+		   dtxProtocolCommand, loggingStr, gid);
 
 	if (Debug_dtm_action == DEBUG_DTM_ACTION_FAIL_END_COMMAND &&
 		CheckDebugDtmActionProtocol(dtxProtocolCommand, contextInfo))
@@ -1531,11 +1531,11 @@ CheckDebugDtmActionSqlCommandTag(const char *sqlCommandTag)
 			  strcmp(Debug_dtm_action_sql_command_tag, sqlCommandTag) == 0 &&
 			  Debug_dtm_action_segment == GpIdentity.segindex);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),"CheckDebugDtmActionSqlCommandTag Debug_dtm_action_target = %d, Debug_dtm_action_sql_command_tag = '%s' check '%s', Debug_dtm_action_segment = %d, Debug_dtm_action_primary = %s, result = %s.",
-		Debug_dtm_action_target,
-		Debug_dtm_action_sql_command_tag, (sqlCommandTag == NULL ? "<NULL>" : sqlCommandTag),
-		Debug_dtm_action_segment, (Debug_dtm_action_primary ? "true" : "false"),
-		(result ? "true" : "false"));
+	elogif(Debug_print_full_dtm, LOG, "CheckDebugDtmActionSqlCommandTag Debug_dtm_action_target = %d, Debug_dtm_action_sql_command_tag = '%s' check '%s', Debug_dtm_action_segment = %d, Debug_dtm_action_primary = %s, result = %s.",
+		   Debug_dtm_action_target,
+		   Debug_dtm_action_sql_command_tag, (sqlCommandTag == NULL ? "<NULL>" : sqlCommandTag),
+		   Debug_dtm_action_segment, (Debug_dtm_action_primary ? "true" : "false"),
+		   (result ? "true" : "false"));
 
 	return result;
 }
@@ -2221,7 +2221,7 @@ exec_bind_message(StringInfo input_message)
 	portal_name = pq_getmsgstring(input_message);
 	stmt_name = pq_getmsgstring(input_message);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5), "Bind: portal %s stmt_name %s", portal_name, stmt_name);
+	elogif(Debug_print_full_dtm, LOG, "Bind: portal %s stmt_name %s", portal_name, stmt_name);
 
 	ereport(DEBUG2,
 			(errmsg("bind %s to %s",
@@ -5216,8 +5216,8 @@ PostgresMain(int argc, char *argv[],
 			restore_guc_to_QE();
 
 
-		ereport((Debug_print_full_dtm ? LOG : DEBUG5),
-				(errmsg_internal("First char: '%c'; gp_role = '%s'.", firstchar, role_to_string(Gp_role))));
+		ereportif(Debug_print_full_dtm, LOG,
+				  (errmsg_internal("First char: '%c'; gp_role = '%s'.", firstchar, role_to_string(Gp_role))));
 
 		check_forbidden_in_gpdb_handlers(firstchar);
 
@@ -5234,7 +5234,7 @@ PostgresMain(int argc, char *argv[],
                     query_string = pq_getmsgstring(&input_message);
 					pq_getmsgend(&input_message);
 
-					elog((Debug_print_full_dtm ? LOG : DEBUG5), "Simple query stmt: %s.",query_string);
+					elogif(Debug_print_full_dtm, LOG, "Simple query stmt: %s.",query_string);
 
 					if (am_walsender)
 						exec_replication_command(query_string);
@@ -5339,7 +5339,7 @@ PostgresMain(int argc, char *argv[],
 
 					pq_getmsgend(&input_message);
 
-					elog((Debug_print_full_dtm ? LOG : DEBUG5), "MPP dispatched stmt from QD: %s.",query_string);
+					elogif(Debug_print_full_dtm, LOG, "MPP dispatched stmt from QD: %s.",query_string);
 
 					if (IsResGroupActivated() && resgroupInfoLen > 0)
 						SwitchResGroupOnSegment(resgroupInfoBuf, resgroupInfoLen);
@@ -5371,7 +5371,7 @@ PostgresMain(int argc, char *argv[],
 							 * Special explicit BEGIN for COPY, etc.
 							 * We've already begun it as part of setting up the context.
 							 */
-							elog((Debug_print_full_dtm ? LOG : DEBUG5), "PostgresMain explicit %s", query_string);
+							elogif(Debug_print_full_dtm, LOG, "PostgresMain explicit %s", query_string);
 
 							// UNDONE: HACK
 							pgstat_report_activity(STATE_RUNNING, "BEGIN");
@@ -5476,7 +5476,7 @@ PostgresMain(int argc, char *argv[],
 					}
 					pq_getmsgend(&input_message);
 
-					elog((Debug_print_full_dtm ? LOG : DEBUG5), "Parse: %s.",query_string);
+					elogif(Debug_print_full_dtm, LOG, "Parse: %s.",query_string);
 
 					exec_parse_message(query_string, stmt_name,
 									   paramTypes, numParams);
@@ -5512,7 +5512,7 @@ PostgresMain(int argc, char *argv[],
 					max_rows = (int64)pq_getmsgint(&input_message, 4);
 					pq_getmsgend(&input_message);
 
-					elog((Debug_print_full_dtm ? LOG : DEBUG5), "Execute: %s.",portal_name);
+					elogif(Debug_print_full_dtm, LOG, "Execute: %s.",portal_name);
 
 					exec_execute_message(portal_name, max_rows);
 				}
@@ -5528,7 +5528,7 @@ PostgresMain(int argc, char *argv[],
 				pgstat_report_activity(STATE_FASTPATH, NULL);
 				set_ps_display("<FASTPATH>", false);
 
-				elog((Debug_print_full_dtm ? LOG : DEBUG5), "Fast path function call.");
+				elogif(Debug_print_full_dtm, LOG, "Fast path function call.");
 
 				/* start an xact for this function invocation */
 				start_xact_command();
@@ -5611,7 +5611,7 @@ PostgresMain(int argc, char *argv[],
 					describe_target = pq_getmsgstring(&input_message);
 					pq_getmsgend(&input_message);
 
-					elog((Debug_print_full_dtm ? LOG : DEBUG5), "Describe: %s.", describe_target);
+					elogif(Debug_print_full_dtm, LOG, "Describe: %s.", describe_target);
 
 					switch (describe_type)
 					{

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5216,8 +5216,8 @@ PostgresMain(int argc, char *argv[],
 			restore_guc_to_QE();
 
 
-		ereportif(Debug_print_full_dtm, LOG,
-				  (errmsg_internal("First char: '%c'; gp_role = '%s'.", firstchar, role_to_string(Gp_role))));
+		elogif(Debug_print_full_dtm, LOG,
+			   "First char: '%c'; gp_role = '%s'.", firstchar, role_to_string(Gp_role));
 
 		check_forbidden_in_gpdb_handlers(firstchar);
 

--- a/src/backend/utils/resowner/resowner.c
+++ b/src/backend/utils/resowner/resowner.c
@@ -215,7 +215,7 @@ ResourceOwnerRelease(ResourceOwner owner,
 	 */
 	if (owner == NULL)
 	{
-		elog((Debug_print_full_dtm ? LOG : DEBUG5),"ResourceOwnerRelease found owner = NULL");
+		elogif(Debug_print_full_dtm, LOG, "ResourceOwnerRelease found owner = NULL");
 		return;
 	}
 

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -551,8 +551,8 @@ SharedSnapshotRemove(volatile SharedSnapshotSlot *slot, char *creatorDescription
 
 	LWLockRelease(SharedSnapshotLock);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),"SharedSnapshotRemove removed slot for slotId = %d, creator = %s (address %p)",
-		 slotId, creatorDescription, SharedLocalSnapshotSlot);
+	elogif(Debug_print_full_dtm, LOG, "SharedSnapshotRemove removed slot for slotId = %d, creator = %s (address %p)",
+		   slotId, creatorDescription, SharedLocalSnapshotSlot);
 }
 
 void
@@ -560,8 +560,8 @@ addSharedSnapshot(char *creatorDescription, int id)
 {
 	SharedLocalSnapshotSlot = SharedSnapshotAdd(id);
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),"%s added Shared Local Snapshot slot for gp_session_id = %d (address %p)",
-		 creatorDescription, id, SharedLocalSnapshotSlot);
+	elogif(Debug_print_full_dtm, LOG, "%s added Shared Local Snapshot slot for gp_session_id = %d (address %p)",
+		   creatorDescription, id, SharedLocalSnapshotSlot);
 }
 
 void
@@ -586,8 +586,8 @@ lookupSharedSnapshot(char *lookerDescription, char *creatorDescription, int id)
 
 	SharedLocalSnapshotSlot = slot;
 
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),"%s found Shared Local Snapshot slot for gp_session_id = %d created by %s (address %p)",
-		 lookerDescription, id, creatorDescription, SharedLocalSnapshotSlot);
+	elogif(Debug_print_full_dtm, LOG, "%s found Shared Local Snapshot slot for gp_session_id = %d created by %s (address %p)",
+		   lookerDescription, id, creatorDescription, SharedLocalSnapshotSlot);
 }
 
 static char *

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -225,11 +225,11 @@ GetTransactionSnapshot(void)
 
 	if (IsolationUsesXactSnapshot())
 	{
-		elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-			 "[Distributed Snapshot #%u] *Serializable* (gxid = %u, '%s')",
-			 CurrentSnapshot->distribSnapshotWithLocalMapping.ds.distribSnapshotId,
-			 getDistributedTransactionId(),
-			 DtxContextToString(DistributedTransactionContext));
+		elogif(Debug_print_snapshot_dtm, LOG,
+			   "[Distributed Snapshot #%u] *Serializable* (gxid = %u, '%s')",
+			   CurrentSnapshot->distribSnapshotWithLocalMapping.ds.distribSnapshotId,
+			   getDistributedTransactionId(),
+			   DtxContextToString(DistributedTransactionContext));
 
 		// GPDB_91_MERGE_FIXME: the name of UpdateSerializableCommandId is a bit
 		// wrong, now that SERIALIZABLE and REPEATABLE READ are not the same.
@@ -245,11 +245,11 @@ GetTransactionSnapshot(void)
 
 	CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData, DistributedTransactionContext);
 
-	elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
-		 "[Distributed Snapshot #%u] (gxid = %u, '%s')",
-		 CurrentSnapshot->distribSnapshotWithLocalMapping.ds.distribSnapshotId,
-		 getDistributedTransactionId(),
-		 DtxContextToString(DistributedTransactionContext));
+	elogif(Debug_print_snapshot_dtm, LOG,
+		   "[Distributed Snapshot #%u] (gxid = %u, '%s')",
+		   CurrentSnapshot->distribSnapshotWithLocalMapping.ds.distribSnapshotId,
+		   getDistributedTransactionId(),
+		   DtxContextToString(DistributedTransactionContext));
 
 	return CurrentSnapshot;
 }

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -257,9 +257,6 @@ typedef struct TMGALLXACTSTATUS
 	TMGXACTSTATUS		*statusArray;
 } TMGALLXACTSTATUS;
 
-
-#define DTM_DEBUG5 (Debug_print_full_dtm ? LOG : DEBUG5)
-
 extern int max_tm_gxacts;
 
 extern DtxContext DistributedTransactionContext;

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -258,7 +258,6 @@ typedef struct TMGALLXACTSTATUS
 } TMGALLXACTSTATUS;
 
 
-#define DTM_DEBUG3 (Debug_print_full_dtm ? LOG : DEBUG3)
 #define DTM_DEBUG5 (Debug_print_full_dtm ? LOG : DEBUG5)
 
 extern int max_tm_gxacts;


### PR DESCRIPTION
`elog(DTM_DEBUG5, ...)` (or `elog((Debug_print_full_dtm ? LOG : DEBUG5), ...)`) and `ereport(DTM_DEBUG5, ...)`
(or `ereport((Debug_print_full_dtm ? LOG : DEBUG5), ...)`) are replaced with
`elogif(Debug_print_full_dtm, LOG, ...)` and `ereportif(Debug_print_full_dtm, LOG)`, respectively.
Similar changes are made for logging statements related to `Debug_print_snapshot_dtm` as well.

This way, in a production setup, each logging statement only pays the cost of checking the value of
`Debug_print_full_dtm`, instead of first evaluating `(Debug_print_full_dtm ? LOG : DEBUG5)` and then checking
log level. Besides, the changes also avoid unnecessarily evaluating parameters passed to `elog()` (e.g.,
call to `DtxContextToString()`).

The changes slightly affect the behavior for debugging. When `log_min_messages` is set to `DEBUG5`, the original
code that uses `elog(DTM_DEBUG5, ...)` emits the log message at `DEBUG5` level if `Debug_print_full_dtm` is set to
`false`. The new code that uses `elogif(Debug_print_full_dtm, LOG, ...)` does not emit the log message unless
`Debug_print_full_dtm` is set to `true`. This means that a developer needs to set `log_min_messages` to `DEBUG5` **AND**
`Debug_print_full_dtm/Debug_print_snapshot_dtm` to `true` to get the full set of debug messages.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
