### PR TITLE
Relfrozenxid must be invalid for append-optimized tables

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -922,21 +922,10 @@ aoco_relation_set_new_filenode(Relation rel,
 	SMgrRelation srel;
 
 	/*
-	 * Initialize to the minimum XID that could put tuples in the table. We
-	 * know that no xacts older than RecentXmin are still running, so that
-	 * will do.
+	 * Append-optimized tables do not contain transaction information in
+	 * tuples.
 	 */
-	*freezeXid = RecentXmin;
-
-	/*
-	 * Similarly, initialize the minimum Multixact to the first value that
-	 * could possibly be stored in tuples in the table.  Running transactions
-	 * could reuse values from their local cache, so we are careful to
-	 * consider all currently running multis.
-	 *
-	 * XXX this could be refined further, but is it worth the hassle?
-	 */
-	*minmulti = GetOldestMultiXactId();
+	*freezeXid = *minmulti = InvalidTransactionId;
 
 	/*
 	 * No special treatment is needed for new AO_ROW/COLUMN relation. Create

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -738,21 +738,10 @@ appendonly_relation_set_new_filenode(Relation rel,
 	SMgrRelation srel;
 
 	/*
-	 * Initialize to the minimum XID that could put tuples in the table. We
-	 * know that no xacts older than RecentXmin are still running, so that
-	 * will do.
+	 * Append-optimized tables do not contain transaction information in
+	 * tuples.
 	 */
-	*freezeXid = RecentXmin;
-
-	/*
-	 * Similarly, initialize the minimum Multixact to the first value that
-	 * could possibly be stored in tuples in the table.  Running transactions
-	 * could reuse values from their local cache, so we are careful to
-	 * consider all currently running multis.
-	 *
-	 * XXX this could be refined further, but is it worth the hassle?
-	 */
-	*minmulti = GetOldestMultiXactId();
+	*freezeXid = *minmulti = InvalidTransactionId;
 
 	/*
 	 * No special treatment is needed for new AO_ROW/COLUMN relation. Create

--- a/src/backend/access/bitmap/bitmapattutil.c
+++ b/src/backend/access/bitmap/bitmapattutil.c
@@ -122,9 +122,7 @@ _bitmap_create_lov_heapandindex(Relation rel,
 		lovIndex = index_open(idxid, AccessExclusiveLock);
 
 		RelationSetNewRelfilenode(lovHeap, lovHeap->rd_rel->relpersistence);
-		// GPDB_12_MERGE_FIXME: RecentXmin, GetOldestMultiXactId()); 
 		RelationSetNewRelfilenode(lovIndex, lovIndex->rd_rel->relpersistence);
-		// GPDB_12_MERGE_FIXME: InvalidTransactionId, InvalidMultiXactId);
 
 		/*
 		 * After creating the new relfilenode for a btee index, this is not

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1305,22 +1305,8 @@ AddNewRelationTuple(Relation pg_class_desc,
 	}
 
 	/* Initialize relfrozenxid and relminmxid */
-	if (should_have_valid_relfrozenxid(new_rel_desc, relkind))
-	{
-		new_rel_reltup->relfrozenxid = relfrozenxid;
-		new_rel_reltup->relminmxid = relminmxid;
-	}
-	else
-	{
-		/*
-		 * Other relation types will not contain XIDs, so set relfrozenxid to
-		 * InvalidTransactionId.  (Note: a sequence does contain a tuple, but
-		 * we force its xmin to be FrozenTransactionId always; see
-		 * commands/sequence.c.)
-		 */
-		new_rel_reltup->relfrozenxid = InvalidTransactionId;
-		new_rel_reltup->relminmxid = InvalidMultiXactId;
-	}
+	new_rel_reltup->relfrozenxid = relfrozenxid;
+	new_rel_reltup->relminmxid = relminmxid;
 	new_rel_reltup->relowner = relowner;
 	new_rel_reltup->reltype = new_type_oid;
 	new_rel_reltup->reloftype = reloftype;
@@ -3977,33 +3963,6 @@ insert_ordered_unique_oid(List *list, Oid datum)
 	/* Insert datum into list after 'prev' */
 	lappend_cell_oid(list, prev, datum);
 	return list;
-}
-
-/*
- * Note: when modifying this function, make sure to modify the query
- * updating 'relfrozenxid' in function set_frozenxids() too.
- * This is to keep consistent behavior for relfrozenxid before
- * and after upgrade.
- */
-bool
-should_have_valid_relfrozenxid(Relation relation,char relkind)
-{
-	switch (relkind)
-	{
-		case RELKIND_RELATION:
-			if (RelationIsAppendOptimized(relation))
-				return false;
-
-			return true;
-		case RELKIND_TOASTVALUE:
-		case RELKIND_MATVIEW:
-		case RELKIND_AOSEGMENTS:
-		case RELKIND_AOBLOCKDIR:
-		case RELKIND_AOVISIMAP:
-			return true;
-	}
-
-	return false;
 }
 
 /*

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -1812,6 +1812,12 @@ RelationInitTableAccessMethod(Relation relation)
 		aform = (Form_pg_am) GETSTRUCT(tuple);
 		relation->rd_amhandler = aform->amhandler;
 		ReleaseSysCache(tuple);
+		/*
+		 * Greenplum: append-optimized relations should not have a valid
+		 * relfrozenxid.
+		 */
+		Assert (!RelationIsAppendOptimized(relation) ||
+				!TransactionIdIsValid(relation->rd_rel->relfrozenxid));
 	}
 
 	/*

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -203,7 +203,4 @@ extern void MetaTrackDropObject(Oid		classid,
 		|| ((relkind) == RELKIND_SEQUENCE) \
 		|| ((relkind) == RELKIND_VIEW)) 
 
-extern bool
-should_have_valid_relfrozenxid(Relation relation,char relkind);
-
 #endif							/* HEAP_H */

--- a/src/test/regress/input/uao_ddl/alter_ao_part_tables.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_part_tables.source
@@ -25,6 +25,16 @@ Insert into sto_altap2 values(generate_series(1,20), 12, 'A');
 
 select count(*) from sto_altap2;
 
+-- Append optimized tables should not have a valid relfrozenxid in
+-- pg_class because per-tuple MVCC information (xmin/xmax) is not
+-- present.
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname like 'sto_altap2%'
+       and n.nspname = 'alter_ao_part_tables_@amname@';
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname like 'sto_altap2%'
+       and n.nspname = 'alter_ao_part_tables_@amname@';
+
 create table sto_altap3 (col1 bigint, col2 date, col3 text, col4 int)
  distributed randomly
  partition by range(col2) subpartition by list (col3)
@@ -116,6 +126,15 @@ select * from sto_altap2 order by a;
 
 -- Truncate a partitioned table
 Truncate table sto_altap2;
+
+-- relfrozenxid should remain invalid after rewrite
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname like 'sto_altap2%'
+       and n.nspname = 'alter_ao_part_tables_@amname@';
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname like 'sto_altap2%'
+       and n.nspname = 'alter_ao_part_tables_@amname@';
+
 select * from sto_altap2;
 Insert into sto_altap2 values(generate_series(1,20), 12, 'A');
 Update sto_altap2 set b = 4 where a = 15 or a = 16;

--- a/src/test/regress/input/uao_ddl/alter_ao_table_col_ddl.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_table_col_ddl.source
@@ -16,6 +16,16 @@ CREATE TABLE sto_alt_uao1(
           date_column date,
           col_set_default numeric) DISTRIBUTED RANDOMLY;
 
+-- Append optimized tables should not have a valid relfrozenxid in
+-- pg_class because per-tuple MVCC information (xmin/xmax) is not
+-- present.
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao1'
+       and n.nspname = 'alter_ao_table_col_ddl_@amname@';
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao1'
+       and n.nspname = 'alter_ao_table_col_ddl_@amname@';
+
 insert into sto_alt_uao1 values ('0_zero', 0, '0_zero', 0, 0, 0, '{0}', 0, 0, '1-1-2000', 0);
 insert into sto_alt_uao1 values ('1_zero', 1, '1_zero', 1, 1, 1, '{1}', 1, 1, '1-1-2001', 1);
 insert into sto_alt_uao1 values ('2_zero', 2, '2_zero', 2, 2, 2, '{2}', 2, 2, '1-1-2002', 2);
@@ -52,4 +62,13 @@ select count(int4_col) = 5 as passed from sto_alt_uao1;
 set gp_select_invisible = true;
 select count(int4_col) from sto_alt_uao1;
 set gp_select_invisible = false;
+
+-- relfrozenxid should remain invalid after table rewrite
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao1'
+       and n.nspname = 'alter_ao_table_col_ddl_@amname@';
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao1'
+       and n.nspname = 'alter_ao_table_col_ddl_@amname@';
+
 COMMIT;

--- a/src/test/regress/input/uao_ddl/alter_ao_table_index.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_table_index.source
@@ -25,6 +25,16 @@ set gp_select_invisible = true;
 select * from sto_alt_uao3_idx where bigint_col = 11;
 set gp_select_invisible = false;
 
+-- Append optimized tables should not have a valid relfrozenxid in
+-- pg_class because per-tuple MVCC information (xmin/xmax) is not
+-- present.
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao3_idx'
+       and n.nspname = 'alter_ao_table_index_@amname@';
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao3_idx'
+       and n.nspname = 'alter_ao_table_index_@amname@';
+
 -- Verify that alter table cluster on indexname is allowed
 Alter table sto_alt_uao3_idx cluster on sto_alt_uao3_idx_idx;
 select indisclustered from pg_index where indexrelid='sto_alt_uao3_idx_idx'::regclass;
@@ -33,5 +43,14 @@ select indisclustered from pg_index where indexrelid='sto_alt_uao3_idx_idx'::reg
 -- Verify that cluster is allowed
 CLUSTER sto_alt_uao3_idx using sto_alt_uao3_idx_idx;
 select indisclustered from pg_index where indexrelid='sto_alt_uao3_idx_idx'::regclass;
+
+-- relfrozenxid should remain invalid after table rewrite
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao3_idx'
+       and n.nspname = 'alter_ao_table_index_@amname@';
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao3_idx'
+       and n.nspname = 'alter_ao_table_index_@amname@';
+
 -- Verify that unique index is not allowed
 CREATE UNIQUE INDEX uni_index ON sto_alt_uao3_idx (text_col);

--- a/src/test/regress/output/uao_ddl/alter_ao_part_tables.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_part_tables.source
@@ -29,6 +29,43 @@ select count(*) from sto_altap2;
     20
 (1 row)
 
+-- Append optimized tables should not have a valid relfrozenxid in
+-- pg_class because per-tuple MVCC information (xmin/xmax) is not
+-- present.
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname like 'sto_altap2%'
+       and n.nspname = 'alter_ao_part_tables_@amname@';
+ relfrozenxid 
+--------------
+            0
+            0
+            0
+            0
+            0
+(5 rows)
+
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname like 'sto_altap2%'
+       and n.nspname = 'alter_ao_part_tables_@amname@';
+ relfrozenxid 
+--------------
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+(15 rows)
+
 create table sto_altap3 (col1 bigint, col2 date, col3 text, col4 int)
  distributed randomly
  partition by range(col2) subpartition by list (col3)
@@ -286,6 +323,49 @@ select * from sto_altap2 order by a;
 
 -- Truncate a partitioned table
 Truncate table sto_altap2;
+-- relfrozenxid should remain invalid after rewrite
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname like 'sto_altap2%'
+       and n.nspname = 'alter_ao_part_tables_@amname@';
+ relfrozenxid 
+--------------
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+(7 rows)
+
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname like 'sto_altap2%'
+       and n.nspname = 'alter_ao_part_tables_@amname@';
+ relfrozenxid 
+--------------
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+(21 rows)
+
 select * from sto_altap2;
  a | b | c 
 ---+---+---

--- a/src/test/regress/output/uao_ddl/alter_ao_table_col_ddl.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_col_ddl.source
@@ -14,6 +14,27 @@ CREATE TABLE sto_alt_uao1(
           change_datatype_col numeric,
           date_column date,
           col_set_default numeric) DISTRIBUTED RANDOMLY;
+-- Append optimized tables should not have a valid relfrozenxid in
+-- pg_class because per-tuple MVCC information (xmin/xmax) is not
+-- present.
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao1'
+       and n.nspname = 'alter_ao_table_col_ddl_@amname@';
+ relfrozenxid 
+--------------
+            0
+(1 row)
+
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao1'
+       and n.nspname = 'alter_ao_table_col_ddl_@amname@';
+ relfrozenxid 
+--------------
+            0
+            0
+            0
+(3 rows)
+
 insert into sto_alt_uao1 values ('0_zero', 0, '0_zero', 0, 0, 0, '{0}', 0, 0, '1-1-2000', 0);
 insert into sto_alt_uao1 values ('1_zero', 1, '1_zero', 1, 1, 1, '{1}', 1, 1, '1-1-2001', 1);
 insert into sto_alt_uao1 values ('2_zero', 2, '2_zero', 2, 2, 2, '{2}', 2, 2, '1-1-2002', 2);
@@ -105,4 +126,23 @@ select count(int4_col) from sto_alt_uao1;
 (1 row)
 
 set gp_select_invisible = false;
+-- relfrozenxid should remain invalid after table rewrite
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao1'
+       and n.nspname = 'alter_ao_table_col_ddl_@amname@';
+ relfrozenxid 
+--------------
+            0
+(1 row)
+
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao1'
+       and n.nspname = 'alter_ao_table_col_ddl_@amname@';
+ relfrozenxid 
+--------------
+            0
+            0
+            0
+(3 rows)
+
 COMMIT;

--- a/src/test/regress/output/uao_ddl/alter_ao_table_col_ddl_optimizer.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_col_ddl_optimizer.source
@@ -14,6 +14,27 @@ CREATE TABLE sto_alt_uao1(
           change_datatype_col numeric,
           date_column date,
           col_set_default numeric) DISTRIBUTED RANDOMLY;
+-- Append optimized tables should not have a valid relfrozenxid in
+-- pg_class because per-tuple MVCC information (xmin/xmax) is not
+-- present.
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao1'
+       and n.nspname = 'alter_ao_table_col_ddl_@amname@';
+ relfrozenxid 
+--------------
+            0
+(1 row)
+
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao1'
+       and n.nspname = 'alter_ao_table_col_ddl_@amname@';
+ relfrozenxid 
+--------------
+            0
+            0
+            0
+(3 rows)
+
 insert into sto_alt_uao1 values ('0_zero', 0, '0_zero', 0, 0, 0, '{0}', 0, 0, '1-1-2000', 0);
 insert into sto_alt_uao1 values ('1_zero', 1, '1_zero', 1, 1, 1, '{1}', 1, 1, '1-1-2001', 1);
 insert into sto_alt_uao1 values ('2_zero', 2, '2_zero', 2, 2, 2, '{2}', 2, 2, '1-1-2002', 2);
@@ -111,4 +132,23 @@ HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For 
 (1 row)
 
 set gp_select_invisible = false;
+-- relfrozenxid should remain invalid after table rewrite
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao1'
+       and n.nspname = 'alter_ao_table_col_ddl_@amname@';
+ relfrozenxid 
+--------------
+            0
+(1 row)
+
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao1'
+       and n.nspname = 'alter_ao_table_col_ddl_@amname@';
+ relfrozenxid 
+--------------
+            0
+            0
+            0
+(3 rows)
+
 COMMIT;

--- a/src/test/regress/output/uao_ddl/alter_ao_table_index.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_index.source
@@ -48,6 +48,27 @@ select * from sto_alt_uao3_idx where bigint_col = 11;
 (1 row)
 
 set gp_select_invisible = false;
+-- Append optimized tables should not have a valid relfrozenxid in
+-- pg_class because per-tuple MVCC information (xmin/xmax) is not
+-- present.
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao3_idx'
+       and n.nspname = 'alter_ao_table_index_@amname@';
+ relfrozenxid 
+--------------
+            0
+(1 row)
+
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao3_idx'
+       and n.nspname = 'alter_ao_table_index_@amname@';
+ relfrozenxid 
+--------------
+            0
+            0
+            0
+(3 rows)
+
 -- Verify that alter table cluster on indexname is allowed
 Alter table sto_alt_uao3_idx cluster on sto_alt_uao3_idx_idx;
 select indisclustered from pg_index where indexrelid='sto_alt_uao3_idx_idx'::regclass;
@@ -70,6 +91,25 @@ select indisclustered from pg_index where indexrelid='sto_alt_uao3_idx_idx'::reg
 ----------------
  t
 (1 row)
+
+-- relfrozenxid should remain invalid after table rewrite
+select relfrozenxid from pg_class c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao3_idx'
+       and n.nspname = 'alter_ao_table_index_@amname@';
+ relfrozenxid 
+--------------
+            0
+(1 row)
+
+select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
+       c.relnamespace = n.oid and relname = 'sto_alt_uao3_idx'
+       and n.nspname = 'alter_ao_table_index_@amname@';
+ relfrozenxid 
+--------------
+            0
+            0
+            0
+(3 rows)
 
 -- Verify that unique index is not allowed
 CREATE UNIQUE INDEX uni_index ON sto_alt_uao3_idx (text_col);


### PR DESCRIPTION
Append-optimized tables do not contain transaction information in their tuples.  Therefore, `pg_class.relfrozenxid` must remain invalid. This is being done correctly during table creation, however, when the table was rewritten, the `relfrozenxid` was accidentally set.  Fix it now.

The fixme comments that led me to this bug can now be removed.

