### PR TITLE
Remove the InSIGUSR1Handler mechanism

### DIFF
--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -164,14 +164,6 @@ SyncRepWaitForLSN(XLogRecPtr lsn, bool commit)
 	else
 		mode = Min(SyncRepWaitMode, SYNC_REP_WAIT_FLUSH);
 
-	/*
-	 * SIGUSR1 is used to wake us up, cannot wait from inside SIGUSR1 handler
-	 * as its non-reentrant, so check for the same and avoid waiting.
-	 */
-	if (AmIInSIGUSR1Handler())
-	{
-		return;
-	}
 	Assert(!am_walsender);
 	elogif(debug_walrepl_syncrep, LOG,
 			"syncrep wait -- This backend's commit LSN for syncrep is %X/%X.",

--- a/src/backend/storage/ipc/procsignal.c
+++ b/src/backend/storage/ipc/procsignal.c
@@ -65,7 +65,6 @@ typedef struct
 
 static ProcSignalSlot *ProcSignalSlots = NULL;
 static volatile ProcSignalSlot *MyProcSignalSlot = NULL;
-static volatile bool InSIGUSR1Handler = false;
 
 static bool CheckProcSignal(ProcSignalReason reason);
 static void CleanupProcSignalState(int status, Datum arg);
@@ -258,12 +257,6 @@ CheckProcSignal(ProcSignalReason reason)
 	return false;
 }
 
-bool
-AmIInSIGUSR1Handler(void)
-{
-	return InSIGUSR1Handler;
-}
-
 /*
  * Query-finish signal from QD.  The executor will deliverately try
  * to finish execution as quickly as possible.
@@ -288,28 +281,14 @@ procsignal_sigusr1_handler(SIGNAL_ARGS)
 {
 	int			save_errno = errno;
 
-	PG_TRY();
-	{
-		InSIGUSR1Handler = true;
+	if (CheckProcSignal(PROCSIG_CATCHUP_INTERRUPT))
+		HandleCatchupInterrupt();
 
-		if (CheckProcSignal(PROCSIG_CATCHUP_INTERRUPT))
-			HandleCatchupInterrupt();
+	if (CheckProcSignal(PROCSIG_NOTIFY_INTERRUPT))
+		HandleNotifyInterrupt();
 
-		if (CheckProcSignal(PROCSIG_NOTIFY_INTERRUPT))
-			HandleNotifyInterrupt();
-
-		if (CheckProcSignal(PROCSIG_QUERY_FINISH))
-			QueryFinishHandler();
-
-		latch_sigusr1_handler();
-		InSIGUSR1Handler = false;
-	}
-	PG_CATCH();
-	{
-		InSIGUSR1Handler = false;
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
+	if (CheckProcSignal(PROCSIG_QUERY_FINISH))
+		QueryFinishHandler();
 
 	if (CheckProcSignal(PROCSIG_WALSND_INIT_STOPPING))
 		HandleWalSndInitStopping();

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2548,24 +2548,13 @@ DeserializeResGroupInfo(struct ResGroupCaps *capsOut,
 
 /*
  * Check whether resource group should be assigned on master.
- *
- * Resource group will not be assigned if we are in SIGUSR1 handler.
- * This is to avoid the deadlock situation cased by the following scenario:
- *
- * Suppose backend A starts a transaction and acquires the LAST slot in resource
- * group G. Then backend A signals other backends who need a catchup interrupt.
- * Suppose backend B receives the signal and wants to respond to catchup event.
- * If backend B is assigned the same resource group G and tries to acquire a slot,
- * it will hang. Backend A will also hang because it is waiting for backend B to
- * catch up and free its space in the global SI message queue.
  */
 bool
 ShouldAssignResGroupOnMaster(void)
 {
 	return IsResGroupActivated() &&
 		IsNormalProcessingMode() &&
-		Gp_role == GP_ROLE_DISPATCH &&
-		!AmIInSIGUSR1Handler();
+		Gp_role == GP_ROLE_DISPATCH;
 }
 
 /*
@@ -2577,8 +2566,7 @@ ShouldUnassignResGroup(void)
 {
 	return IsResGroupActivated() &&
 		IsNormalProcessingMode() &&
-		(Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) &&
-		!AmIInSIGUSR1Handler();
+		(Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE);
 }
 
 /*

--- a/src/include/storage/procsignal.h
+++ b/src/include/storage/procsignal.h
@@ -59,6 +59,5 @@ extern int	SendProcSignal(pid_t pid, ProcSignalReason reason,
 						   BackendId backendId);
 
 extern void procsignal_sigusr1_handler(SIGNAL_ARGS);
-extern bool AmIInSIGUSR1Handler(void);
 
 #endif							/* PROCSIGNAL_H */


### PR DESCRIPTION
Commit 4f85fde refactored the infrastructure for interrupt processing,
simplified signal handlers and it had no more need to perform
StartTransactionCommand()...CommitTransactionCommand() call inside any
signal handler.

So the AmIInSIGUSR1Handler() should not happen at all, remove it.
