### PR TITLE
Configure: disable gpcloud, enable python by default

### DIFF
--- a/concourse/scripts/builds/GpBuild.py
+++ b/concourse/scripts/builds/GpBuild.py
@@ -16,6 +16,7 @@ class GpBuild:
                                     "--enable-orafce",
                                     "--with-gssapi",
                                     "--with-perl",
+                                    "--enable-gpcloud",
                                     "--with-libxml",
                                     "--with-python",
                                     # TODO: Remove this line as soon as zstd is built into Ubuntu docker image

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -31,7 +31,7 @@ function configure() {
       # The full set of configure options which were used for building the
       # tree must be used here as well since the toplevel Makefile depends
       # on these options for deciding what to test. Since we don't ship
-      ./configure --prefix=/usr/local/greenplum-db-devel --with-perl --with-python PYTHON=python3 --with-libxml --enable-mapreduce --enable-orafce --enable-tap-tests --disable-orca --with-openssl ${CONFIGURE_FLAGS}
+      ./configure --prefix=/usr/local/greenplum-db-devel --with-perl --with-python PYTHON=python3 --enable-gpcloud --with-libxml --enable-mapreduce --enable-orafce --enable-tap-tests --disable-orca --with-openssl ${CONFIGURE_FLAGS}
 
   popd
 }

--- a/configure
+++ b/configure
@@ -1600,7 +1600,7 @@ Optional Packages:
   --with-tcl              build Tcl modules (PL/Tcl)
   --with-tclconfig=DIR    tclConfig.sh is in DIR
   --with-perl             build Perl modules (PL/Perl)
-  --with-python           build Python modules (PL/Python)
+  --without-python        build Python modules (PL/Python)
   --with-gssapi           build with GSSAPI support
   --with-krb-srvnam=NAME  default service principal name in Kerberos (GSSAPI)
                           [postgres]
@@ -8609,7 +8609,7 @@ if test "${with_python+set}" = set; then :
   esac
 
 else
-  with_python=no
+  with_python=yes
 
 fi
 

--- a/configure
+++ b/configure
@@ -1573,7 +1573,7 @@ Optional Features:
   --enable-cassert        enable assertion checks (for debugging)
   --disable-orca          disable ORCA optimizer
   --enable-mapreduce      enable Greenplum Mapreduce support
-  --disable-gpcloud       disable gpcloud support
+  --enable-gpcloud        enable gpcloud support
   --enable-ic-proxy       enable interconnect proxy mode (requires libuv
                           library)
   --disable-thread-safety disable thread-safety in client libraries
@@ -7649,9 +7649,7 @@ $as_echo "#define USE_GPCLOUD 1" >>confdefs.h
   esac
 
 else
-  enable_gpcloud=yes
-
-$as_echo "#define USE_GPCLOUD 1" >>confdefs.h
+  enable_gpcloud=no
 
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -893,7 +893,7 @@ AC_SUBST(with_perl)
 # Optionally build Python modules (PL/Python)
 #
 AC_MSG_CHECKING([whether to build Python modules])
-PGAC_ARG_BOOL(with, python, no, [build Python modules (PL/Python)])
+PGAC_ARG_BOOL(with, python, yes, [build Python modules (PL/Python)])
 AC_MSG_RESULT([$with_python])
 AC_SUBST(with_python)
 

--- a/configure.in
+++ b/configure.in
@@ -791,7 +791,7 @@ AC_SUBST(enable_mapreduce)
 #
 # gpcloud, enabled by default
 #
-PGAC_ARG_BOOL(enable, gpcloud, yes, [disable gpcloud support],
+PGAC_ARG_BOOL(enable, gpcloud, no, [enable gpcloud support],
               [AC_DEFINE([USE_GPCLOUD], 1,
 			             [Define to 1 to build with gpcloud (--enable-gpcloud)])])
 AC_MSG_RESULT([checking whether to build with gpcloud... $enable_gpcloud])

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -126,11 +126,11 @@ APR_CONFIG=--with-apr-config=$(BLD_THIRDPARTY_BIN_DIR)/apr-1-config
 endif
 
 aix7_ppc_64_CONFIGFLAGS=--disable-gpcloud --without-readline --without-libcurl --disable-orca --disable-pxf --without-zstd $(APR_CONFIG)
-rhel6_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
-rhel7_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
-linux_x86_64_CONFIGFLAGS=${ORCA_CONFIG} --with-libxml $(APR_CONFIG)
-ubuntu18.04_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
-sles12_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
+rhel6_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --enable-gpcloud --with-libxml
+rhel7_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --enable-gpcloud --with-libxml
+linux_x86_64_CONFIGFLAGS=${ORCA_CONFIG} --enable-gpcloud --with-libxml $(APR_CONFIG)
+ubuntu18.04_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --enable-gpcloud --with-libxml
+sles12_x86_64_CONFIGFLAGS=--with-quicklz --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --enable-gpcloud --with-libxml
 BLD_CONFIGFLAGS=$($(BLD_ARCH)_CONFIGFLAGS)
 
 CONFIGFLAGS=$(strip $(BLD_CONFIGFLAGS) --with-pgport=$(DEFPORT) $(BLD_DEPLOYMENT_SETTING))

--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -690,7 +690,7 @@ AllocSetReset(MemoryContext context)
 {
 	AllocSet	set = (AllocSet) context;
 	AllocBlock	block;
-	Size		keepersize = set->keeper->endptr - ((char *) set);
+	Size		keepersize PG_USED_FOR_ASSERTS_ONLY = set->keeper->endptr - ((char *) set);
 
 	AssertArg(AllocSetIsValid(set));
 
@@ -764,7 +764,7 @@ AllocSetDelete(MemoryContext context, MemoryContext parent)
 {
 	AllocSet	set = (AllocSet) context;
 	AllocBlock	block = set->blocks;
-	Size		keepersize = set->keeper->endptr - ((char *) set);
+	Size		keepersize PG_USED_FOR_ASSERTS_ONLY = set->keeper->endptr - ((char *) set);
 
 	AssertArg(AllocSetIsValid(set));
 


### PR DESCRIPTION

With this can do `configure && make install && make installcheck`

---
    Enable building with python by default in configure
    
    Many tests in GPDB depend on plpython, hence enabling it by default is
    helpful, instead of required to specify everytime. Given python is
    needed on developer system for GPDB Management Scripts so its not
    adding any new dependency.
---
    Disable gpcloud by default in configure
    
    gpcloud has dependency on libxml. gpcloud enabled by default and
    libxml disabled by default in configure, creates a weird pattern where
    at least one option needs to be specified for configure to pass, just
    ./configure never passes for Greenplum.
    
    ICG and isolation2 tests just pass without it so seems a better route
    to disable gpcloud. Alternatively, can enable libxml by default but
    seems conflicts with upstream and seems unnecessary dependency to add
    for routine development.
    
    Discussion:
    https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/laqc2YXxCWU/m/fS6ojeDIAQAJ
---
Also has a small commit to fix compiler warning for non-assert enabled builds.
