### PR TITLE
[5X only] Skip setting PT information in WAL during recovery

### DIFF
--- a/src/backend/access/nbtree/nbtinsert.c
+++ b/src/backend/access/nbtree/nbtinsert.c
@@ -1231,7 +1231,16 @@ _bt_split(Relation rel, Buffer buf, OffsetNumber firstright,
 		xlrec.firstright = firstright;
 
 		/* Set persistentTid and persistentSerialNum like xl_btreetid_set() does */
-		RelationGetPTInfo(rel, &xlrec.persistentTid, &xlrec.persistentSerialNum);
+		if (RelationNeedToFetchGpRelationNodeForXLog(rel))
+		{
+			RelationGetPTInfo(rel, &xlrec.persistentTid, &xlrec.persistentSerialNum);
+		}
+		else
+		{
+			/* set invalid persistentTid and persistentSerialNum if in recovery */
+			ItemPointerSetInvalid(&xlrec.persistentTid);
+			xlrec.persistentSerialNum = 0;
+		}
 
 		rdata[0].data = (char *) &xlrec;
 		rdata[0].len = SizeOfBtreeSplit;


### PR DESCRIPTION
If the system crashes when splitting a btree page and the WAL of downlink to
the parent is not flushed, crash recovery will complete this step in
'btree_xlog_cleanup' and it may led to split the parent, which will write a new
WAL record in '_bt_split'. We skip populating the PT information during
recovery in function 'RelationNeedToFetchGpRelationNodeForXLog' and it will
cause PANIC in this case. This is fixed in 6X and later version by commit
'40dae7ec'. This commit only set invalid PT information in the new WAL record.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
