### PR TITLE
Extract new error message fields in cdbdisp_get_PQerror()

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -580,6 +580,28 @@ cdbdisp_get_PQerror(PGresult *pgresult)
 	if (fld)
 		errcontext("%s", fld);
 
+	fld = PQresultErrorField(pgresult, PG_DIAG_SCHEMA_NAME);
+	if (fld)
+		err_generic_string(PG_DIAG_SCHEMA_NAME, fld);
+
+	fld = PQresultErrorField(pgresult, PG_DIAG_TABLE_NAME);
+	if (fld)
+		err_generic_string(PG_DIAG_TABLE_NAME, fld);
+
+	fld = PQresultErrorField(pgresult, PG_DIAG_COLUMN_NAME);
+	if (fld)
+		err_generic_string(PG_DIAG_COLUMN_NAME, fld);
+
+	fld = PQresultErrorField(pgresult, PG_DIAG_DATATYPE_NAME);
+	if (fld)
+		err_generic_string(PG_DIAG_DATATYPE_NAME, fld);
+
+	fld = PQresultErrorField(pgresult, PG_DIAG_CONSTRAINT_NAME);
+	if (fld)
+		err_generic_string(PG_DIAG_CONSTRAINT_NAME, fld);
+
+	Assert(TopTransactionContext);
+
 	oldcontext = MemoryContextSwitchTo(TopTransactionContext);
 	ErrorData *edata = errfinish_and_return(filename, lineno, funcname);
 	MemoryContextSwitchTo(oldcontext);

--- a/src/test/regress/expected/gp_constraints.out
+++ b/src/test/regress/expected/gp_constraints.out
@@ -7,6 +7,10 @@
 -- error becomes time-sensitive and less predictable.
 -- To preserve coverage, we test those error details here (with greater care).
 --
+-- start_matchsubs
+-- m/^LOCATION:.*:\d+/
+-- s/:\d+/:/
+-- end_matchsubs
 CREATE SCHEMA gpdb_insert;
 SET search_path TO gpdb_insert;
 --
@@ -47,6 +51,16 @@ INSERT INTO tmp VALUES (1, 'three');
 INSERT INTO PRIMARY_TBL SELECT * FROM tmp;
 ERROR:  duplicate key value violates unique constraint "primary_tbl_pkey"
 DETAIL:  Key (i)=(1) already exists.
+-- database object names as separate fields in error messages can be shown when VERBOSITY set to verbose
+\set VERBOSITY verbose
+INSERT INTO PRIMARY_TBL SELECT * FROM tmp;
+ERROR:  23505: duplicate key value violates unique constraint "primary_tbl_pkey"
+DETAIL:  Key (i)=(1) already exists.
+SCHEMA NAME:  gpdb_insert
+TABLE NAME:  primary_tbl
+CONSTRAINT NAME:  primary_tbl_pkey
+LOCATION:  _bt_check_unique, nbtinsert.c:500
+\set VERBOSITY default
 SELECT '' AS four, * FROM PRIMARY_TBL;
  four | i |  t  
 ------+---+-----

--- a/src/test/regress/sql/gp_constraints.sql
+++ b/src/test/regress/sql/gp_constraints.sql
@@ -7,6 +7,10 @@
 -- error becomes time-sensitive and less predictable.
 -- To preserve coverage, we test those error details here (with greater care).
 --
+-- start_matchsubs
+-- m/^LOCATION:.*:\d+/
+-- s/:\d+/:/
+-- end_matchsubs
 
 CREATE SCHEMA gpdb_insert;
 SET search_path TO gpdb_insert;
@@ -39,6 +43,10 @@ INSERT INTO PRIMARY_TBL VALUES (2, 'two');
 
 INSERT INTO tmp VALUES (1, 'three');
 INSERT INTO PRIMARY_TBL SELECT * FROM tmp;
+-- database object names as separate fields in error messages can be shown when VERBOSITY set to verbose
+\set VERBOSITY verbose
+INSERT INTO PRIMARY_TBL SELECT * FROM tmp;
+\set VERBOSITY default
 
 SELECT '' AS four, * FROM PRIMARY_TBL;
 


### PR DESCRIPTION
This is essentially refresher of PR #8220 based on latest code.

Postgres 991f3e5ab3f8196d18d5b313c81a5f744f3baaea introduce new error
message fields, but cdbdisp_get_PQerror() did not extract these newly
added message field. These fields client cannot see from libpq.

This fixes https://github.com/greenplum-db/gpdb/issues/7934.

Also enable gp_constraints test, it hasn't been run for unknown
reason.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
