### PR TITLE
fix gprecoverseg -r when password authentification enabled for gpadmin

### DIFF
--- a/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
@@ -14,12 +14,12 @@ class SegmentReconfigurer:
         self.timeout = timeout
 
     def _trigger_fts_probe(self, dburl):
-        conn = pg.connect(dburl.pgdb,
-                dburl.pghost,
-                dburl.pgport,
-                None,
-                dburl.pguser,
-                dburl.pgpass,
+        conn = pg.connect(dbname=dburl.pgdb,
+                host=dburl.pghost,
+                port=dburl.pgport,
+                opt=None,
+                user=dburl.pguser,
+                passwd=dburl.pgpass,
                 )
         conn.query(FTS_PROBE_QUERY)
         conn.close()


### PR DESCRIPTION
gprecoverseg -r fails when password authentification enabled for gpadmin. 
Here is [issue](https://github.com/greenplum-db/gpdb/issues/10991) with detailed explanations. The bug exists in 6X also.

Thanks.
