### PR TITLE
Improve partition elimination when indexes are present

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
@@ -416,7 +416,7 @@ select * from x, y where x.i > y.j and y.k = 10;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="499.130120" Rows="1.000000" Width="48"/>
+          <dxl:Cost StartupCost="0" TotalCost="499.130142" Rows="1.000000" Width="48"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -448,7 +448,7 @@ select * from x, y where x.i > y.j and y.k = 10;
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="499.129941" Rows="1.000000" Width="48"/>
+            <dxl:Cost StartupCost="0" TotalCost="499.129963" Rows="1.000000" Width="48"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -538,7 +538,7 @@ select * from x, y where x.i > y.j and y.k = 10;
           </dxl:BroadcastMotion>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.128736" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="68.128758" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="i">
@@ -563,7 +563,31 @@ select * from x, y where x.i > y.j and y.k = 10;
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:Or>
+                  <dxl:And>
+                    <dxl:Not>
+                      <dxl:Or>
+                        <dxl:DefaultPart Level="0"/>
+                        <dxl:Or>
+                          <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                          <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                        </dxl:Or>
+                      </dxl:Or>
+                    </dxl:Not>
+                    <dxl:And>
+                      <dxl:IsNotNull>
+                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                      </dxl:IsNotNull>
+                      <dxl:IsNotNull>
+                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                      </dxl:IsNotNull>
+                    </dxl:And>
+                  </dxl:And>
+                  <dxl:Or>
+                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                  </dxl:Or>
+                </dxl:Or>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -572,12 +596,16 @@ select * from x, y where x.i > y.j and y.k = 10;
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:PropagationExpression>
               <dxl:PrintableFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:Not>
+                  <dxl:IsNull>
+                    <dxl:Ident ColId="12" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:IsNull>
+                </dxl:Not>
               </dxl:PrintableFilter>
             </dxl:PartitionSelector>
             <dxl:DynamicBitmapTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="68.128736" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="68.128758" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="11" Alias="i">
@@ -594,10 +622,16 @@ select * from x, y where x.i > y.j and y.k = 10;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="13" ColName="k" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:Comparison>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="12" ColName="j" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="13" ColName="k" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  </dxl:Comparison>
+                </dxl:And>
               </dxl:Filter>
               <dxl:RecheckCond>
                 <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
@@ -1400,7 +1400,7 @@ ORDER BY 1 asc ;
     <dxl:Plan Id="0" SpaceSize="35">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="24.847656" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="49.447266" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1413,7 +1413,7 @@ ORDER BY 1 asc ;
         </dxl:SortingColumnList>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="23.843750" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="48.443359" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="23"/>
@@ -1426,7 +1426,7 @@ ORDER BY 1 asc ;
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="22.820312" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="47.419922" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1441,7 +1441,7 @@ ORDER BY 1 asc ;
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="21.820312" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="46.419922" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1457,7 +1457,7 @@ ORDER BY 1 asc ;
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="20.816406" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="45.416016" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1477,7 +1477,7 @@ ORDER BY 1 asc ;
                 <dxl:OneTimeFilter/>
                 <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="19.808594" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="44.408203" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -1532,7 +1532,7 @@ ORDER BY 1 asc ;
                   </dxl:BroadcastMotion>
                   <dxl:Sequence>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2.419922" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="27.019531" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="11" Alias="ets">
@@ -1568,7 +1568,7 @@ ORDER BY 1 asc ;
                     </dxl:PartitionSelector>
                     <dxl:DynamicBitmapTableScan PartIndexId="1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2.419922" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="27.019531" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="11" Alias="ets">
@@ -1582,12 +1582,22 @@ ORDER BY 1 asc ;
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                          <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
-                            <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
-                          </dxl:Cast>
-                          <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                        </dxl:Comparison>
+                        <dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                            <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                            <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                            <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                              <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
+                            </dxl:Cast>
+                            <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:And>
                       </dxl:Filter>
                       <dxl:RecheckCond>
                         <dxl:And>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProject.mdp
@@ -59,6 +59,18 @@
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:ColumnStatistics Mdid="1.32977.1.0.3" Name="part_d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1978.1.0"/>
+          <dxl:Opfamily Mdid="0.3027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
       <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
@@ -1597,7 +1609,7 @@
     <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="868.003815" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="868.286653" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="dist_e">
@@ -1629,7 +1641,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="868.003696" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="868.286534" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="dist_e">
@@ -1694,7 +1706,7 @@
           </dxl:TableScan>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="437.001901" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.284739" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="21" Alias="empty_col">
@@ -1717,7 +1729,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="437.001894" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.284732" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="dist_a">
@@ -1742,7 +1754,22 @@
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  <dxl:Or>
+                    <dxl:Or>
+                      <dxl:And>
+                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                        </dxl:Comparison>
+                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                      </dxl:And>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                      </dxl:Comparison>
+                    </dxl:Or>
+                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                  </dxl:Or>
                 </dxl:PartFilters>
                 <dxl:ResidualFilter>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1751,12 +1778,15 @@
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:PropagationExpression>
                 <dxl:PrintableFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="13" ColName="part_d" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  </dxl:Comparison>
                 </dxl:PrintableFilter>
               </dxl:PartitionSelector>
               <dxl:DynamicBitmapTableScan PartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="437.001894" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="437.284732" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="dist_a">
@@ -1773,10 +1803,24 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="1" ColName="f" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
+                  <dxl:And>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="10" ColName="dist_a" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="0" ColName="dist_e" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                      <dxl:Ident ColId="13" ColName="part_d" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="2" ColName="g" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                      <dxl:Ident ColId="13" ColName="part_d" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="1" ColName="f" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:And>
                 </dxl:Filter>
                 <dxl:RecheckCond>
                   <dxl:And>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProjectNoFilt.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProjectNoFilt.mdp
@@ -804,7 +804,7 @@
     <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="499.155821" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="204815.580059" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="dist_e">
@@ -836,7 +836,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="499.155702" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="204815.579940" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="dist_e">
@@ -901,7 +901,7 @@
           </dxl:TableScan>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.138089" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="204384.562327" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="21" Alias="empty_col">
@@ -924,7 +924,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="68.138082" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="204384.562320" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="dist_a">
@@ -963,7 +963,7 @@
               </dxl:PartitionSelector>
               <dxl:DynamicBitmapTableScan PartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="68.138082" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="204384.562320" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="dist_a">
@@ -980,10 +980,16 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="1" ColName="f" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
+                  <dxl:And>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="10" ColName="dist_a" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="0" ColName="dist_e" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="1" ColName="f" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:And>
                 </dxl:Filter>
                 <dxl:RecheckCond>
                   <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
@@ -57,6 +57,18 @@
       <dxl:TraceFlags Value="101013,102029,102046,102048,102053,102054,102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1978.1.0"/>
+          <dxl:Opfamily Mdid="0.3027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
       <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
@@ -1591,7 +1603,7 @@
     <dxl:Plan Id="0" SpaceSize="4">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="868.019317" Rows="100.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="868.302155" Rows="100.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="dist_e">
@@ -1623,7 +1635,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="868.007392" Rows="100.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="868.290230" Rows="100.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="dist_e">
@@ -1688,7 +1700,7 @@
           </dxl:TableScan>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="437.001901" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.284739" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="21" Alias="empty_col">
@@ -1711,7 +1723,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="437.001894" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="437.284732" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="dist_a">
@@ -1736,7 +1748,22 @@
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  <dxl:Or>
+                    <dxl:Or>
+                      <dxl:And>
+                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                        </dxl:Comparison>
+                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                      </dxl:And>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                      </dxl:Comparison>
+                    </dxl:Or>
+                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                  </dxl:Or>
                 </dxl:PartFilters>
                 <dxl:ResidualFilter>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1745,12 +1772,15 @@
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:PropagationExpression>
                 <dxl:PrintableFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="13" ColName="part_d" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  </dxl:Comparison>
                 </dxl:PrintableFilter>
               </dxl:PartitionSelector>
               <dxl:DynamicBitmapTableScan PartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="437.001894" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="437.284732" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="dist_a">
@@ -1767,10 +1797,24 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="1" ColName="f" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
+                  <dxl:And>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="10" ColName="dist_a" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="0" ColName="dist_e" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                      <dxl:Ident ColId="13" ColName="part_d" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="2" ColName="g" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                      <dxl:Ident ColId="13" ColName="part_d" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="1" ColName="f" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:And>
                 </dxl:Filter>
                 <dxl:RecheckCond>
                   <dxl:And>

--- a/src/backend/gporca/data/dxl/minidump/BtreeIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BtreeIndexNLOJWithProject.mdp
@@ -60,6 +60,18 @@
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:ColumnStatistics Mdid="1.33136.1.0.1" Name="f" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.33136.1.0.0" Name="dist_e" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1978.1.0"/>
+          <dxl:Opfamily Mdid="0.3027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
       <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
@@ -406,7 +418,7 @@
     <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="437.000414" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.000922" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="dist_e">
@@ -438,7 +450,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="437.000295" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="437.000802" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="dist_e">
@@ -503,7 +515,7 @@
           </dxl:TableScan>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000205" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000712" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="21" Alias="empty_col">
@@ -526,7 +538,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6.000198" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="6.000706" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="dist_a">
@@ -551,7 +563,22 @@
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  <dxl:Or>
+                    <dxl:Or>
+                      <dxl:And>
+                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                        </dxl:Comparison>
+                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
+                      </dxl:And>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                      </dxl:Comparison>
+                    </dxl:Or>
+                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                  </dxl:Or>
                 </dxl:PartFilters>
                 <dxl:ResidualFilter>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -560,12 +587,15 @@
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:PropagationExpression>
                 <dxl:PrintableFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="13" ColName="part_d" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  </dxl:Comparison>
                 </dxl:PrintableFilter>
               </dxl:PartitionSelector>
               <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6.000198" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6.000706" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="dist_a">
@@ -582,10 +612,24 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="1" ColName="f" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
+                  <dxl:And>
+                    <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                      <dxl:Ident ColId="13" ColName="part_d" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="2" ColName="g" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="10" ColName="dist_a" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="0" ColName="dist_e" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                      <dxl:Ident ColId="13" ColName="part_d" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="1" ColName="f" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:And>
                 </dxl:Filter>
                 <dxl:IndexCondList>
                   <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
@@ -481,7 +481,7 @@ see sql/DynamicBitmapIndexScan.sql
     <dxl:Plan Id="0" SpaceSize="95">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5184.781941" Rows="1.000000" Width="9"/>
+          <dxl:Cost StartupCost="0" TotalCost="5989.546228" Rows="1.000000" Width="9"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="24" Alias="fid">
@@ -492,7 +492,7 @@ see sql/DynamicBitmapIndexScan.sql
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5184.781921" Rows="1.000000" Width="9"/>
+            <dxl:Cost StartupCost="0" TotalCost="5989.546208" Rows="1.000000" Width="9"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="24" Alias="fid">
@@ -607,7 +607,7 @@ see sql/DynamicBitmapIndexScan.sql
           </dxl:RedistributeMotion>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.193481" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="204.384553" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="flex_value_set_id">
@@ -640,7 +640,7 @@ see sql/DynamicBitmapIndexScan.sql
             </dxl:PartitionSelector>
             <dxl:DynamicBitmapTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.193481" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="204.384553" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="flex_value_set_id">
@@ -651,10 +651,16 @@ see sql/DynamicBitmapIndexScan.sql
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
-                  <dxl:Ident ColId="24" ColName="fid" TypeMdid="0.1700.1.0"/>
-                  <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-                </dxl:Comparison>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
+                    <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                    <dxl:Ident ColId="7" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
+                    <dxl:Ident ColId="24" ColName="fid" TypeMdid="0.1700.1.0"/>
+                    <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
+                  </dxl:Comparison>
+                </dxl:And>
               </dxl:Filter>
               <dxl:RecheckCond>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -1298,10 +1298,10 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20095485">
+    <dxl:Plan Id="0" SpaceSize="21244151">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1357145192.816764" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="1357145192.840398" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="26" Alias="cd_gender">
@@ -1312,7 +1312,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1357145192.816761" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="1357145192.840394" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="26" Alias="cd_gender">
@@ -1361,7 +1361,7 @@
           </dxl:BroadcastMotion>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324475.102324" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324475.102347" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -1382,7 +1382,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324475.102318" Rows="1.000000" Width="6"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324475.102341" Rows="1.000000" Width="6"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="c_customer_sk">
@@ -1405,7 +1405,7 @@
               <dxl:LimitOffset/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324475.102318" Rows="1.000000" Width="6"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324475.102341" Rows="1.000000" Width="6"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="c_customer_sk">
@@ -1443,7 +1443,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:HashJoin JoinType="Left">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324475.102186" Rows="2.000000" Width="6"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324475.102209" Rows="2.000000" Width="6"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="c_customer_sk">
@@ -1466,7 +1466,7 @@
                   </dxl:HashCondList>
                   <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="443.002179" Rows="1.000000" Width="5"/>
+                      <dxl:Cost StartupCost="0" TotalCost="443.002202" Rows="1.000000" Width="5"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="c_customer_sk">
@@ -1479,13 +1479,13 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="0" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="443.002163" Rows="1.000000" Width="5"/>
+                        <dxl:Cost StartupCost="0" TotalCost="443.002186" Rows="1.000000" Width="5"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>
@@ -1502,7 +1502,7 @@
                       <dxl:Filter/>
                       <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="443.002155" Rows="1.000000" Width="5"/>
+                          <dxl:Cost StartupCost="0" TotalCost="443.002178" Rows="1.000000" Width="5"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="c_customer_sk">
@@ -1521,7 +1521,7 @@
                         <dxl:LimitOffset/>
                         <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="443.002155" Rows="1.000000" Width="5"/>
+                            <dxl:Cost StartupCost="0" TotalCost="443.002178" Rows="1.000000" Width="5"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="0" Alias="c_customer_sk">
@@ -1534,16 +1534,16 @@
                           <dxl:Filter/>
                           <dxl:SortingColumnList/>
                           <dxl:HashExprList>
-                            <dxl:HashExpr TypeMdid="0.23.1.0">
+                            <dxl:HashExpr>
                               <dxl:Ident ColId="0" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
                             </dxl:HashExpr>
-                            <dxl:HashExpr TypeMdid="0.16.1.0">
+                            <dxl:HashExpr>
                               <dxl:Ident ColId="193" ColName="ColRef_0193" TypeMdid="0.16.1.0"/>
                             </dxl:HashExpr>
                           </dxl:HashExprList>
                           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="443.002147" Rows="1.000000" Width="5"/>
+                              <dxl:Cost StartupCost="0" TotalCost="443.002170" Rows="1.000000" Width="5"/>
                             </dxl:Properties>
                             <dxl:GroupingColumns>
                               <dxl:GroupingColumn ColId="0"/>
@@ -1560,7 +1560,7 @@
                             <dxl:Filter/>
                             <dxl:Sort SortDiscardDuplicates="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="443.002143" Rows="2.000000" Width="5"/>
+                                <dxl:Cost StartupCost="0" TotalCost="443.002166" Rows="2.000000" Width="5"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="0" Alias="c_customer_sk">
@@ -1579,7 +1579,7 @@
                               <dxl:LimitOffset/>
                               <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="443.002143" Rows="2.000000" Width="5"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="443.002166" Rows="2.000000" Width="5"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="0" Alias="c_customer_sk">
@@ -1593,7 +1593,7 @@
                                 <dxl:SortingColumnList/>
                                 <dxl:HashJoin JoinType="Left">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="443.002117" Rows="2.000000" Width="5"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="443.002140" Rows="2.000000" Width="5"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="0" Alias="c_customer_sk">
@@ -1636,7 +1636,7 @@
                                   </dxl:TableScan>
                                   <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="12.001555" Rows="1.000000" Width="5"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="12.001578" Rows="1.000000" Width="5"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="45" Alias="ws_bill_customer_sk">
@@ -1649,13 +1649,13 @@
                                     <dxl:Filter/>
                                     <dxl:SortingColumnList/>
                                     <dxl:HashExprList>
-                                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                                      <dxl:HashExpr>
                                         <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
                                       </dxl:HashExpr>
                                     </dxl:HashExprList>
                                     <dxl:Result>
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="12.001547" Rows="1.000000" Width="5"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="12.001570" Rows="1.000000" Width="5"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
                                         <dxl:ProjElem ColId="45" Alias="ws_bill_customer_sk">
@@ -1669,7 +1669,7 @@
                                       <dxl:OneTimeFilter/>
                                       <dxl:Result>
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="12.001547" Rows="1.000000" Width="5"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="12.001570" Rows="1.000000" Width="5"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
                                           <dxl:ProjElem ColId="193" Alias="ColRef_0193">
@@ -1683,7 +1683,7 @@
                                         <dxl:OneTimeFilter/>
                                         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="12.001546" Rows="1.000000" Width="4"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="12.001569" Rows="1.000000" Width="4"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
                                             <dxl:ProjElem ColId="45" Alias="ws_bill_customer_sk">
@@ -1791,9 +1791,12 @@
                                           </dxl:BroadcastMotion>
                                           <dxl:Sequence>
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="6.000441" Rows="1.000000" Width="4"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="6.000441" Rows="1.000000" Width="8"/>
                                             </dxl:Properties>
                                             <dxl:ProjList>
+                                              <dxl:ProjElem ColId="41" Alias="ws_sold_date_sk">
+                                                <dxl:Ident ColId="41" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                              </dxl:ProjElem>
                                               <dxl:ProjElem ColId="45" Alias="ws_bill_customer_sk">
                                                 <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
                                               </dxl:ProjElem>
@@ -1807,7 +1810,31 @@
                                                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                               </dxl:PartEqFilters>
                                               <dxl:PartFilters>
-                                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                                <dxl:Or>
+                                                  <dxl:And>
+                                                    <dxl:Not>
+                                                      <dxl:Or>
+                                                        <dxl:DefaultPart Level="0"/>
+                                                        <dxl:Or>
+                                                          <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                                                          <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                                                        </dxl:Or>
+                                                      </dxl:Or>
+                                                    </dxl:Not>
+                                                    <dxl:And>
+                                                      <dxl:IsNotNull>
+                                                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                                                      </dxl:IsNotNull>
+                                                      <dxl:IsNotNull>
+                                                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                                                      </dxl:IsNotNull>
+                                                    </dxl:And>
+                                                  </dxl:And>
+                                                  <dxl:Or>
+                                                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                                                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                                                  </dxl:Or>
+                                                </dxl:Or>
                                               </dxl:PartFilters>
                                               <dxl:ResidualFilter>
                                                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1816,14 +1843,21 @@
                                                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                                               </dxl:PropagationExpression>
                                               <dxl:PrintableFilter>
-                                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                                <dxl:Not>
+                                                  <dxl:IsNull>
+                                                    <dxl:Ident ColId="41" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                                  </dxl:IsNull>
+                                                </dxl:Not>
                                               </dxl:PrintableFilter>
                                             </dxl:PartitionSelector>
                                             <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="6.000441" Rows="1.000000" Width="4"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="6.000441" Rows="1.000000" Width="8"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
+                                                <dxl:ProjElem ColId="41" Alias="ws_sold_date_sk">
+                                                  <dxl:Ident ColId="41" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
                                                 <dxl:ProjElem ColId="45" Alias="ws_bill_customer_sk">
                                                   <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
                                                 </dxl:ProjElem>
@@ -1880,7 +1914,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>

--- a/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
@@ -825,7 +825,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="35">
+    <dxl:Plan Id="0" SpaceSize="36">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="635.393021" Rows="22.230000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable.mdp
@@ -547,7 +547,7 @@ SELECT * FROM s i1, t t2 where t2.c2 = i1.c2 and t2.c1 > 10;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="437.001192" Rows="1.000000" Width="58"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.001258" Rows="1.000000" Width="58"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="c1">
@@ -597,7 +597,7 @@ SELECT * FROM s i1, t t2 where t2.c2 = i1.c2 and t2.c1 > 10;
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="437.000976" Rows="1.000000" Width="58"/>
+            <dxl:Cost StartupCost="0" TotalCost="437.001041" Rows="1.000000" Width="58"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="c1">
@@ -726,7 +726,7 @@ SELECT * FROM s i1, t t2 where t2.c2 = i1.c2 and t2.c1 > 10;
           </dxl:BroadcastMotion>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000420" Rows="1.000000" Width="33"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000485" Rows="1.000000" Width="33"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="14" Alias="c1">
@@ -783,7 +783,7 @@ SELECT * FROM s i1, t t2 where t2.c2 = i1.c2 and t2.c1 > 10;
             </dxl:PartitionSelector>
             <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6.000420" Rows="1.000000" Width="33"/>
+                <dxl:Cost StartupCost="0" TotalCost="6.000485" Rows="1.000000" Width="33"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="14" Alias="c1">
@@ -809,10 +809,16 @@ SELECT * FROM s i1, t t2 where t2.c2 = i1.c2 and t2.c1 > 10;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                  <dxl:Ident ColId="14" ColName="c1" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:Comparison>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                    <dxl:Ident ColId="15" ColName="c2" TypeMdid="0.25.1.0"/>
+                    <dxl:Ident ColId="1" ColName="c2" TypeMdid="0.25.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                    <dxl:Ident ColId="14" ColName="c1" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  </dxl:Comparison>
+                </dxl:And>
               </dxl:Filter>
               <dxl:IndexCondList>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable2.mdp
@@ -406,7 +406,7 @@ select * from bar, (select * from foo where foo.a in (select h.a from bar h, bar
     <dxl:Plan Id="0" SpaceSize="22893">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324469.354152" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324469.354209" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -426,7 +426,7 @@ select * from bar, (select * from foo where foo.a in (select h.a from bar h, bar
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="In">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324469.354092" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324469.354150" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -452,7 +452,7 @@ select * from bar, (select * from foo where foo.a in (select h.a from bar h, bar
           </dxl:HashCondList>
           <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="437.000386" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.000444" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-IncompletePDS-3-DistCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-IncompletePDS-3-DistCols.mdp
@@ -1,0 +1,562 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Nested index loop join in which we have a select node but don't
+               manage to create a complete distribution spec for the outer.
+
+    drop table if exists foo, bar;
+    create table foo(a int, b int, c int, d int, e int) distributed by(a,b,c);
+    create table bar(a int, b int, c int, d int, e int) distributed by(a,b,c);
+
+    create index bar_ixb on bar(b);
+
+    set optimizer_enable_hashjoin to off;
+    set optimizer_enumerate_plans = on;
+
+    Look for an index join plan with a broadcast on the outer, since we can't
+    generate a matching distribution spec for the outer table, foo.
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="101013,102029,102046,102048,102053,102054,102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.409636.1.0.3" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.409636.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.409633.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.409633.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.409633.1.0" Name="foo" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.409633.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0,1,2" Keys="11,5" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="e" Attno="5" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.409636.1.0" Name="bar" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.409636.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0,1,2" Keys="11,5" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="e" Attno="5" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="0.409651.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Index Mdid="0.409651.1.0" Name="bar_ixb" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:ColumnStatistics Mdid="1.409636.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.409636.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.409633.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="4" ColName="d" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="5" ColName="e" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="13" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="14" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="15" ColName="c" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="16" ColName="d" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="17" ColName="e" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:And>
+          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+            <dxl:Ident ColId="15" ColName="c" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="16" ColName="d" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="11"/>
+          </dxl:Comparison>
+        </dxl:And>
+        <dxl:LogicalJoin JoinType="Inner">
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.409633.1.0" TableName="foo">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="5" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.409636.1.0" TableName="bar">
+              <dxl:Columns>
+                <dxl:Column ColId="13" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="5" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="19" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="20" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="21" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="22" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:And>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="13" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="14" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:LogicalJoin>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="3">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="437.000760" Rows="1.000000" Width="40"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="3" Alias="d">
+            <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="4" Alias="e">
+            <dxl:Ident ColId="4" ColName="e" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="12" Alias="a">
+            <dxl:Ident ColId="12" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="13" Alias="b">
+            <dxl:Ident ColId="13" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="14" Alias="c">
+            <dxl:Ident ColId="14" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="15" Alias="d">
+            <dxl:Ident ColId="15" ColName="d" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="16" Alias="e">
+            <dxl:Ident ColId="16" ColName="e" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="437.000611" Rows="1.000000" Width="40"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="3" Alias="d">
+              <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="4" Alias="e">
+              <dxl:Ident ColId="4" ColName="e" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="12" Alias="a">
+              <dxl:Ident ColId="12" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="13" Alias="b">
+              <dxl:Ident ColId="13" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="14" Alias="c">
+              <dxl:Ident ColId="14" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="15" Alias="d">
+              <dxl:Ident ColId="15" ColName="d" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="16" Alias="e">
+              <dxl:Ident ColId="16" ColName="e" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
+          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000380" Rows="3.000000" Width="20"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="c">
+                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="3" Alias="d">
+                <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="4" Alias="e">
+                <dxl:Ident ColId="4" ColName="e" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="20"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="c">
+                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="3" Alias="d">
+                  <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="4" Alias="e">
+                  <dxl:Ident ColId="4" ColName="e" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.409633.1.0" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="5" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:BroadcastMotion>
+          <dxl:IndexScan IndexScanDirection="Forward">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="6.000172" Rows="1.000000" Width="20"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="12" Alias="a">
+                <dxl:Ident ColId="12" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="13" Alias="b">
+                <dxl:Ident ColId="13" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="c">
+                <dxl:Ident ColId="14" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="d">
+                <dxl:Ident ColId="15" ColName="d" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="e">
+                <dxl:Ident ColId="16" ColName="e" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:And>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="12" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                  <dxl:Ident ColId="14" ColName="c" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="15" ColName="d" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="11"/>
+                </dxl:Comparison>
+              </dxl:And>
+            </dxl:Filter>
+            <dxl:IndexCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="13" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:IndexCondList>
+            <dxl:IndexDescriptor Mdid="0.409651.1.0" IndexName="bar_ixb"/>
+            <dxl:TableDescriptor Mdid="0.409636.1.0" TableName="bar">
+              <dxl:Columns>
+                <dxl:Column ColId="12" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="5" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:IndexScan>
+          <dxl:NLJIndexParamList>
+            <dxl:NLJIndexParam ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:NLJIndexParam ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:NLJIndexParamList>
+        </dxl:NestedLoopJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-IncompletePDS-3-DistCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-IncompletePDS-3-DistCols.mdp
@@ -13,6 +13,10 @@
     set optimizer_enable_hashjoin to off;
     set optimizer_enumerate_plans = on;
 
+    select *
+    from foo join bar on foo.a=bar.a and foo.b=bar.b
+    where bar.c > 10 and bar.d = 11;
+
     Look for an index join plan with a broadcast on the outer, since we can't
     generate a matching distribution spec for the outer table, foo.
   ]]>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
@@ -583,7 +583,7 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
     <dxl:Plan Id="0" SpaceSize="15">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="12.001188" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="12.001227" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="j">
@@ -594,7 +594,7 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="12.001170" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="12.001209" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="j">
@@ -693,9 +693,13 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
           </dxl:BroadcastMotion>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000152" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000152" Rows="1.000000" Width="8"/>
             </dxl:Properties>
-            <dxl:ProjList/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="i">
+                <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
             <dxl:PartitionSelector RelationMdid="0.41880825.1.1" PartitionLevels="1" ScanId="2">
               <dxl:Properties>
                 <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
@@ -705,7 +709,31 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:Or>
+                  <dxl:And>
+                    <dxl:Not>
+                      <dxl:Or>
+                        <dxl:DefaultPart Level="0"/>
+                        <dxl:Or>
+                          <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                          <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                        </dxl:Or>
+                      </dxl:Or>
+                    </dxl:Not>
+                    <dxl:And>
+                      <dxl:IsNotNull>
+                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
+                      </dxl:IsNotNull>
+                      <dxl:IsNotNull>
+                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
+                      </dxl:IsNotNull>
+                    </dxl:And>
+                  </dxl:And>
+                  <dxl:Or>
+                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
+                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
+                  </dxl:Or>
+                </dxl:Or>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -714,14 +742,22 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
               </dxl:PropagationExpression>
               <dxl:PrintableFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:Not>
+                  <dxl:IsNull>
+                    <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:IsNull>
+                </dxl:Not>
               </dxl:PrintableFilter>
             </dxl:PartitionSelector>
             <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6.000152" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="6.000152" Rows="1.000000" Width="8"/>
               </dxl:Properties>
-              <dxl:ProjList/>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="10" Alias="i">
+                  <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
               <dxl:Filter/>
               <dxl:IndexCondList>
                 <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartResolverExpand.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartResolverExpand.mdp
@@ -593,7 +593,7 @@ select count(*) from x, y where (x.i > y.j AND x.j <= y.i);
     <dxl:Plan Id="0" SpaceSize="7">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="491.039538" Rows="1.000000" Width="214"/>
+          <dxl:Cost StartupCost="0" TotalCost="491.048021" Rows="1.000000" Width="214"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -625,7 +625,7 @@ select count(*) from x, y where (x.i > y.j AND x.j <= y.i);
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="491.038577" Rows="1.000000" Width="214"/>
+            <dxl:Cost StartupCost="0" TotalCost="491.047060" Rows="1.000000" Width="214"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -715,7 +715,7 @@ select count(*) from x, y where (x.i > y.j AND x.j <= y.i);
           </dxl:BroadcastMotion>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="60.001174" Rows="1.000000" Width="82"/>
+              <dxl:Cost StartupCost="0" TotalCost="60.009658" Rows="1.000000" Width="82"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="i">
@@ -754,7 +754,7 @@ select count(*) from x, y where (x.i > y.j AND x.j <= y.i);
             </dxl:PartitionSelector>
             <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="60.001174" Rows="1.000000" Width="82"/>
+                <dxl:Cost StartupCost="0" TotalCost="60.009658" Rows="1.000000" Width="82"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="11" Alias="i">
@@ -771,10 +771,16 @@ select count(*) from x, y where (x.i > y.j AND x.j <= y.i);
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.665.1.0">
-                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.25.1.0"/>
-                  <dxl:Ident ColId="11" ColName="i" TypeMdid="0.25.1.0"/>
-                </dxl:Comparison>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.664.1.0">
+                    <dxl:Ident ColId="12" ColName="j" TypeMdid="0.25.1.0"/>
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.25.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.665.1.0">
+                    <dxl:Ident ColId="1" ColName="j" TypeMdid="0.25.1.0"/>
+                    <dxl:Ident ColId="11" ColName="i" TypeMdid="0.25.1.0"/>
+                  </dxl:Comparison>
+                </dxl:And>
               </dxl:Filter>
               <dxl:IndexCondList>
                 <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.664.1.0">

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartTable.mdp
@@ -1401,7 +1401,7 @@ ORDER BY 1 asc ;
     <dxl:Plan Id="0" SpaceSize="35">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="24.979036" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="380.525391" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1414,7 +1414,7 @@ ORDER BY 1 asc ;
         </dxl:SortingColumnList>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="23.975130" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="379.521484" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="23"/>
@@ -1427,7 +1427,7 @@ ORDER BY 1 asc ;
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="22.951693" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="378.498047" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1442,7 +1442,7 @@ ORDER BY 1 asc ;
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="21.951693" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="377.498047" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1458,7 +1458,7 @@ ORDER BY 1 asc ;
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="20.947786" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="376.494141" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1478,7 +1478,7 @@ ORDER BY 1 asc ;
                 <dxl:OneTimeFilter/>
                 <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="19.939974" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="375.486328" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -1533,11 +1533,17 @@ ORDER BY 1 asc ;
                   </dxl:BroadcastMotion>
                   <dxl:Sequence>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2.551302" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="358.097656" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
+                      <dxl:ProjElem ColId="11" Alias="ets">
+                        <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="12" Alias="sym">
                         <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="15" Alias="end_ts">
+                        <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:PartitionSelector RelationMdid="0.16166659.1.1" PartitionLevels="1" ScanId="1">
@@ -1563,20 +1569,36 @@ ORDER BY 1 asc ;
                     </dxl:PartitionSelector>
                     <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2.551302" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="358.097656" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
+                        <dxl:ProjElem ColId="11" Alias="ets">
+                          <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="12" Alias="sym">
                           <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="15" Alias="end_ts">
+                          <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                          <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
-                            <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
-                          </dxl:Cast>
-                          <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                        </dxl:Comparison>
+                        <dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                            <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                            <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                            <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                              <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
+                            </dxl:Cast>
+                            <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:And>
                       </dxl:Filter>
                       <dxl:IndexCondList>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">

--- a/src/backend/gporca/data/dxl/minidump/IndexedNLJBitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexedNLJBitmap.mdp
@@ -363,7 +363,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="499.127705" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="635.382908" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -383,7 +383,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="499.127645" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="635.382848" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -466,7 +466,7 @@
           </dxl:Sequence>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127570" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="204.382710" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="c">
@@ -499,7 +499,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicBitmapTableScan PartIndexId="2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="68.127570" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="204.382710" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
@@ -4,6 +4,7 @@
     Test case: Test CXformLeftOuterJoin2DynamicBitmapIndexGetApply, for
                index left outer joins on bitmap indexes on partitioned tables
                
+    drop table if exists touter, tinner;
     create table touter(a int, b int)
       distributed by (a);
     create table tinner(a int, b int)
@@ -15,6 +16,7 @@
 
     create index tinner_ix on tinner using bitmap(a);
 
+    set optimizer_enable_hashjoin = off;
     set optimizer_enumerate_plans = on;
 
     explain
@@ -42,17 +44,17 @@
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
-      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
         <dxl:CostParams>
           <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
       <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
-      <dxl:TraceFlags Value="101013,102074,102113,102120,102146,102147,103001,103014,103015,103022,103027,103029,104003,104004,104005,105000"/>
+      <dxl:TraceFlags Value="101013,102029,102046,102048,102053,102054,102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true">
+      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
@@ -61,27 +63,12 @@
         <dxl:InverseOp Mdid="0.97.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.3027.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.27660.1.0" Name="tinner_ix_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
-        <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.3027.1.0"/>
-        </dxl:Opfamilies>
-        <dxl:PartConstraint DefaultPartition="" Unbounded="false">
-          <dxl:And>
-            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-            </dxl:Comparison>
-            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
-            </dxl:Comparison>
-          </dxl:And>
-        </dxl:PartConstraint>
-      </dxl:Index>
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -96,7 +83,9 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
         <dxl:EqualityOp Mdid="0.96.1.0"/>
         <dxl:InequalityOp Mdid="0.518.1.0"/>
         <dxl:LessThanOp Mdid="0.97.1.0"/>
@@ -111,7 +100,9 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
         <dxl:LessThanOp Mdid="0.609.1.0"/>
@@ -126,7 +117,9 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
         <dxl:EqualityOp Mdid="0.387.1.0"/>
         <dxl:InequalityOp Mdid="0.402.1.0"/>
         <dxl:LessThanOp Mdid="0.2799.1.0"/>
@@ -141,64 +134,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.385.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1012.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1011.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:ColumnStatistics Mdid="1.27644.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
-        <dxl:LeftType Mdid="0.23.1.0"/>
-        <dxl:RightType Mdid="0.23.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.65.1.0"/>
-        <dxl:Commutator Mdid="0.96.1.0"/>
-        <dxl:InverseOp Mdid="0.518.1.0"/>
-        <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.1977.1.0"/>
-          <dxl:Opfamily Mdid="0.3027.1.0"/>
-        </dxl:Opfamilies>
-      </dxl:GPDBScalarOp>
-      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
-        <dxl:LeftType Mdid="0.23.1.0"/>
-        <dxl:RightType Mdid="0.23.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.66.1.0"/>
-        <dxl:Commutator Mdid="0.521.1.0"/>
-        <dxl:InverseOp Mdid="0.525.1.0"/>
-        <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.3027.1.0"/>
-        </dxl:Opfamilies>
-      </dxl:GPDBScalarOp>
-      <dxl:ColumnStatistics Mdid="1.27641.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+      <dxl:ColumnStatistics Mdid="1.417825.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.111111" DistinctValues="1.111111">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
@@ -236,8 +172,40 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:RelationStatistics Mdid="2.27641.1.0" Name="touter" Rows="10.000000" EmptyRelation="false"/>
-      <dxl:Relation Mdid="0.27641.1.0" Name="touter" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.417825.1.0" Name="touter" Rows="10.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.417825.1.0" Name="touter" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -270,9 +238,12 @@
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:RelationStatistics Mdid="2.27644.1.0" Name="tinner" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.27644.1.0" Name="tinner" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="2">
+      <dxl:RelationStatistics Mdid="2.417828.1.0" Name="tinner" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.417828.1.0" Name="tinner" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="2">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -303,10 +274,13 @@
           </dxl:Column>
         </dxl:Columns>
         <dxl:IndexInfoList>
-          <dxl:IndexInfo Mdid="0.27660.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="0.417854.1.0" IsPartial="false"/>
         </dxl:IndexInfoList>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
         <dxl:PartConstraint DefaultPartition="" Unbounded="false">
           <dxl:And>
             <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
@@ -320,6 +294,52 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.417828.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Index Mdid="0.417854.1.0" Name="tinner_1_prt_1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+        <dxl:PartConstraint DefaultPartition="" Unbounded="false">
+          <dxl:And>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Index>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -331,7 +351,7 @@
       <dxl:CTEList/>
       <dxl:LogicalJoin JoinType="Left">
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.27641.1.0" TableName="touter">
+          <dxl:TableDescriptor Mdid="0.417825.1.0" TableName="touter">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -346,7 +366,7 @@
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.27644.1.0" TableName="tinner">
+          <dxl:TableDescriptor Mdid="0.417828.1.0" TableName="tinner">
             <dxl:Columns>
               <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -366,10 +386,10 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="499.128496" Rows="10.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2474.828730" Rows="10.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -387,9 +407,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
+        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="499.127900" Rows="10.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2474.828134" Rows="10.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -422,7 +442,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.27641.1.0" TableName="touter">
+            <dxl:TableDescriptor Mdid="0.417825.1.0" TableName="touter">
               <dxl:Columns>
                 <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -438,7 +458,7 @@
           </dxl:TableScan>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127570" Rows="0.100000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="2043.827104" Rows="0.100000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -448,7 +468,7 @@
                 <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:PartitionSelector RelationMdid="0.27644.1.0" PartitionLevels="1" ScanId="1">
+            <dxl:PartitionSelector RelationMdid="0.417828.1.0" PartitionLevels="1" ScanId="1">
               <dxl:Properties>
                 <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
               </dxl:Properties>
@@ -471,7 +491,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicBitmapTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="68.127570" Rows="0.100000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="2043.827104" Rows="0.100000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="a">
@@ -495,9 +515,9 @@
                     <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:Comparison>
                 </dxl:IndexCondList>
-                <dxl:IndexDescriptor Mdid="0.27660.1.0" IndexName="tinner_ix_1_prt_1"/>
+                <dxl:IndexDescriptor Mdid="0.417854.1.0" IndexName="tinner_1_prt_1_a_idx"/>
               </dxl:BitmapIndexProbe>
-              <dxl:TableDescriptor Mdid="0.27644.1.0" TableName="tinner">
+              <dxl:TableDescriptor Mdid="0.417828.1.0" TableName="tinner">
                 <dxl:Columns>
                   <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                   <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -512,6 +532,9 @@
               </dxl:TableDescriptor>
             </dxl:DynamicBitmapTableScan>
           </dxl:Sequence>
+          <dxl:NLJIndexParamList>
+            <dxl:NLJIndexParam ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:NLJIndexParamList>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
@@ -5,6 +5,7 @@
                index left outer joins on btree indexes on partitioned tables
                with an additional selection predicate
                
+    drop table if exists touter, tinner;
     create table touter(a int, b int)
       distributed by (a);
     create table tinner(a int, b int)
@@ -16,6 +17,7 @@
 
     create index tinner_ix on tinner using bitmap(a);
 
+    set optimizer_enable_hashjoin = off;
     set optimizer_enumerate_plans = on;
 
     explain
@@ -42,17 +44,17 @@
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
-      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
         <dxl:CostParams>
           <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
       <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
-      <dxl:TraceFlags Value="101013,102074,102113,102120,102146,102147,103001,103014,103015,103022,103027,103029,104003,104004,104005,105000"/>
+      <dxl:TraceFlags Value="101013,102029,102046,102048,102053,102054,102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true">
+      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
@@ -61,10 +63,12 @@
         <dxl:InverseOp Mdid="0.97.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.3027.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -79,7 +83,9 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
         <dxl:EqualityOp Mdid="0.96.1.0"/>
         <dxl:InequalityOp Mdid="0.518.1.0"/>
         <dxl:LessThanOp Mdid="0.97.1.0"/>
@@ -94,7 +100,9 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
         <dxl:LessThanOp Mdid="0.609.1.0"/>
@@ -109,7 +117,9 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
         <dxl:EqualityOp Mdid="0.387.1.0"/>
         <dxl:InequalityOp Mdid="0.402.1.0"/>
         <dxl:LessThanOp Mdid="0.2799.1.0"/>
@@ -124,7 +134,8 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
         <dxl:InequalityOp Mdid="0.0.0.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
@@ -139,7 +150,8 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
         <dxl:EqualityOp Mdid="0.352.1.0"/>
         <dxl:InequalityOp Mdid="0.0.0.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
@@ -154,43 +166,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:RelationStatistics Mdid="2.27686.1.0" Name="touter" Rows="10.000000" EmptyRelation="false"/>
-      <dxl:Relation Mdid="0.27686.1.0" Name="touter" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
-      <dxl:RelationStatistics Mdid="2.27689.1.0" Name="tinner" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:ColumnStatistics Mdid="1.27686.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+      <dxl:ColumnStatistics Mdid="1.417862.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.111111" DistinctValues="1.111111">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
           <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
@@ -228,7 +204,46 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Relation Mdid="0.27689.1.0" Name="tinner" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="2">
+      <dxl:RelationStatistics Mdid="2.417862.1.0" Name="touter" Rows="10.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.417862.1.0" Name="touter" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.417865.1.0" Name="tinner" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.417865.1.0" Name="tinner" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="2">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -259,10 +274,13 @@
           </dxl:Column>
         </dxl:Columns>
         <dxl:IndexInfoList>
-          <dxl:IndexInfo Mdid="0.27705.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="0.417881.1.0" IsPartial="false"/>
         </dxl:IndexInfoList>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
         <dxl:PartConstraint DefaultPartition="" Unbounded="false">
           <dxl:And>
             <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
@@ -276,9 +294,9 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.27705.1.0" Name="tinner_ix_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.417881.1.0" Name="tinner_1_prt_1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.3027.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>
         <dxl:PartConstraint DefaultPartition="" Unbounded="false">
           <dxl:And>
@@ -293,23 +311,9 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Index>
-      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:ColumnStatistics Mdid="1.27689.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.27689.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
-        <dxl:LeftType Mdid="0.23.1.0"/>
-        <dxl:RightType Mdid="0.23.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.65.1.0"/>
-        <dxl:Commutator Mdid="0.96.1.0"/>
-        <dxl:InverseOp Mdid="0.518.1.0"/>
-        <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.1977.1.0"/>
-          <dxl:Opfamily Mdid="0.3027.1.0"/>
-        </dxl:Opfamilies>
-      </dxl:GPDBScalarOp>
-      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+      <dxl:ColumnStatistics Mdid="1.417865.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.417865.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
@@ -318,7 +322,23 @@
         <dxl:InverseOp Mdid="0.525.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.3027.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
     </dxl:Metadata>
@@ -332,7 +352,7 @@
       <dxl:CTEList/>
       <dxl:LogicalJoin JoinType="Left">
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.27686.1.0" TableName="touter">
+          <dxl:TableDescriptor Mdid="0.417862.1.0" TableName="touter">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -347,7 +367,7 @@
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.27689.1.0" TableName="tinner">
+          <dxl:TableDescriptor Mdid="0.417865.1.0" TableName="tinner">
             <dxl:Columns>
               <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -373,10 +393,10 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="499.128549" Rows="10.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2474.829059" Rows="10.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -394,9 +414,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
+        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="499.127953" Rows="10.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2474.828463" Rows="10.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -429,7 +449,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.27686.1.0" TableName="touter">
+            <dxl:TableDescriptor Mdid="0.417862.1.0" TableName="touter">
               <dxl:Columns>
                 <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -445,7 +465,7 @@
           </dxl:TableScan>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="68.127631" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="2043.828141" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -455,7 +475,7 @@
                 <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:PartitionSelector RelationMdid="0.27689.1.0" PartitionLevels="1" ScanId="1">
+            <dxl:PartitionSelector RelationMdid="0.417865.1.0" PartitionLevels="1" ScanId="1">
               <dxl:Properties>
                 <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
               </dxl:Properties>
@@ -481,7 +501,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicBitmapTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="68.127631" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="2043.828141" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="a">
@@ -492,10 +512,16 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:Comparison>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  </dxl:Comparison>
+                </dxl:And>
               </dxl:Filter>
               <dxl:RecheckCond>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
@@ -510,9 +536,9 @@
                     <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:Comparison>
                 </dxl:IndexCondList>
-                <dxl:IndexDescriptor Mdid="0.27705.1.0" IndexName="tinner_ix_1_prt_1"/>
+                <dxl:IndexDescriptor Mdid="0.417881.1.0" IndexName="tinner_1_prt_1_a_idx"/>
               </dxl:BitmapIndexProbe>
-              <dxl:TableDescriptor Mdid="0.27689.1.0" TableName="tinner">
+              <dxl:TableDescriptor Mdid="0.417865.1.0" TableName="tinner">
                 <dxl:Columns>
                   <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                   <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -527,6 +553,9 @@
               </dxl:TableDescriptor>
             </dxl:DynamicBitmapTableScan>
           </dxl:Sequence>
+          <dxl:NLJIndexParamList>
+            <dxl:NLJIndexParam ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:NLJIndexParamList>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndex.mdp
@@ -367,7 +367,7 @@
     <dxl:Plan Id="0" SpaceSize="6">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="491.001027" Rows="10.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="491.004667" Rows="10.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -387,7 +387,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="491.000431" Rows="10.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="491.004071" Rows="10.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -436,7 +436,7 @@
           </dxl:TableScan>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="60.000101" Rows="0.100000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="60.003041" Rows="0.100000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -469,7 +469,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="60.000101" Rows="0.100000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="60.003041" Rows="0.100000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndexWithSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndexWithSelect.mdp
@@ -378,7 +378,7 @@
     <dxl:Plan Id="0" SpaceSize="6">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="491.001080" Rows="10.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="491.004996" Rows="10.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -398,7 +398,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="491.000484" Rows="10.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="491.004400" Rows="10.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -447,7 +447,7 @@
           </dxl:TableScan>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="60.000162" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="60.004077" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -483,7 +483,7 @@
             </dxl:PartitionSelector>
             <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="60.000162" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="60.004077" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="a">
@@ -494,10 +494,16 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:Comparison>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  </dxl:Comparison>
+                </dxl:And>
               </dxl:Filter>
               <dxl:IndexCondList>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
@@ -355,7 +355,7 @@
     <dxl:Plan Id="0" SpaceSize="13">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="437.000791" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.000687" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -378,7 +378,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="437.000522" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="437.000597" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -401,9 +401,9 @@
           <dxl:JoinFilter>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
           </dxl:JoinFilter>
-          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000155" Rows="3.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -415,11 +415,6 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
             <dxl:TableScan>
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="8"/>
@@ -447,7 +442,7 @@
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>
-          </dxl:RedistributeMotion>
+          </dxl:BroadcastMotion>
           <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="6.000409" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/NewBtreeIndexScanCost.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NewBtreeIndexScanCost.mdp
@@ -4175,7 +4175,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="556.843582" Rows="12606.449785" Width="156"/>
+          <dxl:Cost StartupCost="0" TotalCost="555.842504" Rows="12606.449785" Width="156"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -4252,7 +4252,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="549.514696" Rows="12606.449785" Width="156"/>
+            <dxl:Cost StartupCost="0" TotalCost="548.513619" Rows="12606.449785" Width="156"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecHashed.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecHashed.h
@@ -233,9 +233,9 @@ public:
 	BOOL HasCompleteEquivSpec(CMemoryPool *mp);
 
 	// use given predicates to complete an incomplete spec, if possible
-	static CDistributionSpecHashed *CompleteEquivSpec(
+	static CDistributionSpecHashed *TryToCompleteEquivSpec(
 		CMemoryPool *mp, CDistributionSpecHashed *pdshashed,
-		CExpression *pexprPred);
+		CExpression *pexprPred, CColRefSet *outerRefs);
 };	// class CDistributionSpecHashed
 
 }  // namespace gpopt

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalIndexApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalIndexApply.h
@@ -29,7 +29,7 @@ protected:
 	// is this an outer join?
 	BOOL m_fOuterJoin;
 
-	// a copy of the original join predicate that is now pushed down to the inner side
+	// a copy of the original join predicate that has been pushed down to the inner side
 	CExpression *m_origJoinPred;
 
 public:

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalIndexApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalIndexApply.h
@@ -29,10 +29,13 @@ protected:
 	// is this an outer join?
 	BOOL m_fOuterJoin;
 
+	// a copy of the original join predicate that is now pushed down to the inner side
+	CExpression *m_origJoinPred;
+
 public:
 	// ctor
 	CLogicalIndexApply(CMemoryPool *mp, CColRefArray *pdrgpcrOuterRefs,
-					   BOOL fOuterJoin);
+					   BOOL fOuterJoin, CExpression *origJoinPred);
 
 	// ctor for patterns
 	explicit CLogicalIndexApply(CMemoryPool *mp);
@@ -66,6 +69,12 @@ public:
 	FouterJoin() const
 	{
 		return m_fOuterJoin;
+	}
+
+	CExpression *
+	OrigJoinPred()
+	{
+		return m_origJoinPred;
 	}
 
 	//-------------------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalInnerIndexNLJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalInnerIndexNLJoin.h
@@ -30,12 +30,16 @@ private:
 	// columns from outer child used for index lookup in inner child
 	CColRefArray *m_pdrgpcrOuterRefs;
 
+	// a copy of the original join predicate that is now pushed down to the inner side
+	CExpression *m_origJoinPred;
+
 	// private copy ctor
 	CPhysicalInnerIndexNLJoin(const CPhysicalInnerIndexNLJoin &);
 
 public:
 	// ctor
-	CPhysicalInnerIndexNLJoin(CMemoryPool *mp, CColRefArray *colref_array);
+	CPhysicalInnerIndexNLJoin(CMemoryPool *mp, CColRefArray *colref_array,
+							  CExpression *origJoinPred);
 
 	// dtor
 	virtual ~CPhysicalInnerIndexNLJoin();
@@ -87,6 +91,12 @@ public:
 		GPOS_ASSERT(EopPhysicalInnerIndexNLJoin == pop->Eopid());
 
 		return dynamic_cast<CPhysicalInnerIndexNLJoin *>(pop);
+	}
+
+	CExpression *
+	OrigJoinPred()
+	{
+		return m_origJoinPred;
 	}
 
 };	// class CPhysicalInnerIndexNLJoin

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalInnerIndexNLJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalInnerIndexNLJoin.h
@@ -30,7 +30,7 @@ private:
 	// columns from outer child used for index lookup in inner child
 	CColRefArray *m_pdrgpcrOuterRefs;
 
-	// a copy of the original join predicate that is now pushed down to the inner side
+	// a copy of the original join predicate that has been pushed down to the inner side
 	CExpression *m_origJoinPred;
 
 	// private copy ctor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterIndexNLJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterIndexNLJoin.h
@@ -18,7 +18,7 @@ private:
 	// columns from outer child used for index lookup in inner child
 	CColRefArray *m_pdrgpcrOuterRefs;
 
-	// a copy of the original join predicate that is now pushed down to the inner side
+	// a copy of the original join predicate that has been pushed down to the inner side
 	CExpression *m_origJoinPred;
 
 	// private copy ctor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterIndexNLJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterIndexNLJoin.h
@@ -18,12 +18,16 @@ private:
 	// columns from outer child used for index lookup in inner child
 	CColRefArray *m_pdrgpcrOuterRefs;
 
+	// a copy of the original join predicate that is now pushed down to the inner side
+	CExpression *m_origJoinPred;
+
 	// private copy ctor
 	CPhysicalLeftOuterIndexNLJoin(const CPhysicalLeftOuterIndexNLJoin &);
 
 public:
 	// ctor
-	CPhysicalLeftOuterIndexNLJoin(CMemoryPool *mp, CColRefArray *colref_array);
+	CPhysicalLeftOuterIndexNLJoin(CMemoryPool *mp, CColRefArray *colref_array,
+								  CExpression *origJoinPred);
 
 	// dtor
 	virtual ~CPhysicalLeftOuterIndexNLJoin();
@@ -75,6 +79,12 @@ public:
 		GPOS_ASSERT(EopPhysicalLeftOuterIndexNLJoin == pop->Eopid());
 
 		return dynamic_cast<CPhysicalLeftOuterIndexNLJoin *>(pop);
+	}
+
+	CExpression *
+	OrigJoinPred()
+	{
+		return m_origJoinPred;
 	}
 
 };	// class CPhysicalLeftOuterIndexNLJoin

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementIndexApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementIndexApply.h
@@ -77,13 +77,14 @@ public:
 		GPOS_ASSERT(FCheckPattern(pexpr));
 
 		CMemoryPool *mp = pxfctxt->Pmp();
+		CLogicalIndexApply *indexApply =
+			CLogicalIndexApply::PopConvert(pexpr->Pop());
 
 		// extract components
 		CExpression *pexprOuter = (*pexpr)[0];
 		CExpression *pexprInner = (*pexpr)[1];
 		CExpression *pexprScalar = (*pexpr)[2];
-		CColRefArray *colref_array =
-			CLogicalIndexApply::PopConvert(pexpr->Pop())->PdrgPcrOuterRefs();
+		CColRefArray *colref_array = indexApply->PdrgPcrOuterRefs();
 		colref_array->AddRef();
 
 		// addref all components
@@ -95,9 +96,11 @@ public:
 		CPhysicalNLJoin *pop = NULL;
 
 		if (CLogicalIndexApply::PopConvert(pexpr->Pop())->FouterJoin())
-			pop = GPOS_NEW(mp) CPhysicalLeftOuterIndexNLJoin(mp, colref_array);
+			pop = GPOS_NEW(mp) CPhysicalLeftOuterIndexNLJoin(
+				mp, colref_array, indexApply->OrigJoinPred());
 		else
-			pop = GPOS_NEW(mp) CPhysicalInnerIndexNLJoin(mp, colref_array);
+			pop = GPOS_NEW(mp) CPhysicalInnerIndexNLJoin(
+				mp, colref_array, indexApply->OrigJoinPred());
 
 		CExpression *pexprResult = GPOS_NEW(mp)
 			CExpression(mp, pop, pexprOuter, pexprInner, pexprScalar);

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
@@ -29,7 +29,7 @@ private:
 	void CreateHomogeneousBtreeIndexApplyAlternatives(
 		CMemoryPool *mp, COperator *joinOp, CExpression *pexprOuter,
 		CExpression *pexprInner, CExpression *pexprScalar,
-		CExpression *nodesToInsertAboveIndexGet,
+		CExpression *origJoinPred, CExpression *nodesToInsertAboveIndexGet,
 		CExpression *endOfNodesToInsertAboveIndexGet,
 		CTableDescriptor *ptabdescInner, CLogicalDynamicGet *popDynamicGet,
 		CColRefSet *pcrsScalarExpr, CColRefSet *outer_refs,
@@ -39,7 +39,8 @@ private:
 	// for homogeneous b-tree indexes
 	void CreateAlternativesForBtreeIndex(
 		CMemoryPool *mp, COperator *joinOp, CExpression *pexprOuter,
-		CExpression *pexprInner, CExpression *nodesToInsertAboveIndexGet,
+		CExpression *pexprInner, CExpression *origJoinPred,
+		CExpression *nodesToInsertAboveIndexGet,
 		CExpression *endOfNodesToInsertAboveIndexGet, CMDAccessor *md_accessor,
 		CExpressionArray *pdrgpexprConjuncts, CColRefSet *pcrsScalarExpr,
 		CColRefSet *outer_refs, CColRefSet *pcrsReqd, const IMDRelation *pmdrel,
@@ -51,7 +52,7 @@ private:
 	void CreateHomogeneousBitmapIndexApplyAlternatives(
 		CMemoryPool *mp, COperator *joinOp, CExpression *pexprOuter,
 		CExpression *pexprInner, CExpression *pexprScalar,
-		CExpression *nodesToInsertAboveIndexGet,
+		CExpression *origJoinPred, CExpression *nodesToInsertAboveIndexGet,
 		CExpression *endOfNodesToInsertAboveIndexGet,
 		CTableDescriptor *ptabdescInner, CColRefSet *outer_refs,
 		CColRefSet *pcrsReqd, CXformResult *pxfres) const;
@@ -117,7 +118,7 @@ protected:
 	virtual void CreateHomogeneousIndexApplyAlternatives(
 		CMemoryPool *mp, COperator *joinOp, CExpression *pexprOuter,
 		CExpression *pexprInner, CExpression *pexprScalar,
-		CExpression *nodesToInsertAboveIndexGet,
+		CExpression *origJoinPred, CExpression *nodesToInsertAboveIndexGet,
 		CExpression *endOfNodesToInsertAboveIndexGet,
 		CTableDescriptor *PtabdescInner, CLogicalDynamicGet *popDynamicGet,
 		CXformResult *pxfres, gpmd::IMDIndex::EmdindexType emdtype) const;
@@ -140,8 +141,9 @@ protected:
 	// that it is trying to transform to in the current
 	// xform rule, caller takes the ownership and
 	// responsibility to release the instance.
-	virtual CLogicalApply *PopLogicalApply(
-		CMemoryPool *mp, CColRefArray *pdrgpcrOuterRefs) const = 0;
+	virtual CLogicalApply *PopLogicalApply(CMemoryPool *mp,
+										   CColRefArray *pdrgpcrOuterRefs,
+										   CExpression *origJoinPred) const = 0;
 
 public:
 	// ctor

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyBase.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyBase.h
@@ -105,9 +105,11 @@ protected:
 	// xform rule, caller takes the ownership and
 	// responsibility to release the instance.
 	virtual CLogicalApply *
-	PopLogicalApply(CMemoryPool *mp, CColRefArray *colref_array) const
+	PopLogicalApply(CMemoryPool *mp, CColRefArray *colref_array,
+					CExpression *origJoinPred) const
 	{
-		return GPOS_NEW(mp) TApply(mp, colref_array, m_fOuterJoin);
+		return GPOS_NEW(mp)
+			TApply(mp, colref_array, m_fOuterJoin, origJoinPred);
 	}
 
 public:
@@ -202,6 +204,7 @@ public:
 		{
 			CreateHomogeneousIndexApplyAlternatives(
 				mp, pexpr->Pop(), pexprOuter, pexprGet, pexprAllPredicates,
+				pexprScalar,
 				NULL,  // extra nodes to copy
 				NULL,  // end of extra nodes to copy
 				ptabdescInner, popDynamicGet, pxfres, eidxtype);

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyBase.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyBase.h
@@ -178,6 +178,13 @@ public:
 			pexprScalar->AddRef();
 		}
 
+		if (pexprAllPredicates->DeriveHasSubquery())
+		{
+			// don't transform an expression that still has subqueries in its predicates
+			CRefCount::SafeRelease(pexprAllPredicates);
+			return;
+		}
+
 		if (m_fOuterJoin && !FCanLeftOuterIndexApply(mp, pexprGet, pexprScalar))
 		{
 			// It is a left outer join, but we can't do outer index apply,

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyGeneric.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyGeneric.h
@@ -82,7 +82,7 @@ public:
 	}
 
 	virtual CLogicalApply *
-	PopLogicalApply(CMemoryPool *, CColRefArray *) const
+	PopLogicalApply(CMemoryPool *, CColRefArray *, CExpression *) const
 	{
 		return NULL;
 	}

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
@@ -956,9 +956,9 @@ CDistributionSpecHashed::HasCompleteEquivSpec(CMemoryPool *mp)
 
 // use given predicates to complete an incomplete spec, if possible
 CDistributionSpecHashed *
-CDistributionSpecHashed::CompleteEquivSpec(CMemoryPool *mp,
-										   CDistributionSpecHashed *pdshashed,
-										   CExpression *pexprPred)
+CDistributionSpecHashed::TryToCompleteEquivSpec(
+	CMemoryPool *mp, CDistributionSpecHashed *pdshashed, CExpression *pexprPred,
+	CColRefSet *outerRefs)
 {
 	CExpressionArray *pdrgpexprPred =
 		CPredicateUtils::PdrgpexprConjuncts(mp, pexprPred);
@@ -972,7 +972,8 @@ CDistributionSpecHashed::CompleteEquivSpec(CMemoryPool *mp,
 		CExpression *pexpr = (*pdrgpexprHashed)[ul];
 		CExpression *pexprMatching =
 			CUtils::PexprMatchEqualityOrINDF(pexpr, pdrgpexprPred);
-		if (NULL != pexprMatching)
+		if (NULL != pexprMatching &&
+			outerRefs->FIntersects(pexprMatching->DeriveUsedColumns()))
 		{
 			pexprMatching->AddRef();
 			pdrgpexprResult->Append(pexprMatching);

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
@@ -975,6 +975,8 @@ CDistributionSpecHashed::TryToCompleteEquivSpec(
 		if (NULL != pexprMatching &&
 			outerRefs->FIntersects(pexprMatching->DeriveUsedColumns()))
 		{
+			// we are able to replace an original expression with one that refers to outer
+			// references (values from the equivalent table), making it more complete
 			pexprMatching->AddRef();
 			pdrgpexprResult->Append(pexprMatching);
 		}

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalIndexApply.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalIndexApply.cpp
@@ -32,6 +32,10 @@ CLogicalIndexApply::CLogicalIndexApply(CMemoryPool *mp,
 	GPOS_ASSERT(NULL != pdrgpcrOuterRefs);
 	if (NULL != origJoinPred)
 	{
+		// We don't allow subqueries in the expression that we
+		// store in the logical operator, since such expressions
+		// would be unsuitable for generating a plan.
+		GPOS_RTL_ASSERT(!origJoinPred->DeriveHasSubquery());
 		origJoinPred->AddRef();
 	}
 }

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalIndexApply.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalIndexApply.cpp
@@ -12,25 +12,35 @@
 using namespace gpopt;
 
 CLogicalIndexApply::CLogicalIndexApply(CMemoryPool *mp)
-	: CLogicalApply(mp), m_pdrgpcrOuterRefs(NULL), m_fOuterJoin(false)
+	: CLogicalApply(mp),
+	  m_pdrgpcrOuterRefs(NULL),
+	  m_fOuterJoin(false),
+	  m_origJoinPred(NULL)
 {
 	m_fPattern = true;
 }
 
 CLogicalIndexApply::CLogicalIndexApply(CMemoryPool *mp,
 									   CColRefArray *pdrgpcrOuterRefs,
-									   BOOL fOuterJoin)
+									   BOOL fOuterJoin,
+									   CExpression *origJoinPred)
 	: CLogicalApply(mp),
 	  m_pdrgpcrOuterRefs(pdrgpcrOuterRefs),
-	  m_fOuterJoin(fOuterJoin)
+	  m_fOuterJoin(fOuterJoin),
+	  m_origJoinPred(origJoinPred)
 {
 	GPOS_ASSERT(NULL != pdrgpcrOuterRefs);
+	if (NULL != origJoinPred)
+	{
+		origJoinPred->AddRef();
+	}
 }
 
 
 CLogicalIndexApply::~CLogicalIndexApply()
 {
 	CRefCount::SafeRelease(m_pdrgpcrOuterRefs);
+	CRefCount::SafeRelease(m_origJoinPred);
 }
 
 
@@ -96,10 +106,22 @@ CLogicalIndexApply::PopCopyWithRemappedColumns(CMemoryPool *mp,
 											   UlongToColRefMap *colref_mapping,
 											   BOOL must_exist)
 {
+	COperator *result = NULL;
 	CColRefArray *colref_array = CUtils::PdrgpcrRemap(
 		mp, m_pdrgpcrOuterRefs, colref_mapping, must_exist);
+	CExpression *remapped_orig_join_pred = NULL;
 
-	return GPOS_NEW(mp) CLogicalIndexApply(mp, colref_array, m_fOuterJoin);
+	if (NULL != m_origJoinPred)
+	{
+		remapped_orig_join_pred = m_origJoinPred->PexprCopyWithRemappedColumns(
+			mp, colref_mapping, must_exist);
+	}
+
+	result = GPOS_NEW(mp) CLogicalIndexApply(mp, colref_array, m_fOuterJoin,
+											 remapped_orig_join_pred);
+	CRefCount::SafeRelease(remapped_orig_join_pred);
+
+	return result;
 }
 
 // EOF

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalFilter.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalFilter.cpp
@@ -340,8 +340,9 @@ CPhysicalFilter::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 			}
 
 			CDistributionSpecHashed *pdshashedComplete =
-				CDistributionSpecHashed::CompleteEquivSpec(mp, pdshashed,
-														   pexprFilterPred);
+				CDistributionSpecHashed::TryToCompleteEquivSpec(
+					mp, pdshashed, pexprFilterPred,
+					exprhdl.DeriveOuterReferences());
 
 			CExpressionArray *pdrgpexprOriginal =
 				pdshashedOriginal->Pdrgpexpr();
@@ -368,16 +369,9 @@ CPhysicalFilter::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 					pdshashedComplete, opfamiliesOriginal);
 			}
 
-			// in any case, returned distribution spec must be complete!
-			GPOS_ASSERT(NULL == pdsResult->PdshashedEquiv() ||
-						pdsResult->HasCompleteEquivSpec(mp));
 			pdsChild->Release();
 			return pdsResult;
 		}
-
-		// in any case, returned distribution spec must be complete!
-		GPOS_ASSERT(NULL == pdshashedEquiv ||
-					pdshashedOriginal->HasCompleteEquivSpec(mp));
 	}
 
 	return pdsChild;

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalInnerIndexNLJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalInnerIndexNLJoin.cpp
@@ -34,10 +34,17 @@ using namespace gpopt;
 //
 //---------------------------------------------------------------------------
 CPhysicalInnerIndexNLJoin::CPhysicalInnerIndexNLJoin(CMemoryPool *mp,
-													 CColRefArray *colref_array)
-	: CPhysicalInnerNLJoin(mp), m_pdrgpcrOuterRefs(colref_array)
+													 CColRefArray *colref_array,
+													 CExpression *origJoinPred)
+	: CPhysicalInnerNLJoin(mp),
+	  m_pdrgpcrOuterRefs(colref_array),
+	  m_origJoinPred(origJoinPred)
 {
 	GPOS_ASSERT(NULL != colref_array);
+	if (NULL != origJoinPred)
+	{
+		origJoinPred->AddRef();
+	}
 }
 
 
@@ -52,6 +59,7 @@ CPhysicalInnerIndexNLJoin::CPhysicalInnerIndexNLJoin(CMemoryPool *mp,
 CPhysicalInnerIndexNLJoin::~CPhysicalInnerIndexNLJoin()
 {
 	m_pdrgpcrOuterRefs->Release();
+	CRefCount::SafeRelease(m_origJoinPred);
 }
 
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftOuterIndexNLJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftOuterIndexNLJoin.cpp
@@ -18,16 +18,23 @@
 using namespace gpopt;
 
 CPhysicalLeftOuterIndexNLJoin::CPhysicalLeftOuterIndexNLJoin(
-	CMemoryPool *mp, CColRefArray *colref_array)
-	: CPhysicalLeftOuterNLJoin(mp), m_pdrgpcrOuterRefs(colref_array)
+	CMemoryPool *mp, CColRefArray *colref_array, CExpression *origJoinPred)
+	: CPhysicalLeftOuterNLJoin(mp),
+	  m_pdrgpcrOuterRefs(colref_array),
+	  m_origJoinPred(origJoinPred)
 {
 	GPOS_ASSERT(NULL != colref_array);
+	if (NULL != origJoinPred)
+	{
+		origJoinPred->AddRef();
+	}
 }
 
 
 CPhysicalLeftOuterIndexNLJoin::~CPhysicalLeftOuterIndexNLJoin()
 {
 	m_pdrgpcrOuterRefs->Release();
+	CRefCount::SafeRelease(m_origJoinPred);
 }
 
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalScan.cpp
@@ -186,8 +186,8 @@ CPhysicalScan::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 		CDistributionSpecHashed *pdshashed =
 			CDistributionSpecHashed::PdsConvert(m_pds);
 		CDistributionSpecHashed *pdshashedEquiv =
-			CDistributionSpecHashed::CompleteEquivSpec(mp, pdshashed,
-													   pexprIndexPred);
+			CDistributionSpecHashed::TryToCompleteEquivSpec(
+				mp, pdshashed, pexprIndexPred, exprhdl.DeriveOuterReferences());
 
 		if (NULL != pdshashedEquiv)
 		{

--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
@@ -220,9 +220,19 @@ CXformJoin2IndexApply::CreateAlternativesForBtreeIndex(
 		// second child has residual predicates, create an apply of outer and inner
 		// and add it to xform results
 		CColRefArray *colref_array = outer_refs->Pdrgpcr(mp);
+		CExpression *indexGetWithOptionalSelect = pexprLogicalIndexGet;
+
+		if (COperator::EopLogicalDynamicGet == pexprInner->Pop()->Eopid())
+		{
+			indexGetWithOptionalSelect =
+				CXformUtils::PexprRedundantSelectForDynamicIndex(
+					mp, pexprLogicalIndexGet);
+			pexprLogicalIndexGet->Release();
+		}
+
 		CExpression *rightChildOfApply =
 			CXformUtils::AddALinearStackOfUnaryExpressions(
-				mp, pexprLogicalIndexGet, nodesToInsertAboveIndexGet,
+				mp, indexGetWithOptionalSelect, nodesToInsertAboveIndexGet,
 				endOfNodesToInsertAboveIndexGet);
 		BOOL isOuterJoin = false;
 
@@ -279,9 +289,19 @@ CXformJoin2IndexApply::CreateHomogeneousBitmapIndexApplyAlternatives(
 		// second child has residual predicates, create an apply of outer and inner
 		// and add it to xform results
 		CColRefArray *colref_array = outer_refs->Pdrgpcr(mp);
+		CExpression *indexGetWithOptionalSelect = pexprLogicalIndexGet;
+
+		if (COperator::EopLogicalDynamicGet == popGet->Eopid())
+		{
+			indexGetWithOptionalSelect =
+				CXformUtils::PexprRedundantSelectForDynamicIndex(
+					mp, pexprLogicalIndexGet);
+			pexprLogicalIndexGet->Release();
+		}
+
 		CExpression *rightChildOfApply =
 			CXformUtils::AddALinearStackOfUnaryExpressions(
-				mp, pexprLogicalIndexGet, nodesToInsertAboveIndexGet,
+				mp, indexGetWithOptionalSelect, nodesToInsertAboveIndexGet,
 				endOfNodesToInsertAboveIndexGet);
 		BOOL isOuterJoin = false;
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
@@ -92,7 +92,7 @@ void
 CXformJoin2IndexApply::CreateHomogeneousIndexApplyAlternatives(
 	CMemoryPool *mp, COperator *joinOp, CExpression *pexprOuter,
 	CExpression *pexprInner, CExpression *pexprScalar,
-	CExpression *nodesToInsertAboveIndexGet,
+	CExpression *origJoinPred, CExpression *nodesToInsertAboveIndexGet,
 	CExpression *endOfNodesToInsertAboveIndexGet,
 	CTableDescriptor *ptabdescInner, CLogicalDynamicGet *popDynamicGet,
 	CXformResult *pxfres, IMDIndex::EmdindexType emdtype) const
@@ -121,7 +121,7 @@ CXformJoin2IndexApply::CreateHomogeneousIndexApplyAlternatives(
 	if (IMDIndex::EmdindBtree == emdtype)
 	{
 		CreateHomogeneousBtreeIndexApplyAlternatives(
-			mp, joinOp, pexprOuter, pexprInner, pexprScalar,
+			mp, joinOp, pexprOuter, pexprInner, pexprScalar, origJoinPred,
 			nodesToInsertAboveIndexGet, endOfNodesToInsertAboveIndexGet,
 			ptabdescInner, popDynamicGet, pcrsScalarExpr, outer_refs, pcrsReqd,
 			ulIndices, pxfres);
@@ -129,7 +129,7 @@ CXformJoin2IndexApply::CreateHomogeneousIndexApplyAlternatives(
 	else
 	{
 		CreateHomogeneousBitmapIndexApplyAlternatives(
-			mp, joinOp, pexprOuter, pexprInner, pexprScalar,
+			mp, joinOp, pexprOuter, pexprInner, pexprScalar, origJoinPred,
 			nodesToInsertAboveIndexGet, endOfNodesToInsertAboveIndexGet,
 			ptabdescInner, outer_refs, pcrsReqd, pxfres);
 	}
@@ -152,7 +152,7 @@ void
 CXformJoin2IndexApply::CreateHomogeneousBtreeIndexApplyAlternatives(
 	CMemoryPool *mp, COperator *joinOp, CExpression *pexprOuter,
 	CExpression *pexprInner, CExpression *pexprScalar,
-	CExpression *nodesToInsertAboveIndexGet,
+	CExpression *origJoinPred, CExpression *nodesToInsertAboveIndexGet,
 	CExpression *endOfNodesToInsertAboveIndexGet,
 	CTableDescriptor *ptabdescInner, CLogicalDynamicGet *popDynamicGet,
 	CColRefSet *pcrsScalarExpr, CColRefSet *outer_refs, CColRefSet *pcrsReqd,
@@ -181,10 +181,10 @@ CXformJoin2IndexApply::CreateHomogeneousBtreeIndexApplyAlternatives(
 				popDynamicGet->PdrgpcrOutput());
 		}
 		CreateAlternativesForBtreeIndex(
-			mp, joinOp, pexprOuter, pexprInner, nodesToInsertAboveIndexGet,
-			endOfNodesToInsertAboveIndexGet, md_accessor, pdrgpexpr,
-			pcrsScalarExpr, outer_refs, pcrsReqd, pmdrel, pmdindex,
-			ppartcnstrIndex, pxfres);
+			mp, joinOp, pexprOuter, pexprInner, origJoinPred,
+			nodesToInsertAboveIndexGet, endOfNodesToInsertAboveIndexGet,
+			md_accessor, pdrgpexpr, pcrsScalarExpr, outer_refs, pcrsReqd,
+			pmdrel, pmdindex, ppartcnstrIndex, pxfres);
 	}
 
 	//clean-up
@@ -203,7 +203,8 @@ CXformJoin2IndexApply::CreateHomogeneousBtreeIndexApplyAlternatives(
 void
 CXformJoin2IndexApply::CreateAlternativesForBtreeIndex(
 	CMemoryPool *mp, COperator *joinOp, CExpression *pexprOuter,
-	CExpression *pexprInner, CExpression *nodesToInsertAboveIndexGet,
+	CExpression *pexprInner, CExpression *origJoinPred,
+	CExpression *nodesToInsertAboveIndexGet,
 	CExpression *endOfNodesToInsertAboveIndexGet, CMDAccessor *md_accessor,
 	CExpressionArray *pdrgpexprConjuncts, CColRefSet *pcrsScalarExpr,
 	CColRefSet *outer_refs, CColRefSet *pcrsReqd, const IMDRelation *pmdrel,
@@ -242,7 +243,9 @@ CXformJoin2IndexApply::CreateAlternativesForBtreeIndex(
 
 		pexprOuter->AddRef();
 		CExpression *pexprIndexApply = GPOS_NEW(mp) CExpression(
-			mp, GPOS_NEW(mp) CLogicalIndexApply(mp, colref_array, isOuterJoin),
+			mp,
+			GPOS_NEW(mp)
+				CLogicalIndexApply(mp, colref_array, isOuterJoin, origJoinPred),
 			pexprOuter, rightChildOfApply,
 			CPredicateUtils::PexprConjunction(mp, NULL /*pdrgpexpr*/));
 		pxfres->Add(pexprIndexApply);
@@ -262,7 +265,7 @@ void
 CXformJoin2IndexApply::CreateHomogeneousBitmapIndexApplyAlternatives(
 	CMemoryPool *mp, COperator *joinOp, CExpression *pexprOuter,
 	CExpression *pexprInner, CExpression *pexprScalar,
-	CExpression *nodesToInsertAboveIndexGet,
+	CExpression *origJoinPred, CExpression *nodesToInsertAboveIndexGet,
 	CExpression *endOfNodesToInsertAboveIndexGet,
 	CTableDescriptor *ptabdescInner, CColRefSet *outer_refs,
 	CColRefSet *pcrsReqd, CXformResult *pxfres) const
@@ -299,7 +302,9 @@ CXformJoin2IndexApply::CreateHomogeneousBitmapIndexApplyAlternatives(
 
 		pexprOuter->AddRef();
 		CExpression *pexprIndexApply = GPOS_NEW(mp) CExpression(
-			mp, GPOS_NEW(mp) CLogicalIndexApply(mp, colref_array, isOuterJoin),
+			mp,
+			GPOS_NEW(mp)
+				CLogicalIndexApply(mp, colref_array, isOuterJoin, origJoinPred),
 			pexprOuter, rightChildOfApply,
 			CPredicateUtils::PexprConjunction(mp, NULL /*pdrgpexpr*/));
 		pxfres->Add(pexprIndexApply);
@@ -704,7 +709,7 @@ CXformJoin2IndexApply::PexprIndexApplyOverCTEConsumer(
 	}
 
 	return GPOS_NEW(mp)
-		CExpression(mp, PopLogicalApply(mp, pdrgpcrOuterRefsInScanNew),
+		CExpression(mp, PopLogicalApply(mp, pdrgpcrOuterRefsInScanNew, NULL),
 					CXformUtils::PexprCTEConsumer(mp, ulCTEId, pdrgpcrOuterNew),
 					pexprDynamicScan,
 					CPredicateUtils::PexprConjunction(mp, NULL /*pdrgpexpr*/));

--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApplyGeneric.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApplyGeneric.cpp
@@ -324,7 +324,7 @@ CXformJoin2IndexApplyGeneric::Transform(CXformContext *pxfctxt,
 
 	// insert the btree or bitmap alternatives
 	CreateHomogeneousIndexApplyAlternatives(
-		mp, pexpr->Pop(), pexprOuter, pexprGet, pexprAllPredicates,
+		mp, pexpr->Pop(), pexprOuter, pexprGet, pexprAllPredicates, pexprScalar,
 		nodesToInsertAboveIndexGet, endOfNodesToInsertAboveIndexGet,
 		ptabdescInner, popDynamicGet, pxfres,
 		(m_generateBitmapPlans ? IMDIndex::EmdindBitmap

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -114,6 +114,7 @@ IndexApply-InnerSelect-Heterogeneous-DTS IndexApply-Heterogeneous-BothSidesParti
 IndexApply-InnerSelect-PartTable2 IndexApply-ForPartialIndex CastedScalarIf-On-Index-Key
 IndexApply-MultiDistKey-WithComplexPreds IndexApply-MultiDistKeys-Bitmap
 IndexApply-MultiDistKeys-Bitmap-WithComplexPreds
+IndexApply-MultiDistKeys-IncompletePDS-3-DistCols
 BitmapIndexNLJWithProject BitmapIndexNLOJWithProject
 BitmapIndexNLJWithProjectNoFilt BtreeIndexNLJWithProjectNoPart
 BitmapIndexNLOJWithProjectNonPart BtreeIndexNLOJWithProject;

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -205,8 +205,6 @@ AND ft.id = dt1.id;
  Optimizer status: Postgres query optimizer
 (36 rows)
 
--- experimental cost model guc generates bitmap scan
-set optimizer_cost_model=experimental;
 explain SELECT count(*)
 FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
@@ -251,7 +249,6 @@ AND ft.id = dt1.id;
  Optimizer: Postgres query optimizer
 (36 rows)
 
-reset optimizer_cost_model;
 -- start_ignore
 create language plpythonu;
 ERROR:  language "plpythonu" already exists

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -169,10 +169,10 @@ FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
                                                              QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..1134.51 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1134.51 rows=1 width=1)
-         ->  Hash Join  (cost=0.00..1134.51 rows=1 width=1)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1134.51 rows=4 width=1)
+         ->  Hash Join  (cost=0.00..1134.51 rows=2 width=1)
                Hash Cond: (bfv_tab2_facttable1.wk_id = bfv_tab2_dimdate.wk_id)
                ->  Nested Loop  (cost=0.00..703.51 rows=1 width=2)
                      Join Filter: true
@@ -180,46 +180,42 @@ AND ft.id = dt1.id;
                            ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
                      ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=0.00..272.51 rows=1 width=2)
                            Recheck Cond: (id = bfv_tab2_dimtabl1.id)
+                           Filter: (id = bfv_tab2_dimtabl1.id)
                            ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
                                  Index Cond: (id = bfv_tab2_dimtabl1.id)
                ->  Hash  (cost=100.00..100.00 rows=34 width=4)
                      ->  Partition Selector for bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=10 width=2)
                                  ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(17 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
 
--- experimental cost model guc generates bitmap scan
-set optimizer_cost_model=experimental;
 explain SELECT count(*)
 FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
                                                                     QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..7.15 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..6.13 rows=4 width=1)
-         ->  Hash Join  (cost=0.00..5.13 rows=2 width=1)
-               Hash Cond: (bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id)
-               ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..0.01 rows=4 width=2)
-               ->  Hash  (cost=4.06..4.06 rows=3 width=2)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..4.06 rows=3 width=2)
-                           Hash Key: bfv_tab2_facttable1.wk_id
-                           ->  Nested Loop  (cost=0.00..3.06 rows=3 width=2)
+----------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1134.51 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1134.51 rows=4 width=1)
+         ->  Hash Join  (cost=0.00..1134.51 rows=2 width=1)
+               Hash Cond: (bfv_tab2_facttable1.wk_id = bfv_tab2_dimdate.wk_id)
+               ->  Nested Loop  (cost=0.00..703.51 rows=1 width=2)
                                  Join Filter: true
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.04 rows=7 width=4)
-                                       ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..0.01 rows=3 width=4)
-                                 ->  Sequence  (cost=0.00..0.00 rows=1 width=2)
-                                       ->  Partition Selector for bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                             Partitions selected: 20 (out of 20)
-                                       ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=0.00..0.00 rows=1 width=2)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                           ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
+                     ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=0.00..272.51 rows=1 width=2)
                                              Recheck Cond: (id = bfv_tab2_dimtabl1.id)
+                           Filter: (id = bfv_tab2_dimtabl1.id)
                                              ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
                                                    Index Cond: (id = bfv_tab2_dimtabl1.id)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.90.0
-(20 rows)
+               ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+                     ->  Partition Selector for bfv_tab2_facttable1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=10 width=2)
+                                 ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
 
-reset optimizer_cost_model;
 -- start_ignore
 create language plpythonu;
 -- end_ignore

--- a/src/test/regress/expected/equivclass_optimizer.out
+++ b/src/test/regress/expected/equivclass_optimizer.out
@@ -151,13 +151,12 @@ explain (costs off)
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Nested Loop
          Join Filter: true
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: 42::bigint
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)
                ->  Seq Scan on ec2
          ->  Index Scan using ec1_pkey on ec1
                Index Cond: ((ff = ec2.x1) AND (ff = 42::bigint))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(9 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
 
 explain (costs off)
   select * from ec1, ec2 where ff = x1 and ff = '42'::int8alias1;

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -98,14 +98,11 @@ FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
 
--- experimental cost model guc generates bitmap scan
-set optimizer_cost_model=experimental;
 explain SELECT count(*)
 FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
 
-reset optimizer_cost_model;
 -- start_ignore
 create language plpythonu;
 -- end_ignore


### PR DESCRIPTION
This PR combines two fixes for partition elimination with index scans and index joins, plus some supporting code:

1. Enable dynamic partition elimination (DPE) with index joins.

    Use original join pred for DPE with index nested loop joins

    Dynamic partition selection is based on a join predicate. For index
    nested loop joins, however, we push the join predicate to the inner
    side and replace the join predicate with "true". This meant that
    we couldn't do DPE for nested index loop joins.

    This commit remembers the original join predicate in the index nested
    loop join, to be used in the generated filter map for DPE. The original
    join predicate needs to be passed through multiple layers.

2. Fix static partition elimination (SPE) with predicates that are both index predicates and partition elimination predicates.

    Some of the xforms use method CXformUtils::PexprRedundantSelectForDynamicIndex
    to duplicate predicates that could be used both as index predicates and as
    partition elimination predicates. The call was missing in some other xforms.
    Added it.

3. Change computation of equivalent distribution specs to deal with redundant predicates.

    Adding redundant predicates causes some issues with generating
    equivalent distribution specs, to be used for the outer table of
    a nested index loop join. We want the equivalent spec to be
    expressed in terms of outer references, which are the columns of
    the outer table.

    By passing in the outer refs, we can ensure that we won't replace
    an outer ref in a distribution spec with a local variable from
    the original distribution spec.

    Also removed the asserts in CPhysicalFilter::PdsDerive that ensure the
    distribution spec is complete (consisting of only columns from the
    outer table) after we see a select node. Even without my changes, the
    asserts do not always hold, as the test case below shows.

    Instead of the asserts, we now use the new method of passing in the
    outer refs to ensure that we move towards completion. Based on the
    test case below, we know that we can't always achieve a complete
    distribution spec, even without redundant predicates:

```
      drop table if exists foo, bar;
      create table foo(a int, b int, c int, d int, e int) distributed by(a,b,c);
      create table bar(a int, b int, c int, d int, e int) distributed by(a,b,c);
      create index bar_ixb on bar(b);

      set optimizer_enable_hashjoin to off;
      set client_min_messages to log;

      -- runs into assert
      explain
      select *
      from foo join bar on foo.a=bar.a and foo.b=bar.b
      where bar.c > 10 and bar.d = 11;
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
