### PR TITLE
gpstart: improve handling of down segment hosts

### DIFF
--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -111,12 +111,19 @@ class GpStart:
             if self.masteronly:
                 return 0
 
+            num_workers = min(len(self.gparray.get_hostlist()), self.parallel)
+            # We check for unreachable segment hosts first thing, because if a host is down but its segments
+            # are marked up, later checks can return invalid or misleading results and the cluster may not
+            # start in a good state.
+            unreachable_hosts = self.get_unreachable_segment_hosts(num_workers)
+            if unreachable_hosts:
+                self.mark_segments_down_for_unreachable_hosts(unreachable_hosts)
+
             if self.skip_heap_checksum_validation:
                 self.master_checksum_value = None
                 logger.warning("Because of --skip-heap-checksum-validation, the GUC for data_checksums "
                                    "will not be checked between master and segments")
             else:
-                num_workers = min(len(self.gparray.get_hostlist()), self.parallel)
                 self.master_checksum_value = HeapChecksum(gparray=self.gparray, num_workers=num_workers,
                                                           logger=logger).get_master_value()
 
@@ -286,6 +293,46 @@ class GpStart:
         cmd.run(validateAfter=True)
         logger.info("Master Stopped...")
         raise ExceptionNoStackTraceNeeded("Standby activated, this node no more can act as master.")
+
+    def get_unreachable_segment_hosts(self, num_workers):
+        hostlist = set(self.gparray.get_hostlist(includeMaster=False))
+
+        pool = base.WorkerPool(numWorkers=num_workers)
+        try:
+            for host in hostlist:
+                cmd = Command(name='check %s is up' % host, cmdStr="ssh %s 'echo %s'" % (host, host))
+                pool.addCommand(cmd)
+            pool.join()
+        finally:
+            pool.haltWork()
+            pool.joinWorkers()
+
+        # There's no good way to map a CommandResult back to its originating Command so instead
+        # of looping through and finding the hosts that errored out, we remove any hosts that
+        # succeeded from the hostlist and any remaining hosts will be ones that were unreachable.
+        for item in pool.getCompletedItems():
+            result = item.get_results()
+            if result.rc == 0:
+                host = result.stdout.strip()
+                hostlist.remove(host)
+
+        if len(hostlist) > 0:
+            logger.warning("One or more hosts are not reachable via SSH.  Any segments on those hosts will be marked down")
+            for host in sorted(hostlist):
+                logger.warning("Host %s is unreachable" % host)
+            return hostlist
+        return None
+
+    def mark_segments_down_for_unreachable_hosts(self, unreachable_hosts):
+        # We only mark the segment down in gparray for use by later checks, as
+        # setting the actual segment down in gp_segment_configuration leads to
+        # an inconsistent state and may prevent the database from starting.
+        for segmentPair in self.gparray.segmentPairs:
+            for seg in [segmentPair.primaryDB, segmentPair.mirrorDB]:
+                host = seg.getSegmentHostName()
+                if host in unreachable_hosts:
+                    logger.warning("Marking segment %d down because %s is unreachable" % (seg.dbid, host))
+                    seg.setSegmentStatus(STATUS_DOWN)
 
     ######
     def _recovery_startup(self):

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -18,11 +18,29 @@ Feature: gpstart behave tests
         Given the database is running
           And the catalog has a standby master entry
 
-         When the database is not running
-          And the standby host goes down
+         When the standby host goes down
+          And the user runs command "pkill -9 postgres"
           And gpstart is run with prompts accepted
 
          Then gpstart should print "Continue only if you are certain that the standby is not acting as the master." to stdout
           And gpstart should print "No standby master configured" to stdout
           And gpstart should return a return code of 0
           And all the segments are running
+
+    @concourse_cluster
+    @demo_cluster
+    Scenario: gpstart starts even if a segment host is unreachable
+        Given the database is running
+          And segment 2 goes down
+          And segment 3 goes down
+          And the user runs command "pkill -9 postgres"
+
+         When gpstart is run with prompts accepted
+
+         Then gpstart should print "Host invalid_host is unreachable" to stdout
+          And gpstart should print "Marking segment 2 down because invalid_host is unreachable" to stdout
+          And gpstart should print "Marking segment 3 down because invalid_host is unreachable" to stdout
+          And the status of segment 2 should be "d"
+          And the status of segment 3 should be "d"
+
+          And the cluster is returned to a good state

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1245,13 +1245,13 @@ def impl(context):
         statrep = dbconn.query(conn, check_stat_replication_query).fetchall()
     conn.close()
 
-    context.standby_dbid = segconfig[0][0]
-
     if len(segconfig) != 1:
         raise Exception("gp_segment_configuration did not have standby master")
 
     if len(statrep) != 1:
         raise Exception("pg_stat_replication did not have standby master")
+
+    context.standby_dbid = segconfig[0][0]
 
 @then('verify the standby master is now acting as master')
 def impl(context):


### PR DESCRIPTION
Currently, if a host is unreachable when gpstart is run, it will not report this and will instead fail with an error that is both inaccurate and unhelpful to the user, such as claiming that checksums are invalid for segments on a given host when it simply can't reach that host to verify the checksums.

This commit adds a check to verify that all hosts are reachable before beginning the startup process and, if one or more hosts are not reachable, marks segments on those hosts down (in gparray, not in the cluster) so gpstart won't try to run any checks against unreachable hosts and so that the cluster can still be started in this state so long as there are otherwise enough valid segments to start it.