### PR TITLE
[6X Backport] Avoid panic after Abort Prepared retry fails. (#10795)

### DIFF
--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -37,7 +37,11 @@
 #include "tcop/tcopprot.h"
 #include "libpq-int.h"
 
-volatile bool *shmDtmStarted;
+#define MAX_FREQ_CHECK_TIMES 12
+static int frequent_check_times;
+
+volatile bool *shmDtmStarted = NULL;
+volatile pid_t *shmDtxRecoveryPid = NULL;
 
 /* transactions need recover */
 TMGXACT_LOG *shmCommittedGxactArray;
@@ -681,6 +685,16 @@ AbortOrphanedPreparedTransactions()
 }
 
 static void
+sigIntHandler(SIGNAL_ARGS)
+{
+	if (frequent_check_times == 0)
+		frequent_check_times = MAX_FREQ_CHECK_TIMES;
+
+	if (MyProc)
+		SetLatch(&MyProc->procLatch);
+}
+
+static void
 sigHupHandler(SIGNAL_ARGS)
 {
 	got_SIGHUP = true;
@@ -689,16 +703,25 @@ sigHupHandler(SIGNAL_ARGS)
 		SetLatch(&MyProc->procLatch);
 }
 
+pid_t
+DtxRecoveryPID(void)
+{
+	return *shmDtxRecoveryPid;
+}
+
 /*
  * DtxRecoveryMain
  */
 void
 DtxRecoveryMain(Datum main_arg)
 {
+	*shmDtxRecoveryPid = MyProcPid;
+
 	/*
 	 * reread postgresql.conf if requested
 	 */
 	pqsignal(SIGHUP, sigHupHandler);
+	pqsignal(SIGINT, sigIntHandler);
 
 	/* We're now ready to receive signals */
 	BackgroundWorkerUnblockSignals();
@@ -740,12 +763,16 @@ DtxRecoveryMain(Datum main_arg)
 
 		rc = WaitLatch(&MyProc->procLatch,
 					   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
-					   gp_dtx_recovery_interval * 1000L);
+					   frequent_check_times > 0 ?
+					   5 * 1000L : gp_dtx_recovery_interval * 1000L);
 		ResetLatch(&MyProc->procLatch);
 
 		/* emergency bailout if postmaster has died */
 		if (rc & WL_POSTMASTER_DEATH)
 			proc_exit(1);
+
+		if (frequent_check_times > 0)
+			frequent_check_times--;
 	}
 
 	/* One iteration done, go away */

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -25,6 +25,7 @@
 #include "libpq/pqformat.h"
 #include "miscadmin.h"
 #include "storage/lmgr.h"
+#include "storage/pmsignal.h"
 #include "storage/s_lock.h"
 #include "storage/shmem.h"
 #include "storage/ipc.h"
@@ -61,6 +62,7 @@ typedef struct TmControlBlock
 	DistributedTransactionTimeStamp	distribTimeStamp;
 	DistributedTransactionId	seqno;
 	bool						DtmStarted;
+	pid_t						DtxRecoveryPid;
 	uint32						NextSnapshotId;
 	int							num_committed_xacts;
 	slock_t						gxidGenLock;
@@ -711,9 +713,15 @@ retryAbortPrepared(void)
 	}
 
 	if (!succeeded)
-		ereport(PANIC,
-				(errmsg("unable to complete 'Abort' broadcast"),
+	{
+		DisconnectAndDestroyAllGangs(true);
+		CheckForResetSession();
+		SendPostmasterSignal(PMSIGNAL_WAKEN_DTX_RECOVERY);
+		ereport(WARNING,
+				(errmsg("unable to complete 'Abort' broadcast. The dtx recovery"
+						" process will continue trying that."),
 				TM_ERRDETAIL));
+	}
 
 	ereport(DTM_DEBUG5,
 			(errmsg("The distributed transaction 'Abort' broadcast succeeded to all the segments"),
@@ -1118,6 +1126,7 @@ tmShmemInit(void)
 		SpinLockInit(&shared->gxidGenLock);
 	}
 	shmDtmStarted = &shared->DtmStarted;
+	shmDtxRecoveryPid = &shared->DtxRecoveryPid;
 	shmNextSnapshotId = &shared->NextSnapshotId;
 	shmNumCommittedGxacts = &shared->num_committed_xacts;
 	shmGxidGenLock = &shared->gxidGenLock;
@@ -1128,6 +1137,7 @@ tmShmemInit(void)
 	{
 		*shmNextSnapshotId = 0;
 		*shmDtmStarted = false;
+		*shmDtxRecoveryPid = 0;
 		*shmNumCommittedGxacts = 0;
 	}
 }

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -5577,6 +5577,11 @@ sigusr1_handler(SIGNAL_ARGS)
 		signal_child(FtsProbePID(), SIGINT);
 	}
 
+	if (CheckPostmasterSignal(PMSIGNAL_WAKEN_DTX_RECOVERY) && DtxRecoveryPID() != 0)
+	{
+		signal_child(DtxRecoveryPID(), SIGINT);
+	}
+
 	/*
 	 * Try to advance postmaster's state machine, if a child requests it.
 	 *

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -267,6 +267,7 @@ extern DtxContext DistributedTransactionContext;
 
 /* state variables for how much of the log file has been flushed */
 extern volatile bool *shmDtmStarted;
+extern volatile pid_t *shmDtxRecoveryPid;
 extern volatile DistributedTransactionTimeStamp *shmDistribTimeStamp;
 extern volatile DistributedTransactionId *shmGIDSeq;
 extern uint32 *shmNextSnapshotId;
@@ -348,6 +349,7 @@ extern void ClearTransactionState(TransactionId latestXid);
 
 extern int dtx_recovery_start(void);
 
+extern pid_t DtxRecoveryPID(void);
 extern void DtxRecoveryMain(Datum main_arg);
 extern bool DtxRecoveryStartRule(Datum main_arg);
 

--- a/src/include/storage/pmsignal.h
+++ b/src/include/storage/pmsignal.h
@@ -33,6 +33,7 @@ typedef enum
 	PMSIGNAL_ADVANCE_STATE_MACHINE,		/* advance postmaster's state machine */
 
 	PMSIGNAL_WAKEN_FTS,         /* wake up FTS to probe segments */
+	PMSIGNAL_WAKEN_DTX_RECOVERY,         /* wake up dtx recovery to abort dtx xacts */
 
 	NUM_PMSIGNALS				/* Must be last value of enum! */
 } PMSignalReason;

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -462,3 +462,116 @@ ALTER
  transaction | gid | prepared | owner | database 
 -------------+-----+----------+-------+----------
 (0 rows)
+
+-- Scenario 7: retry Abort Prepared on QD fails but won't cause panic. The dtx
+-- recovery process finally aborts it.
+
+-- speed up testing by setting some gucs.
+20: ALTER SYSTEM SET gp_dtx_recovery_prepared_period to 0;
+ALTER
+20: ALTER SYSTEM SET gp_dtx_recovery_interval to 5;
+ALTER
+20: ALTER SYSTEM SET dtx_phase2_retry_count to 2;
+ALTER
+20: SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+
+20: CREATE TABLE test_retry_abort(a int);
+CREATE
+
+-- master: set fault to trigger abort prepare
+-- primary 0: set fault so that retry prepared abort fails.
+20: SELECT gp_inject_fault('dtm_broadcast_prepare', 'error', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+20: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'error', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- run two phase query.
+21: INSERT INTO test_retry_abort SELECT generate_series(1,10);
+ERROR:  fault triggered, fault name:'dtm_broadcast_prepare' fault type:'error'
+
+-- verify the transaction was aborted and there is one orphaned prepared
+-- transaction on seg0.
+20: SELECT * from test_retry_abort;
+ a 
+---
+(0 rows)
+0U: SELECT count(*) from pg_prepared_xacts;
+ count 
+-------
+ 1     
+(1 row)
+
+-- dtx recovery ready to handle the orphaned prepared transaction.
+20: SELECT gp_inject_fault_infinite('before_orphaned_check', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+20: SELECT gp_wait_until_triggered_fault('before_orphaned_check', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+20: SELECT gp_inject_fault_infinite('after_orphaned_check', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- kick off abort prepared on seg0 and then dtx recovery will abort that one.
+20: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+20: SELECT gp_inject_fault_infinite('before_orphaned_check', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- verify there is no orphaned prepared transaction on seg0.
+20: SELECT gp_wait_until_triggered_fault('after_orphaned_check', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+0U: SELECT * from pg_prepared_xacts;
+ transaction | gid | prepared | owner | database 
+-------------+-----+----------+-------+----------
+(0 rows)
+
+-- cleanup
+20: ALTER SYSTEM RESET gp_dtx_recovery_interval;
+ALTER
+20: ALTER SYSTEM RESET gp_dtx_recovery_prepared_period;
+ALTER
+20: ALTER SYSTEM RESET dtx_phase2_retry_count;
+ALTER
+20: SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+20: SELECT gp_inject_fault('dtm_broadcast_prepare', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+20: SELECT gp_inject_fault_infinite('after_orphaned_check', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+20: DROP TABLE test_retry_abort;
+DROP

--- a/src/test/isolation2/sql/crash_recovery_dtm.sql
+++ b/src/test/isolation2/sql/crash_recovery_dtm.sql
@@ -244,3 +244,59 @@ $$ LANGUAGE plpgsql;
 
 -- ensure the orphaned prepared transaction is gone.
 1U: SELECT * from pg_prepared_xacts;
+
+-- Scenario 7: retry Abort Prepared on QD fails but won't cause panic. The dtx
+-- recovery process finally aborts it.
+
+-- speed up testing by setting some gucs.
+20: ALTER SYSTEM SET gp_dtx_recovery_prepared_period to 0;
+20: ALTER SYSTEM SET gp_dtx_recovery_interval to 5;
+20: ALTER SYSTEM SET dtx_phase2_retry_count to 2;
+20: SELECT pg_reload_conf();
+
+20: CREATE TABLE test_retry_abort(a int);
+
+-- master: set fault to trigger abort prepare
+-- primary 0: set fault so that retry prepared abort fails.
+20: SELECT gp_inject_fault('dtm_broadcast_prepare', 'error', dbid)
+   from gp_segment_configuration where role = 'p' and content = -1;
+20: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'error', dbid)
+   from gp_segment_configuration where role = 'p' and content = 0;
+
+-- run two phase query.
+21: INSERT INTO test_retry_abort SELECT generate_series(1,10);
+
+-- verify the transaction was aborted and there is one orphaned prepared
+-- transaction on seg0.
+20: SELECT * from test_retry_abort;
+0U: SELECT count(*) from pg_prepared_xacts;
+
+-- dtx recovery ready to handle the orphaned prepared transaction.
+20: SELECT gp_inject_fault_infinite('before_orphaned_check', 'suspend', dbid)
+   from gp_segment_configuration where role = 'p' and content = -1;
+20: SELECT gp_wait_until_triggered_fault('before_orphaned_check', 1, dbid)
+   from gp_segment_configuration where role = 'p' and content = -1;
+20: SELECT gp_inject_fault_infinite('after_orphaned_check', 'skip', dbid)
+   from gp_segment_configuration where role = 'p' and content = -1;
+
+-- kick off abort prepared on seg0 and then dtx recovery will abort that one.
+20: SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'reset', dbid)
+   from gp_segment_configuration where role = 'p' and content = 0;
+20: SELECT gp_inject_fault_infinite('before_orphaned_check', 'reset', dbid)
+   from gp_segment_configuration where role = 'p' and content = -1;
+
+-- verify there is no orphaned prepared transaction on seg0.
+20: SELECT gp_wait_until_triggered_fault('after_orphaned_check', 1, dbid)
+   from gp_segment_configuration where role = 'p' and content = -1;
+0U: SELECT * from pg_prepared_xacts;
+
+-- cleanup
+20: ALTER SYSTEM RESET gp_dtx_recovery_interval;
+20: ALTER SYSTEM RESET gp_dtx_recovery_prepared_period;
+20: ALTER SYSTEM RESET dtx_phase2_retry_count;
+20: SELECT pg_reload_conf();
+20: SELECT gp_inject_fault('dtm_broadcast_prepare', 'reset', dbid)
+   from gp_segment_configuration where role = 'p' and content = -1;
+20: SELECT gp_inject_fault_infinite('after_orphaned_check', 'reset', dbid)
+   from gp_segment_configuration where role = 'p' and content = -1;
+20: DROP TABLE test_retry_abort;


### PR DESCRIPTION
Previously QD panicks when Abort Prepared retry fails but this is not friendly
due to master reset (all sessions are gone). The panic is not that needed since
even Abort Prepared fails the cluster is consistent, but we still need to try
to finish the Abort since the orphaned prepared transaction still holds
resources.  Now that we do periodical handling of orphaned prepared transaction
in the dtx recovery process, QD could simply ignore and then proceed if Abort
Prepared retry fails.

Reviewed-by: Gang Xiong <gangx@vmware.com>
(cherry picked from commit ea3514afdd1b04fbfd544a7851b88afadbd9843c)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
