### PR TITLE
Use palloc() instead of palloc0() in buildGpQueryString()

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -893,7 +893,7 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 		sizeof(resgroupInfo.len) +
 		resgroupInfo.len;
 
-	shared_query = palloc0(total_query_len);
+	shared_query = palloc(total_query_len);
 
 	pos = shared_query;
 


### PR DESCRIPTION
The buildGpQueryString() function should use palloc() instead of palloc0()
to allocate the buffer for holding the serialized query string, thus
avoiding the unnecessary cost of setting all bytes in buffer to zero.

Reviewed-by: Heikki Linnakangas <hlinnaka@iki.fi>
Reviewed-by: Ashwin Agrawal <aashwin@vmware.com>
(cherry picked from commit 073be714a1be0f3ecba8d98dd4e0433499e03bcf)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
