### PR TITLE
Fix flaky test regress/partition

### DIFF
--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -538,7 +538,7 @@ partition by range (f1)
 );
 drop table TIME_TBL_HOUR_2;
 -- Check for every parameters that just don't make sense
-create table hhh_r1 (a char(1), b date, d char(3)) 
+create table hhh_r2 (a char(1), b date, d char(3))
 distributed by (a) partition by range (b)
 (                                                              
 partition aa start (date '2007-01-01') end (date '2008-01-01') 

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -538,7 +538,7 @@ partition by range (f1)
 );
 drop table TIME_TBL_HOUR_2;
 -- Check for every parameters that just don't make sense
-create table hhh_r1 (a char(1), b date, d char(3)) 
+create table hhh_r2 (a char(1), b date, d char(3))
 distributed by (a) partition by range (b)
 (                                                              
 partition aa start (date '2007-01-01') end (date '2008-01-01') 

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -386,7 +386,7 @@ partition by range (f1)
 );
 drop table TIME_TBL_HOUR_2;
 -- Check for every parameters that just don't make sense
-create table hhh_r1 (a char(1), b date, d char(3)) 
+create table hhh_r2 (a char(1), b date, d char(3))
 distributed by (a) partition by range (b)
 (                                                              
 partition aa start (date '2007-01-01') end (date '2008-01-01') 


### PR DESCRIPTION
Test partition1 creates table hhh_r1 also and that test runs with test
partition in parallel with schedule file greenplum_schedule, and this
could cause below test failure. Fixing this by renaming the table name.

@@ -523,9 +523,7 @@
 partition aa start (date '2007-01-01') end (date '2008-01-01')
       every (interval '0 days')
 );
-ERROR:  EVERY parameter too small
-LINE 5:       every (interval '0 days')
-                     ^
+ERROR:  relation "hhh_r1" already exists
 create table foo_p (i int) distributed by(i)
 partition by range(i)
 (start (1) end (20) every(0));
