### PR TITLE
Hardcode missing cdblegacyhash_bpchar in isLegacyCdbHashFunction check

### DIFF
--- a/src/backend/cdb/cdblegacyhash.c
+++ b/src/backend/cdb/cdblegacyhash.c
@@ -311,6 +311,7 @@ isLegacyCdbHashFunction(Oid funcid)
 		case F_CDBLEGACYHASH_UUID:
 		case F_CDBLEGACYHASH_COMPLEX:
 		case F_CDBLEGACYHASH_ANYENUM:
+		case 6148: // cdblegacyhash_bpchar
 			return true;
 
 		default:


### PR DESCRIPTION
Currently, when inserting into a table distributed by a bpchar using
the legacy bpchar hash operator, the row goes through jump consistent
hashing instead of lazy modular hashing. This is because the
cdblegacyhash_bpchar funcid is missing from the
isLegacyCdbHashFunction check function which determines if an
attribute is using a legacy hash function or not. The funcids
currently in that check function come from the auto-generated
fmgroids.h header file which only creates a DEFINE for the
pg_proc.prosrc field. Unfortunately, cdblegacyhash_bpchar is left out
because its prosrc is cdblegacyhash_text.

A proper fix would require a catalog change. To fix this issue in
6X_STABLE, we need to hardcode cdblegacyhash_bpchar funcid 6148 into
the isLegacyCdbHashFunction check function. This should be fine since
the GPDB 6X_STABLE catalog is frozen.

This issue was reported by github user cobolbaby in the gpbackup
repository while the user was migrating GPDB 5X tables to GPDB 6X:
https://github.com/greenplum-db/gpbackup/issues/425