### PR TITLE
Increment ExternalScan::scancounter across queries in ORCA

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -61,6 +61,8 @@ using namespace gpmd;
 #define GPDXL_MOTION_ID_START 1
 #define GPDXL_PARAM_ID_START 0
 
+ULONG CTranslatorDXLToPlStmt::m_external_scan_counter = 0;
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CTranslatorDXLToPlStmt::CTranslatorDXLToPlStmt
@@ -78,7 +80,6 @@ CTranslatorDXLToPlStmt::CTranslatorDXLToPlStmt(
 	  m_cmd_type(CMD_SELECT),
 	  m_is_tgt_tbl_distributed(false),
 	  m_result_rel_list(NULL),
-	  m_external_scan_counter(0),
 	  m_num_of_segments(num_of_segments),
 	  m_partition_selector_counter(0)
 {

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -143,7 +143,7 @@ private:
 	List *m_result_rel_list;
 
 	// external scan counter
-	ULONG m_external_scan_counter;
+	static ULONG m_external_scan_counter;
 
 	// number of segments
 	ULONG m_num_of_segments;


### PR DESCRIPTION
gpfdist uses the global xid & timestamp to distinguish whether each
connection belongs to the same external scan or not.

ORCA generates a unique scan number for each ExternalScan within the
same plan, but not accross plans. So, within a transaction, we may issue
multiple external scans that do not get differentiated properly,
producing different results.

This commit patches that by using a different scan number accross plans,
just like what planner does. Ideally gpfdist should also take into
account the command-id of the query to prevent this problem for other
cases such as prepared statements.
