### PR TITLE
Fix release candidate on master pipeline

### DIFF
--- a/concourse/tasks/rename_rc_artifacts.yml
+++ b/concourse/tasks/rename_rc_artifacts.yml
@@ -11,7 +11,6 @@ inputs:
 - name: bin_gpdb_ubuntu18.04
 - name: bin_gpdb_clients_centos7
 - name: bin_gpdb_clients_ubuntu18.04
-- name: bin_gpdb_clients_windows
 
 outputs:
 - name: release_candidates
@@ -29,7 +28,3 @@ run:
     cp -v bin_gpdb_ubuntu18.04/bin_gpdb.tar.gz release_candidates/server-rc-${gpdb_semver}-ubuntu18.04_x86_64${RC_BUILD_TYPE_GCS}.tar.gz
     cp -v bin_gpdb_clients_centos7/bin_gpdb_clients.tar.gz release_candidates/clients-rc-${gpdb_semver}-rhel7_x86_64${RC_BUILD_TYPE_GCS}.tar.gz
     cp -v bin_gpdb_clients_ubuntu18.04/bin_gpdb_clients.tar.gz release_candidates/clients-rc-${gpdb_semver}-ubuntu18.04_x86_64${RC_BUILD_TYPE_GCS}.tar.gz
-    pushd bin_gpdb_clients_windows
-        tar xzvf *.tar.gz
-    popd
-    cp bin_gpdb_clients_windows/greenplum-clients-x86_64.msi release_candidates/clients-rc-${gpdb_semver}-windows_x86_64${RC_BUILD_TYPE_GCS}.msi


### PR DESCRIPTION
Client package test on windows and the related binary was removed
by commit c2574cc4 and 8bb057ac, but there's still one usage in
rename_rc_artifacts task. Remove it also to fix release candidate
job.