### PR TITLE
Enable index only scan on ao/aocs table

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1618,10 +1618,9 @@ aocs_fetch(AOCSFetchDesc aocsFetchDesc,
 	return found;
 }
 
-
 bool
 aocs_tuple_visible(AOCSFetchDesc aocsFetchDesc,
-						 AOTupleId *aoTupleId)
+				   AOTupleId *aoTupleId)
 {
 	int				segmentFileNum = AOTupleIdGet_segmentFileNum(aoTupleId);
 	int64			rowNum = AOTupleIdGet_rowNum(aoTupleId);
@@ -1667,7 +1666,6 @@ aocs_tuple_visible(AOCSFetchDesc aocsFetchDesc,
 
 	return true;
 }
-
 
 void
 aocs_fetch_finish(AOCSFetchDesc aocsFetchDesc)

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1618,6 +1618,57 @@ aocs_fetch(AOCSFetchDesc aocsFetchDesc,
 	return found;
 }
 
+
+bool
+aocs_tuple_visible(AOCSFetchDesc aocsFetchDesc,
+						 AOTupleId *aoTupleId)
+{
+	int				segmentFileNum = AOTupleIdGet_segmentFileNum(aoTupleId);
+	int64			rowNum = AOTupleIdGet_rowNum(aoTupleId);
+	int				numCols = aocsFetchDesc->relation->rd_att->natts;
+	AOCSFileSegInfo	*segInfo;
+	AppendOnlyBlockDirectoryEntry *curBlockDirectoryEntry;
+	bool		isSnapshotAny = (aocsFetchDesc->snapshot == SnapshotAny);
+
+	segInfo = aocsFetchDesc->segmentFileInfo[segmentFileNum];
+	Assert(segInfo);
+
+	if (numCols == 0)
+		return false;
+
+	DatumStreamFetchDesc datumStreamFetchDesc = aocsFetchDesc->datumStreamFetchDesc[0];
+
+	if (rowNum > aocsFetchDesc->lastRowNum[segmentFileNum] ||
+		rowNum < aocsFetchDesc->firstRowNum[segmentFileNum])
+	{
+		curBlockDirectoryEntry = &datumStreamFetchDesc->currentBlock.blockDirectoryEntry;
+		if(!AppendOnlyBlockDirectory_GetEntry(&aocsFetchDesc->blockDirectory,
+											  aoTupleId,
+											  0,
+											  curBlockDirectoryEntry))
+			return false;
+		if (rowNum > aocsFetchDesc->lastRowNum[segmentFileNum])
+			aocsFetchDesc->lastRowNum[segmentFileNum] = curBlockDirectoryEntry->range.lastRowNum;
+		if (rowNum < aocsFetchDesc->firstRowNum[segmentFileNum])
+			aocsFetchDesc->firstRowNum[segmentFileNum] = curBlockDirectoryEntry->range.firstRowNum;
+
+		if (curBlockDirectoryEntry->range.afterFileOffset > segInfo->vpinfo.entry[0].eof)
+			return false;
+	}
+
+	if (rowNum > aocsFetchDesc->lastRowNum[segmentFileNum])
+		return false;
+
+	if (!isSnapshotAny &&
+		!AppendOnlyVisimap_IsVisible(&aocsFetchDesc->visibilityMap, aoTupleId))
+	{
+		return false;			/* row has been deleted or updated. */
+	}
+
+	return true;
+}
+
+
 void
 aocs_fetch_finish(AOCSFetchDesc aocsFetchDesc)
 {

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -685,6 +685,9 @@ aoco_index_fetch_tuple(struct IndexFetchTableData *scan,
 
 	ExecClearTuple(slot);
 
+	if (aocoscan->xs_base.indexonly)
+		return aocs_tuple_visible(aocoscan->aocofetch, (AOTupleId *) tid);
+
 	if (aocs_fetch(aocoscan->aocofetch, (AOTupleId *) tid, slot))
 	{
 		ExecStoreVirtualTuple(slot);

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -685,9 +685,6 @@ aoco_index_fetch_tuple(struct IndexFetchTableData *scan,
 
 	ExecClearTuple(slot);
 
-	if (aocoscan->xs_base.indexonly)
-		return aocs_tuple_visible(aocoscan->aocofetch, (AOTupleId *) tid);
-
 	if (aocs_fetch(aocoscan->aocofetch, (AOTupleId *) tid, slot))
 	{
 		ExecStoreVirtualTuple(slot);
@@ -695,6 +692,48 @@ aoco_index_fetch_tuple(struct IndexFetchTableData *scan,
 	}
 
 	return false;
+}
+
+static bool
+aocs_tid_visible(struct IndexFetchTableData *scan,
+				 ItemPointer tid,
+				 Snapshot snapshot)
+{
+	IndexFetchAOCOData *aocoscan = (IndexFetchAOCOData *) scan;
+
+	if (!aocoscan->aocofetch)
+	{
+		Snapshot	appendOnlyMetaDataSnapshot;
+		int			natts;
+
+		/* Initiallize the projection info, assumes the whole row */
+		Assert(!aocoscan->proj);
+		natts = RelationGetNumberOfAttributes(scan->rel);
+		aocoscan->proj = palloc(natts * sizeof(*aocoscan->proj));
+		MemSet(aocoscan->proj, true, natts * sizeof(*aocoscan->proj));
+
+		appendOnlyMetaDataSnapshot = snapshot;
+		if (appendOnlyMetaDataSnapshot == SnapshotAny)
+		{
+			/*
+			 * the append-only meta data should never be fetched with
+			 * SnapshotAny as bogus results are returned.
+			 */
+			appendOnlyMetaDataSnapshot = GetTransactionSnapshot();
+		}
+
+		aocoscan->aocofetch = aocs_fetch_init(aocoscan->xs_base.rel,
+											  snapshot,
+											  appendOnlyMetaDataSnapshot,
+											  aocoscan->proj);
+	}
+	else
+	{
+		/* GPDB_12_MERGE_FIXME: Is it possible for the 'snapshot' to change
+		 * between calls? Add a sanity check for that here. */
+	}
+
+	return aocs_tuple_visible(aocoscan->aocofetch, tid);
 }
 
 static void
@@ -1880,6 +1919,7 @@ static const TableAmRoutine ao_column_methods = {
 	.index_fetch_reset = aoco_index_fetch_reset,
 	.index_fetch_end = aoco_index_fetch_end,
 	.index_fetch_tuple = aoco_index_fetch_tuple,
+	.tid_visible = aocs_tid_visible,
 
 	.tuple_insert = aoco_tuple_insert,
 	.tuple_insert_speculative = aoco_tuple_insert_speculative,

--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -300,6 +300,46 @@ GetAllAOCSFileSegInfo(Relation prel,
 	return results;
 }
 
+AOCSFileSegInfo **
+GetAllAOCSFileSegInfoArray(Relation prel,
+						   Snapshot appendOnlyMetaDataSnapshot)
+{
+	AOCSFileSegInfo	  **segArray;
+	AOCSFileSegInfo	  **segs;
+	int 				totalsegs;
+	segArray = palloc0(AOTupleId_MultiplierSegmentFileNum * sizeof(AOCSFileSegInfo *));
+	segs = GetAllAOCSFileSegInfo(prel, appendOnlyMetaDataSnapshot, &totalsegs);
+
+	for (int i = 0; i < totalsegs; ++i)
+	{
+		AOCSFileSegInfo *seg;
+		seg = segs[i];
+		segArray[seg->segno] = seg;
+	}
+	pfree(segs);
+
+	return segArray;
+}
+
+AOCSFileSegInfo **
+AllAOCSFileSegInfoToArray(AOCSFileSegInfo **allSegInfo, int totalsegs)
+{
+	AOCSFileSegInfo	  **segArray;
+
+	if (allSegInfo == NULL)
+		return NULL;
+	segArray = palloc0(AOTupleId_MultiplierSegmentFileNum * sizeof(AOCSFileSegInfo *));
+	for (int i = 0; i < totalsegs; ++i)
+	{
+		AOCSFileSegInfo *seg;
+		seg = allSegInfo[i];
+		segArray[seg->segno] = seg;
+	}
+	pfree(allSegInfo);
+
+	return segArray;
+}
+
 /*
  * The comparison routine that sorts an array of AOCSFileSegInfos
  * in the ascending order of the segment number.
@@ -1701,5 +1741,20 @@ FreeAllAOCSSegFileInfo(AOCSFileSegInfo **allAOCSSegInfo, int totalSegFiles)
 		Assert(allAOCSSegInfo[file_no] != NULL);
 
 		pfree(allAOCSSegInfo[file_no]);
+	}
+}
+
+void
+FreeAllAOCSSegFileInfoArray(AOCSFileSegInfo **allAOCSSegInfoArray)
+{
+	AOCSFileSegInfo *segInfo;
+
+	Assert(allAOCSSegInfoArray);
+
+	for (int i = 0; i < AOTupleId_MultiplierSegmentFileNum; ++i)
+	{
+		segInfo = allAOCSSegInfoArray[i];
+		if (segInfo)
+			pfree(segInfo);
 	}
 }

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -375,6 +375,46 @@ GetAllFileSegInfo(Relation parentrel,
 	return result;
 }
 
+FileSegInfo **
+GetAllFileSegInfoArray(Relation parentrel,
+					   Snapshot appendOnlyMetaDataSnapshot)
+{
+	FileSegInfo	  **segArray;
+	FileSegInfo	  **segs;
+	int 			totalsegs;
+	segArray = palloc0(AOTupleId_MultiplierSegmentFileNum * sizeof(FileSegInfo *));
+	segs = GetAllFileSegInfo(parentrel, appendOnlyMetaDataSnapshot, &totalsegs);
+
+	for (int i = 0; i < totalsegs; ++i)
+	{
+		FileSegInfo *seg;
+		seg = segs[i];
+		segArray[seg->segno] = seg;
+	}
+	pfree(segs);
+
+	return segArray;
+}
+FileSegInfo **
+AllFileSegInfoToArray(FileSegInfo **allSegInfo, int totalsegs)
+{
+	FileSegInfo	  **segArray;
+
+	if (allSegInfo == NULL)
+		return NULL;
+
+	segArray = palloc0(AOTupleId_MultiplierSegmentFileNum * sizeof(FileSegInfo *));
+	for (int i = 0; i < totalsegs; ++i)
+	{
+		FileSegInfo *seg;
+		seg = allSegInfo[i];
+		segArray[seg->segno] = seg;
+	}
+	pfree(allSegInfo);
+
+	return segArray;
+}
+
 
 /*
  * The comparison routine that sorts an array of FileSegInfos
@@ -1691,6 +1731,21 @@ FreeAllSegFileInfo(FileSegInfo **allSegInfo, int totalSegFiles)
 		Assert(allSegInfo[file_no] != NULL);
 
 		pfree(allSegInfo[file_no]);
+	}
+}
+
+void
+FreeAllSegFileInfoArray(FileSegInfo **allSegInfoArray)
+{
+	FileSegInfo *segInfo;
+
+	Assert(allSegInfoArray);
+
+	for (int i = 0; i < AOTupleId_MultiplierSegmentFileNum; ++i)
+	{
+		segInfo = allSegInfoArray[i];
+		if (segInfo)
+			pfree(segInfo);
 	}
 }
 

--- a/src/backend/access/appendonly/appendonly_visimap.c
+++ b/src/backend/access/appendonly/appendonly_visimap.c
@@ -192,12 +192,20 @@ AppendOnlyVisimap_IsVisible(
 							AppendOnlyVisimap *visiMap,
 							AOTupleId *aoTupleId)
 {
+	int segNum, rowNum, rangeNum;
+
 	Assert(visiMap);
 
 	elogif(Debug_appendonly_print_visimap, LOG,
 		   "Append-only visi map: Visibility check: "
 		   "(tupleId) = %s",
 		   AOTupleIdToString(aoTupleId));
+	rowNum = AOTupleIdGet_rowNum(aoTupleId);
+	segNum = AOTupleIdGet_segmentFileNum(aoTupleId);
+	rangeNum =  rowNum / APPENDONLY_VISIMAP_MAX_RANGE;
+
+	if (bms_is_member(rangeNum, visiMap->allvisible_bitmap[segNum]))
+		return true;
 
 	if (!AppendOnlyVisimapEntry_CoversTuple(&visiMap->visimapEntry,
 											aoTupleId))
@@ -213,7 +221,8 @@ AppendOnlyVisimap_IsVisible(
 
 	/* visimap entry is now positioned to cover the aoTupleId */
 	return AppendOnlyVisimapEntry_IsVisible(&visiMap->visimapEntry,
-											aoTupleId);
+											aoTupleId,
+											&visiMap->allvisible_bitmap[segNum]);
 }
 
 /*

--- a/src/backend/access/appendonly/appendonly_visimap_entry.c
+++ b/src/backend/access/appendonly/appendonly_visimap_entry.c
@@ -431,10 +431,11 @@ AppendOnlyVisimapEntry_GetFirstRowNum(
 bool
 AppendOnlyVisimapEntry_IsVisible(
 								 AppendOnlyVisimapEntry *visiMapEntry,
-								 AOTupleId *tupleId)
+								 AOTupleId *tupleId, Bitmapset **allVisibleSet)
 {
 	int64		rowNum,
-				rowNumOffset;
+				rowNumOffset,
+				rangeNum;
 	bool		visibilityBit;
 
 	Assert(visiMapEntry);
@@ -454,6 +455,8 @@ AppendOnlyVisimapEntry_IsVisible(
 			   "Append-only visi map entry: All entries are visibile: "
 			   "(firstRowNum, rowNum) = (" INT64_FORMAT ", " INT64_FORMAT ")",
 			   visiMapEntry->firstRowNum, rowNum);
+		rangeNum = rowNum / APPENDONLY_VISIMAP_MAX_RANGE;
+		*allVisibleSet = bms_add_member(*allVisibleSet, rangeNum);
 		return true;
 	}
 	Assert(rowNum >= visiMapEntry->firstRowNum);

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2525,6 +2525,49 @@ appendonly_fetch(AppendOnlyFetchDesc aoFetchDesc,
 	/* Segment file not in aoseg table.. */
 }
 
+bool
+appendonly_tuple_visible(AppendOnlyFetchDesc aoFetchDesc,
+						 AOTupleId *aoTupleId)
+{
+	int				segmentFileNum = AOTupleIdGet_segmentFileNum(aoTupleId);
+	int64			rowNum = AOTupleIdGet_rowNum(aoTupleId);
+	FileSegInfo	   *segInfo;
+	AppendOnlyBlockDirectoryEntry *curBlockDirectoryEntry;
+	bool		isSnapshotAny = (aoFetchDesc->snapshot == SnapshotAny);
+
+	segInfo = aoFetchDesc->segmentFileInfo[segmentFileNum];
+	Assert(segInfo);
+
+	if (rowNum > aoFetchDesc->lastRowNum[segmentFileNum] ||
+		rowNum < aoFetchDesc->firstRowNum[segmentFileNum])
+	{
+		curBlockDirectoryEntry = &aoFetchDesc->currentBlock.blockDirectoryEntry;
+		if(!AppendOnlyBlockDirectory_GetEntry(&aoFetchDesc->blockDirectory,
+											  aoTupleId,
+											  0,
+											  curBlockDirectoryEntry))
+			return false;
+		if (rowNum > aoFetchDesc->lastRowNum[segmentFileNum])
+			aoFetchDesc->lastRowNum[segmentFileNum] = curBlockDirectoryEntry->range.lastRowNum;
+		if (rowNum < aoFetchDesc->firstRowNum[segmentFileNum])
+			aoFetchDesc->firstRowNum[segmentFileNum] = curBlockDirectoryEntry->range.firstRowNum;
+
+		if (curBlockDirectoryEntry->range.afterFileOffset > segInfo->eof)
+			return false;
+	}
+
+	if (rowNum > aoFetchDesc->lastRowNum[segmentFileNum])
+		return false;
+
+	if (!isSnapshotAny &&
+		!AppendOnlyVisimap_IsVisible(&aoFetchDesc->visibilityMap, aoTupleId))
+	{
+		return false;			/* row has been deleted or updated. */
+	}
+
+	return true;
+}
+
 void
 appendonly_fetch_finish(AppendOnlyFetchDesc aoFetchDesc)
 {

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1919,39 +1919,22 @@ static bool
 openFetchSegmentFile(AppendOnlyFetchDesc aoFetchDesc,
 					 int openSegmentFileNum)
 {
-	int			i;
-
 	FileSegInfo *fsInfo;
-	int			segmentFileNum;
 	int64		logicalEof;
 	int32		fileSegNo;
 
 	Assert(!aoFetchDesc->currentSegmentFile.isOpen);
 
-	i = 0;
-	while (true)
+	fsInfo = aoFetchDesc->segmentFileInfo[openSegmentFileNum];
+	if (fsInfo->state == AOSEG_STATE_AWAITING_DROP)
 	{
-		if (i >= aoFetchDesc->totalSegfiles)
-			return false;
-		/* Segment file not visible in catalog information. */
-
-		fsInfo = aoFetchDesc->segmentFileInfo[i];
-		segmentFileNum = fsInfo->segno;
-		if (openSegmentFileNum == segmentFileNum)
-		{
-			if (fsInfo->state == AOSEG_STATE_AWAITING_DROP)
-			{
-				/*
-				 * File compacted, but not dropped. All information are
-				 * declared invisible
-				 */
-				return false;
-			}
-			logicalEof = (int64) fsInfo->eof;
-			break;
-		}
-		i++;
+		/*
+		 * File compacted, but not dropped. All information are
+		 * declared invisible
+		 */
+		return false;
 	}
+	logicalEof = (int64) fsInfo->eof;
 
 	/*
 	 * Don't try to open a segment file when its EOF is 0, since the file may
@@ -2263,14 +2246,15 @@ appendonly_fetch_init(Relation relation,
 	 * Get information about all the file segments we need to scan
 	 */
 	aoFetchDesc->segmentFileInfo =
-		GetAllFileSegInfo(
+		GetAllFileSegInfoArray(
 						  relation,
-						  appendOnlyMetaDataSnapshot,
-						  &aoFetchDesc->totalSegfiles);
+						  appendOnlyMetaDataSnapshot);
 	for (segno = 0; segno < AOTupleId_MultiplierSegmentFileNum; ++segno)
 	{
 		aoFetchDesc->lastSequence[segno] = ReadLastSequence(segrelid, segno);
+		aoFetchDesc->firstRowNum[segno] = AOTupleId_MaxRowNum;
 	}
+
 
 	AppendOnlyStorageRead_Init(
 							   &aoFetchDesc->storageRead,
@@ -2312,7 +2296,6 @@ appendonly_fetch_init(Relation relation,
 											&aoFetchDesc->blockDirectory,
 											appendOnlyMetaDataSnapshot,
 											aoFetchDesc->segmentFileInfo,
-											aoFetchDesc->totalSegfiles,
 											aoFetchDesc->relation,
 											1,
 											false,
@@ -2557,7 +2540,7 @@ appendonly_fetch_finish(AppendOnlyFetchDesc aoFetchDesc)
 
 	if (aoFetchDesc->segmentFileInfo)
 	{
-		FreeAllSegFileInfo(aoFetchDesc->segmentFileInfo, aoFetchDesc->totalSegfiles);
+		FreeAllSegFileInfoArray(aoFetchDesc->segmentFileInfo);
 		pfree(aoFetchDesc->segmentFileInfo);
 		aoFetchDesc->segmentFileInfo = NULL;
 	}

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -471,6 +471,9 @@ appendonly_index_fetch_tuple(struct IndexFetchTableData *scan,
 		 * between calls? Add a sanity check for that here. */
 	}
 
+	if (aoscan->xs_base.indexonly)
+		return appendonly_tuple_visible(aoscan->aofetch, (AOTupleId *) tid);
+
 	appendonly_fetch(aoscan->aofetch, (AOTupleId *) tid, slot);
 
 	return !TupIsNull(slot);

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -471,14 +471,44 @@ appendonly_index_fetch_tuple(struct IndexFetchTableData *scan,
 		 * between calls? Add a sanity check for that here. */
 	}
 
-	if (aoscan->xs_base.indexonly)
-		return appendonly_tuple_visible(aoscan->aofetch, (AOTupleId *) tid);
-
 	appendonly_fetch(aoscan->aofetch, (AOTupleId *) tid, slot);
 
 	return !TupIsNull(slot);
 }
 
+static bool
+appendonly_tid_visible(struct IndexFetchTableData *scan,
+					   ItemPointer tid,
+					   Snapshot snapshot)
+{
+	IndexFetchAppendOnlyData *aoscan = (IndexFetchAppendOnlyData *) scan;
+	if (!aoscan->aofetch)
+	{
+		Snapshot	appendOnlyMetaDataSnapshot;
+
+		appendOnlyMetaDataSnapshot = snapshot;
+		if (appendOnlyMetaDataSnapshot == SnapshotAny)
+		{
+			/*
+			 * the append-only meta data should never be fetched with
+			 * SnapshotAny as bogus results are returned.
+			 */
+			appendOnlyMetaDataSnapshot = GetTransactionSnapshot();
+		}
+
+		aoscan->aofetch =
+				appendonly_fetch_init(aoscan->xs_base.rel,
+									  snapshot,
+									  appendOnlyMetaDataSnapshot);
+	}
+	else
+	{
+		/* GPDB_12_MERGE_FIXME: Is it possible for the 'snapshot' to change
+		 * between calls? Add a sanity check for that here. */
+	}
+
+	return appendonly_tuple_visible(aoscan->aofetch, (AOTupleId *) tid);
+}
 
 /* ------------------------------------------------------------------------
  * Callbacks for non-modifying operations on individual tuples for
@@ -1942,6 +1972,7 @@ static const TableAmRoutine ao_row_methods = {
 	.index_fetch_reset = appendonly_index_fetch_reset,
 	.index_fetch_end = appendonly_index_fetch_end,
 	.index_fetch_tuple = appendonly_index_fetch_tuple,
+	.tid_visible = appendonly_tid_visible,
 
 	.tuple_insert = appendonly_tuple_insert,
 	.tuple_insert_speculative = appendonly_tuple_insert_speculative,

--- a/src/backend/access/appendonly/appendonlyblockdirectory.c
+++ b/src/backend/access/appendonly/appendonlyblockdirectory.c
@@ -171,7 +171,6 @@ AppendOnlyBlockDirectory_Init_forSearch(
 										AppendOnlyBlockDirectory *blockDirectory,
 										Snapshot appendOnlyMetaDataSnapshot,
 										FileSegInfo **segmentFileInfo,
-										int totalSegfiles,
 										Relation aoRel,
 										int numColumnGroups,
 										bool isAOCol,
@@ -194,12 +193,11 @@ AppendOnlyBlockDirectory_Init_forSearch(
 
 	ereportif(Debug_appendonly_print_blockdirectory, LOG,
 			  (errmsg("Append-only block directory init for search: "
-					  "(totalSegfiles, numColumnGroups, isAOCol)="
-					  "(%d, %d, %d)",
-					  totalSegfiles, numColumnGroups, isAOCol)));
+					  "(numColumnGroups, isAOCol)="
+					  "(%d, %d)",
+					  numColumnGroups, isAOCol)));
 
 	blockDirectory->segmentFileInfo = segmentFileInfo;
-	blockDirectory->totalSegfiles = totalSegfiles;
 	blockDirectory->aoRel = aoRel;
 	blockDirectory->appendOnlyMetaDataSnapshot = appendOnlyMetaDataSnapshot;
 	blockDirectory->numColumnGroups = numColumnGroups;
@@ -259,7 +257,6 @@ AppendOnlyBlockDirectory_Init_forInsert(
 	}
 
 	blockDirectory->segmentFileInfo = NULL;
-	blockDirectory->totalSegfiles = -1;
 	blockDirectory->currentSegmentFileInfo = segmentFileInfo;
 
 	blockDirectory->currentSegmentFileNum = segno;
@@ -328,7 +325,6 @@ AppendOnlyBlockDirectory_Init_addCol(
 	}
 
 	blockDirectory->segmentFileInfo = NULL;
-	blockDirectory->totalSegfiles = -1;
 	blockDirectory->currentSegmentFileInfo = segmentFileInfo;
 
 	blockDirectory->currentSegmentFileNum = segno;
@@ -473,7 +469,6 @@ AppendOnlyBlockDirectory_GetEntry(
 {
 	int			segmentFileNum = AOTupleIdGet_segmentFileNum(aoTupleId);
 	int64		rowNum = AOTupleIdGet_rowNum(aoTupleId);
-	int			i;
 	Relation	blkdirRel = blockDirectory->blkdirRel;
 	Relation	blkdirIdx = blockDirectory->blkdirIdx;
 	int			numScanKeys = blockDirectory->numScanKeys;
@@ -556,16 +551,7 @@ AppendOnlyBlockDirectory_GetEntry(
 		}
 	}
 
-	for (i = 0; i < blockDirectory->totalSegfiles; i++)
-	{
-		fsInfo = blockDirectory->segmentFileInfo[i];
-
-		if (!blockDirectory->isAOCol && segmentFileNum == fsInfo->segno)
-			break;
-		else if (blockDirectory->isAOCol && segmentFileNum ==
-				 ((AOCSFileSegInfo *) fsInfo)->segno)
-			break;
-	}
+	fsInfo = blockDirectory->segmentFileInfo[segmentFileNum];
 
 	Assert(fsInfo != NULL);
 
@@ -1296,9 +1282,8 @@ AppendOnlyBlockDirectory_End_forSearch(
 
 	ereportif(Debug_appendonly_print_blockdirectory, LOG,
 			  (errmsg("Append-only block directory end for search: "
-					  "(totalSegfiles, numColumnGroups, isAOCol)="
-					  "(%d, %d, %d)",
-					  blockDirectory->totalSegfiles,
+					  "(numColumnGroups, isAOCol)="
+					  "(%d, %d)",
 					  blockDirectory->numColumnGroups,
 					  blockDirectory->isAOCol)));
 

--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -30,6 +30,7 @@
 #include "access/tableam.h"
 #include "access/tsmapi.h"
 #include "access/tuptoaster.h"
+#include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "catalog/catalog.h"
 #include "catalog/index.h"
@@ -88,6 +89,7 @@ heapam_index_fetch_begin(Relation rel)
 
 	hscan->xs_base.rel = rel;
 	hscan->xs_cbuf = InvalidBuffer;
+	hscan->xs_vbuf = InvalidBuffer;
 
 	return &hscan->xs_base;
 }
@@ -101,6 +103,11 @@ heapam_index_fetch_reset(IndexFetchTableData *scan)
 	{
 		ReleaseBuffer(hscan->xs_cbuf);
 		hscan->xs_cbuf = InvalidBuffer;
+	}
+	if (BufferIsValid(hscan->xs_vbuf))
+	{
+		ReleaseBuffer(hscan->xs_vbuf);
+		hscan->xs_vbuf = InvalidBuffer;
 	}
 }
 
@@ -174,6 +181,18 @@ heapam_index_fetch_tuple(struct IndexFetchTableData *scan,
 	}
 
 	return got_heap_tuple;
+}
+
+static bool
+heapam_tid_visible(struct IndexFetchTableData *scan,
+				   ItemPointer tid,
+				   Snapshot snapshot)
+{
+	IndexFetchHeapData *hscan = (IndexFetchHeapData *) scan;
+
+	return VM_ALL_VISIBLE(hscan->xs_base.rel,
+						  ItemPointerGetBlockNumber(tid),
+						  &hscan->xs_vbuf);
 }
 
 
@@ -2637,6 +2656,7 @@ static const TableAmRoutine heapam_methods = {
 	.index_fetch_reset = heapam_index_fetch_reset,
 	.index_fetch_end = heapam_index_fetch_end,
 	.index_fetch_tuple = heapam_index_fetch_tuple,
+	.tid_visible = heapam_tid_visible,
 
 	.tuple_insert = heapam_tuple_insert,
 	.tuple_insert_speculative = heapam_tuple_insert_speculative,

--- a/src/backend/access/index/indexam.c
+++ b/src/backend/access/index/indexam.c
@@ -216,6 +216,21 @@ index_beginscan(Relation heapRelation,
 	return scan;
 }
 
+IndexScanDesc
+indexonly_beginscan(Relation heapRelation,
+					Relation indexRelation,
+					Snapshot snapshot,
+					int nkeys, int norderbys)
+{
+	IndexScanDesc scan;
+
+	scan = index_beginscan(heapRelation, indexRelation, snapshot, nkeys, norderbys);
+
+	scan->xs_heapfetch->indexonly = true;
+
+	return scan;
+}
+
 /*
  * index_beginscan_bitmap - start a scan of an index with amgetbitmap
  *

--- a/src/backend/access/index/indexam.c
+++ b/src/backend/access/index/indexam.c
@@ -226,8 +226,6 @@ indexonly_beginscan(Relation heapRelation,
 
 	scan = index_beginscan(heapRelation, indexRelation, snapshot, nkeys, norderbys);
 
-	scan->xs_heapfetch->indexonly = true;
-
 	return scan;
 }
 

--- a/src/backend/commands/vacuum_ao.c
+++ b/src/backend/commands/vacuum_ao.c
@@ -479,10 +479,18 @@ vacuum_appendonly_indexes(Relation aoRelation, int options,
 			AccessShareLock,
 			appendOnlyMetaDataSnapshot);
 
+	if (RelationIsAoRows(aoRelation))
+	{
+		segmentFileInfo = AllFileSegInfoToArray(segmentFileInfo, totalSegfiles);
+	}
+	else
+	{
+		segmentFileInfo = (FileSegInfo **) AllAOCSFileSegInfoToArray(
+				(AOCSFileSegInfo **)segmentFileInfo, totalSegfiles);
+	}
 	AppendOnlyBlockDirectory_Init_forSearch(&vacuumIndexState.blockDirectory,
 			appendOnlyMetaDataSnapshot,
 			segmentFileInfo,
-			totalSegfiles,
 			aoRelation,
 			1,
 			RelationIsAoCols(aoRelation),
@@ -530,11 +538,11 @@ vacuum_appendonly_indexes(Relation aoRelation, int options,
 	{
 		if (RelationIsAoRows(aoRelation))
 		{
-			FreeAllSegFileInfo(segmentFileInfo, totalSegfiles);
+			FreeAllSegFileInfoArray(segmentFileInfo);
 		}
 		else
 		{
-			FreeAllAOCSSegFileInfo((AOCSFileSegInfo **)segmentFileInfo, totalSegfiles);
+			FreeAllAOCSSegFileInfoArray((AOCSFileSegInfo **)segmentFileInfo);
 		}
 		pfree(segmentFileInfo);
 	}

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -158,9 +158,8 @@ IndexOnlyNext(IndexOnlyScanState *node)
 		 * It's worth going through this complexity to avoid needing to lock
 		 * the VM buffer, which could cause significant contention.
 		 */
-		if (!VM_ALL_VISIBLE(scandesc->heapRelation,
-							ItemPointerGetBlockNumber(tid),
-							&node->ioss_VMBuffer))
+		if (!scandesc->xs_heapfetch->rel->rd_tableam->tid_visible(
+				scandesc->xs_heapfetch, tid, scandesc->xs_snapshot))
 		{
 			/*
 			 * Rats, we have to visit the heap to check visibility.

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -90,11 +90,11 @@ IndexOnlyNext(IndexOnlyScanState *node)
 		 * serially executing an index only scan that was planned to be
 		 * parallel.
 		 */
-		scandesc = index_beginscan(node->ss.ss_currentRelation,
-								   node->ioss_RelationDesc,
-								   estate->es_snapshot,
-								   node->ioss_NumScanKeys,
-								   node->ioss_NumOrderByKeys);
+		scandesc = indexonly_beginscan(node->ss.ss_currentRelation,
+									   node->ioss_RelationDesc,
+									   estate->es_snapshot,
+									   node->ioss_NumScanKeys,
+									   node->ioss_NumOrderByKeys);
 
 		node->ioss_ScanDesc = scandesc;
 

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -78,6 +78,7 @@
 #include "access/amapi.h"
 #include "access/htup_details.h"
 #include "access/tsmapi.h"
+#include "catalog/pg_proc.h"
 #include "executor/executor.h"
 #include "executor/nodeAgg.h"
 #include "executor/nodeHash.h"
@@ -701,6 +702,10 @@ cost_index(IndexPath *path, PlannerInfo *root, double loop_count,
 	get_tablespace_page_costs(baserel->reltablespace,
 							  &spc_random_page_cost,
 							  &spc_seq_page_cost);
+
+	if (baserel_orig->amhandler == AO_ROW_TABLE_AM_HANDLER_OID ||
+		baserel_orig->amhandler == AO_COLUMN_TABLE_AM_HANDLER_OID)
+		baserel->allvisfrac = 1.0;
 
 	/*----------
 	 * Estimate number of main-table pages fetched, and compute I/O cost.

--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -813,12 +813,14 @@ get_index_paths(PlannerInfo *root, RelOptInfo *rel,
 		 * able to use index only scans on AO/AOCO relations. However it is
 		 * suboptimal to have to expose the relation's access method here. There
 		 * are no straight forward solutions though.
+		 *
+		 * Enable index only scan here, but the index scan is still disabled.
 		 */
 		if (index->amhasgettuple &&
-				(rel->amhandler != AO_ROW_TABLE_AM_HANDLER_OID &&
-				 rel->amhandler != AO_COLUMN_TABLE_AM_HANDLER_OID))
+				((rel->amhandler != AO_ROW_TABLE_AM_HANDLER_OID &&
+				 rel->amhandler != AO_COLUMN_TABLE_AM_HANDLER_OID) ||
+				 ipath->path.pathtype == T_IndexOnlyScan))
 			add_path(rel, (Path *) ipath);
-
 		if (index->amhasgetbitmap &&
 			/* GPDB: Give a chance of bitmap index path if seqscan is disabled.
 			 * GPDB_92_MERGE_FIXME: Maybe we should remove this check to follow

--- a/src/include/access/aocssegfiles.h
+++ b/src/include/access/aocssegfiles.h
@@ -141,7 +141,11 @@ extern AOCSFileSegInfo *GetAOCSFileSegInfo(Relation prel,
 extern AOCSFileSegInfo **GetAllAOCSFileSegInfo(Relation prel,
 					  Snapshot appendOnlyMetaDataSnapshot,
 					  int *totalseg);
+extern AOCSFileSegInfo **GetAllAOCSFileSegInfoArray(Relation prel,
+					   Snapshot appendOnlyMetaDataSnapshot);
+extern AOCSFileSegInfo **AllAOCSFileSegInfoToArray(AOCSFileSegInfo **allSegInfo, int totalsegs);
 extern void FreeAllAOCSSegFileInfo(AOCSFileSegInfo **allAOCSSegInfo, int totalSegFiles);
+extern void FreeAllAOCSSegFileInfoArray(AOCSFileSegInfo **allAOCSSegInfoArray);
 
 extern FileSegTotals *GetAOCSSSegFilesTotals(Relation parentrel,
 					   Snapshot appendOnlyMetaDataSnapshot);

--- a/src/include/access/aosegfiles.h
+++ b/src/include/access/aosegfiles.h
@@ -137,6 +137,8 @@ extern void ValidateAppendonlySegmentDataBeforeStorage(int segno);
 extern FileSegInfo *GetFileSegInfo(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot, int segno, bool locked);
 
 extern FileSegInfo **GetAllFileSegInfo(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot, int *totalsegs);
+extern FileSegInfo **GetAllFileSegInfoArray(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot);
+extern FileSegInfo **AllFileSegInfoToArray(FileSegInfo **allSegInfo, int totalsegs);
 
 extern void UpdateFileSegInfo(Relation parentrel,
 				  int segno,
@@ -154,6 +156,7 @@ extern FileSegTotals *GetSegFilesTotals(Relation parentrel, Snapshot appendOnlyM
 
 extern void FreeAllSegFileInfo(FileSegInfo **allSegInfo,
 				   int totalSegFiles);
+extern void FreeAllSegFileInfoArray(FileSegInfo **allSegInfoArray);
 
 extern bool pg_aoseg_tuple_could_be_updated(Relation relation, HeapTuple tuple);
 extern bool pg_aoseg_tuple_is_locked_by_me(HeapTuple tuple);

--- a/src/include/access/appendonly_visimap.h
+++ b/src/include/access/appendonly_visimap.h
@@ -57,6 +57,7 @@ typedef struct AppendOnlyVisimap
 	 * Support operations to search, load, and store visibility map entries.
 	 */
 	AppendOnlyVisimapStore visimapStore;
+	Bitmapset			  *allvisible_bitmap[AOTupleId_MultiplierSegmentFileNum];
 
 } AppendOnlyVisimap;
 

--- a/src/include/access/appendonly_visimap_entry.h
+++ b/src/include/access/appendonly_visimap_entry.h
@@ -121,7 +121,8 @@ bool AppendOnlyVisimapEntry_CoversTuple(
 
 bool AppendOnlyVisimapEntry_IsVisible(
 								 AppendOnlyVisimapEntry *visiMapEntry,
-								 AOTupleId *aoTupleId);
+								 AOTupleId *aoTupleId,
+								 Bitmapset **allVisibleSet);
 
 TM_Result AppendOnlyVisimapEntry_HideTuple(
 								 AppendOnlyVisimapEntry *visiMapEntry,

--- a/src/include/access/genam.h
+++ b/src/include/access/genam.h
@@ -142,6 +142,10 @@ extern IndexScanDesc index_beginscan(Relation heapRelation,
 									 Relation indexRelation,
 									 Snapshot snapshot,
 									 int nkeys, int norderbys);
+extern IndexScanDesc indexonly_beginscan(Relation heapRelation,
+										 Relation indexRelation,
+										 Snapshot snapshot,
+										 int nkeys, int norderbys);
 extern IndexScanDesc index_beginscan_bitmap(Relation indexRelation,
 											Snapshot snapshot,
 											int nkeys);

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -80,6 +80,7 @@ typedef struct IndexFetchHeapData
 
 	Buffer		xs_cbuf;		/* current heap buffer in scan, if any */
 	/* NB: if xs_cbuf is not InvalidBuffer, we hold a pin on that buffer */
+	Buffer 		xs_vbuf;	/* current buffer in visibility map */
 } IndexFetchHeapData;
 
 /* Result codes for HeapTupleSatisfiesVacuum */

--- a/src/include/access/relscan.h
+++ b/src/include/access/relscan.h
@@ -89,6 +89,7 @@ typedef struct ParallelBlockTableScanDescData *ParallelBlockTableScanDesc;
 typedef struct IndexFetchTableData
 {
 	Relation	rel;
+	bool		indexonly;
 } IndexFetchTableData;
 
 /*

--- a/src/include/access/relscan.h
+++ b/src/include/access/relscan.h
@@ -89,7 +89,6 @@ typedef struct ParallelBlockTableScanDescData *ParallelBlockTableScanDesc;
 typedef struct IndexFetchTableData
 {
 	Relation	rel;
-	bool		indexonly;
 } IndexFetchTableData;
 
 /*

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -322,6 +322,9 @@ typedef struct TableAmRoutine
 									  TupleTableSlot *slot,
 									  bool *call_again, bool *all_dead);
 
+	bool		(*tid_visible) (struct IndexFetchTableData *scan,
+								ItemPointer tid,
+								Snapshot snapshot);
 
 	/* ------------------------------------------------------------------------
 	 * Callbacks for non-modifying operations on individual tuples

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -214,6 +214,8 @@ typedef struct AOCSFetchDescData
 	 * maximum row number.
 	 */
 	int64			lastSequence[AOTupleId_MultiplierSegmentFileNum];
+	int64 			lastRowNum[AOTupleId_MultiplierSegmentFileNum];
+	int64 			firstRowNum[AOTupleId_MultiplierSegmentFileNum];
 
 	char			*segmentFileName;
 	int				segmentFileNameMaxLen;
@@ -314,6 +316,8 @@ extern AOCSFetchDesc aocs_fetch_init(Relation relation,
 extern bool aocs_fetch(AOCSFetchDesc aocsFetchDesc,
 					   AOTupleId *aoTupleId,
 					   TupleTableSlot *slot);
+extern bool aocs_tuple_visible(AOCSFetchDesc aocsFetchDesc,
+							   AOTupleId *aoTupleId);
 extern void aocs_fetch_finish(AOCSFetchDesc aocsFetchDesc);
 
 extern AOCSUpdateDesc aocs_update_init(Relation rel, int segno);

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -317,6 +317,9 @@ typedef struct AppendOnlyFetchDescData
 	 * maximum row number.
 	 */
 	int64			lastSequence[AOTupleId_MultiplierSegmentFileNum];
+	int64 			lastRowNum[AOTupleId_MultiplierSegmentFileNum];
+	int64 			firstRowNum[AOTupleId_MultiplierSegmentFileNum];
+
 
 	int32			usableBlockSize;
 
@@ -385,6 +388,8 @@ extern bool appendonly_fetch(
 	AppendOnlyFetchDesc aoFetchDesc,
 	AOTupleId *aoTid,
 	TupleTableSlot *slot);
+extern bool appendonly_tuple_visible(AppendOnlyFetchDesc aoFetchDesc,
+									 AOTupleId *aoTupleId);
 extern void appendonly_fetch_finish(AppendOnlyFetchDesc aoFetchDesc);
 extern void appendonly_dml_init(Relation relation, CmdType operation);
 extern AppendOnlyInsertDesc appendonly_insert_init(Relation rel, int segno);

--- a/src/include/cdb/cdbappendonlyblockdirectory.h
+++ b/src/include/cdb/cdbappendonlyblockdirectory.h
@@ -97,7 +97,6 @@ typedef struct AppendOnlyBlockDirectory
 
 	MemoryContext memoryContext;
 	
-	int				totalSegfiles;
 	FileSegInfo 	**segmentFileInfo;
 
 	/*
@@ -181,7 +180,6 @@ extern void AppendOnlyBlockDirectory_Init_forSearch(
 	AppendOnlyBlockDirectory *blockDirectory,
 	Snapshot appendOnlyMetaDataSnapshot,
 	FileSegInfo **segmentFileInfo,
-	int totalSegfiles,
 	Relation aoRel,
 	int numColumnGroups,
 	bool isAOCol,

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -712,6 +712,9 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 --
 CREATE INDEX ON table_with_reversed_index(c, a);
 INSERT INTO table_with_reversed_index VALUES (10, true, 'ab');
+reset enable_seqscan;
+reset enable_indexscan;
+reset enable_bitmapscan;
 --
 -- Then an index only scan should succeed. (i.e. varattno is set up correctly)
 --
@@ -740,3 +743,80 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_indexscan;
 RESET optimizer_enable_indexonlyscan;
+--
+-- Enable the index only scan in append only table
+--
+CREATE TABLE bfv_index_only_ao(a int, b int) WITH (appendonly =true);
+CREATE INDEX bfv_index_only_ao_a_b on bfv_index_only_ao(a) include (b);
+insert into bfv_index_only_ao select i,i from generate_series(1, 10000) i;
+explain select count(*) from bfv_index_only_ao where a < 100;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=5.37..5.38 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=5.31..5.36 rows=3 width=8)
+         ->  Partial Aggregate  (cost=5.31..5.32 rows=1 width=8)
+               ->  Index Only Scan using bfv_index_only_ao_a_b on bfv_index_only_ao  (cost=0.16..5.23 rows=33 width=0)
+                     Index Cond: (a < 100)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select count(*) from bfv_index_only_ao where a < 100;
+ count 
+-------
+    99
+(1 row)
+
+explain select count(*) from bfv_index_only_ao where a < 1000;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=19.87..19.88 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=19.81..19.86 rows=3 width=8)
+         ->  Partial Aggregate  (cost=19.81..19.82 rows=1 width=8)
+               ->  Index Only Scan using bfv_index_only_ao_a_b on bfv_index_only_ao  (cost=0.16..18.98 rows=333 width=0)
+                     Index Cond: (a < 1000)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select count(*) from bfv_index_only_ao where a < 1000;
+ count 
+-------
+   999
+(1 row)
+
+CREATE TABLE bfv_index_only_aocs(a int, b int) WITH (appendonly =true, orientation=column);
+CREATE INDEX bfv_index_only_aocs_a_b on bfv_index_only_aocs(a) include (b);
+insert into bfv_index_only_aocs select i,i from generate_series(1, 10000) i;
+explain select count(*) from bfv_index_only_aocs where a < 100;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=5.37..5.38 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=5.31..5.36 rows=3 width=8)
+         ->  Partial Aggregate  (cost=5.31..5.32 rows=1 width=8)
+               ->  Index Only Scan using bfv_index_only_aocs_a_b on bfv_index_only_aocs  (cost=0.16..5.23 rows=33 width=0)
+                     Index Cond: (a < 100)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select count(*) from bfv_index_only_aocs where a < 100;
+ count 
+-------
+    99
+(1 row)
+
+explain select count(*) from bfv_index_only_aocs where a < 1000;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=19.87..19.88 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=19.81..19.86 rows=3 width=8)
+         ->  Partial Aggregate  (cost=19.81..19.82 rows=1 width=8)
+               ->  Index Only Scan using bfv_index_only_aocs_a_b on bfv_index_only_aocs  (cost=0.16..18.98 rows=333 width=0)
+                     Index Cond: (a < 1000)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select count(*) from bfv_index_only_aocs where a < 1000;
+ count 
+-------
+   999
+(1 row)
+

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -710,6 +710,9 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 --
 CREATE INDEX ON table_with_reversed_index(c, a);
 INSERT INTO table_with_reversed_index VALUES (10, true, 'ab');
+reset enable_seqscan;
+reset enable_indexscan;
+reset enable_bitmapscan;
 --
 -- Then an index only scan should succeed. (i.e. varattno is set up correctly)
 --
@@ -738,3 +741,80 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_indexscan;
 RESET optimizer_enable_indexonlyscan;
+--
+-- Enable the index only scan in append only table
+--
+CREATE TABLE bfv_index_only_ao(a int, b int) WITH (appendonly =true);
+CREATE INDEX bfv_index_only_ao_a_b on bfv_index_only_ao(a) include (b);
+insert into bfv_index_only_ao select i,i from generate_series(1, 10000) i;
+explain select count(*) from bfv_index_only_ao where a < 100;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.15 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.15 rows=1 width=8)
+               ->  Seq Scan on bfv_index_only_ao  (cost=0.00..431.15 rows=34 width=1)
+                     Filter: (a < 100)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+select count(*) from bfv_index_only_ao where a < 100;
+ count 
+-------
+    99
+(1 row)
+
+explain select count(*) from bfv_index_only_ao where a < 1000;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.15 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.15 rows=1 width=8)
+               ->  Seq Scan on bfv_index_only_ao  (cost=0.00..431.15 rows=334 width=1)
+                     Filter: (a < 1000)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+select count(*) from bfv_index_only_ao where a < 1000;
+ count 
+-------
+   999
+(1 row)
+
+CREATE TABLE bfv_index_only_aocs(a int, b int) WITH (appendonly =true, orientation=column);
+CREATE INDEX bfv_index_only_aocs_a_b on bfv_index_only_aocs(a) include (b);
+insert into bfv_index_only_aocs select i,i from generate_series(1, 10000) i;
+explain select count(*) from bfv_index_only_aocs where a < 100;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.15 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.15 rows=1 width=8)
+               ->  Seq Scan on bfv_index_only_aocs  (cost=0.00..431.15 rows=34 width=1)
+                     Filter: (a < 100)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+select count(*) from bfv_index_only_aocs where a < 100;
+ count 
+-------
+    99
+(1 row)
+
+explain select count(*) from bfv_index_only_aocs where a < 1000;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.15 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.15 rows=1 width=8)
+               ->  Seq Scan on bfv_index_only_aocs  (cost=0.00..431.15 rows=334 width=1)
+                     Filter: (a < 1000)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+select count(*) from bfv_index_only_aocs where a < 1000;
+ count 
+-------
+   999
+(1 row)
+

--- a/src/test/regress/expected/co_nestloop_idxscan.out
+++ b/src/test/regress/expected/co_nestloop_idxscan.out
@@ -28,7 +28,7 @@ explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b wh
  Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..1528.77 rows=6 width=8)
    ->  Hash Join  (cost=1.02..1528.77 rows=2 width=8)
          Hash Cond: (f.id = b.id)
-         ->  Seq Scan on foo f  (cost=0.00..1527.50 rows=17 width=8)
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..400.56 rows=17 width=8)
          ->  Hash  (cost=1.01..1.01 rows=1 width=8)
                ->  Seq Scan on bar b  (cost=0.00..1.01 rows=1 width=8)
  Optimizer: Postgres query optimizer
@@ -50,12 +50,10 @@ explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b wh
  Gather Motion 3:1  (slice1; segments: 3)  (cost=200.15..301.18 rows=6 width=8)
    ->  Nested Loop  (cost=200.15..301.18 rows=2 width=8)
          ->  Seq Scan on bar b  (cost=0.00..1.01 rows=1 width=8)
-         ->  Bitmap Heap Scan on foo f  (cost=200.15..300.16 rows=1 width=8)
-               Recheck Cond: (id = b.id)
-               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..200.15 rows=1 width=0)
-                     Index Cond: (id = b.id)
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..8.16 rows=1 width=8)
+               Index Cond: (id = b.id)
  Optimizer: Postgres query optimizer
-(8 rows)
+(6 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
  id 
@@ -74,12 +72,10 @@ explain select f.id from co_nestloop_idxscan.bar b, co_nestloop_idxscan.foo f wh
  Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000200.15..10000000301.18 rows=6 width=8)
    ->  Nested Loop  (cost=10000000200.15..10000000301.18 rows=2 width=8)
          ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.01 rows=1 width=8)
-         ->  Bitmap Heap Scan on foo f  (cost=200.15..300.16 rows=1 width=8)
-               Recheck Cond: (id = b.id)
-               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..200.15 rows=1 width=0)
-                     Index Cond: (id = b.id)
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..8.16 rows=1 width=8)
+               Index Cond: (id = b.id)
  Optimizer: Postgres query optimizer
-(8 rows)
+(6 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
  id 
@@ -107,16 +103,15 @@ set enable_hashagg=off;
 explain select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000048.90..10000000054.01 rows=4 width=8)
-   ->  Nested Loop Semi Join  (cost=10000000048.90..10000000053.95 rows=2 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.14..10000000049.99 rows=3 width=8)
+   ->  Nested Loop Semi Join  (cost=10000000000.14..10000000049.95 rows=1 width=8)
+         Join Filter: (b.id = f.id)
          ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.02 rows=1 width=8)
                Filter: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
-         ->  Bitmap Heap Scan on foo f  (cost=48.90..52.92 rows=1 width=8)
-               Recheck Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
-               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..48.90 rows=1 width=0)
-                     Index Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..48.91 rows=2 width=8)
+               Index Cond: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
  Optimizer: Postgres query optimizer
-(9 rows)
+(8 rows)
 
 select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
  id 
@@ -130,22 +125,17 @@ select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_ne
 reset enable_sort;
 reset enable_hashagg;
 explain select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000054.02..10000000054.10 rows=4 width=8)
-   ->  HashAggregate  (cost=10000000054.02..10000000054.03 rows=2 width=8)
-         Group Key: (RowIdExpr)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000048.90..10000000054.01 rows=2 width=8)
-               Hash Key: (RowIdExpr)
-               ->  Nested Loop  (cost=10000000048.90..10000000053.95 rows=2 width=8)
-                     ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.02 rows=1 width=8)
-                           Filter: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
-                     ->  Bitmap Heap Scan on foo f  (cost=48.90..52.92 rows=1 width=8)
-                           Recheck Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
-                           ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..48.90 rows=1 width=0)
-                                 Index Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.14..10000000049.99 rows=3 width=8)
+   ->  Nested Loop Semi Join  (cost=10000000000.14..10000000049.95 rows=1 width=8)
+         Join Filter: (b.id = f.id)
+         ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.02 rows=1 width=8)
+               Filter: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..48.91 rows=2 width=8)
+               Index Cond: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
  Optimizer: Postgres query optimizer
-(13 rows)
+(8 rows)
 
 select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
  id 

--- a/src/test/regress/expected/co_nestloop_idxscan_optimizer.out
+++ b/src/test/regress/expected/co_nestloop_idxscan_optimizer.out
@@ -111,16 +111,15 @@ set enable_hashagg=off;
 explain select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000048.90..10000000054.01 rows=4 width=8)
-   ->  Nested Loop Semi Join  (cost=10000000048.90..10000000053.95 rows=2 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.14..10000000049.99 rows=3 width=8)
+   ->  Nested Loop Semi Join  (cost=10000000000.14..10000000049.95 rows=1 width=8)
+         Join Filter: (b.id = f.id)
          ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.02 rows=1 width=8)
                Filter: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
-         ->  Bitmap Heap Scan on foo f  (cost=48.90..52.92 rows=1 width=8)
-               Recheck Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
-               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..48.90 rows=1 width=0)
-                     Index Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..48.91 rows=2 width=8)
+               Index Cond: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
  Optimizer: Postgres query optimizer
-(9 rows)
+(8 rows)
 
 select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
  id 
@@ -134,22 +133,17 @@ select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_ne
 reset enable_sort;
 reset enable_hashagg;
 explain select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000054.02..10000000054.10 rows=4 width=8)
-   ->  HashAggregate  (cost=10000000054.02..10000000054.03 rows=2 width=8)
-         Group Key: (RowIdExpr)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000048.90..10000000054.01 rows=2 width=8)
-               Hash Key: (RowIdExpr)
-               ->  Nested Loop  (cost=10000000048.90..10000000053.95 rows=2 width=8)
-                     ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.02 rows=1 width=8)
-                           Filter: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
-                     ->  Bitmap Heap Scan on foo f  (cost=48.90..52.92 rows=1 width=8)
-                           Recheck Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
-                           ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..48.90 rows=1 width=0)
-                                 Index Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.14..10000000049.99 rows=3 width=8)
+   ->  Nested Loop Semi Join  (cost=10000000000.14..10000000049.95 rows=1 width=8)
+         Join Filter: (b.id = f.id)
+         ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.02 rows=1 width=8)
+               Filter: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..48.91 rows=2 width=8)
+               Index Cond: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
  Optimizer: Postgres query optimizer
-(13 rows)
+(8 rows)
 
 select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
  id 

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -338,6 +338,10 @@ CREATE TABLE table_with_reversed_index(a int, b bool, c text);
 CREATE INDEX ON table_with_reversed_index(c, a);
 INSERT INTO table_with_reversed_index VALUES (10, true, 'ab');
 
+reset enable_seqscan;
+reset enable_indexscan;
+reset enable_bitmapscan;
+
 --
 -- Then an index only scan should succeed. (i.e. varattno is set up correctly)
 --
@@ -353,3 +357,26 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_indexscan;
 RESET optimizer_enable_indexonlyscan;
+
+--
+-- Enable the index only scan in append only table
+--
+CREATE TABLE bfv_index_only_ao(a int, b int) WITH (appendonly =true);
+CREATE INDEX bfv_index_only_ao_a_b on bfv_index_only_ao(a) include (b);
+
+insert into bfv_index_only_ao select i,i from generate_series(1, 10000) i;
+
+explain select count(*) from bfv_index_only_ao where a < 100;
+select count(*) from bfv_index_only_ao where a < 100;
+explain select count(*) from bfv_index_only_ao where a < 1000;
+select count(*) from bfv_index_only_ao where a < 1000;
+
+CREATE TABLE bfv_index_only_aocs(a int, b int) WITH (appendonly =true, orientation=column);
+CREATE INDEX bfv_index_only_aocs_a_b on bfv_index_only_aocs(a) include (b);
+
+insert into bfv_index_only_aocs select i,i from generate_series(1, 10000) i;
+
+explain select count(*) from bfv_index_only_aocs where a < 100;
+select count(*) from bfv_index_only_aocs where a < 100;
+explain select count(*) from bfv_index_only_aocs where a < 1000;
+select count(*) from bfv_index_only_aocs where a < 1000;


### PR DESCRIPTION
The index scan has disabled on ao/aocs table for that
random access performance on the ao/aocs table is extremely
low. But index only scan does not access data files. Its
performance should be as good as the heap table. So index
only scan should be enable on ao/aocs table.

The san node use eof in aoseg table and visibility map to
exam the visibility of tuples in index. The member variables
lastRowNum and firstRowNum are introduced into AOCSFetchDesc
/ AppendOnlyFetchDesc to describe the range of visible row
numbers. Then use the visibility map to check the visibility
of each tuple.

Another problem we encountered was the poor random access
performance of the visibility map. So we added a bitmap to
record the tuple id range of all the tuples visible.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
