### PR TITLE
fix gprecoverseg -r when password authentification enabled for gpadmin

### DIFF
--- a/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
@@ -14,12 +14,12 @@ class SegmentReconfigurer:
         self.timeout = timeout
 
     def _trigger_fts_probe(self, dburl):
-        conn = pygresql.pg.connect(dburl.pgdb,
-                dburl.pghost,
-                dburl.pgport,
-                None,
-                dburl.pguser,
-                dburl.pgpass,
+        conn = pygresql.pg.connect(dbname=dburl.pgdb,
+                                   host=dburl.pghost,
+                                   port=dburl.pgport,
+                                   opt=None,
+                                   user=dburl.pguser,
+                                   passwd=dburl.pgpass,
                 )
         conn.query(FTS_PROBE_QUERY)
         conn.close()

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_reconfigurer.py
@@ -51,7 +51,7 @@ class SegmentReconfiguerTestCase(GpTestCase):
                 worker_pool=self.worker_pool, timeout=self.timeout)
         reconfigurer.reconfigure()
         pygresql.pg.connect.assert_has_calls([
-            call(self.db, self.host, self.port, None, self.user, self.passwd),
+            call(dbname=self.db, host=self.host, port=self.port, opt=None, user=self.user, passwd=self.passwd),
             call().query(FTS_PROBE_QUERY),
             call().close(),
             ]


### PR DESCRIPTION
The parameters were incorrectly passed while gprecoverseg was invoked
causing gprecoverseg to fail.

Co-authored-by: Aleksey Kashin <kashinav@yandex-team.ru>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
