### PR TITLE
Fix 6x gpload fail when column types are not specified

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1876,7 +1876,7 @@ class gpload:
                     self.log(self.DEBUG,
                              'getting source column data type from target')
                     for name, typ, mapto, hasseq in self.into_columns:
-                        if sqlIdentifierCompare(name, key):
+                        if sqlIdentifierCompare(name,quote_ident(key) ):
                             d[key] = typ
                             break
 

--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -135,6 +135,10 @@ def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',
         f.write("\n    - COLUMNS:")
         f.write("\n           - 'Field1': bigint")
         f.write("\n           - 'Field#2': text")
+    if columns_flag == '2':
+        f.write("\n    - COLUMNS:")
+        f.write("\n           - 'Field1':")
+        f.write("\n           - 'Field#2':")
     if format:
         f.write("\n    - FORMAT: "+format)
     if log_errors:
@@ -454,7 +458,7 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
 
     def test_00_gpload_formatOpts_setup(self):
         "0  gpload setup"
-        for num in range(1,42):
+        for num in range(1,43):
            f = open(mkpath('query%d.sql' % num),'w')
            f.write("\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n"+"\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n")
            f.close()
@@ -810,6 +814,13 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         f.write("\! gpload -f "+mkpath('config/config_file2')+ " -d reuse_gptest\n")
         f.close()
         self.doTest(41)
+    
+    def test_42_gpload_column_without_data_type(self):
+        file = mkpath('setup.sql')
+        runfile(file)
+        copy_data('external_file_15.txt','data_file.txt')
+        write_config_file(mode='insert',reuse_flag='true',fast_match='false', file='data_file.txt',table='testSpecialChar',columns_flag='3', delimiter=";")
+        self.doTest(42)
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(GPLoad_FormatOpts_TestCase)

--- a/gpMgmt/bin/gpload_test/gpload2/query42.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query42.ans
@@ -1,0 +1,18 @@
+2020-10-13 17:52:40|INFO|gpload session started 2020-10-13 17:52:40
+2020-10-13 17:52:40|INFO|setting schema 'public' for table 'testspecialchar'
+2020-10-13 17:52:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2020-10-13 17:52:40|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d5200d42_0d39_11eb_992a_00505698707d
+2020-10-13 17:52:40|INFO|running time: 0.09 seconds
+2020-10-13 17:52:40|INFO|rows Inserted          = 8
+2020-10-13 17:52:40|INFO|rows Updated           = 0
+2020-10-13 17:52:40|INFO|data formatting errors = 0
+2020-10-13 17:52:40|INFO|gpload succeeded
+2020-10-13 17:52:40|INFO|gpload session started 2020-10-13 17:52:40
+2020-10-13 17:52:40|INFO|setting schema 'public' for table 'testspecialchar'
+2020-10-13 17:52:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2020-10-13 17:52:40|INFO|reusing external table ext_gpload_reusable_d5200d42_0d39_11eb_992a_00505698707d
+2020-10-13 17:52:40|INFO|running time: 0.07 seconds
+2020-10-13 17:52:40|INFO|rows Inserted          = 8
+2020-10-13 17:52:40|INFO|rows Updated           = 0
+2020-10-13 17:52:40|INFO|data formatting errors = 0
+2020-10-13 17:52:40|INFO|gpload succeeded


### PR DESCRIPTION
* fix 6x gpload fail when capital letters in column names without data type
quote column names before comparing
* add test case

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
