### PR TITLE
The inner relation of LASJ_NOTIN should not have partition locaus

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -1182,6 +1182,91 @@ find_nonnullable_vars_walker(Node *node, NonNullableVarsContext *context)
 }
 
 
+/*
+ * This function is used to determine whether the parameters of an expression in
+ * ALL Sublink can be NULL.
+ */
+static bool
+is_param_nullable(Node *node, Query *query, Value *oprname)
+{
+	bool result = false;
+	NonNullableVarsContext context;
+	Expr *expr;
+	ListCell *lc;
+	Expr *arg;
+
+	Assert(query);
+	context.query = query;
+	context.nonNullableVars = NIL;
+
+	/* Find nullable vars in the jointree */
+	expression_tree_walker((Node *) query->jointree, find_nonnullable_vars_walker, &context);
+
+	/*
+	 * A null value "not in / > all / < all" a non-empty set, the result is
+	 * always false, but a null value "not in / > all / < all" a empty set, the
+	 * result is always true. So if the param is nullable, we should not make
+	 * the locus as "Partitioned".
+	 * If the sql is "... a not in (select ...)", the node should be a BoolExpr.
+	 * if the sql is "... a < all (select ...), the node should be a OpExpr"
+	 */
+	if (nodeTag(node) == T_BoolExpr)
+	{
+		if(((BoolExpr *) node)->boolop != NOT_EXPR)
+			return false;
+		expr = lfirst(list_head(((BoolExpr*) node)->args));
+	}
+	else if (nodeTag(node) == T_OpExpr)
+	{
+		if(strcmp(oprname->val.str, "=") == 0)
+			return false;
+		expr = (Expr *) node;
+	}
+	else
+		return true;
+
+	if (nodeTag(expr) != T_OpExpr)
+		return true;
+
+	foreach(lc, ((OpExpr*)expr)->args)
+	{
+		arg = lfirst(lc);
+
+		if (nodeTag(arg) == T_RelabelType)
+			arg = ((RelabelType*)arg)->arg;
+
+		if (nodeTag(arg) == T_Param)
+			continue;
+		else if (nodeTag(arg) == T_Const)
+		{
+			/*
+			 * Is the constant entry in the targetlist null?
+			 */
+			Const	   *constant = (Const *) arg;
+
+			/*
+			 * Note: the 'dummy' column is not NULL, so we don't need any special handling for it
+			 */
+			if (constant->constisnull == true)
+				result = true;
+		}
+		else if (nodeTag(arg) == T_Var)
+		{
+			Var		   *var = (Var *) arg;
+
+			/* Was this var determined to be non-nullable? */
+			if (!list_member(context.nonNullableVars, var))
+			{
+				result = true;
+			}
+		}
+		else
+			result = true;
+	}
+
+	return result;
+}
+
 /**
  * This method determines if the targetlist of a query is nullable.
  * Consider a query of the form: select t1.x, t2.y from t1, t2 where t1.x > 5
@@ -1307,11 +1392,16 @@ convert_IN_to_antijoin(PlannerInfo *root, SubLink *sublink,
 
 		int			subq_indx = add_notin_subquery_rte(parse, subselect);
 		bool		inner_nullable = is_targetlist_nullable(subselect);
+
+		ListCell   *lc = list_head(sublink->operName);
+		bool		outer_nullable = is_param_nullable(sublink->testexpr,
+										   root->parse,
+										   lc? list_head(sublink->operName)->data.ptr_value : NULL);
 		JoinExpr   *join_expr = make_join_expr(NULL, subq_indx, JOIN_LASJ_NOTIN);
 
 		join_expr->quals = make_lasj_quals(root, sublink, subq_indx);
 
-		if (inner_nullable)
+		if (inner_nullable || outer_nullable)
 		{
 			join_expr->quals = add_null_match_clause(join_expr->quals);
 		}

--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -105,22 +105,23 @@ select c1 from t1 where c1 not in
 explain select c1 from t1 where c1 not in 
 	(select c2 from t2 where c2 > 2 and c2 not in 
 		(select c3 from t3));
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=4.43..7.59 rows=4 width=4)
-   ->  Hash Left Anti Semi (Not-In) Join  (cost=4.43..7.59 rows=2 width=4)
-         Hash Cond: t1.c1 = t2.c2
-         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
-         ->  Hash  (cost=4.38..4.38 rows=2 width=4)
-               ->  Hash Left Anti Semi (Not-In) Join  (cost=2.26..4.38 rows=2 width=4)
-                     Hash Cond: t2.c2 = t3.c3
-                     ->  Seq Scan on t2  (cost=0.00..2.06 rows=2 width=4)
-                           Filter: c2 > 2
-                     ->  Hash  (cost=2.15..2.15 rows=3 width=4)
-                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2.15 rows=3 width=4)
-                                 ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
- Optimizer status: Postgres query optimizer
-(13 rows)
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.21..3.31 rows=3 width=4)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=2.21..3.26 rows=1 width=4)
+         Hash Cond: (t1.c1 = t2.c2)
+         ->  Seq Scan on t1  (cost=0.00..1.03 rows=3 width=4)
+         ->  Hash  (cost=2.17..2.17 rows=3 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=1.09..2.17 rows=3 width=4)
+                     ->  Hash Left Anti Semi (Not-In) Join  (cost=1.09..2.12 rows=1 width=4)
+                           Hash Cond: (t2.c2 = t3.c3)
+                           ->  Seq Scan on t2  (cost=0.00..1.02 rows=1 width=4)
+                                 Filter: (c2 > 2)
+                           ->  Hash  (cost=1.05..1.05 rows=3 width=4)
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.05 rows=3 width=4)
+                                       ->  Seq Scan on t3  (cost=0.00..1.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(14 rows)
 
 select c1 from t1 where c1 not in 
 	(select c2 from t2 where c2 > 2 and c2 not in 
@@ -1095,17 +1096,17 @@ select c1 from t1 where not not not c1 in (select c2 from t2);
 --q43
 --
 explain select c1 from t1 where c1 not in (select c2 from t2 where c2 > 4) and c1 is not null;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2.08..5.24 rows=4 width=4)
-   ->  Hash Left Anti Semi (Not-In) Join  (cost=2.08..5.24 rows=2 width=4)
-         Hash Cond: t1.c1 = t2.c2
-         ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
-               Filter: c1 IS NOT NULL
-         ->  Hash  (cost=2.06..2.06 rows=1 width=4)
-               ->  Seq Scan on t2  (cost=0.00..2.06 rows=1 width=4)
-                     Filter: c2 > 4
- Optimizer status: Postgres query optimizer
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.10..2.20 rows=3 width=4)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=1.10..2.15 rows=1 width=4)
+         Hash Cond: (t1.c1 = t2.c2)
+         ->  Seq Scan on t1  (cost=0.00..1.03 rows=3 width=4)
+               Filter: (c1 IS NOT NULL)
+         ->  Hash  (cost=1.02..1.02 rows=1 width=4)
+               ->  Seq Scan on t2  (cost=0.00..1.02 rows=1 width=4)
+                     Filter: (c2 > 4)
+ Optimizer: Postgres query optimizer
 (9 rows)
 
 select c1 from t1 where c1 not in (select c2 from t2 where c2 > 4) and c1 is not null;
@@ -1166,9 +1167,106 @@ select c1 from t1 where c1::absint not in
 ----
 (0 rows)
 
+-- Test the null not in an empty set
+-- null not in an unempty set, always returns false
+-- null not in an empty set, always returns true
+--
+-- q46
+--
+create table table_source (c1 varchar(100),c2 varchar(100),c3 varchar(100),c4 varchar(100));
+insert into table_source (c1 ,c2 ,c3 ,c4 ) values ('000181202006010000003158',null,'INC','0000000001') ;
+create table table_source2 as select * from table_source distributed by (c2);
+create table table_source3 as select * from table_source distributed replicated;
+create table table_source4 (c1 varchar(100),c2 varchar(100) not null,c3 varchar(100),c4 varchar(100));
+insert into table_source4 (c1 ,c2 ,c3 ,c4 ) values ('000181202006010000003158','a','INC','0000000001') ;
+create table table_config (c1 varchar(10) ,c2 varchar(10) ,PRIMARY KEY (c1));
+insert into table_config select i, 'test' from generate_series(1, 1000)i;
+delete from table_config where gp_segment_id = 0;
+explain select * from table_source where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=31.00..32.18 rows=10 width=258)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=31.00..32.05 rows=3 width=258)
+         Hash Cond: ((table_source.c2)::text = (table_config.c1)::text)
+         ->  Seq Scan on table_source  (cost=0.00..1.01 rows=1 width=258)
+               Filter: (((c3)::text = 'INC'::text) AND ((c4)::text = '0000000001'::text))
+         ->  Hash  (cost=18.50..18.50 rows=1000 width=3)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..18.50 rows=1000 width=3)
+                     ->  Seq Scan on table_config  (cost=0.00..5.17 rows=333 width=3)
+                           Filter: ((c2)::text = 'test'::text)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select * from table_source where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+ c1 | c2 | c3 | c4 
+----+----+----+----
+(0 rows)
+
+explain select * from table_source2 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=31.00..32.18 rows=10 width=258)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=31.00..32.05 rows=3 width=258)
+         Hash Cond: ((table_source2.c2)::text = (table_config.c1)::text)
+         ->  Seq Scan on table_source2  (cost=0.00..1.01 rows=1 width=258)
+               Filter: (((c3)::text = 'INC'::text) AND ((c4)::text = '0000000001'::text))
+         ->  Hash  (cost=18.50..18.50 rows=1000 width=3)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..18.50 rows=1000 width=3)
+                     ->  Seq Scan on table_config  (cost=0.00..5.17 rows=333 width=3)
+                           Filter: ((c2)::text = 'test'::text)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select * from table_source2 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+ c1 | c2 | c3 | c4 
+----+----+----+----
+(0 rows)
+
+explain select * from table_source3 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Hash Left Anti Semi (Not-In) Join  (cost=32.02..32.12 rows=10 width=258)
+   Hash Cond: ((table_source3.c2)::text = (table_config.c1)::text)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=1.01..1.01 rows=1 width=258)
+         ->  Seq Scan on table_source3  (cost=0.00..1.01 rows=1 width=258)
+               Filter: (((c3)::text = 'INC'::text) AND ((c4)::text = '0000000001'::text))
+   ->  Hash  (cost=18.50..18.50 rows=1000 width=3)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..18.50 rows=1000 width=3)
+               ->  Seq Scan on table_config  (cost=0.00..5.17 rows=333 width=3)
+                     Filter: ((c2)::text = 'test'::text)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select * from table_source3 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+ c1 | c2 | c3 | c4 
+----+----+----+----
+(0 rows)
+
+explain select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=9.33..10.54 rows=10 width=42)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=9.33..10.41 rows=3 width=42)
+         Hash Cond: ((table_source4.c2)::text = (table_config.c1)::text)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=42)
+               Hash Key: table_source4.c2
+               ->  Seq Scan on table_source4  (cost=0.00..1.01 rows=1 width=42)
+                     Filter: (((c3)::text = 'INC'::text) AND ((c4)::text = '0000000001'::text))
+         ->  Hash  (cost=5.17..5.17 rows=333 width=3)
+               ->  Seq Scan on table_config  (cost=0.00..5.17 rows=333 width=3)
+                     Filter: ((c2)::text = 'test'::text)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+            c1            | c2 | c3  |     c4     
+--------------------------+----+-----+------------
+ 000181202006010000003158 | a  | INC | 0000000001
+(1 row)
+
 reset search_path;
 drop schema notin cascade;
-NOTICE:  drop cascades to 11 other objects
+NOTICE:  drop cascades to 16 other objects
 DETAIL:  drop cascades to table notin.t1
 drop cascades to table notin.t2
 drop cascades to table notin.t3
@@ -1180,3 +1278,8 @@ drop cascades to type notin.absint
 drop cascades to function notin.iszero(notin.absint)
 drop cascades to function notin.abseq(notin.absint,notin.absint)
 drop cascades to operator notin.=(notin.absint,notin.absint)
+drop cascades to table notin.table_source
+drop cascades to table notin.table_source2
+drop cascades to table notin.table_source3
+drop cascades to table notin.table_source4
+drop cascades to table notin.table_config

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1235,9 +1235,106 @@ select c1 from t1 where c1::absint not in
 ----
 (0 rows)
 
+-- Test the null not in an empty set
+-- null not in an unempty set, always returns false
+-- null not in an empty set, always returns true
+--
+-- q46
+--
+create table table_source (c1 varchar(100),c2 varchar(100),c3 varchar(100),c4 varchar(100));
+insert into table_source (c1 ,c2 ,c3 ,c4 ) values ('000181202006010000003158',null,'INC','0000000001') ;
+create table table_source2 as select * from table_source distributed by (c2);
+create table table_source3 as select * from table_source distributed replicated;
+create table table_source4 (c1 varchar(100),c2 varchar(100) not null,c3 varchar(100),c4 varchar(100));
+insert into table_source4 (c1 ,c2 ,c3 ,c4 ) values ('000181202006010000003158','a','INC','0000000001') ;
+create table table_config (c1 varchar(10) ,c2 varchar(10) ,PRIMARY KEY (c1));
+insert into table_config select i, 'test' from generate_series(1, 1000)i;
+delete from table_config where gp_segment_id = 0;
+explain select * from table_source where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.20 rows=1 width=40)
+   Hash Cond: ((table_source.c2)::text = (table_config.c1)::text)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=40)
+         ->  Seq Scan on table_source  (cost=0.00..431.00 rows=1 width=40)
+               Filter: (((c3)::text = 'INC'::text) AND ((c4)::text = '0000000001'::text))
+   ->  Hash  (cost=431.03..431.03 rows=1000 width=3)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.03 rows=1000 width=3)
+               ->  Seq Scan on table_config  (cost=0.00..431.02 rows=334 width=3)
+                     Filter: ((c2)::text = 'test'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+select * from table_source where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+ c1 | c2 | c3 | c4 
+----+----+----+----
+(0 rows)
+
+explain select * from table_source2 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.20 rows=1 width=40)
+   Hash Cond: ((table_source2.c2)::text = (table_config.c1)::text)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=40)
+         ->  Seq Scan on table_source2  (cost=0.00..431.00 rows=1 width=40)
+               Filter: (((c3)::text = 'INC'::text) AND ((c4)::text = '0000000001'::text))
+   ->  Hash  (cost=431.03..431.03 rows=1000 width=3)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.03 rows=1000 width=3)
+               ->  Seq Scan on table_config  (cost=0.00..431.02 rows=334 width=3)
+                     Filter: ((c2)::text = 'test'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+select * from table_source2 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+ c1 | c2 | c3 | c4 
+----+----+----+----
+(0 rows)
+
+explain select * from table_source3 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.20 rows=1 width=40)
+   Hash Cond: ((table_source3.c2)::text = (table_config.c1)::text)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=40)
+         ->  Seq Scan on table_source3  (cost=0.00..431.00 rows=3 width=40)
+               Filter: (((c3)::text = 'INC'::text) AND ((c4)::text = '0000000001'::text))
+   ->  Hash  (cost=431.03..431.03 rows=1000 width=3)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.03 rows=1000 width=3)
+               ->  Seq Scan on table_config  (cost=0.00..431.02 rows=334 width=3)
+                     Filter: ((c2)::text = 'test'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+select * from table_source3 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+ c1 | c2 | c3 | c4 
+----+----+----+----
+(0 rows)
+
+explain select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.19 rows=1 width=42)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.19 rows=1 width=42)
+         Hash Cond: ((table_source4.c2)::text = (table_config.c1)::text)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=42)
+               Hash Key: table_source4.c2
+               ->  Seq Scan on table_source4  (cost=0.00..431.00 rows=1 width=42)
+                     Filter: (((c3)::text = 'INC'::text) AND ((c4)::text = '0000000001'::text))
+         ->  Hash  (cost=431.02..431.02 rows=334 width=3)
+               ->  Seq Scan on table_config  (cost=0.00..431.02 rows=334 width=3)
+                     Filter: ((c2)::text = 'test'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
+            c1            | c2 | c3  |     c4     
+--------------------------+----+-----+------------
+ 000181202006010000003158 | a  | INC | 0000000001
+(1 row)
+
 reset search_path;
 drop schema notin cascade;
-NOTICE:  drop cascades to 11 other objects
+NOTICE:  drop cascades to 16 other objects
 DETAIL:  drop cascades to table notin.t1
 drop cascades to table notin.t2
 drop cascades to table notin.t3
@@ -1249,3 +1346,8 @@ drop cascades to type notin.absint
 drop cascades to function notin.iszero(notin.absint)
 drop cascades to function notin.abseq(notin.absint,notin.absint)
 drop cascades to operator notin.=(notin.absint,notin.absint)
+drop cascades to table notin.table_source
+drop cascades to table notin.table_source2
+drop cascades to table notin.table_source3
+drop cascades to table notin.table_source4
+drop cascades to table notin.table_config

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -193,25 +193,26 @@ select * from A where exists (select * from B where A.i in (select C.i from C wh
 -- Test for ALL_SUBLINK pull-up based on both left-hand and right-hand input
 explain (costs off)
 select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
-                          QUERY PLAN                           
----------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
    ->  Nested Loop Semi Join
          ->  Nested Loop
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
                      ->  Hash Left Anti Semi (Not-In) Join
                            Hash Cond: (b.i = c_1.i)
                            ->  Seq Scan on b
                            ->  Hash
-                                 ->  Seq Scan on c c_1
-                                       Filter: (i <> 10)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                       ->  Seq Scan on c c_1
+                                             Filter: (i <> 10)
                ->  Materialize
                      ->  Seq Scan on a
          ->  Materialize
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)
                      ->  Seq Scan on c
  Optimizer: Postgres query optimizer
-(16 rows)
+(17 rows)
 
 select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
  i  | j  | i  | j 

--- a/src/test/regress/expected/qp_subquery.out
+++ b/src/test/regress/expected/qp_subquery.out
@@ -809,19 +809,20 @@ explain (costs off)
 select Tbl04.* from Tbl04 where not ((Tbl04.a,Tbl04.b) in (select Tbl06.a,Tbl06.b from Tbl06) or (Tbl04.a,Tbl04.b) in (select i3.a, i3.b from i3));
                                 QUERY PLAN                                
 --------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
-   ->  Hash Left Anti Semi (Not-In) Join
-         Hash Cond: ((tbl04.a = i3.a) AND (tbl04.b = i3.b))
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop Left Anti Semi (Not-In) Join
+         Join Filter: ((tbl04.a = i3.a) AND (tbl04.b = i3.b))
          ->  Nested Loop Left Anti Semi (Not-In) Join
                Join Filter: ((tbl04.a = tbl06.a) AND (tbl04.b = tbl06.b))
                ->  Seq Scan on tbl04
                ->  Materialize
                      ->  Broadcast Motion 3:3  (slice1; segments: 3)
                            ->  Seq Scan on tbl06
-         ->  Hash
-               ->  Seq Scan on i3
+         ->  Materialize
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on i3
  Optimizer: Postgres query optimizer
-(12 rows)
+(13 rows)
 
 select Tbl04.* from Tbl04 where not ((Tbl04.a,Tbl04.b) in (select Tbl06.a,Tbl06.b from Tbl06) or (Tbl04.a,Tbl04.b) in (select i3.a, i3.b from i3)); -- expected: (5,6)
  a | b 
@@ -1086,16 +1087,18 @@ explain delete from TabDel1 where TabDel1.a not in (select a from TabDel3); -- d
 (9 rows)
 
 explain delete from TabDel2 where TabDel2.a not in (select a from TabDel4); -- support this
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Delete on tabdel2  (cost=1.02..3.10 rows=2 width=16)
-   ->  Hash Left Anti Semi (Not-In) Join  (cost=1.02..3.10 rows=2 width=10)
-         Hash Cond: tabdel2.a = tabdel4.a
-         ->  Seq Scan on tabdel2  (cost=0.00..2.03 rows=1 width=14)
-         ->  Hash  (cost=1.01..1.01 rows=1 width=4)
-               ->  Seq Scan on tabdel4  (cost=0.00..1.01 rows=1 width=4)
- Optimizer status: Postgres query optimizer
-(7 rows)
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Delete on tabdel2  (cost=1.09..4.17 rows=2 width=16)
+   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.09..4.17 rows=2 width=16)
+         ->  Hash Left Anti Semi (Not-In) Join  (cost=1.09..4.17 rows=2 width=16)
+               Hash Cond: (tabdel2.a = tabdel4.a)
+               ->  Seq Scan on tabdel2  (cost=0.00..3.03 rows=1 width=14)
+               ->  Hash  (cost=1.05..1.05 rows=1 width=10)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.05 rows=1 width=10)
+                           ->  Seq Scan on tabdel4  (cost=0.00..1.01 rows=1 width=10)
+ Optimizer: Postgres query optimizer
+(9 rows)
 
 delete from TabDel2 where TabDel2.a not in (select a from TabDel4); 
 select * from TabDel2;

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -810,19 +810,20 @@ explain (costs off)
 select Tbl04.* from Tbl04 where not ((Tbl04.a,Tbl04.b) in (select Tbl06.a,Tbl06.b from Tbl06) or (Tbl04.a,Tbl04.b) in (select i3.a, i3.b from i3));
                                 QUERY PLAN                                
 --------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
-   ->  Hash Left Anti Semi (Not-In) Join
-         Hash Cond: ((tbl04.a = i3.a) AND (tbl04.b = i3.b))
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop Left Anti Semi (Not-In) Join
+         Join Filter: ((tbl04.a = i3.a) AND (tbl04.b = i3.b))
          ->  Nested Loop Left Anti Semi (Not-In) Join
                Join Filter: ((tbl04.a = tbl06.a) AND (tbl04.b = tbl06.b))
                ->  Seq Scan on tbl04
                ->  Materialize
                      ->  Broadcast Motion 3:3  (slice1; segments: 3)
                            ->  Seq Scan on tbl06
-         ->  Hash
-               ->  Seq Scan on i3
+         ->  Materialize
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on i3
  Optimizer: Postgres query optimizer
-(12 rows)
+(13 rows)
 
 select Tbl04.* from Tbl04 where not ((Tbl04.a,Tbl04.b) in (select Tbl06.a,Tbl06.b from Tbl06) or (Tbl04.a,Tbl04.b) in (select i3.a, i3.b from i3)); -- expected: (5,6)
  a | b 


### PR DESCRIPTION

The result of NULL not in an unempty set is false. The result of
NULL not in an empty set is true. But if an unempty set has
partitioned locus. This set will be divided into several subsets.
Some subsets may be empty. Because NULL not in empty set equals
true. There will be some tuples that shouldn't exist in the result
set.

The patch disable the partitioned locus of inner table by removing
the join clause from the redistribution_clauses.

this commit cherry pick from master f77bf0879a287ff4b67ea1774878a8b7af216e3a

Co-authored-by: Hubert Zhang <hubertzhang@apache.org>
Co-authored-by: Richard Guo <riguo@pivotal.io>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
