### PR TITLE
[ORCA] Remove unused private fields

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -1698,7 +1698,6 @@ CTranslatorQueryToDXL::TranslateWindowToDXL(
 						m_mp,
 						GPOS_NEW(m_mp) CDXLScalarIdent(
 							m_mp, GPOS_NEW(m_mp) CDXLColRef(
-									  m_mp,
 									  GPOS_NEW(m_mp) CMDName(
 										  m_mp, mdname_alias->GetMDName()),
 									  colid,
@@ -4183,8 +4182,8 @@ CTranslatorQueryToDXL::CreateDXLOutputCols(
 		IMDId *mdid_type = GPOS_NEW(m_mp)
 			CMDIdGPDB(gpdb::ExprType((Node *) target_entry->expr));
 		INT type_modifier = gpdb::ExprTypeMod((Node *) target_entry->expr);
-		CDXLColRef *dxl_colref = GPOS_NEW(m_mp)
-			CDXLColRef(m_mp, mdname, colid, mdid_type, type_modifier);
+		CDXLColRef *dxl_colref =
+			GPOS_NEW(m_mp) CDXLColRef(mdname, colid, mdid_type, type_modifier);
 		CDXLScalarIdent *dxl_ident =
 			GPOS_NEW(m_mp) CDXLScalarIdent(m_mp, dxl_colref);
 

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -2716,7 +2716,7 @@ CTranslatorQueryToDXL::CreateDXLSetOpFromColumns(
 	CDXLLogicalSetOp *dxlop =
 		GPOS_NEW(m_mp) CDXLLogicalSetOp(m_mp, setop_type, output_col_descrs,
 										input_colids, is_cast_across_input);
-	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop, children_dxlnodes);
+	CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(dxlop, children_dxlnodes);
 
 	bitset->Release();
 	output_col_pos->Release();
@@ -3440,7 +3440,7 @@ CTranslatorQueryToDXL::TranslateValueScanRTEToDXL(const RangeTblEntry *rte,
 		// create a UNION ALL operator
 		CDXLLogicalSetOp *dxlop = GPOS_NEW(m_mp) CDXLLogicalSetOp(
 			m_mp, EdxlsetopUnionAll, dxl_col_descr_array, input_colids, false);
-		CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop, dxlnodes);
+		CDXLNode *dxlnode = GPOS_NEW(m_mp) CDXLNode(dxlop, dxlnodes);
 
 		// make note of new columns from UNION ALL
 		m_var_to_colid_map->LoadColumns(m_query_level, rt_index,
@@ -3516,7 +3516,7 @@ CTranslatorQueryToDXL::TranslateColumnValuesToDXL(
 	// create a project node for the list of project elements
 	project_elem_dxlnode_array->AddRef();
 	CDXLNode *project_list_dxlnode =
-		GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp),
+		GPOS_NEW(m_mp) CDXLNode(GPOS_NEW(m_mp) CDXLScalarProjList(m_mp),
 								project_elem_dxlnode_array);
 
 	CDXLNode *project_dxlnode =

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3515,9 +3515,8 @@ CTranslatorQueryToDXL::TranslateColumnValuesToDXL(
 
 	// create a project node for the list of project elements
 	project_elem_dxlnode_array->AddRef();
-	CDXLNode *project_list_dxlnode =
-		GPOS_NEW(m_mp) CDXLNode(GPOS_NEW(m_mp) CDXLScalarProjList(m_mp),
-								project_elem_dxlnode_array);
+	CDXLNode *project_list_dxlnode = GPOS_NEW(m_mp) CDXLNode(
+		GPOS_NEW(m_mp) CDXLScalarProjList(m_mp), project_elem_dxlnode_array);
 
 	CDXLNode *project_dxlnode =
 		GPOS_NEW(m_mp) CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalProject(m_mp),

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -886,11 +886,11 @@ CTranslatorQueryToDXL::TranslateCTASToDXL()
 		GPOS_ASSERT(NULL != md_colname);
 		IMDId *mdid = dxl_ident->MdidType();
 		mdid->AddRef();
-		CDXLColDescr *dxl_col_descr = GPOS_NEW(m_mp) CDXLColDescr(
-			m_mp, md_colname, m_context->m_colid_counter->next_id(),
-			resno /* attno */, mdid, dxl_ident->TypeModifier(),
-			false /* is_dropped */
-		);
+		CDXLColDescr *dxl_col_descr = GPOS_NEW(m_mp)
+			CDXLColDescr(md_colname, m_context->m_colid_counter->next_id(),
+						 resno /* attno */, mdid, dxl_ident->TypeModifier(),
+						 false /* is_dropped */
+			);
 		dxl_col_descr_array->Append(dxl_col_descr);
 	}
 
@@ -2479,7 +2479,7 @@ CTranslatorQueryToDXL::DXLDummyConstTableGet() const
 	CWStringConst str_unnamed_col(GPOS_WSZ_LIT(""));
 	CMDName *mdname = GPOS_NEW(m_mp) CMDName(m_mp, &str_unnamed_col);
 	CDXLColDescr *dxl_col_descr = GPOS_NEW(m_mp)
-		CDXLColDescr(m_mp, mdname, m_context->m_colid_counter->next_id(),
+		CDXLColDescr(mdname, m_context->m_colid_counter->next_id(),
 					 1 /* attno */, GPOS_NEW(m_mp) CMDIdGPDB(mdid->Oid()),
 					 default_type_modifier, false /* is_dropped */
 		);
@@ -3352,7 +3352,7 @@ CTranslatorQueryToDXL::TranslateValueScanRTEToDXL(const RangeTblEntry *rte,
 				GPOS_DELETE(alias_str);
 
 				CDXLColDescr *dxl_col_descr = GPOS_NEW(m_mp) CDXLColDescr(
-					m_mp, mdname, colid, col_pos_idx + 1 /* attno */,
+					mdname, colid, col_pos_idx + 1 /* attno */,
 					GPOS_NEW(m_mp) CMDIdGPDB(const_expr->consttype),
 					const_expr->consttypmod, false /* is_dropped */
 				);
@@ -3384,7 +3384,7 @@ CTranslatorQueryToDXL::TranslateValueScanRTEToDXL(const RangeTblEntry *rte,
 					GPOS_DELETE(alias_str);
 
 					CDXLColDescr *dxl_col_descr = GPOS_NEW(m_mp) CDXLColDescr(
-						m_mp, mdname, colid, col_pos_idx + 1 /* attno */,
+						mdname, colid, col_pos_idx + 1 /* attno */,
 						GPOS_NEW(m_mp) CMDIdGPDB(gpdb::ExprType((Node *) expr)),
 						gpdb::ExprTypeMod((Node *) expr), false /* is_dropped */
 					);

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1889,7 +1889,7 @@ CTranslatorRelcacheToDXL::RetrieveCheckConstraints(CMemoryPool *mp,
 
 		// create a column descriptor for the column
 		CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr(
-			mp, md_colname, ul + 1 /*colid*/, md_col->AttrNum(), mdid_col_type,
+			md_colname, ul + 1 /*colid*/, md_col->AttrNum(), mdid_col_type,
 			md_col->TypeModifier(), false /* fColDropped */
 		);
 		dxl_col_descr_array->Append(dxl_col_descr);
@@ -3128,7 +3128,7 @@ CTranslatorRelcacheToDXL::RetrievePartConstraintForIndex(
 
 		// create a column descriptor for the column
 		CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr(
-			mp, md_colname,
+			md_colname,
 			ul + 1,	 // colid
 			md_col->AttrNum(), mdid_col_type, md_col->TypeModifier(),
 			false  // fColDropped

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -217,9 +217,8 @@ CTranslatorScalarToDXL::TranslateVarToDXL(
 	CMDName *mdname = GPOS_NEW(m_mp) CMDName(m_mp, str);
 
 	// create a column reference for the given var
-	CDXLColRef *dxl_colref = GPOS_NEW(m_mp)
-		CDXLColRef(m_mp, mdname, id, GPOS_NEW(m_mp) CMDIdGPDB(var->vartype),
-				   var->vartypmod);
+	CDXLColRef *dxl_colref = GPOS_NEW(m_mp) CDXLColRef(
+		mdname, id, GPOS_NEW(m_mp) CMDIdGPDB(var->vartype), var->vartypmod);
 
 	// create the scalar ident operator
 	CDXLScalarIdent *scalar_ident =
@@ -1471,12 +1470,12 @@ CTranslatorScalarToDXL::TranslateWindowFrameEdgeToDXL(
 
 		// construct a new scalar ident
 		CDXLScalarIdent *scalar_ident = GPOS_NEW(m_mp) CDXLScalarIdent(
-			m_mp, GPOS_NEW(m_mp) CDXLColRef(
-					  m_mp, GPOS_NEW(m_mp) CMDName(m_mp, &unnamed_col),
-					  project_element_id,
-					  GPOS_NEW(m_mp)
-						  CMDIdGPDB(gpdb::ExprType(const_cast<Node *>(node))),
-					  gpdb::ExprTypeMod(const_cast<Node *>(node))));
+			m_mp,
+			GPOS_NEW(m_mp) CDXLColRef(
+				GPOS_NEW(m_mp) CMDName(m_mp, &unnamed_col), project_element_id,
+				GPOS_NEW(m_mp)
+					CMDIdGPDB(gpdb::ExprType(const_cast<Node *>(node))),
+				gpdb::ExprTypeMod(const_cast<Node *>(node))));
 
 		val_node = GPOS_NEW(m_mp) CDXLNode(m_mp, scalar_ident);
 	}

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -100,7 +100,7 @@ CTranslatorUtils::GetIndexDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 	const CWStringConst *index_name = index->Mdname().GetMDName();
 	CMDName *index_mdname = GPOS_NEW(mp) CMDName(mp, index_name);
 
-	return GPOS_NEW(mp) CDXLIndexDescr(mp, mdid, index_mdname);
+	return GPOS_NEW(mp) CDXLIndexDescr(mdid, index_mdname);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1415,7 +1415,7 @@ CTranslatorUtils::CreateDummyProjectElem(CMemoryPool *mp, ULONG colid_input,
 	CMDName *mdname =
 		GPOS_NEW(mp) CMDName(mp, dxl_col_descr->MdName()->GetMDName());
 	CDXLColRef *dxl_colref = GPOS_NEW(mp) CDXLColRef(
-		mp, mdname, colid_input, copy_mdid, dxl_col_descr->TypeModifier());
+		mdname, colid_input, copy_mdid, dxl_col_descr->TypeModifier());
 	CDXLScalarIdent *dxl_scalar_ident =
 		GPOS_NEW(mp) CDXLScalarIdent(mp, dxl_colref);
 

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -183,7 +183,7 @@ CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 
 		// create a column descriptor for the column
 		CDXLColDescr *dxl_col_descr = GPOS_NEW(mp)
-			CDXLColDescr(mp, col, id_generator->next_id(), md_col->AttrNum(),
+			CDXLColDescr(col, id_generator->next_id(), md_col->AttrNum(),
 						 col_type, md_col->TypeModifier(), /* type_modifier */
 						 false,							   /* fColDropped */
 						 md_col->Length());
@@ -479,7 +479,7 @@ CTranslatorUtils::GetColumnDescriptorsFromRecord(CMemoryPool *mp,
 		IMDId *col_type = GPOS_NEW(mp) CMDIdGPDB(coltype);
 
 		CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr(
-			mp, col_mdname, id_generator->next_id(), INT(ul + 1) /* attno */,
+			col_mdname, id_generator->next_id(), INT(ul + 1) /* attno */,
 			col_type, type_modifier, false /* fColDropped */
 		);
 		column_descrs->Append(dxl_col_descr);
@@ -526,7 +526,7 @@ CTranslatorUtils::GetColumnDescriptorsFromRecord(CMemoryPool *mp,
 		// This function is only called to construct column descriptors for table-valued functions
 		// which won't have type modifiers for columns of the returned table
 		CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr(
-			mp, col_mdname, id_generator->next_id(), INT(ul + 1) /* attno */,
+			col_mdname, id_generator->next_id(), INT(ul + 1) /* attno */,
 			col_type, default_type_modifier, false /* fColDropped */
 		);
 		column_descrs->Append(dxl_col_descr);
@@ -556,11 +556,11 @@ CTranslatorUtils::GetColumnDescriptorsFromBase(CMemoryPool *mp,
 	mdid_return_type->AddRef();
 	CMDName *col_mdname = GPOS_NEW(mp) CMDName(mp, pmdName->GetMDName());
 
-	CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr(
-		mp, col_mdname, id_generator->next_id(), INT(1) /* attno */,
-		mdid_return_type, type_modifier, /* type_modifier */
-		false							 /* fColDropped */
-	);
+	CDXLColDescr *dxl_col_descr = GPOS_NEW(mp)
+		CDXLColDescr(col_mdname, id_generator->next_id(), INT(1) /* attno */,
+					 mdid_return_type, type_modifier, /* type_modifier */
+					 false							  /* fColDropped */
+		);
 
 	column_descrs->Append(dxl_col_descr);
 
@@ -595,7 +595,7 @@ CTranslatorUtils::GetColumnDescriptorsFromComposite(CMemoryPool *mp,
 
 		col_type->AddRef();
 		CDXLColDescr *dxl_col_descr = GPOS_NEW(mp) CDXLColDescr(
-			mp, col_mdname, id_generator->next_id(), INT(ul + 1) /* attno */,
+			col_mdname, id_generator->next_id(), INT(ul + 1) /* attno */,
 			col_type, md_col->TypeModifier(), /* type_modifier */
 			false							  /* fColDropped */
 		);
@@ -1386,7 +1386,7 @@ CTranslatorUtils::GetColumnDescrAt(CMemoryPool *mp, TargetEntry *target_entry,
 	INT type_modifier = gpdb::ExprTypeMod((Node *) target_entry->expr);
 	CMDIdGPDB *col_type = GPOS_NEW(mp) CMDIdGPDB(type_oid);
 	CDXLColDescr *dxl_col_descr =
-		GPOS_NEW(mp) CDXLColDescr(mp, mdname, colid, pos,  /* attno */
+		GPOS_NEW(mp) CDXLColDescr(mdname, colid, pos,	   /* attno */
 								  col_type, type_modifier, /* type_modifier */
 								  false					   /* fColDropped */
 		);

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CKeyCollection.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CKeyCollection.h
@@ -33,9 +33,6 @@ using namespace gpos;
 class CKeyCollection : public CRefCount
 {
 private:
-	// memory pool
-	CMemoryPool *m_mp;
-
 	// array of key sets
 	CColRefSetArray *m_pdrgpcrs;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -82,9 +82,6 @@ private:
 	// key sets
 	CBitSetArray *m_pdrgpbsKeys;
 
-	// number of leaf partitions
-	ULONG m_num_of_partitions;
-
 	// id of user the table needs to be accessed with
 	ULONG m_execute_as_user_id;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/minidump/CMiniDumperDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/minidump/CMiniDumperDXL.h
@@ -34,7 +34,7 @@ private:
 
 public:
 	// ctor
-	explicit CMiniDumperDXL(CMemoryPool *mp);
+	CMiniDumperDXL();
 
 	// dtor
 	virtual ~CMiniDumperDXL();

--- a/src/backend/gporca/libgpopt/src/base/CKeyCollection.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CKeyCollection.cpp
@@ -23,7 +23,7 @@ using namespace gpopt;
 //		ctor
 //
 //---------------------------------------------------------------------------
-CKeyCollection::CKeyCollection(CMemoryPool *mp) : m_mp(mp), m_pdrgpcrs(NULL)
+CKeyCollection::CKeyCollection(CMemoryPool *mp) : m_pdrgpcrs(NULL)
 {
 	GPOS_ASSERT(NULL != mp);
 
@@ -40,7 +40,7 @@ CKeyCollection::CKeyCollection(CMemoryPool *mp) : m_mp(mp), m_pdrgpcrs(NULL)
 //
 //---------------------------------------------------------------------------
 CKeyCollection::CKeyCollection(CMemoryPool *mp, CColRefSet *pcrs)
-	: m_mp(mp), m_pdrgpcrs(NULL)
+	: m_pdrgpcrs(NULL)
 {
 	GPOS_ASSERT(NULL != pcrs && 0 < pcrs->Size());
 
@@ -60,7 +60,7 @@ CKeyCollection::CKeyCollection(CMemoryPool *mp, CColRefSet *pcrs)
 //
 //---------------------------------------------------------------------------
 CKeyCollection::CKeyCollection(CMemoryPool *mp, CColRefArray *colref_array)
-	: m_mp(mp), m_pdrgpcrs(NULL)
+	: m_pdrgpcrs(NULL)
 {
 	GPOS_ASSERT(NULL != mp);
 	GPOS_ASSERT(NULL != colref_array && 0 < colref_array->Size());

--- a/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -48,7 +48,6 @@ CTableDescriptor::CTableDescriptor(
 	  m_convert_hash_to_random(convert_hash_to_random),
 	  m_pdrgpulPart(NULL),
 	  m_pdrgpbsKeys(NULL),
-	  m_num_of_partitions(0),
 	  m_execute_as_user_id(ulExecuteAsUser),
 	  m_fHasPartialIndexes(FDescriptorWithPartialIndexes())
 {

--- a/src/backend/gporca/libgpopt/src/minidump/CMiniDumperDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/minidump/CMiniDumperDXL.cpp
@@ -33,7 +33,7 @@ using namespace gpopt;
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CMiniDumperDXL::CMiniDumperDXL(CMemoryPool *mp) : CMiniDumper(mp)
+CMiniDumperDXL::CMiniDumperDXL() : CMiniDumper()
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/optimizer/COptimizer.cpp
+++ b/src/backend/gporca/libgpopt/src/optimizer/COptimizer.cpp
@@ -247,7 +247,7 @@ COptimizer::PdxlnOptimize(
 	// If minidump was requested, open the minidump file and initialize
 	// minidumper. (We create the minidumper object even if we're not
 	// dumping, but without the Init-call, it will stay inactive.)
-	CMiniDumperDXL mdmp(mp);
+	CMiniDumperDXL mdmp;
 	CAutoP<std::wofstream> wosMinidump;
 	CAutoP<COstreamBasic> osMinidump;
 	if (fMinidump)

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3456,8 +3456,8 @@ CTranslatorExprToDXL::PdxlnCorrelatedNLJoin(
 		CMDName *mdname = GPOS_NEW(m_mp) CMDName(m_mp, colref->Name().Pstr());
 		IMDId *mdid = colref->RetrieveType()->MDId();
 		mdid->AddRef();
-		CDXLColRef *dxl_colref = GPOS_NEW(m_mp) CDXLColRef(
-			m_mp, mdname, colref->Id(), mdid, colref->TypeModifier());
+		CDXLColRef *dxl_colref = GPOS_NEW(m_mp)
+			CDXLColRef(mdname, colref->Id(), mdid, colref->TypeModifier());
 		dxl_colref_array->Append(dxl_colref);
 	}
 
@@ -3953,7 +3953,7 @@ CTranslatorExprToDXL::PdxlnNLJoin(CExpression *pexprInnerNLJ,
 			IMDId *mdid = col_ref->RetrieveType()->MDId();
 			mdid->AddRef();
 			CDXLColRef *colref_dxl = GPOS_NEW(m_mp) CDXLColRef(
-				m_mp, md_name, col_ref->Id(), mdid, col_ref->TypeModifier());
+				md_name, col_ref->Id(), mdid, col_ref->TypeModifier());
 			col_refs->Append(colref_dxl);
 		}
 	}

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -5705,7 +5705,7 @@ CTranslatorExprToDXL::PdxlnCTAS(CExpression *pexpr,
 		pmdidColType->AddRef();
 
 		CDXLColDescr *pdxlcd = GPOS_NEW(m_mp) CDXLColDescr(
-			m_mp, pmdnameCol, colref->Id(), pcd->AttrNum(), pmdidColType,
+			pmdnameCol, colref->Id(), pcd->AttrNum(), pmdidColType,
 			colref->TypeModifier(), false /* fdropped */, pcd->Width());
 
 		dxl_col_descr_array->Append(pdxlcd);
@@ -7368,7 +7368,7 @@ CTranslatorExprToDXL::MakeDXLTableDescr(const CTableDescriptor *ptabdesc,
 		pmdidColType->AddRef();
 
 		CDXLColDescr *pdxlcd = GPOS_NEW(m_mp) CDXLColDescr(
-			m_mp, pmdnameCol, colref->Id(), pcd->AttrNum(), pmdidColType,
+			pmdnameCol, colref->Id(), pcd->AttrNum(), pmdidColType,
 			colref->TypeModifier(), false /* fdropped */, pcd->Width());
 
 		table_descr->AddColumnDescr(pdxlcd);

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -656,7 +656,7 @@ CTranslatorExprToDXL::PdxlnIndexScan(CExpression *pexprIndexScan,
 	IMDId *pmdidIndex = pindexdesc->MDId();
 	pmdidIndex->AddRef();
 	CDXLIndexDescr *dxl_index_descr =
-		GPOS_NEW(m_mp) CDXLIndexDescr(m_mp, pmdidIndex, pmdnameIndex);
+		GPOS_NEW(m_mp) CDXLIndexDescr(pmdidIndex, pmdnameIndex);
 
 	// TODO: vrgahavan; we assume that the index are always forward access.
 	// create the physical index scan operator
@@ -760,7 +760,7 @@ CTranslatorExprToDXL::PdxlnIndexOnlyScan(CExpression *pexprIndexOnlyScan,
 	IMDId *pmdidIndex = pindexdesc->MDId();
 	pmdidIndex->AddRef();
 	CDXLIndexDescr *dxl_index_descr =
-		GPOS_NEW(m_mp) CDXLIndexDescr(m_mp, pmdidIndex, pmdnameIndex);
+		GPOS_NEW(m_mp) CDXLIndexDescr(pmdidIndex, pmdnameIndex);
 
 	// TODO: vrgahavan; we assume that the index are always forward access.
 	// create the physical index scan operator
@@ -842,7 +842,7 @@ CTranslatorExprToDXL::PdxlnBitmapIndexProbe(CExpression *pexprBitmapIndexProbe)
 	pmdidIndex->AddRef();
 
 	CDXLIndexDescr *dxl_index_descr =
-		GPOS_NEW(m_mp) CDXLIndexDescr(m_mp, pmdidIndex, pmdnameIndex);
+		GPOS_NEW(m_mp) CDXLIndexDescr(pmdidIndex, pmdnameIndex);
 	CDXLScalarBitmapIndexProbe *dxl_op =
 		GPOS_NEW(m_mp) CDXLScalarBitmapIndexProbe(m_mp, dxl_index_descr);
 	CDXLNode *pdxlnBitmapIndexProbe = GPOS_NEW(m_mp) CDXLNode(m_mp, dxl_op);
@@ -1309,7 +1309,7 @@ CTranslatorExprToDXL::PdxlnDynamicIndexScan(
 	IMDId *pmdidIndex = pindexdesc->MDId();
 	pmdidIndex->AddRef();
 	CDXLIndexDescr *dxl_index_descr =
-		GPOS_NEW(m_mp) CDXLIndexDescr(m_mp, pmdidIndex, pmdnameIndex);
+		GPOS_NEW(m_mp) CDXLIndexDescr(pmdidIndex, pmdnameIndex);
 
 	// TODO: vrgahavan; we assume that the index are always forward access.
 	// create the physical index scan operator

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
@@ -1443,8 +1443,8 @@ CTranslatorExprToDXLUtils::ReplaceSubplan(
 	mdid_type->AddRef();
 	CMDName *mdname =
 		GPOS_NEW(mp) CMDName(mp, pdxlopPrEl->GetMdNameAlias()->GetMDName());
-	CDXLColRef *dxl_colref = GPOS_NEW(mp) CDXLColRef(
-		mp, mdname, pdxlopPrEl->Id(), mdid_type, colref->TypeModifier());
+	CDXLColRef *dxl_colref = GPOS_NEW(mp)
+		CDXLColRef(mdname, pdxlopPrEl->Id(), mdid_type, colref->TypeModifier());
 	CDXLScalarIdent *pdxlnScId = GPOS_NEW(mp) CDXLScalarIdent(mp, dxl_colref);
 	CDXLNode *dxlnode = GPOS_NEW(mp) CDXLNode(mp, pdxlnScId);
 	BOOL fReplaced GPOS_ASSERTS_ONLY =
@@ -1542,7 +1542,7 @@ CTranslatorExprToDXLUtils::PdxlnIdent(CMemoryPool *mp,
 	mdid->AddRef();
 
 	CDXLColRef *dxl_colref = GPOS_NEW(mp)
-		CDXLColRef(mp, mdname, colref->Id(), mdid, colref->TypeModifier());
+		CDXLColRef(mdname, colref->Id(), mdid, colref->TypeModifier());
 
 	CDXLScalarIdent *dxl_op = GPOS_NEW(mp) CDXLScalarIdent(mp, dxl_colref);
 	return GPOS_NEW(mp) CDXLNode(mp, dxl_op);

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
@@ -163,7 +163,7 @@ CTranslatorExprToDXLUtils::PdxlnPartialScanTest(
 	}
 
 	return GPOS_NEW(mp)
-		CDXLNode(mp, GPOS_NEW(mp) CDXLScalarBoolExpr(mp, Edxland), dxl_array);
+		CDXLNode(GPOS_NEW(mp) CDXLScalarBoolExpr(mp, Edxland), dxl_array);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpos/include/gpos/error/CMiniDumper.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CMiniDumper.h
@@ -28,9 +28,6 @@ namespace gpos
 class CMiniDumper : CStackObject
 {
 private:
-	// memory pool
-	CMemoryPool *m_mp;
-
 	// flag indicating if handler is initialized
 	BOOL m_initialized;
 
@@ -46,7 +43,7 @@ protected:
 
 public:
 	// ctor
-	CMiniDumper(CMemoryPool *mp);
+	CMiniDumper();
 
 	// dtor
 	virtual ~CMiniDumper();

--- a/src/backend/gporca/libgpos/server/include/unittest/gpos/error/CMiniDumperTest.h
+++ b/src/backend/gporca/libgpos/server/include/unittest/gpos/error/CMiniDumperTest.h
@@ -42,7 +42,7 @@ private:
 	{
 	public:
 		// ctor
-		CMiniDumperStream(CMemoryPool *mp);
+		CMiniDumperStream();
 
 		// dtor
 		virtual ~CMiniDumperStream();

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/error/CMiniDumperTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/error/CMiniDumperTest.cpp
@@ -57,7 +57,7 @@ CMiniDumperTest::EresUnittest_Basic()
 	CAutoMemoryPool amp;
 	CMemoryPool *mp = amp.Pmp();
 
-	CMiniDumperStream mdrs(mp);
+	CMiniDumperStream mdrs;
 
 	CWStringDynamic wstrMinidump(mp);
 	COstreamString oss(&wstrMinidump);
@@ -113,8 +113,7 @@ CMiniDumperTest::PvRaise(void *	 // pv
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CMiniDumperTest::CMiniDumperStream::CMiniDumperStream(CMemoryPool *mp)
-	: CMiniDumper(mp)
+CMiniDumperTest::CMiniDumperStream::CMiniDumperStream() : CMiniDumper()
 {
 }
 

--- a/src/backend/gporca/libgpos/src/error/CMiniDumper.cpp
+++ b/src/backend/gporca/libgpos/src/error/CMiniDumper.cpp
@@ -26,10 +26,9 @@ using namespace gpos;
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CMiniDumper::CMiniDumper(CMemoryPool *mp)
-	: m_mp(mp), m_initialized(false), m_finalized(false), m_oos(NULL)
+CMiniDumper::CMiniDumper()
+	: m_initialized(false), m_finalized(false), m_oos(NULL)
 {
-	GPOS_ASSERT(NULL != mp);
 }
 
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLColDescr.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLColDescr.h
@@ -41,9 +41,6 @@ typedef CDynamicPtrArray<CDXLColDescr, CleanupRelease> CDXLColDescrArray;
 class CDXLColDescr : public CRefCount
 {
 private:
-	// memory pool
-	CMemoryPool *m_mp;
-
 	// name
 	CMDName *m_md_name;
 
@@ -69,7 +66,7 @@ private:
 
 public:
 	// ctor
-	CDXLColDescr(CMemoryPool *, CMDName *, ULONG column_id, INT attr_no,
+	CDXLColDescr(CMDName *, ULONG column_id, INT attr_no,
 				 IMDId *column_mdid_type, INT type_modifier, BOOL is_dropped,
 				 ULONG width = gpos::ulong_max);
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLColRef.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLColRef.h
@@ -44,9 +44,6 @@ typedef CDynamicPtrArray<CDXLColRef, CleanupRelease> CDXLColRefArray;
 class CDXLColRef : public CRefCount
 {
 private:
-	// memory pool
-	CMemoryPool *m_mp;
-
 	// name
 	CMDName *m_mdname;
 
@@ -64,8 +61,7 @@ private:
 
 public:
 	// ctor/dtor
-	CDXLColRef(CMemoryPool *mp, CMDName *mdname, ULONG id, IMDId *mdid_type,
-			   INT type_modifier);
+	CDXLColRef(CMDName *mdname, ULONG id, IMDId *mdid_type, INT type_modifier);
 
 	~CDXLColRef();
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLIndexDescr.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLIndexDescr.h
@@ -31,9 +31,6 @@ using namespace gpmd;
 class CDXLIndexDescr : public CRefCount
 {
 private:
-	// memory pool
-	CMemoryPool *m_mp;
-
 	// id and version information for the table
 	IMDId *m_mdid;
 
@@ -45,7 +42,7 @@ private:
 
 public:
 	// ctor
-	CDXLIndexDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname);
+	CDXLIndexDescr(IMDId *mdid, CMDName *mdname);
 
 	// dtor
 	virtual ~CDXLIndexDescr();

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLNode.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLNode.h
@@ -48,9 +48,6 @@ typedef CHashMap<ULONG, CDXLNode, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
 class CDXLNode : public CRefCount
 {
 private:
-	// memory pool
-	CMemoryPool *m_mp;
-
 	// dxl tree operator class
 	CDXLOperator *m_dxl_op;
 
@@ -77,7 +74,7 @@ public:
 	CDXLNode(CMemoryPool *mp, CDXLOperator *dxl_op,
 			 CDXLNode *first_child_dxlnode, CDXLNode *second_child_dxlnode,
 			 CDXLNode *third_child_dxlnode);
-	CDXLNode(CMemoryPool *mp, CDXLOperator *dxl_op, CDXLNodeArray *dxl_array);
+	CDXLNode(CDXLOperator *dxl_op, CDXLNodeArray *dxl_array);
 
 	// dtor
 	virtual ~CDXLNode();

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
@@ -34,9 +34,6 @@ using namespace gpmd;
 class CDXLTableDescr : public CRefCount
 {
 private:
-	// memory pool
-	CMemoryPool *m_mp;
-
 	// id and version information for the table
 	IMDId *m_mdid;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalWindow.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalWindow.h
@@ -34,9 +34,6 @@ XERCES_CPP_NAMESPACE_USE
 class CParseHandlerLogicalWindow : public CParseHandlerLogicalOp
 {
 private:
-	// list of window specification
-	CDXLWindowSpecArray *m_window_spec_array;
-
 	// private copy ctor
 	CParseHandlerLogicalWindow(const CParseHandlerLogicalWindow &);
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDIndex.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDIndex.h
@@ -42,9 +42,6 @@ private:
 	// name of the index
 	CMDName *m_mdname;
 
-	// mdid of the indexed relation
-	IMDId *m_rel_mdid;
-
 	// is the index clustered
 	BOOL m_clustered;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerPlan.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerPlan.h
@@ -45,9 +45,6 @@ private:
 	// the root of the parsed DXL tree constructed by the parse handler
 	CDXLNode *m_dxl_node;
 
-	// direct dispatch info spec
-	CDXLDirectDispatchInfo *m_direct_dispatch_info;
-
 	// private ctor
 	CParseHandlerPlan(const CParseHandlerPlan &);
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarComp.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarComp.h
@@ -37,12 +37,6 @@ private:
 	// the scalar comparison operator
 	CDXLScalarComp *m_dxl_op;
 
-	// the left side of the comparison
-	CDXLNode *m_dxl_left;
-
-	// the right side of the comparison
-	CDXLNode *m_dxl_right;
-
 	// private copy ctor
 	CParseHandlerScalarComp(const CParseHandlerScalarComp &);
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarWindowFrameEdge.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarWindowFrameEdge.h
@@ -33,9 +33,6 @@ XERCES_CPP_NAMESPACE_USE
 class CParseHandlerScalarWindowFrameEdge : public CParseHandlerScalarOp
 {
 private:
-	// identify if the parser is for a leading or trailing edge
-	BOOL m_leading_edge;
-
 	// private copy ctor
 	CParseHandlerScalarWindowFrameEdge(
 		const CParseHandlerScalarWindowFrameEdge &);
@@ -54,8 +51,7 @@ public:
 	// ctor
 	CParseHandlerScalarWindowFrameEdge(CMemoryPool *mp,
 									   CParseHandlerManager *parse_handler_mgr,
-									   CParseHandlerBase *parse_handler_root,
-									   BOOL leading_edge);
+									   CParseHandlerBase *parse_handler_root);
 };
 }  // namespace gpdxl
 

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLColDescr.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLColDescr.cpp
@@ -27,11 +27,10 @@ using namespace gpmd;
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CDXLColDescr::CDXLColDescr(CMemoryPool *mp, CMDName *md_name, ULONG column_id,
-						   INT attr_no, IMDId *column_mdid_type,
-						   INT type_modifier, BOOL is_dropped, ULONG width)
-	: m_mp(mp),
-	  m_md_name(md_name),
+CDXLColDescr::CDXLColDescr(CMDName *md_name, ULONG column_id, INT attr_no,
+						   IMDId *column_mdid_type, INT type_modifier,
+						   BOOL is_dropped, ULONG width)
+	: m_md_name(md_name),
 	  m_column_id(column_id),
 	  m_attr_no(attr_no),
 	  m_column_mdid_type(column_mdid_type),

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLColRef.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLColRef.cpp
@@ -24,10 +24,9 @@ using namespace gpdxl;
 //		Constructs a column reference
 //
 //---------------------------------------------------------------------------
-CDXLColRef::CDXLColRef(CMemoryPool *mp, CMDName *mdname, ULONG id,
-					   IMDId *mdid_type, INT type_modifier)
-	: m_mp(mp),
-	  m_mdname(mdname),
+CDXLColRef::CDXLColRef(CMDName *mdname, ULONG id, IMDId *mdid_type,
+					   INT type_modifier)
+	: m_mdname(mdname),
 	  m_id(id),
 	  m_mdid_type(mdid_type),
 	  m_iTypeModifer(type_modifier)

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLIndexDescr.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLIndexDescr.cpp
@@ -25,8 +25,8 @@ using namespace gpdxl;
 //		Constructor
 //
 //---------------------------------------------------------------------------
-CDXLIndexDescr::CDXLIndexDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname)
-	: m_mp(mp), m_mdid(mdid), m_mdname(mdname)
+CDXLIndexDescr::CDXLIndexDescr(IMDId *mdid, CMDName *mdname)
+	: m_mdid(mdid), m_mdname(mdname)
 {
 	GPOS_ASSERT(m_mdid->IsValid());
 	GPOS_ASSERT(NULL != m_mdname);

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLNode.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLNode.cpp
@@ -27,10 +27,7 @@ using namespace gpdxl;
 //
 //---------------------------------------------------------------------------
 CDXLNode::CDXLNode(CMemoryPool *mp)
-	: m_mp(mp),
-	  m_dxl_op(NULL),
-	  m_dxl_properties(NULL),
-	  m_direct_dispatch_info(NULL)
+	: m_dxl_op(NULL), m_dxl_properties(NULL), m_direct_dispatch_info(NULL)
 {
 	m_dxl_array = GPOS_NEW(mp) CDXLNodeArray(mp);
 }
@@ -44,10 +41,7 @@ CDXLNode::CDXLNode(CMemoryPool *mp)
 //
 //---------------------------------------------------------------------------
 CDXLNode::CDXLNode(CMemoryPool *mp, CDXLOperator *dxl_op)
-	: m_mp(mp),
-	  m_dxl_op(dxl_op),
-	  m_dxl_properties(NULL),
-	  m_direct_dispatch_info(NULL)
+	: m_dxl_op(dxl_op), m_dxl_properties(NULL), m_direct_dispatch_info(NULL)
 {
 	GPOS_ASSERT(NULL != dxl_op);
 	m_dxl_array = GPOS_NEW(mp) CDXLNodeArray(mp);
@@ -63,8 +57,7 @@ CDXLNode::CDXLNode(CMemoryPool *mp, CDXLOperator *dxl_op)
 //---------------------------------------------------------------------------
 CDXLNode::CDXLNode(CMemoryPool *mp, CDXLOperator *dxl_op,
 				   CDXLNode *child_dxlnode)
-	: m_mp(mp),
-	  m_dxl_op(dxl_op),
+	: m_dxl_op(dxl_op),
 	  m_dxl_properties(NULL),
 	  m_dxl_array(NULL),
 	  m_direct_dispatch_info(NULL)
@@ -87,8 +80,7 @@ CDXLNode::CDXLNode(CMemoryPool *mp, CDXLOperator *dxl_op,
 CDXLNode::CDXLNode(CMemoryPool *mp, CDXLOperator *dxl_op,
 				   CDXLNode *first_child_dxlnode,
 				   CDXLNode *second_child_dxlnode)
-	: m_mp(mp),
-	  m_dxl_op(dxl_op),
+	: m_dxl_op(dxl_op),
 	  m_dxl_properties(NULL),
 	  m_dxl_array(NULL),
 	  m_direct_dispatch_info(NULL)
@@ -114,8 +106,7 @@ CDXLNode::CDXLNode(CMemoryPool *mp, CDXLOperator *dxl_op,
 				   CDXLNode *first_child_dxlnode,
 				   CDXLNode *second_child_dxlnode,
 				   CDXLNode *third_child_dxlnode)
-	: m_mp(mp),
-	  m_dxl_op(dxl_op),
+	: m_dxl_op(dxl_op),
 	  m_dxl_properties(NULL),
 	  m_dxl_array(NULL),
 	  m_direct_dispatch_info(NULL)
@@ -139,10 +130,8 @@ CDXLNode::CDXLNode(CMemoryPool *mp, CDXLOperator *dxl_op,
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CDXLNode::CDXLNode(CMemoryPool *mp, CDXLOperator *dxl_op,
-				   CDXLNodeArray *dxl_array)
-	: m_mp(mp),
-	  m_dxl_op(dxl_op),
+CDXLNode::CDXLNode(CDXLOperator *dxl_op, CDXLNodeArray *dxl_array)
+	: m_dxl_op(dxl_op),
 	  m_dxl_properties(NULL),
 	  m_dxl_array(dxl_array),
 	  m_direct_dispatch_info(NULL)

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -1472,7 +1472,7 @@ CDXLOperatorFactory::MakeDXLIndexDescr(CDXLMemoryManager *dxl_memory_manager,
 	CMDName *mdname = GPOS_NEW(mp) CMDName(mp, index_name);
 	GPOS_DELETE(index_name);
 
-	return GPOS_NEW(mp) CDXLIndexDescr(mp, mdid, mdname);
+	return GPOS_NEW(mp) CDXLIndexDescr(mdid, mdname);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -1551,7 +1551,7 @@ CDXLOperatorFactory::MakeColumnDescr(CDXLMemoryManager *dxl_memory_manager,
 
 	GPOS_DELETE(col_name);
 
-	return GPOS_NEW(mp) CDXLColDescr(mp, mdname, id, attno, mdid_type,
+	return GPOS_NEW(mp) CDXLColDescr(mdname, id, attno, mdid_type,
 									 type_modifier, col_dropped, col_len);
 }
 

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -1604,7 +1604,7 @@ CDXLOperatorFactory::MakeDXLColRef(CDXLMemoryManager *dxl_memory_manager,
 		dxl_memory_manager, attrs, EdxltokenTypeMod, target_elem, true,
 		default_type_modifier);
 
-	return GPOS_NEW(mp) CDXLColRef(mp, mdname, id, mdid_type, type_modifier);
+	return GPOS_NEW(mp) CDXLColRef(mdname, id, mdid_type, type_modifier);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
@@ -30,8 +30,7 @@ using namespace gpdxl;
 //---------------------------------------------------------------------------
 CDXLTableDescr::CDXLTableDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
 							   ULONG ulExecuteAsUser)
-	: m_mp(mp),
-	  m_mdid(mdid),
+	: m_mdid(mdid),
 	  m_mdname(mdname),
 	  m_dxl_column_descr_array(NULL),
 	  m_execute_as_user_id(ulExecuteAsUser)

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerFactory.cpp
@@ -1969,7 +1969,7 @@ CParseHandlerFactory::CreateFrameTrailingEdgeParseHandler(
 	CParseHandlerBase *parse_handler_root)
 {
 	return GPOS_NEW(mp) CParseHandlerScalarWindowFrameEdge(
-		mp, parse_handler_mgr, parse_handler_root, false /*fLeading*/);
+		mp, parse_handler_mgr, parse_handler_root);
 }
 
 // creates a leading window frame edge parser
@@ -1979,7 +1979,7 @@ CParseHandlerFactory::CreateFrameLeadingEdgeParseHandler(
 	CParseHandlerBase *parse_handler_root)
 {
 	return GPOS_NEW(mp) CParseHandlerScalarWindowFrameEdge(
-		mp, parse_handler_mgr, parse_handler_root, true /*fLeading*/);
+		mp, parse_handler_mgr, parse_handler_root);
 }
 
 // creates a parse handler for parsing search strategy

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalWindow.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalWindow.cpp
@@ -32,8 +32,7 @@ XERCES_CPP_NAMESPACE_USE
 CParseHandlerLogicalWindow::CParseHandlerLogicalWindow(
 	CMemoryPool *mp, CParseHandlerManager *parse_handler_mgr,
 	CParseHandlerBase *parse_handler_root)
-	: CParseHandlerLogicalOp(mp, parse_handler_mgr, parse_handler_root),
-	  m_window_spec_array(NULL)
+	: CParseHandlerLogicalOp(mp, parse_handler_mgr, parse_handler_root)
 {
 }
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPlan.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPlan.cpp
@@ -36,8 +36,7 @@ CParseHandlerPlan::CParseHandlerPlan(CMemoryPool *mp,
 	: CParseHandlerBase(mp, parse_handler_mgr, parse_handler_root),
 	  m_plan_id(0),
 	  m_plan_space_size(0),
-	  m_dxl_node(NULL),
-	  m_direct_dispatch_info(NULL)
+	  m_dxl_node(NULL)
 {
 }
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarAssertConstraintList.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarAssertConstraintList.cpp
@@ -124,7 +124,7 @@ CParseHandlerScalarAssertConstraintList::EndElement(
 
 		// assemble final assert predicate node
 		m_dxl_node = GPOS_NEW(m_mp)
-			CDXLNode(m_mp, m_dxl_op, m_dxlnode_assert_constraints_parsed_array);
+			CDXLNode(m_dxl_op, m_dxlnode_assert_constraints_parsed_array);
 
 #ifdef GPOS_DEBUG
 		m_dxl_op->AssertValid(m_dxl_node, false /* validate_children */);

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarWindowFrameEdge.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarWindowFrameEdge.cpp
@@ -31,9 +31,8 @@ XERCES_CPP_NAMESPACE_USE
 //---------------------------------------------------------------------------
 CParseHandlerScalarWindowFrameEdge::CParseHandlerScalarWindowFrameEdge(
 	CMemoryPool *mp, CParseHandlerManager *parse_handler_mgr,
-	CParseHandlerBase *parse_handler_root, BOOL leading_edge)
-	: CParseHandlerScalarOp(mp, parse_handler_mgr, parse_handler_root),
-	  m_leading_edge(leading_edge)
+	CParseHandlerBase *parse_handler_root)
+	: CParseHandlerScalarOp(mp, parse_handler_mgr, parse_handler_root)
 {
 }
 

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CMiniDumperDXLTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CMiniDumperDXLTest.cpp
@@ -78,7 +78,7 @@ CMiniDumperDXLTest::EresUnittest_Basic()
 
 	CWStringDynamic minidumpstr(mp);
 	COstreamString oss(&minidumpstr);
-	CMiniDumperDXL mdrs(mp);
+	CMiniDumperDXL mdrs;
 	mdrs.Init(&oss);
 
 	CHAR file_name[GPOS_FILE_NAME_BUF_SIZE];


### PR DESCRIPTION
## Update
I've rebased #10979 on top of this, so this change set is left here only for exposition purpose. Reviewers please move to #10979 .

## Original description
While working on #10979 I got to a stopping point where one unexpected benefit of modernizing the code to C++ 11 appeared: the compiler started complaining about unused private fields that it didn't realize were unused before...

This fixes the following compiler errors (upgraded warnings by `-Werror` in ORCA):

```
In file included from CMiniDumper.cpp:14:
In file included from ../../../../../../src/backend/gporca/libgpos/include/gpos/error/CErrorContext.h:17:
../../../../../../src/backend/gporca/libgpos/include/gpos/error/CMiniDumper.h:32:15: error: private field 'm_mp' is not used [-Werror,-Wunused-private-field]
        CMemoryPool *m_mp;
                     ^
1 error generated.
In file included from CDXLColDescr.cpp:14:
../../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLColDescr.h:45:15: error: private field 'm_mp' is not used [-Werror,-Wunused-private-field]
        CMemoryPool *m_mp;
                     ^
1 error generated.
In file included from CDXLColRef.cpp:13:
../../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLColRef.h:48:15: error: private field 'm_mp' is not used [-Werror,-Wunused-private-field]
        CMemoryPool *m_mp;
                     ^
1 error generated.
In file included from CDXLIndexDescr.cpp:14:
../../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLIndexDescr.h:35:15: error: private field 'm_mp' is not used [-Werror,-Wunused-private-field]
        CMemoryPool *m_mp;
                     ^
1 error generated.
In file included from CDXLNode.cpp:12:
../../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLNode.h:52:15: error: private field 'm_mp' is not used [-Werror,-Wunused-private-field]
        CMemoryPool *m_mp;
                     ^
1 error generated.
In file included from CDXLTableDescr.cpp:15:
../../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h:38:15: error: private field 'm_mp' is not used [-Werror,-Wunused-private-field]
        CMemoryPool *m_mp;
                     ^
1 error generated.
In file included from CParseHandlerLogicalWindow.cpp:13:
../../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalWindow.h:38:23: error: private field 'm_window_spec_array' is not used [-Werror,-Wunused-private-field]
        CDXLWindowSpecArray *m_window_spec_array;
                             ^
1 error generated.
In file included from CParseHandlerMDIndex.cpp:14:
../../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDIndex.h:46:9: error: private field 'm_rel_mdid' is not used [-Werror,-Wunused-private-field]
        IMDId *m_rel_mdid;
               ^
1 error generated.
In file included from CParseHandlerPlan.cpp:15:
../../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerPlan.h:49:26: error: private field 'm_direct_dispatch_info' is not used [-Werror,-Wunused-private-field]
        CDXLDirectDispatchInfo *m_direct_dispatch_info;
                                ^
1 error generated.
In file included from CParseHandlerScalarComp.cpp:19:
../../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarComp.h:41:12: error: private field 'm_dxl_left' is not used [-Werror,-Wunused-private-field]
        CDXLNode *m_dxl_left;
                  ^
../../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarComp.h:44:12: error: private field 'm_dxl_right' is not used [-Werror,-Wunused-private-field]
        CDXLNode *m_dxl_right;
                  ^
2 errors generated.
In file included from CParseHandlerScalarWindowFrameEdge.cpp:13:
../../../../../../src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarWindowFrameEdge.h:37:7: error: private field 'm_leading_edge' is not used [-Werror,-Wunused-private-field]
        BOOL m_leading_edge;
             ^
1 error generated.
In file included from CKeyCollection.cpp:13:
../../../../../../src/backend/gporca/libgpopt/include/gpopt/base/CKeyCollection.h:37:15: error: private field 'm_mp' is not used [-Werror,-Wunused-private-field]
        CMemoryPool *m_mp;
                     ^
1 error generated.
In file included from CTableDescriptor.cpp:17:
In file included from ../../../../../../src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecSingleton.h:18:
In file included from ../../../../../../src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpec.h:18:
In file included from ../../../../../../src/backend/gporca/libgpopt/include/gpopt/base/CPropSpec.h:17:
In file included from ../../../../../../src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h:22:
In file included from ../../../../../../src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropRelational.h:23:
../../../../../../src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h:86:8: error: private field 'm_num_of_partitions' is not used [-Werror,-Wunused-private-field]
        ULONG m_num_of_partitions;
              ^
1 error generated.
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
