### PR TITLE
Fix: might recycle wrong gang size

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -230,7 +230,7 @@ buildGangDefinition(List *segments, SegmentType segmentType)
 {
 	Gang *newGangDefinition = NULL;
 	ListCell *lc;
-	int	i = 0;
+	volatile int i = 0;
 	int	size;
 	int contentId;
 
@@ -260,6 +260,7 @@ buildGangDefinition(List *segments, SegmentType segmentType)
 	}
 	PG_CATCH();
 	{
+		newGangDefinition->size = i;
 		RecycleGang(newGangDefinition, true /* destroy */);
 		PG_RE_THROW();
 	}


### PR DESCRIPTION
In buildGangDefinition, newGangDefinition->db_descriptors are
initialized one by one, but newGangDefinition->size was already
set to its final value. If an error was caught, its size should
be reset to the right number.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
