### PR TITLE
[6X Bugfix] Fix an orphaned prepared transaction case due to race between checkpo…

### DIFF
--- a/src/test/isolation2/expected/checkpoint_prepare.out
+++ b/src/test/isolation2/expected/checkpoint_prepare.out
@@ -1,0 +1,61 @@
+-- Test a bug that previously checkpoint would collect prepared transactions
+-- which are actually committed. If the commit prepare xlog is before
+-- checkpoint.redo, after the segment reboot, there would always be an orphaned
+-- (actually committed) prepared transaction in memory. That could lead to
+-- various issues. e.g. dtx recovery would try to abort that and then cause
+-- panic on the segment with message like "cannot abort transaction 3285003, it
+-- was already committed (twophase.c:2205)".
+
+create extension if not exists gp_inject_fault;
+CREATE
+include: helpers/server_helpers.sql;
+CREATE
+
+create table crash_foo(i int);
+CREATE
+
+1: select gp_inject_fault('after_commit_prepared', 'suspend', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2&: insert into crash_foo select i from generate_series(1,10) i;  <waiting ...>
+1: select gp_wait_until_triggered_fault('after_commit_prepared', 1, dbid) from gp_segment_configuration where role='p' and content = 0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+1: checkpoint;
+CHECKPOINT
+1: select gp_inject_fault('after_commit_prepared', 'resume', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: select gp_inject_fault('after_commit_prepared', 'reset', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2<:  <... completed>
+INSERT 10
+
+-- Restart seg0.
+SELECT pg_ctl(datadir, 'restart', 'immediate') FROM gp_segment_configuration WHERE role='p' AND content=0;
+ pg_ctl 
+--------
+ OK     
+(1 row)
+-- Ensure there is no prepared xacts in memory after rebooting, else the below
+-- drop query would hang and after cluster rebooting, dtx recovery will cause
+-- panic on seg0 due to "cannot abort transaction 3285003, it was already
+-- committed (twophase.c:2205)" kind of message, when trying to abort the
+-- orphaned prepared transactions collected from segments.
+0U: select * from pg_prepared_xacts;
+ transaction | gid | prepared | owner | database 
+-------------+-----+----------+-------+----------
+(0 rows)
+
+4: drop table crash_foo;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -73,6 +73,7 @@ test: gpexpand_catalog_lock
 
 test: reindex
 test: reindex_gpfastsequence
+test: checkpoint_prepare
 test: commit_transaction_block_checkpoint
 test: instr_in_shmem_setup
 test: instr_in_shmem_terminate

--- a/src/test/isolation2/sql/checkpoint_prepare.sql
+++ b/src/test/isolation2/sql/checkpoint_prepare.sql
@@ -1,0 +1,36 @@
+-- Test a bug that previously checkpoint would collect prepared transactions
+-- which are actually committed. If the commit prepare xlog is before
+-- checkpoint.redo, after the segment reboot, there would always be an orphaned
+-- (actually committed) prepared transaction in memory. That could lead to
+-- various issues. e.g. dtx recovery would try to abort that and then cause
+-- panic on the segment with message like "cannot abort transaction 3285003, it
+-- was already committed (twophase.c:2205)".
+
+create extension if not exists gp_inject_fault;
+include: helpers/server_helpers.sql;
+
+create table crash_foo(i int);
+
+1: select gp_inject_fault('after_commit_prepared', 'suspend', dbid)
+   from gp_segment_configuration where content=0 and role='p';
+2&: insert into crash_foo select i from generate_series(1,10) i;
+1: select gp_wait_until_triggered_fault('after_commit_prepared', 1, dbid)
+   from gp_segment_configuration where role='p' and content = 0;
+
+1: checkpoint;
+1: select gp_inject_fault('after_commit_prepared', 'resume', dbid)
+        from gp_segment_configuration where content=0 and role='p';
+1: select gp_inject_fault('after_commit_prepared', 'reset', dbid)
+        from gp_segment_configuration where content=0 and role='p';
+2<:
+
+-- Restart seg0.
+SELECT pg_ctl(datadir, 'restart', 'immediate') FROM gp_segment_configuration WHERE role='p' AND content=0;
+-- Ensure there is no prepared xacts in memory after rebooting, else the below
+-- drop query would hang and after cluster rebooting, dtx recovery will cause
+-- panic on seg0 due to "cannot abort transaction 3285003, it was already
+-- committed (twophase.c:2205)" kind of message, when trying to abort the
+-- orphaned prepared transactions collected from segments.
+0U: select * from pg_prepared_xacts;
+
+4: drop table crash_foo;


### PR DESCRIPTION
…inter and COMMIT PREPARE xlog recording

On Greenplum, checkpoint would collect prepared transactions which are actually
committed. If the COMMIT PREPARE xlog is before checkpoint.redo, after the
segment reboot, there would always be an orphaned (actually committed) prepared
transaction in memory. That happens when we collect the prepared transaction in
checkpointer before gxact->valid is reset and after the COMMIT PREPARE xlog is
recorded, see code in FinishPreparedTransaction().

That could lead to various issues. e.g. dtx recovery would keep trying to abort
that and then cause panic on the segment with message like "cannot abort
transaction 3285003, it was already committed (twophase.c:2205)".

Fixing this by delaying checkpointer later than previous code, i.e. Resetting
delayChkpt value after resetting gxact->valid in FinishPreparedTransaction())

There were two solutions were discussed for this issue. One is to use locking
to prevent the false positive case but that might hurt OLTP performance; Another
is to remove the false positive case in RecoverPreparedTransactions(), but
it is possible that related clog has been removed.

Co-authored-by: Hao Wu <gfphoenix78@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
