### PR TITLE
Re-enable GROUP BY GROUPTING SETS/ROLLUP and GroupingFunc support in GPORCA

### DIFF
--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -47,7 +47,8 @@ using namespace gpmd;
 BOOL
 CQueryMutators::NeedsProjListNormalization(const Query *query)
 {
-	if (!query->hasAggs && NULL == query->groupClause)
+	if (!query->hasAggs && NULL == query->groupClause &&
+		NULL == query->groupingSets)
 	{
 		return false;
 	}
@@ -975,7 +976,8 @@ CQueryMutators::NormalizeHaving(CMemoryPool *mp, CMDAccessor *md_accessor,
 
 	ReassignSortClause(new_query, rte->subquery);
 
-	if (!rte->subquery->hasAggs && NIL == rte->subquery->groupClause)
+	if (!rte->subquery->hasAggs && NIL == rte->subquery->groupClause &&
+		NIL == rte->subquery->groupingSets)
 	{
 		// if the derived table has no grouping columns or aggregates then the
 		// subquery is equivalent to select XXXX FROM CONST-TABLE
@@ -1009,6 +1011,7 @@ CQueryMutators::NormalizeHaving(CMemoryPool *mp, CMDAccessor *md_accessor,
 		rte->subquery = new_subquery;
 		rte->subquery->jointree = MakeNode(FromExpr);
 		rte->subquery->groupClause = NIL;
+		rte->subquery->groupingSets = NIL;
 		rte->subquery->sortClause = NIL;
 		rte->subquery->windowClause = NIL;
 	}
@@ -1390,6 +1393,7 @@ CQueryMutators::NormalizeWindowProjList(CMemoryPool *mp,
 	// transformation, which separates GROUP BY from window functions
 	GPOS_ASSERT(NULL == original_query->distinctClause);
 	GPOS_ASSERT(NULL == original_query->groupClause);
+	GPOS_ASSERT(NULL == original_query->groupingSets);
 
 	// we do not fix target list of the derived table since we will be mutating it below
 	// to ensure that it does not have window functions

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -43,6 +43,7 @@ extern "C" {
 #include "naucrates/dxl/CDXLUtils.h"
 #include "naucrates/dxl/operators/dxlops.h"
 #include "naucrates/dxl/operators/CDXLScalarBooleanTest.h"
+#include "naucrates/dxl/operators/CDXLDatumInt4.h"
 #include "naucrates/dxl/operators/CDXLDatumInt8.h"
 #include "naucrates/dxl/xml/dxltokens.h"
 
@@ -50,6 +51,7 @@ extern "C" {
 #include "naucrates/md/IMDScalarOp.h"
 #include "naucrates/md/IMDAggregate.h"
 #include "naucrates/md/IMDTypeBool.h"
+#include "naucrates/md/IMDTypeInt4.h"
 #include "naucrates/md/IMDTypeInt8.h"
 #include "naucrates/md/CMDIdGPDBCtas.h"
 
@@ -268,8 +270,6 @@ CTranslatorQueryToDXL::CheckUnsupportedNodeTypes(Query *query)
 		{T_CoerceToDomainValue, GPOS_WSZ_LIT("COERCETODOMAINVALUE")},
 		{T_GroupId, GPOS_WSZ_LIT("GROUPID")},
 		{T_CurrentOfExpr, GPOS_WSZ_LIT("CURRENT OF")},
-		{T_GroupingFunc, GPOS_WSZ_LIT("GROUPINGFUNC")},
-
 	};
 
 	List *unsupported_list = NIL;
@@ -3873,7 +3873,25 @@ CTranslatorQueryToDXL::TranslateTargetListToDXLProject(
 
 		BOOL is_grouping_col =
 			CTranslatorUtils::IsGroupingColumn(target_entry, plgrpcl);
-		if (!is_groupby || (is_groupby && is_grouping_col))
+		if (IsA(target_entry->expr, GroupingFunc))
+		{
+			GroupingFunc *grouping_func = (GroupingFunc *) target_entry->expr;
+
+			if (1 != gpdb::ListLength(grouping_func->refs))
+			{
+				GPOS_RAISE(
+					gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+					GPOS_WSZ_LIT("Grouping function with multiple arguments"));
+			}
+
+			if (0 != grouping_func->agglevelsup)
+			{
+				GPOS_RAISE(
+					gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+					GPOS_WSZ_LIT("Grouping function with outer references"));
+			}
+		}
+		else if (!is_groupby || (is_groupby && is_grouping_col))
 		{
 			// Insist projection for any outer refs to ensure any decorelation of a
 			// subquery results in a correct plan using the projected reference,
@@ -4024,7 +4042,26 @@ CTranslatorQueryToDXL::CreateDXLProjectNullsForGroupingSets(
 
 		ULONG colid = 0;
 
-		if (!is_grouping_col && !IsA(target_entry->expr, Aggref))
+		if (IsA(target_entry->expr, GroupingFunc))
+		{
+			colid = m_context->m_colid_counter->next_id();
+			CDXLNode *grouping_func_dxlnode = TranslateGroupingFuncToDXL(
+				target_entry->expr, bitset, grpcol_index_to_colid_mapping);
+
+			CWStringDynamic *alias_str =
+				CDXLUtils::CreateDynamicStringFromCharArray(
+					m_mp, target_entry->resname);
+			CMDName *mdname_alias = GPOS_NEW(m_mp) CMDName(m_mp, alias_str);
+			GPOS_DELETE(alias_str);
+
+			CDXLNode *project_elem_dxlnode = GPOS_NEW(m_mp) CDXLNode(
+				m_mp,
+				GPOS_NEW(m_mp) CDXLScalarProjElem(m_mp, colid, mdname_alias),
+				grouping_func_dxlnode);
+			project_list_dxlnode->AddChild(project_elem_dxlnode);
+			StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
+		}
+		else if (!is_grouping_col && !IsA(target_entry->expr, Aggref))
 		{
 			OID oid_type = gpdb::ExprType((Node *) target_entry->expr);
 
@@ -4088,6 +4125,37 @@ CTranslatorQueryToDXL::CreateDXLProjectGroupingFuncs(
 
 	// construct a proj element node for those non-aggregate entries in the target list which
 	// are not included in the grouping set
+	ListCell *lc = NULL;
+	ForEach(lc, target_list)
+	{
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+		GPOS_ASSERT(IsA(target_entry, TargetEntry));
+
+		ULONG resno = target_entry->resno;
+
+		if (IsA(target_entry->expr, GroupingFunc))
+		{
+			ULONG colid = m_context->m_colid_counter->next_id();
+			CDXLNode *grouping_func_dxlnode = TranslateGroupingFuncToDXL(
+				target_entry->expr, bitset, grpcol_index_to_colid_mapping);
+
+			CWStringDynamic *alias_str =
+				CDXLUtils::CreateDynamicStringFromCharArray(
+					m_mp, target_entry->resname);
+			CMDName *mdname_alias = GPOS_NEW(m_mp) CMDName(m_mp, alias_str);
+			GPOS_DELETE(alias_str);
+
+			CDXLNode *project_elem_dxlnode = GPOS_NEW(m_mp) CDXLNode(
+				m_mp,
+				GPOS_NEW(m_mp) CDXLScalarProjElem(m_mp, colid, mdname_alias),
+				grouping_func_dxlnode);
+			project_list_dxlnode->AddChild(project_elem_dxlnode);
+			StoreAttnoColIdMapping(output_attno_to_colid_mapping, resno, colid);
+			AddSortingGroupingColumn(target_entry, sort_grpref_to_colid_mapping,
+									 colid);
+		}
+	}
+
 	if (0 == project_list_dxlnode->Arity())
 	{
 		// no project necessary
@@ -4267,6 +4335,50 @@ CTranslatorQueryToDXL::CreateDXLConstValueTrue()
 	gpdb::GPDBFree(const_expr);
 
 	return dxlnode;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CTranslatorQueryToDXL::TranslateGroupingFuncToDXL
+//
+//	@doc:
+//		Translate grouping func
+//
+//---------------------------------------------------------------------------
+CDXLNode *
+CTranslatorQueryToDXL::TranslateGroupingFuncToDXL(
+	const Expr *expr, CBitSet *bitset,
+	UlongToUlongMap *grpcol_index_to_colid_mapping) const
+{
+	GPOS_ASSERT(IsA(expr, GroupingFunc));
+	GPOS_ASSERT(NULL != grpcol_index_to_colid_mapping);
+
+	const GroupingFunc *grouping_func = (GroupingFunc *) expr;
+	GPOS_ASSERT(1 == gpdb::ListLength(grouping_func->refs));
+	GPOS_ASSERT(0 == grouping_func->agglevelsup);
+
+	// generate a constant value for the result of the grouping function as follows:
+	// if the grouping function argument is a group-by column, result is 0
+	// otherwise, the result is 1
+	LINT l_value = 0;
+
+	ULONG sort_group_ref = gpdb::ListNthInt(grouping_func->refs, 0);
+	BOOL is_grouping_col = bitset->Get(sort_group_ref);
+	if (!is_grouping_col)
+	{
+		// not a grouping column
+		l_value = 1;
+	}
+
+	const IMDType *md_type = m_md_accessor->PtMDType<IMDTypeInt4>(m_sysid);
+	CMDIdGPDB *mdid_cast = CMDIdGPDB::CastMdid(md_type->MDId());
+	CMDIdGPDB *mdid = GPOS_NEW(m_mp) CMDIdGPDB(*mdid_cast);
+
+	CDXLDatum *datum_dxl =
+		GPOS_NEW(m_mp) CDXLDatumInt4(m_mp, mdid, false /* is_null */, l_value);
+	CDXLScalarConstValue *dxlop =
+		GPOS_NEW(m_mp) CDXLScalarConstValue(m_mp, datum_dxl);
+	return GPOS_NEW(m_mp) CDXLNode(m_mp, dxlop);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1814,13 +1814,10 @@ CTranslatorUtils::IsGroupingColumn(const TargetEntry *target_entry,
 	{
 		Node *group_clause_node = (Node *) lfirst(group_clause_cell);
 
-		if (NULL == group_clause_node)
-		{
-			continue;
-		}
+		GPOS_ASSERT(NULL != group_clause_node);
+		GPOS_ASSERT(IsA(group_clause_node, SortGroupClause));
 
-		if (IsA(group_clause_node, SortGroupClause) &&
-			IsGroupingColumn(target_entry,
+		if (IsGroupingColumn(target_entry,
 							 (SortGroupClause *) group_clause_node))
 		{
 			return true;

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1413,7 +1413,6 @@ CTranslatorUtils::GetDXLColumnDescrArray(CMemoryPool *mp, List *target_list,
 										 ULongPtrArray *colids,
 										 BOOL keep_res_junked)
 {
-	GPOS_ASSERT(NULL != target_list);
 	GPOS_ASSERT(NULL != colids);
 
 	ListCell *target_entry_cell = NULL;
@@ -1563,7 +1562,6 @@ ULongPtrArray *
 CTranslatorUtils::GetOutputColIdsArray(CMemoryPool *mp, List *target_list,
 									   IntToUlongMap *attno_to_colid_map)
 {
-	GPOS_ASSERT(NULL != target_list);
 	GPOS_ASSERT(NULL != attno_to_colid_map);
 
 	ULongPtrArray *colids = GPOS_NEW(mp) ULongPtrArray(mp);

--- a/src/backend/gpopt/translate/README
+++ b/src/backend/gpopt/translate/README
@@ -1,0 +1,167 @@
+Query To DXL Translator
+=======================
+
+The Query To DXL Translator, as known as the algebrizer, takes as
+input a parsed query object and returns its DXL representation, which
+is an algebrized tree comprised of logical and scalar operations. The
+serialized DXL is then shipped to GPORCA for optimization.
+
+
+Nomenclature
+------------
+
+Logical Operator:
+Set based operator that maps one or more sets of tuples to a set of
+tuples.
+
+Physical Operator:
+Implementation of the logical operator, e.g. a logical join operation
+can be implemented as a nested-loop, hash- or merge-join.
+
+Scalar Operator:
+Maps a single or set of tuples to a single value.
+
+Algebrized Representation (Tree):
+The DXL representation of the GPDB query object
+
+
+Algebrizer Components
+---------------------
+
+CQueryMutator: normalize the incoming GPDB Query object.
+
+CTranslatorQueryToDXL: translate the normalized Query into a DXL tree
+structure. This DXL structure will then be serialized into DXL
+document and be shipped to the optimizer.
+
+CTranslatorDXLToQuery: translates the DXL back into a GPDB Query, this
+is only used to verify the correctness of the translation from Query
+to DXL.
+
+
+Normalized Query Form
+---------------------
+
+1) GROUP BY
+
+We assert that the group by operator has aggregate functions, grouping
+functions and grouping columns and nothing else. Expression on
+aggregate operators or grouping functions are translated as a project
+on top of the group by operation. To facilitate this we mutate the
+original query to a form that conforms to this assumption. To
+illustrate consider the following queries:
+
+Example 1:
+    INPUT:
+        SELECT a, count(*) + 1, grouping(a) + 1 FROM foo GROUP BY a
+    OUTPUT:
+        SELECT q_new.a, q_new.ct + 1, q_new.grouping + 1 FROM (SELECT
+        a, count(*) ct, grouping(a) grouping FROM foo GROUP BY a)
+        q_new
+
+Example 2:
+	INPUT:
+        SELECT * FROM bar where bar.c = (SELECT count(*) + sum(a) FROM
+        foo GROUP BY a)
+	OUTPUT:
+        SELECT * FROM bar where bar.c = (SELECT q_new.ct + q_new.sm
+        FROM (SELECT a, count(*) ct, sum(b) sm FROM foo GROUP BY a)
+        q_new)
+
+
+2) HAVING
+
+The having clause is translated into a select on top the
+original query. To accomplish this, we traverse the having clause to
+collect all aggregates pertaining to the current grouping operation
+and replacing it with the corresponding variable. To illustrate
+consider the following queries:
+
+Example:
+    INPUT:
+        SELECT a FROM foo GROUP BY a HAVING (count(*) > (SELECT
+        sum(foo.b) FROM bar))
+    OUTPUT:
+        SELECT q_new.a FROM (SELECT a, count(*) ct, sum(foo.b) sm FROM
+        foo GROUP BY a) q_new) WHERE q_new.ct > (SELECT q_new.sm FROM
+        bar))
+
+
+3) WINDOW
+
+Similar to GROUP BY, a window operator only has simple window
+functions rather than expression on window functions. The expression
+involving window functions are then translated into a project on top
+of the window operator. The mutation methodology is identical to the
+process described in GROUP BY.
+
+
+4) DISTINCT
+
+We transform the distinct clause into a GROUP BY on top the original
+query.
+
+Example:
+    INPUT:
+        SELECT distinct a, count(*) FROM foo GROUP BY a, b
+    OUTPUT:
+        SELECT q_new.a, q_new.ct FROM (SELECT a, count(*) ct, FROM foo
+        GROUP BY a) q_new) GROUP BY q_new.a, q_new.ct
+
+
+Query To DXL Translation
+------------------------
+
+Input: Query Object
+
+CTranslatorQueryToDXL assumes that the query has already been
+normalized. Therefore the following members in the query objects are
+NULL:
+1. Distinct Columns
+2. Having Clause
+
+
+Output: DXL
+
+DXL containing:
+1. List of output columns along with their alias name
+2. List of CTE Producers where each CTE producer has:
+        a. An unique identifier
+        b. List of output columns
+3. The DXL representation of the query
+
+
+Translation Algorithm
+
+1. If the query has set operations then
+    a. Process the inputs to the set op.
+    b. Check if the inputs need to casted
+        - If so the optimizer will generate new output column for the
+          casting functions
+    c. Create a logical set operator that contains:
+        - List of input columns from each input
+        - List of output columns of the set op
+2. If not, process the from clause (FROM EXPR)
+    a. Translate each range table entry used in the from clause based
+       on the type of the range table entry
+        - Table Entries: translate into logical get or logical
+          external get
+        - TVF: translate into logical tvf
+        - Value Scan: translate into a constant table get
+        - CTE: represented as a logical CTE consumer with it CTE
+          Producer ID and list of output columns.
+        - Translate a derived table to a logical tree
+3. Check if the query has window operation
+    a. If the window specification is a computed column then create a
+       project child
+    b. Add window function in the target list to the project list of
+       the window operator
+4. Check if the query has GROUP BY (including grouping sets/rollup)
+    a. Expand rollup/grouping sets into a union all over group bys
+    b. Add the aggregates in the target list to the project list of
+       the group by operator
+5. Check if the query has ordering clause
+    a. Create a logical limit operator with
+        - Order Spec (sorting columns and sorting functions used)
+        - limit count, and limit offset
+6. Generate the list of output columns and the alias name (for display)

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
@@ -75,7 +75,6 @@ CDistributionSpecHashed::CDistributionSpecHashed(
 	  m_equiv_hash_exprs(NULL)
 {
 	GPOS_ASSERT(NULL != pdrgpexpr);
-	GPOS_ASSERT(0 < pdrgpexpr->Size());
 	if (GPOS_FTRACE(EopttraceConsiderOpfamiliesForDistribution) &&
 		NULL == opfamilies)
 	{

--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -507,7 +507,8 @@ transformGroupedWindows(Node *node, void *context)
 		/*
 		 * we are done if this query doesn't have both window functions and group by/aggregates
 		 */
-		if (!qry->hasWindowFuncs || !(qry->groupClause || qry->hasAggs))
+		if (!qry->hasWindowFuncs ||
+			!(qry->groupClause || qry->groupingSets || qry->hasAggs))
 			return (Node *) qry;
 
 		Query	   *subq;

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -230,7 +230,8 @@ private:
 	// translate a query with grouping sets
 	CDXLNode *TranslateGroupingSets(
 		FromExpr *from_expr, List *target_list, List *group_clause,
-		BOOL has_aggs, IntToUlongMap *phmiulSortGrpColsColId,
+		List *grouping_set, BOOL has_aggs,
+		IntToUlongMap *phmiulSortGrpColsColId,
 		IntToUlongMap *output_attno_to_colid_mapping);
 
 	// expand the grouping sets into a union all operator

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -393,6 +393,11 @@ private:
 	// table of a DML query
 	void GetCtidAndSegmentId(ULONG *ctid, ULONG *segment_id);
 
+	// translate a grouping func expression
+	CDXLNode *TranslateGroupingFuncToDXL(
+		const Expr *expr, CBitSet *bitset,
+		UlongToUlongMap *grpcol_index_to_colid_mapping) const;
+
 	// construct a list of CTE producers from the query's CTE list
 	void ConstructCTEProducerList(List *cte_list, ULONG query_level);
 

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -71,12 +71,14 @@ enum DistributionHashOpsKind
 class CTranslatorUtils
 {
 private:
-	// construct a set of column attnos corresponding to a single grouping set
+	// Construct a set of column attnos corresponding to a single grouping set
+	// from either a plain GROUP BY or one set in a list of grouping sets
 	static CBitSet *CreateAttnoSetForGroupingSet(CMemoryPool *mp,
 												 List *group_elems,
 												 ULONG num_cols,
 												 UlongToUlongMap *group_col_pos,
-												 CBitSet *group_cols);
+												 CBitSet *group_cols,
+												 bool use_group_clause);
 
 	// check if the given mdid array contains any of the polymorphic
 	// types (ANYELEMENT, ANYARRAY)
@@ -93,6 +95,16 @@ private:
 	static void UpdateGrpColMapping(CMemoryPool *mp,
 									UlongToUlongMap *grouping_col_to_pos_map,
 									CBitSet *group_cols, ULONG sort_group_ref);
+
+	// create a set of grouping sets for a rollup
+	static CBitSetArray *CreateGroupingSetsForRollup(
+		CMemoryPool *mp, const GroupingSet *grouping_set, ULONG num_cols,
+		CBitSet *group_cols, UlongToUlongMap *group_col_pos);
+
+	// create a set of grouping sets for a grouping sets subclause
+	static CBitSetArray *CreateGroupingSetsForSets(
+		CMemoryPool *mp, const GroupingSet *grouping_set_node, ULONG num_cols,
+		CBitSet *group_cols, UlongToUlongMap *group_col_pos);
 
 public:
 	struct SCmptypeStrategy
@@ -179,8 +191,8 @@ public:
 	// construct a dynamic array of sets of column attnos corresponding
 	// to the group by clause
 	static CBitSetArray *GetColumnAttnosForGroupBy(
-		CMemoryPool *mp, List *group_clause, ULONG num_cols,
-		UlongToUlongMap *group_col_pos, CBitSet *group_cold);
+		CMemoryPool *mp, List *group_clause, List *grouping_set_list,
+		ULONG num_cols, UlongToUlongMap *group_col_pos, CBitSet *group_cold);
 
 	// return a copy of the query with constant of unknown type being coerced
 	// to the common data type of the output target list

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -4349,6 +4349,14 @@ select a,1 from orca.r group by rollup(a);
     |        1
 (22 rows)
 
+select distinct grouping(a) + grouping(b) from orca.m group by rollup(a,b);
+ ?column? 
+----------
+        0
+        2
+        1
+(3 rows)
+
 -- arrays
 select array[array[a,b]], array[b] from orca.r;
    array    | array 
@@ -8727,7 +8735,7 @@ select max(a) from foo group by (select g from jazz where foo.a = (select max(a)
    3
 (2 rows)
 
--- group by inside groupby inside group by ;S
+-- group by inside groupby inside group by
 select max(a) from foo group by (select min(g) from jazz where foo.a = (select max(g) from jazz group by h) group by h);
  max 
 -----

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -3726,8 +3726,6 @@ select * from orca.m where a=abs(b);
 
 -- grouping sets
 select a,b,count(*) from orca.m group by grouping sets ((a), (a,b));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  a  | b  | count 
 ----+----+-------
   0 |  1 |     1
@@ -3806,8 +3804,6 @@ DETAIL:  Feature not supported: Grouping Sets
 (73 rows)
 
 select b,count(*) from orca.m group by grouping sets ((a), (a,b));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  b  | count 
 ----+-------
   1 |     1
@@ -3886,8 +3882,6 @@ DETAIL:  Feature not supported: Grouping Sets
 (73 rows)
 
 select a,count(*) from orca.m group by grouping sets ((a), (a,b));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  a  | count 
 ----+-------
   0 |     1
@@ -3966,8 +3960,6 @@ DETAIL:  Feature not supported: Grouping Sets
 (73 rows)
 
 select a,count(*) from orca.m group by grouping sets ((a), (b));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  a  | count 
 ----+-------
     |     1
@@ -4012,8 +4004,6 @@ DETAIL:  Feature not supported: Grouping Sets
 (39 rows)
 
 select a,b,count(*) from orca.m group by rollup(a, b);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  a  | b  | count 
 ----+----+-------
   0 |  1 |     1
@@ -4093,8 +4083,6 @@ DETAIL:  Feature not supported: Grouping Sets
 (74 rows)
 
 select a,b,count(*) from orca.m group by rollup((a),(a,b)) order by 1,2,3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  a  | b  | count 
 ----+----+-------
   0 |  1 |     1
@@ -4174,8 +4162,6 @@ DETAIL:  Feature not supported: Grouping Sets
 (74 rows)
 
 select count(*) from orca.m group by ();
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  count 
 -------
     38
@@ -4208,8 +4194,6 @@ select a, count(*) from orca.r group by (), a;
 (21 rows)
 
 select a, count(*) from orca.r group by grouping sets ((),(a));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  a  | count 
 ----+-------
   2 |     1
@@ -4237,8 +4221,6 @@ DETAIL:  Feature not supported: Grouping Sets
 (22 rows)
 
 select a, b, count(*) c from orca.r group by grouping sets ((),(a), (a,b)) order by b,a,c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  a  | b | c  
 ----+---+----
   3 | 0 |  1
@@ -4287,8 +4269,6 @@ DETAIL:  Feature not supported: Grouping Sets
 (43 rows)
 
 select a, count(*) c from orca.r group by grouping sets ((),(a), (a,b)) order by b,a,c;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  a  | c  
 ----+----
   3 |  1
@@ -4337,16 +4317,12 @@ DETAIL:  Feature not supported: Grouping Sets
 (43 rows)
 
 select 1 from orca.r group by ();
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  ?column? 
 ----------
         1
 (1 row)
 
 select a,1 from orca.r group by rollup(a);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  a  | ?column? 
 ----+----------
   1 |        1
@@ -4372,6 +4348,14 @@ DETAIL:  Feature not supported: Grouping Sets
  18 |        1
  20 |        1
 (22 rows)
+
+select distinct grouping(a) + grouping(b) from orca.m group by rollup(a,b);
+ ?column? 
+----------
+        0
+        1
+        2
+(3 rows)
 
 -- arrays
 select array[array[a,b]], array[b] from orca.r;
@@ -8951,7 +8935,7 @@ DETAIL:  DXL-to-PlStmt Translation: Assert not supported
    1
 (2 rows)
 
--- group by inside groupby inside group by ;S
+-- group by inside groupby inside group by
 select max(a) from foo group by (select min(g) from jazz where foo.a = (select max(g) from jazz group by h) group by h);
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  DXL-to-PlStmt Translation: Assert not supported
@@ -10987,9 +10971,9 @@ set log_statement='none';
 set log_min_duration_statement=-1;
 set client_min_messages='log';
 explain select count(*) from foo group by cube(a,b);
-LOG:  2019-05-31 15:13:50:374760 PDT,THD000,NOTICE,"Feature not supported: Grouping Sets",
+LOG:  2020-10-19 17:17:37:192241 PDT,THD000,NOTICE,"Feature not supported: Cube",
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: Cube
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=1319.44..1496.29 rows=10611 width=16)

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -1,0 +1,1995 @@
+--
+-- grouping sets
+--
+-- GPDB: Some of the tests in this file test the case that some columns are
+-- unsortable, and some are unhashable. For the unhashable column, the upstream
+-- tests use 'bit' datatype. However, we have added a hash opclass for 'bit'
+-- in GPDB, which makes the tests ineffective in testing that.
+--
+-- To work around that, create a new datatype that is just like the built-in
+-- 'bit' type, but doesn't have the hash opclass.
+create type unhashable_bit;
+create function unhashable_bit_out (unhashable_bit) returns cstring immutable
+language internal as 'bit_out';
+NOTICE:  argument type unhashable_bit is only a shell
+create function unhashable_bit_in (cstring) returns unhashable_bit immutable
+language internal as 'bit_in';
+NOTICE:  return type unhashable_bit is only a shell
+create type unhashable_bit (
+  input = unhashable_bit_in,
+  output = unhashable_bit_out,
+  typmod_in = bittypmodin,
+  typmod_out = bittypmodout,
+  like = bit);
+create function unhashable_biteq(unhashable_bit, unhashable_bit) returns bool
+immutable language internal as 'biteq';
+create function unhashable_bitne(unhashable_bit, unhashable_bit) returns bool
+immutable language internal as 'bitne';
+create function unhashable_bitge(unhashable_bit, unhashable_bit) returns bool
+immutable language internal as 'bitge';
+create function unhashable_bitgt(unhashable_bit, unhashable_bit) returns bool
+immutable language internal as 'bitgt';
+create function unhashable_bitle(unhashable_bit, unhashable_bit) returns bool
+immutable language internal as 'bitle';
+create function unhashable_bitlt(unhashable_bit, unhashable_bit) returns bool
+immutable language internal as 'bitlt';
+create function unhashable_bitcmp(unhashable_bit, unhashable_bit) returns int4
+immutable language internal as 'bitcmp';
+create operator = (function=unhashable_biteq, leftarg=unhashable_bit, rightarg=unhashable_bit,
+                   merges, commutator = "=", negator = "<>",
+		   restrict = 'eqsel', join = 'eqjoinsel');
+create operator <> (function=unhashable_bitne, leftarg=unhashable_bit, rightarg=unhashable_bit,
+                   commutator = "<>", negator = "=",
+		   restrict = 'neqsel', join = 'neqjoinsel');
+create operator >= (function=unhashable_bitge, leftarg=unhashable_bit, rightarg=unhashable_bit,
+                   commutator = "<=", negator = "<",
+		   restrict = 'scalargesel', join = 'scalargejoinsel');
+create operator > (function=unhashable_bitgt, leftarg=unhashable_bit, rightarg=unhashable_bit,
+                   commutator = "<", negator = "<=",
+		   restrict = 'scalargtsel', join = 'scalargtjoinsel');
+create operator <= (function=unhashable_bitle, leftarg=unhashable_bit, rightarg=unhashable_bit,
+                   commutator = ">=", negator = ">",
+		   restrict = 'scalarlesel', join = 'scalarlejoinsel');
+create operator < (function=unhashable_bitlt, leftarg=unhashable_bit, rightarg=unhashable_bit,
+                   commutator = ">", negator = ">=",
+		   restrict = 'scalarltsel', join = 'scalarltjoinsel');
+create operator class unhashable_bit_ops
+  default for type unhashable_bit using btree as
+    operator 1 <  ,
+    operator 2 <= ,
+    operator 3 =  ,
+    operator 4 >= ,
+    operator 5 >  ,
+    function 1 unhashable_bitcmp(unhashable_bit, unhashable_bit);
+create cast (bit as unhashable_bit) without function as assignment;
+-- test data sources
+create temp view gstest1(a,b,v)
+  as values (1,1,10),(1,1,11),(1,2,12),(1,2,13),(1,3,14),
+            (2,3,15),
+            (3,3,16),(3,4,17),
+            (4,1,18),(4,1,19);
+create temp table gstest2 (a integer, b integer, c integer, d integer,
+                           e integer, f integer, g integer, h integer);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+copy gstest2 from stdin;
+create temp table gstest3 (a integer, b integer, c integer, d integer);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+copy gstest3 from stdin;
+alter table gstest3 add primary key (a);
+create temp table gstest4(id integer, v integer,
+                          unhashable_col unhashable_bit(4), unsortable_col xid);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into gstest4
+values (1,1,b'0000','1'), (2,2,b'0001','1'),
+       (3,4,b'0010','2'), (4,8,b'0011','2'),
+       (5,16,b'0000','2'), (6,32,b'0001','2'),
+       (7,64,b'0010','1'), (8,128,b'0011','1');
+create temp table gstest_empty (a integer, b integer, v integer);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create function gstest_data(v integer, out a integer, out b integer)
+  returns setof record
+  as $f$
+    begin
+      return query select v, i from generate_series(1,3) i;
+    end;
+  $f$ language plpgsql;
+-- basic functionality
+set enable_hashagg = false;  -- test hashing explicitly later
+-- simple rollup with multiple plain aggregates, with and without ordering
+-- (and with ordering differing from grouping)
+select a, b, grouping(a,b), sum(v), count(*), max(v)
+  from gstest1 group by rollup (a,b);
+ a | b | grouping | sum | count | max 
+---+---+----------+-----+-------+-----
+ 1 | 1 |        0 |  21 |     2 |  11
+ 1 | 2 |        0 |  25 |     2 |  13
+ 1 | 3 |        0 |  14 |     1 |  14
+ 1 |   |        1 |  60 |     5 |  14
+ 2 | 3 |        0 |  15 |     1 |  15
+ 2 |   |        1 |  15 |     1 |  15
+ 3 | 3 |        0 |  16 |     1 |  16
+ 3 | 4 |        0 |  17 |     1 |  17
+ 3 |   |        1 |  33 |     2 |  17
+ 4 | 1 |        0 |  37 |     2 |  19
+ 4 |   |        1 |  37 |     2 |  19
+   |   |        3 | 145 |    10 |  19
+(12 rows)
+
+select a, b, grouping(a,b), sum(v), count(*), max(v)
+  from gstest1 group by rollup (a,b) order by a,b;
+ a | b | grouping | sum | count | max 
+---+---+----------+-----+-------+-----
+ 1 | 1 |        0 |  21 |     2 |  11
+ 1 | 2 |        0 |  25 |     2 |  13
+ 1 | 3 |        0 |  14 |     1 |  14
+ 1 |   |        1 |  60 |     5 |  14
+ 2 | 3 |        0 |  15 |     1 |  15
+ 2 |   |        1 |  15 |     1 |  15
+ 3 | 3 |        0 |  16 |     1 |  16
+ 3 | 4 |        0 |  17 |     1 |  17
+ 3 |   |        1 |  33 |     2 |  17
+ 4 | 1 |        0 |  37 |     2 |  19
+ 4 |   |        1 |  37 |     2 |  19
+   |   |        3 | 145 |    10 |  19
+(12 rows)
+
+select a, b, grouping(a,b), sum(v), count(*), max(v)
+  from gstest1 group by rollup (a,b) order by b desc, a;
+ a | b | grouping | sum | count | max 
+---+---+----------+-----+-------+-----
+ 1 |   |        1 |  60 |     5 |  14
+ 2 |   |        1 |  15 |     1 |  15
+ 3 |   |        1 |  33 |     2 |  17
+ 4 |   |        1 |  37 |     2 |  19
+   |   |        3 | 145 |    10 |  19
+ 3 | 4 |        0 |  17 |     1 |  17
+ 1 | 3 |        0 |  14 |     1 |  14
+ 2 | 3 |        0 |  15 |     1 |  15
+ 3 | 3 |        0 |  16 |     1 |  16
+ 1 | 2 |        0 |  25 |     2 |  13
+ 1 | 1 |        0 |  21 |     2 |  11
+ 4 | 1 |        0 |  37 |     2 |  19
+(12 rows)
+
+select a, b, grouping(a,b), sum(v), count(*), max(v)
+  from gstest1 group by rollup (a,b) order by coalesce(a,0)+coalesce(b,0);
+ a | b | grouping | sum | count | max 
+---+---+----------+-----+-------+-----
+   |   |        3 | 145 |    10 |  19
+ 1 |   |        1 |  60 |     5 |  14
+ 1 | 1 |        0 |  21 |     2 |  11
+ 2 |   |        1 |  15 |     1 |  15
+ 3 |   |        1 |  33 |     2 |  17
+ 1 | 2 |        0 |  25 |     2 |  13
+ 1 | 3 |        0 |  14 |     1 |  14
+ 4 |   |        1 |  37 |     2 |  19
+ 4 | 1 |        0 |  37 |     2 |  19
+ 2 | 3 |        0 |  15 |     1 |  15
+ 3 | 3 |        0 |  16 |     1 |  16
+ 3 | 4 |        0 |  17 |     1 |  17
+(12 rows)
+
+-- various types of ordered aggs
+select a, b, grouping(a,b),
+       array_agg(v order by v),
+       string_agg(v::text, ':' order by v desc),
+       percentile_disc(0.5) within group (order by v),
+       rank(1,2,12) within group (order by a,b,v)
+  from gstest1 group by rollup (a,b) order by a,b;
+ a | b | grouping |            array_agg            |          string_agg           | percentile_disc | rank 
+---+---+----------+---------------------------------+-------------------------------+-----------------+------
+ 1 | 1 |        0 | {10,11}                         | 11:10                         |              10 |    3
+ 1 | 2 |        0 | {12,13}                         | 13:12                         |              12 |    1
+ 1 | 3 |        0 | {14}                            | 14                            |              14 |    1
+ 1 |   |        1 | {10,11,12,13,14}                | 14:13:12:11:10                |              12 |    3
+ 2 | 3 |        0 | {15}                            | 15                            |              15 |    1
+ 2 |   |        1 | {15}                            | 15                            |              15 |    1
+ 3 | 3 |        0 | {16}                            | 16                            |              16 |    1
+ 3 | 4 |        0 | {17}                            | 17                            |              17 |    1
+ 3 |   |        1 | {16,17}                         | 17:16                         |              16 |    1
+ 4 | 1 |        0 | {18,19}                         | 19:18                         |              18 |    1
+ 4 |   |        1 | {18,19}                         | 19:18                         |              18 |    1
+   |   |        3 | {10,11,12,13,14,15,16,17,18,19} | 19:18:17:16:15:14:13:12:11:10 |              14 |    3
+(12 rows)
+
+-- test usage of grouped columns in direct args of aggs
+select grouping(a), a, array_agg(b),
+       rank(a) within group (order by b nulls first),
+       rank(a) within group (order by b nulls last)
+  from (values (1,1),(1,4),(1,5),(3,1),(3,2)) v(a,b)
+ group by rollup (a) order by a;
+ grouping | a |  array_agg  | rank | rank 
+----------+---+-------------+------+------
+        0 | 1 | {1,4,5}     |    1 |    1
+        0 | 3 | {1,2}       |    3 |    3
+        1 |   | {1,4,5,1,2} |    1 |    6
+(3 rows)
+
+-- nesting with window functions
+select a, b, sum(c), sum(sum(c)) over (order by a,b) as rsum
+  from gstest2 group by rollup (a,b) order by rsum, a, b;
+ a | b | sum | rsum 
+---+---+-----+------
+ 1 | 1 |   8 |    8
+ 1 | 2 |   2 |   10
+ 1 |   |  10 |   20
+ 2 | 2 |   2 |   22
+ 2 |   |   2 |   24
+   |   |  12 |   36
+(6 rows)
+
+-- nesting with grouping sets
+select sum(c) from gstest2
+  group by grouping sets((), grouping sets((), grouping sets(())))
+  order by 1 desc;
+ sum 
+-----
+  12
+  12
+  12
+(3 rows)
+
+select sum(c) from gstest2
+  group by grouping sets((), grouping sets((), grouping sets(((a, b)))))
+  order by 1 desc;
+ sum 
+-----
+  12
+  12
+   8
+   2
+   2
+(5 rows)
+
+select sum(c) from gstest2
+  group by grouping sets(grouping sets(rollup(c), grouping sets(cube(c))))
+  order by 1 desc;
+ sum 
+-----
+  12
+  12
+   6
+   6
+   6
+   6
+(6 rows)
+
+select sum(c) from gstest2
+  group by grouping sets(a, grouping sets(a, cube(b)))
+  order by 1 desc;
+ sum 
+-----
+  12
+  10
+  10
+   8
+   4
+   2
+   2
+(7 rows)
+
+select sum(c) from gstest2
+  group by grouping sets(grouping sets((a, (b))))
+  order by 1 desc;
+ sum 
+-----
+   8
+   2
+   2
+(3 rows)
+
+select sum(c) from gstest2
+  group by grouping sets(grouping sets((a, b)))
+  order by 1 desc;
+ sum 
+-----
+   8
+   2
+   2
+(3 rows)
+
+select sum(c) from gstest2
+  group by grouping sets(grouping sets(a, grouping sets(a), a))
+  order by 1 desc;
+ sum 
+-----
+  10
+  10
+  10
+   2
+   2
+   2
+(6 rows)
+
+select sum(c) from gstest2
+  group by grouping sets(grouping sets(a, grouping sets(a, grouping sets(a), ((a)), a, grouping sets(a), (a)), a))
+  order by 1 desc;
+ sum 
+-----
+  10
+  10
+  10
+  10
+  10
+  10
+  10
+  10
+   2
+   2
+   2
+   2
+   2
+   2
+   2
+   2
+(16 rows)
+
+select sum(c) from gstest2
+  group by grouping sets((a,(a,b)), grouping sets((a,(a,b)),a))
+  order by 1 desc;
+ sum 
+-----
+  10
+   8
+   8
+   2
+   2
+   2
+   2
+   2
+(8 rows)
+
+-- empty input: first is 0 rows, second 1, third 3 etc.
+select a, b, sum(v), count(*) from gstest_empty group by grouping sets ((a,b),a);
+ a | b | sum | count 
+---+---+-----+-------
+(0 rows)
+
+select a, b, sum(v), count(*) from gstest_empty group by grouping sets ((a,b),());
+ a | b | sum | count 
+---+---+-----+-------
+   |   |     |     0
+(1 row)
+
+select a, b, sum(v), count(*) from gstest_empty group by grouping sets ((a,b),(),(),());
+ a | b | sum | count 
+---+---+-----+-------
+   |   |     |     0
+   |   |     |     0
+   |   |     |     0
+(3 rows)
+
+select sum(v), count(*) from gstest_empty group by grouping sets ((),(),());
+ sum | count 
+-----+-------
+     |     0
+     |     0
+     |     0
+(3 rows)
+
+-- empty input with joins tests some important code paths
+select t1.a, t2.b, sum(t1.v), count(*) from gstest_empty t1, gstest_empty t2
+ group by grouping sets ((t1.a,t2.b),());
+ a | b | sum | count 
+---+---+-----+-------
+   |   |     |     0
+(1 row)
+
+-- simple joins, var resolution, GROUPING on join vars
+select t1.a, t2.b, grouping(t1.a, t2.b), sum(t1.v), max(t2.a)
+  from gstest1 t1, gstest2 t2
+ group by grouping sets ((t1.a, t2.b), ());
+ a | b | grouping | sum  | max 
+---+---+----------+------+-----
+ 1 | 1 |        0 |  420 |   1
+ 1 | 2 |        0 |  120 |   2
+ 2 | 1 |        0 |  105 |   1
+ 2 | 2 |        0 |   30 |   2
+ 3 | 1 |        0 |  231 |   1
+ 3 | 2 |        0 |   66 |   2
+ 4 | 1 |        0 |  259 |   1
+ 4 | 2 |        0 |   74 |   2
+   |   |        3 | 1305 |   2
+(9 rows)
+
+select t1.a, t2.b, grouping(t1.a, t2.b), sum(t1.v), max(t2.a)
+  from gstest1 t1 join gstest2 t2 on (t1.a=t2.a)
+ group by grouping sets ((t1.a, t2.b), ());
+ a | b | grouping | sum | max 
+---+---+----------+-----+-----
+ 1 | 1 |        0 | 420 |   1
+ 1 | 2 |        0 |  60 |   1
+ 2 | 2 |        0 |  15 |   2
+   |   |        3 | 495 |   2
+(4 rows)
+
+select a, b, grouping(a, b), sum(t1.v), max(t2.c)
+  from gstest1 t1 join gstest2 t2 using (a,b)
+ group by grouping sets ((a, b), ());
+ a | b | grouping | sum | max 
+---+---+----------+-----+-----
+ 1 | 1 |        0 | 147 |   2
+ 1 | 2 |        0 |  25 |   2
+   |   |        3 | 172 |   2
+(3 rows)
+
+-- check that functionally dependent cols are not nulled
+select a, d, grouping(a,b,c)
+  from gstest3
+ group by grouping sets ((a,b), (a,c));
+ a | d | grouping 
+---+---+----------
+ 1 | 1 |        1
+ 1 | 1 |        2
+ 2 | 2 |        1
+ 2 | 2 |        2
+(4 rows)
+
+-- check that distinct grouping columns are kept separate
+-- even if they are equal()
+explain (costs off)
+select g as alias1, g as alias2
+  from generate_series(1,3) g
+ group by alias1, rollup(alias2);
+                   QUERY PLAN                   
+------------------------------------------------
+ GroupAggregate
+   Group Key: g, g
+   Group Key: g
+   ->  Sort
+         Sort Key: g
+         ->  Function Scan on generate_series g
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select g as alias1, g as alias2
+  from generate_series(1,3) g
+ group by alias1, rollup(alias2);
+ alias1 | alias2 
+--------+--------
+      1 |      1
+      1 |       
+      2 |      2
+      2 |       
+      3 |      3
+      3 |       
+(6 rows)
+
+-- check that pulled-up subquery outputs still go to null when appropriate
+select four, x
+  from (select four, ten, 'foo'::text as x from tenk1) as t
+  group by grouping sets (four, x)
+  having x = 'foo';
+ four |  x  
+------+-----
+      | foo
+(1 row)
+
+select four, x || 'x'
+  from (select four, ten, 'foo'::text as x from tenk1) as t
+  group by grouping sets (four, x)
+  order by four;
+ four | ?column? 
+------+----------
+    0 | 
+    1 | 
+    2 | 
+    3 | 
+      | foox
+(5 rows)
+
+select (x+y)*1, sum(z)
+ from (select 1 as x, 2 as y, 3 as z) s
+ group by grouping sets (x+y, x);
+ ?column? | sum 
+----------+-----
+          |   3
+        3 |   3
+(2 rows)
+
+select x, not x as not_x, q2 from
+  (select *, q1 = 1 as x from int8_tbl i1) as t
+  group by grouping sets(x, q2)
+  order by x, q2;
+ x | not_x |        q2         
+---+-------+-------------------
+ f | t     |                  
+   |       | -4567890123456789
+   |       |               123
+   |       |               456
+   |       |  4567890123456789
+(5 rows)
+
+-- simple rescan tests
+select a, b, sum(v.x)
+  from (values (1),(2)) v(x), gstest_data(v.x)
+ group by rollup (a,b);
+ a | b | sum 
+---+---+-----
+ 1 | 1 |   1
+ 1 | 2 |   1
+ 1 | 3 |   1
+ 1 |   |   3
+ 2 | 1 |   2
+ 2 | 2 |   2
+ 2 | 3 |   2
+ 2 |   |   6
+   |   |   9
+(9 rows)
+
+select *
+  from (values (1),(2)) v(x),
+       lateral (select a, b, sum(v.x) from gstest_data(v.x) group by rollup (a,b)) s;
+ERROR:  aggregate functions are not allowed in FROM clause of their own query level
+LINE 3:        lateral (select a, b, sum(v.x) from gstest_data(v.x) ...
+                                     ^
+-- min max optimization should still work with GROUP BY ()
+explain (costs off)
+  select min(unique1) from tenk1 GROUP BY ();
+                   QUERY PLAN                   
+------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on tenk1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- Views with GROUPING SET queries
+CREATE VIEW gstest_view AS select a, b, grouping(a,b), sum(c), count(*), max(c)
+  from gstest2 group by rollup ((a,b,c),(c,d));
+NOTICE:  view "gstest_view" will be a temporary view
+select pg_get_viewdef('gstest_view'::regclass, true);
+                                pg_get_viewdef                                 
+-------------------------------------------------------------------------------
+  SELECT gstest2.a,                                                           +
+     gstest2.b,                                                               +
+     GROUPING(gstest2.a, gstest2.b) AS "grouping",                            +
+     sum(gstest2.c) AS sum,                                                   +
+     count(*) AS count,                                                       +
+     max(gstest2.c) AS max                                                    +
+    FROM gstest2                                                              +
+   GROUP BY ROLLUP((gstest2.a, gstest2.b, gstest2.c), (gstest2.c, gstest2.d));
+(1 row)
+
+-- Nested queries with 3 or more levels of nesting
+select(select (select grouping(a,b) from (values (1)) v2(c)) from (values (1,2)) v1(a,b) group by (a,b)) from (values(6,7)) v3(e,f) GROUP BY ROLLUP(e,f);
+ grouping 
+----------
+        0
+        0
+        0
+(3 rows)
+
+select(select (select grouping(e,f) from (values (1)) v2(c)) from (values (1,2)) v1(a,b) group by (a,b)) from (values(6,7)) v3(e,f) GROUP BY ROLLUP(e,f);
+ grouping 
+----------
+        0
+        1
+        3
+(3 rows)
+
+select(select (select grouping(c) from (values (1)) v2(c) GROUP BY c) from (values (1,2)) v1(a,b) group by (a,b)) from (values(6,7)) v3(e,f) GROUP BY ROLLUP(e,f);
+ grouping 
+----------
+        0
+        0
+        0
+(3 rows)
+
+-- Combinations of operations
+select a, b, c, d from gstest2 group by rollup(a,b),grouping sets(c,d);
+ a | b | c | d 
+---+---+---+---
+ 1 | 1 | 1 |  
+ 1 |   | 1 |  
+   |   | 1 |  
+ 1 | 1 | 2 |  
+ 1 | 2 | 2 |  
+ 1 |   | 2 |  
+ 2 | 2 | 2 |  
+ 2 |   | 2 |  
+   |   | 2 |  
+ 1 | 1 |   | 1
+ 1 |   |   | 1
+   |   |   | 1
+ 1 | 1 |   | 2
+ 1 | 2 |   | 2
+ 1 |   |   | 2
+ 2 | 2 |   | 2
+ 2 |   |   | 2
+   |   |   | 2
+(18 rows)
+
+select a, b from (values (1,2),(2,3)) v(a,b) group by a,b, grouping sets(a);
+ a | b 
+---+---
+ 1 | 2
+ 2 | 3
+(2 rows)
+
+-- Tests for chained aggregates
+select a, b, grouping(a,b), sum(v), count(*), max(v)
+  from gstest1 group by grouping sets ((a,b),(a+1,b+1),(a+2,b+2)) order by 3,6;
+ a | b | grouping | sum | count | max 
+---+---+----------+-----+-------+-----
+ 1 | 1 |        0 |  21 |     2 |  11
+ 1 | 2 |        0 |  25 |     2 |  13
+ 1 | 3 |        0 |  14 |     1 |  14
+ 2 | 3 |        0 |  15 |     1 |  15
+ 3 | 3 |        0 |  16 |     1 |  16
+ 3 | 4 |        0 |  17 |     1 |  17
+ 4 | 1 |        0 |  37 |     2 |  19
+   |   |        3 |  21 |     2 |  11
+   |   |        3 |  21 |     2 |  11
+   |   |        3 |  25 |     2 |  13
+   |   |        3 |  25 |     2 |  13
+   |   |        3 |  14 |     1 |  14
+   |   |        3 |  14 |     1 |  14
+   |   |        3 |  15 |     1 |  15
+   |   |        3 |  15 |     1 |  15
+   |   |        3 |  16 |     1 |  16
+   |   |        3 |  16 |     1 |  16
+   |   |        3 |  17 |     1 |  17
+   |   |        3 |  17 |     1 |  17
+   |   |        3 |  37 |     2 |  19
+   |   |        3 |  37 |     2 |  19
+(21 rows)
+
+select(select (select grouping(a,b) from (values (1)) v2(c)) from (values (1,2)) v1(a,b) group by (a,b)) from (values(6,7)) v3(e,f) GROUP BY ROLLUP((e+1),(f+1));
+ grouping 
+----------
+        0
+        0
+        0
+(3 rows)
+
+select(select (select grouping(a,b) from (values (1)) v2(c)) from (values (1,2)) v1(a,b) group by (a,b)) from (values(6,7)) v3(e,f) GROUP BY CUBE((e+1),(f+1)) ORDER BY (e+1),(f+1);
+ grouping 
+----------
+        0
+        0
+        0
+        0
+(4 rows)
+
+select a, b, sum(c), sum(sum(c)) over (order by a,b) as rsum
+  from gstest2 group by cube (a,b) order by rsum, a, b;
+ a | b | sum | rsum 
+---+---+-----+------
+ 1 | 1 |   8 |    8
+ 1 | 2 |   2 |   10
+ 1 |   |  10 |   20
+ 2 | 2 |   2 |   22
+ 2 |   |   2 |   24
+   | 1 |   8 |   32
+   | 2 |   4 |   36
+   |   |  12 |   48
+(8 rows)
+
+select a, b, sum(c) from (values (1,1,10),(1,1,11),(1,2,12),(1,2,13),(1,3,14),(2,3,15),(3,3,16),(3,4,17),(4,1,18),(4,1,19)) v(a,b,c) group by rollup (a,b);
+ a | b | sum 
+---+---+-----
+   |   | 145
+ 1 | 1 |  21
+ 1 | 2 |  25
+ 1 | 3 |  14
+ 2 | 3 |  15
+ 3 | 3 |  16
+ 3 | 4 |  17
+ 4 | 1 |  37
+ 1 |   |  60
+ 4 |   |  37
+ 2 |   |  15
+ 3 |   |  33
+(12 rows)
+
+select a, b, sum(v.x)
+  from (values (1),(2)) v(x), gstest_data(v.x)
+ group by cube (a,b) order by a,b;
+ a | b | sum 
+---+---+-----
+ 1 | 1 |   1
+ 1 | 2 |   1
+ 1 | 3 |   1
+ 1 |   |   3
+ 2 | 1 |   2
+ 2 | 2 |   2
+ 2 | 3 |   2
+ 2 |   |   6
+   | 1 |   3
+   | 2 |   3
+   | 3 |   3
+   |   |   9
+(12 rows)
+
+-- Test reordering of grouping sets
+explain (costs off)
+select * from gstest1 group by grouping sets((a,b,v),(v)) order by v,b,a;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: share0_ref2.column3, (NULL::integer), (NULL::integer)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 0:0)
+               ->  Values Scan on "Values"
+         ->  Append
+               ->  GroupAggregate
+                     Group Key: share0_ref2.column3
+                     ->  Sort
+                           Sort Key: share0_ref2.column3
+                           ->  Shared Scan (share slice:id 0:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref3.column3, share0_ref3.column2, share0_ref3.column1
+                     ->  Sort
+                           Sort Key: share0_ref3.column3, share0_ref3.column2, share0_ref3.column1
+                           ->  Shared Scan (share slice:id 0:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
+
+-- Agg level check. This query should error out.
+select (select grouping(a,b) from gstest2) from gstest2 group by a,b;
+ERROR:  arguments to GROUPING must be grouping expressions of the associated query level
+LINE 1: select (select grouping(a,b) from gstest2) from gstest2 grou...
+                                ^
+--Nested queries
+select a, b, sum(c), count(*) from gstest2 group by grouping sets (rollup(a,b),a);
+ a | b | sum | count 
+---+---+-----+-------
+ 1 | 1 |   8 |     7
+ 1 | 2 |   2 |     1
+ 1 |   |  10 |     8
+ 1 |   |  10 |     8
+ 2 | 2 |   2 |     1
+ 2 |   |   2 |     1
+ 2 |   |   2 |     1
+   |   |  12 |     9
+(8 rows)
+
+-- HAVING queries
+select ten, sum(distinct four) from onek a
+group by grouping sets((ten,four),(ten))
+having exists (select 1 from onek b where sum(distinct a.four) = b.four);
+ ten | sum 
+-----+-----
+   2 |   2
+   4 |   2
+   8 |   2
+   0 |   2
+   6 |   2
+   1 |   3
+   4 |   2
+   5 |   3
+   7 |   3
+   8 |   2
+   9 |   3
+   6 |   2
+   0 |   2
+   2 |   2
+   3 |   3
+   1 |   1
+   4 |   0
+   0 |   0
+   2 |   0
+   3 |   1
+   6 |   0
+   9 |   1
+   5 |   1
+   7 |   1
+   8 |   0
+(25 rows)
+
+-- Tests around pushdown of HAVING clauses, partially testing against previous bugs
+select a,count(*) from gstest2 group by rollup(a) order by a;
+ a | count 
+---+-------
+ 1 |     8
+ 2 |     1
+   |     9
+(3 rows)
+
+select a,count(*) from gstest2 group by rollup(a) having a is distinct from 1 order by a;
+ a | count 
+---+-------
+ 2 |     1
+   |     9
+(2 rows)
+
+explain (costs off)
+  select a,count(*) from gstest2 group by rollup(a) having a is distinct from 1 order by a;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: (NULL::integer)
+   ->  Sort
+         Sort Key: (NULL::integer)
+         ->  Sequence
+               ->  Shared Scan (share slice:id 1:0)
+                     ->  Seq Scan on gstest2
+               ->  Redistribute Motion 1:3  (slice2)
+                     ->  Append
+                           ->  Result
+                                 Filter: ((NULL::integer) IS DISTINCT FROM 1)
+                                 ->  Finalize Aggregate
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)
+                                             ->  Partial Aggregate
+                                                   ->  Shared Scan (share slice:id 3:0)
+                           ->  Gather Motion 3:1  (slice4; segments: 3)
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref3.a
+                                       ->  Sort
+                                             Sort Key: share0_ref3.a
+                                             ->  Result
+                                                   Filter: (share0_ref3.a IS DISTINCT FROM 1)
+                                                   ->  Shared Scan (share slice:id 4:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(24 rows)
+
+select v.c, (select count(*) from gstest2 group by () having v.c)
+  from (values (false),(true)) v(c) order by v.c;
+ c | count 
+---+-------
+ f |      
+ t |     9
+(2 rows)
+
+explain (costs off)
+  select v.c, (select count(*) from gstest2 group by () having v.c)
+    from (values (false),(true)) v(c) order by v.c;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Sort
+   Sort Key: "*VALUES*".column1
+   ->  Values Scan on "*VALUES*"
+         SubPlan 1
+           ->  Aggregate
+                 Group Key: ()
+                 Filter: "*VALUES*".column1
+                 ->  Result
+                       One-Time Filter: "*VALUES*".column1
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice1; segments: 3)
+                                   ->  Seq Scan on gstest2
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+-- HAVING with GROUPING queries
+select ten, grouping(ten) from onek
+group by grouping sets(ten) having grouping(ten) >= 0
+order by 2,1;
+ ten | grouping 
+-----+----------
+   0 |        0
+   1 |        0
+   2 |        0
+   3 |        0
+   4 |        0
+   5 |        0
+   6 |        0
+   7 |        0
+   8 |        0
+   9 |        0
+(10 rows)
+
+select ten, grouping(ten) from onek
+group by grouping sets(ten, four) having grouping(ten) > 0
+order by 2,1;
+ ten | grouping 
+-----+----------
+     |        1
+     |        1
+     |        1
+     |        1
+(4 rows)
+
+select ten, grouping(ten) from onek
+group by rollup(ten) having grouping(ten) > 0
+order by 2,1;
+ ten | grouping 
+-----+----------
+     |        1
+(1 row)
+
+select ten, grouping(ten) from onek
+group by cube(ten) having grouping(ten) > 0
+order by 2,1;
+ ten | grouping 
+-----+----------
+     |        1
+(1 row)
+
+select ten, grouping(ten) from onek
+group by (ten) having grouping(ten) >= 0
+order by 2,1;
+ ten | grouping 
+-----+----------
+   0 |        0
+   1 |        0
+   2 |        0
+   3 |        0
+   4 |        0
+   5 |        0
+   6 |        0
+   7 |        0
+   8 |        0
+   9 |        0
+(10 rows)
+
+-- FILTER queries
+select ten, sum(distinct four) filter (where four::text ~ '123') from onek a
+group by rollup(ten);
+ ten | sum 
+-----+-----
+   0 |    
+   1 |    
+   2 |    
+   3 |    
+   4 |    
+   5 |    
+   6 |    
+   7 |    
+   8 |    
+   9 |    
+     |    
+(11 rows)
+
+-- More rescan tests
+-- start_ignore
+-- GPDB_95_MERGE_FIXME: the lateral query with grouping sets do not make right plans
+select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, count(*) from onek group by cube(four,ten)) s on true order by v.a,four,ten;
+ a | a | four | ten | count 
+---+---+------+-----+-------
+ 1 | 1 |    0 |   0 |    50
+ 1 | 1 |    0 |   2 |    50
+ 1 | 1 |    0 |   4 |    50
+ 1 | 1 |    0 |   6 |    50
+ 1 | 1 |    0 |   8 |    50
+ 1 | 1 |    0 |     |   250
+ 1 | 1 |    1 |   1 |    50
+ 1 | 1 |    1 |   3 |    50
+ 1 | 1 |    1 |   5 |    50
+ 1 | 1 |    1 |   7 |    50
+ 1 | 1 |    1 |   9 |    50
+ 1 | 1 |    1 |     |   250
+ 1 | 1 |    2 |   0 |    50
+ 1 | 1 |    2 |   2 |    50
+ 1 | 1 |    2 |   4 |    50
+ 1 | 1 |    2 |   6 |    50
+ 1 | 1 |    2 |   8 |    50
+ 1 | 1 |    2 |     |   250
+ 1 | 1 |    3 |   1 |    50
+ 1 | 1 |    3 |   3 |    50
+ 1 | 1 |    3 |   5 |    50
+ 1 | 1 |    3 |   7 |    50
+ 1 | 1 |    3 |   9 |    50
+ 1 | 1 |    3 |     |   250
+ 1 | 1 |      |   0 |   100
+ 1 | 1 |      |   1 |   100
+ 1 | 1 |      |   2 |   100
+ 1 | 1 |      |   3 |   100
+ 1 | 1 |      |   4 |   100
+ 1 | 1 |      |   5 |   100
+ 1 | 1 |      |   6 |   100
+ 1 | 1 |      |   7 |   100
+ 1 | 1 |      |   8 |   100
+ 1 | 1 |      |   9 |   100
+ 1 | 1 |      |     |  1000
+ 2 | 2 |    0 |   0 |    50
+ 2 | 2 |    0 |   2 |    50
+ 2 | 2 |    0 |   4 |    50
+ 2 | 2 |    0 |   6 |    50
+ 2 | 2 |    0 |   8 |    50
+ 2 | 2 |    0 |     |   250
+ 2 | 2 |    1 |   1 |    50
+ 2 | 2 |    1 |   3 |    50
+ 2 | 2 |    1 |   5 |    50
+ 2 | 2 |    1 |   7 |    50
+ 2 | 2 |    1 |   9 |    50
+ 2 | 2 |    1 |     |   250
+ 2 | 2 |    2 |   0 |    50
+ 2 | 2 |    2 |   2 |    50
+ 2 | 2 |    2 |   4 |    50
+ 2 | 2 |    2 |   6 |    50
+ 2 | 2 |    2 |   8 |    50
+ 2 | 2 |    2 |     |   250
+ 2 | 2 |    3 |   1 |    50
+ 2 | 2 |    3 |   3 |    50
+ 2 | 2 |    3 |   5 |    50
+ 2 | 2 |    3 |   7 |    50
+ 2 | 2 |    3 |   9 |    50
+ 2 | 2 |    3 |     |   250
+ 2 | 2 |      |   0 |   100
+ 2 | 2 |      |   1 |   100
+ 2 | 2 |      |   2 |   100
+ 2 | 2 |      |   3 |   100
+ 2 | 2 |      |   4 |   100
+ 2 | 2 |      |   5 |   100
+ 2 | 2 |      |   6 |   100
+ 2 | 2 |      |   7 |   100
+ 2 | 2 |      |   8 |   100
+ 2 | 2 |      |   9 |   100
+ 2 | 2 |      |     |  1000
+(70 rows)
+
+-- end_ignore
+select array(select row(v.a,s1.*) from (select two,four, count(*) from onek group by cube(two,four) order by two,four) s1) from (values (1),(2)) v(a);
+                                                                        array                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"(1,0,0,250)","(1,0,2,250)","(1,0,,500)","(1,1,1,250)","(1,1,3,250)","(1,1,,500)","(1,,0,250)","(1,,1,250)","(1,,2,250)","(1,,3,250)","(1,,,1000)"}
+ {"(2,0,0,250)","(2,0,2,250)","(2,0,,500)","(2,1,1,250)","(2,1,3,250)","(2,1,,500)","(2,,0,250)","(2,,1,250)","(2,,2,250)","(2,,3,250)","(2,,,1000)"}
+(2 rows)
+
+-- Grouping on text columns
+select sum(ten) from onek group by two, rollup(four::text) order by 1;
+ sum  
+------
+ 1000
+ 1000
+ 1250
+ 1250
+ 2000
+ 2500
+(6 rows)
+
+select sum(ten) from onek group by rollup(four::text), two order by 1;
+ sum  
+------
+ 1000
+ 1000
+ 1250
+ 1250
+ 2000
+ 2500
+(6 rows)
+
+-- hashing support
+set enable_hashagg = true;
+-- failure cases
+select count(*) from gstest4 group by rollup(unhashable_col,unsortable_col);
+ERROR:  could not implement GROUP BY
+DETAIL:  Some of the datatypes only support hashing, while others only support sorting.
+select array_agg(v order by v) from gstest4 group by grouping sets ((id,unsortable_col),(id));
+ERROR:  could not implement GROUP BY
+DETAIL:  Some of the datatypes only support hashing, while others only support sorting.
+-- simple cases
+select a, b, grouping(a,b), sum(v), count(*), max(v)
+  from gstest1 group by grouping sets ((a),(b)) order by 3,1,2;
+ a | b | grouping | sum | count | max 
+---+---+----------+-----+-------+-----
+ 1 |   |        1 |  60 |     5 |  14
+ 2 |   |        1 |  15 |     1 |  15
+ 3 |   |        1 |  33 |     2 |  17
+ 4 |   |        1 |  37 |     2 |  19
+   | 1 |        2 |  58 |     4 |  19
+   | 2 |        2 |  25 |     2 |  13
+   | 3 |        2 |  45 |     3 |  16
+   | 4 |        2 |  17 |     1 |  17
+(8 rows)
+
+explain (costs off) select a, b, grouping(a,b), sum(v), count(*), max(v)
+  from gstest1 group by grouping sets ((a),(b)) order by 3,1,2;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (GROUPING("*VALUES*".column1, "*VALUES*".column2)), "*VALUES*".column1, "*VALUES*".column2
+   ->  HashAggregate
+         Hash Key: "*VALUES*".column1
+         Hash Key: "*VALUES*".column2
+         ->  Values Scan on "*VALUES*"
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select a, b, grouping(a,b), sum(v), count(*), max(v)
+  from gstest1 group by cube(a,b) order by 3,1,2;
+ a | b | grouping | sum | count | max 
+---+---+----------+-----+-------+-----
+ 1 | 1 |        0 |  21 |     2 |  11
+ 1 | 2 |        0 |  25 |     2 |  13
+ 1 | 3 |        0 |  14 |     1 |  14
+ 2 | 3 |        0 |  15 |     1 |  15
+ 3 | 3 |        0 |  16 |     1 |  16
+ 3 | 4 |        0 |  17 |     1 |  17
+ 4 | 1 |        0 |  37 |     2 |  19
+ 1 |   |        1 |  60 |     5 |  14
+ 2 |   |        1 |  15 |     1 |  15
+ 3 |   |        1 |  33 |     2 |  17
+ 4 |   |        1 |  37 |     2 |  19
+   | 1 |        2 |  58 |     4 |  19
+   | 2 |        2 |  25 |     2 |  13
+   | 3 |        2 |  45 |     3 |  16
+   | 4 |        2 |  17 |     1 |  17
+   |   |        3 | 145 |    10 |  19
+(16 rows)
+
+explain (costs off) select a, b, grouping(a,b), sum(v), count(*), max(v)
+  from gstest1 group by cube(a,b) order by 3,1,2;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (GROUPING("*VALUES*".column1, "*VALUES*".column2)), "*VALUES*".column1, "*VALUES*".column2
+   ->  MixedAggregate
+         Hash Key: "*VALUES*".column1, "*VALUES*".column2
+         Hash Key: "*VALUES*".column1
+         Hash Key: "*VALUES*".column2
+         Group Key: ()
+         ->  Values Scan on "*VALUES*"
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+-- shouldn't try and hash
+explain (costs off)
+  select a, b, grouping(a,b), array_agg(v order by v)
+    from gstest1 group by cube(a,b);
+                        QUERY PLAN                        
+----------------------------------------------------------
+ GroupAggregate
+   Group Key: "*VALUES*".column1, "*VALUES*".column2
+   Group Key: "*VALUES*".column1
+   Group Key: ()
+   Sort Key: "*VALUES*".column2
+     Group Key: "*VALUES*".column2
+   ->  Sort
+         Sort Key: "*VALUES*".column1, "*VALUES*".column2
+         ->  Values Scan on "*VALUES*"
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- unsortable cases
+select unsortable_col, count(*)
+  from gstest4 group by grouping sets ((unsortable_col),(unsortable_col))
+  order by unsortable_col::text;
+ unsortable_col | count 
+----------------+-------
+              1 |     4
+              1 |     4
+              2 |     4
+              2 |     4
+(4 rows)
+
+-- mixed hashable/sortable cases
+select unhashable_col, unsortable_col,
+       grouping(unhashable_col, unsortable_col),
+       count(*), sum(v)
+  from gstest4 group by grouping sets ((unhashable_col),(unsortable_col))
+ order by 3, 5;
+ unhashable_col | unsortable_col | grouping | count | sum 
+----------------+----------------+----------+-------+-----
+ 0000           |                |        1 |     2 |  17
+ 0001           |                |        1 |     2 |  34
+ 0010           |                |        1 |     2 |  68
+ 0011           |                |        1 |     2 | 136
+                |              2 |        2 |     4 |  60
+                |              1 |        2 |     4 | 195
+(6 rows)
+
+explain (costs off)
+  select unhashable_col, unsortable_col,
+         grouping(unhashable_col, unsortable_col),
+         count(*), sum(v)
+    from gstest4 group by grouping sets ((unhashable_col),(unsortable_col))
+   order by 3,5;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Sort
+   Sort Key: (GROUPING(unhashable_col, unsortable_col)), (sum(v))
+   ->  MixedAggregate
+         Hash Key: unsortable_col
+         Group Key: unhashable_col
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: unhashable_col
+               ->  Sort
+                     Sort Key: unhashable_col
+                     ->  Seq Scan on gstest4
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select unhashable_col, unsortable_col,
+       grouping(unhashable_col, unsortable_col),
+       count(*), sum(v)
+  from gstest4 group by grouping sets ((v,unhashable_col),(v,unsortable_col))
+ order by 3,5;
+ unhashable_col | unsortable_col | grouping | count | sum 
+----------------+----------------+----------+-------+-----
+ 0000           |                |        1 |     1 |   1
+ 0001           |                |        1 |     1 |   2
+ 0010           |                |        1 |     1 |   4
+ 0011           |                |        1 |     1 |   8
+ 0000           |                |        1 |     1 |  16
+ 0001           |                |        1 |     1 |  32
+ 0010           |                |        1 |     1 |  64
+ 0011           |                |        1 |     1 | 128
+                |              1 |        2 |     1 |   1
+                |              1 |        2 |     1 |   2
+                |              2 |        2 |     1 |   4
+                |              2 |        2 |     1 |   8
+                |              2 |        2 |     1 |  16
+                |              2 |        2 |     1 |  32
+                |              1 |        2 |     1 |  64
+                |              1 |        2 |     1 | 128
+(16 rows)
+
+explain (costs off)
+  select unhashable_col, unsortable_col,
+         grouping(unhashable_col, unsortable_col),
+         count(*), sum(v)
+    from gstest4 group by grouping sets ((v,unhashable_col),(v,unsortable_col))
+   order by 3,5;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: (GROUPING(unhashable_col, unsortable_col)), (sum(v))
+   ->  Sort
+         Sort Key: (GROUPING(unhashable_col, unsortable_col)), (sum(v))
+         ->  MixedAggregate
+               Hash Key: v, unsortable_col
+               Group Key: v, unhashable_col
+               ->  Sort
+                     Sort Key: v, unhashable_col
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: v
+                           ->  Seq Scan on gstest4
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+-- empty input: first is 0 rows, second 1, third 3 etc.
+select a, b, sum(v), count(*) from gstest_empty group by grouping sets ((a,b),a);
+ a | b | sum | count 
+---+---+-----+-------
+(0 rows)
+
+explain (costs off)
+  select a, b, sum(v), count(*) from gstest_empty group by grouping sets ((a,b),a);
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Sequence
+   ->  Shared Scan (share slice:id 0:0)
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Seq Scan on gstest_empty
+   ->  Append
+         ->  GroupAggregate
+               Group Key: share0_ref2.a
+               ->  Sort
+                     Sort Key: share0_ref2.a
+                     ->  Shared Scan (share slice:id 0:0)
+         ->  GroupAggregate
+               Group Key: share0_ref3.a, share0_ref3.b
+               ->  Sort
+                     Sort Key: share0_ref3.a, share0_ref3.b
+                     ->  Shared Scan (share slice:id 0:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
+select a, b, sum(v), count(*) from gstest_empty group by grouping sets ((a,b),());
+ a | b | sum | count 
+---+---+-----+-------
+   |   |     |     0
+(1 row)
+
+select a, b, sum(v), count(*) from gstest_empty group by grouping sets ((a,b),(),(),());
+ a | b | sum | count 
+---+---+-----+-------
+   |   |     |     0
+   |   |     |     0
+   |   |     |     0
+(3 rows)
+
+explain (costs off)
+  select a, b, sum(v), count(*) from gstest_empty group by grouping sets ((a,b),(),(),());
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Sequence
+   ->  Shared Scan (share slice:id 0:0)
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Seq Scan on gstest_empty
+   ->  Append
+         ->  Aggregate
+               ->  Shared Scan (share slice:id 0:0)
+         ->  Aggregate
+               ->  Shared Scan (share slice:id 0:0)
+         ->  Aggregate
+               ->  Shared Scan (share slice:id 0:0)
+         ->  GroupAggregate
+               Group Key: share0_ref5.a, share0_ref5.b
+               ->  Sort
+                     Sort Key: share0_ref5.a, share0_ref5.b
+                     ->  Shared Scan (share slice:id 0:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
+
+select sum(v), count(*) from gstest_empty group by grouping sets ((),(),());
+ sum | count 
+-----+-------
+     |     0
+     |     0
+     |     0
+(3 rows)
+
+explain (costs off)
+  select sum(v), count(*) from gstest_empty group by grouping sets ((),(),());
+                      QUERY PLAN                      
+------------------------------------------------------
+ Sequence
+   ->  Shared Scan (share slice:id 0:0)
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Seq Scan on gstest_empty
+   ->  Append
+         ->  Aggregate
+               ->  Shared Scan (share slice:id 0:0)
+         ->  Aggregate
+               ->  Shared Scan (share slice:id 0:0)
+         ->  Aggregate
+               ->  Shared Scan (share slice:id 0:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+-- check that functionally dependent cols are not nulled
+select a, d, grouping(a,b,c)
+  from gstest3
+ group by grouping sets ((a,b), (a,c));
+ a | d | grouping 
+---+---+----------
+ 1 | 1 |        1
+ 1 | 1 |        2
+ 2 | 2 |        1
+ 2 | 2 |        2
+(4 rows)
+
+explain (costs off)
+  select a, d, grouping(a,b,c)
+    from gstest3
+   group by grouping sets ((a,b), (a,c));
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Hash Key: a, b
+         Hash Key: a, c
+         ->  Seq Scan on gstest3
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+-- simple rescan tests
+select a, b, sum(v.x)
+  from (values (1),(2)) v(x), gstest_data(v.x)
+ group by grouping sets (a,b)
+ order by 1, 2, 3;
+ a | b | sum 
+---+---+-----
+ 1 |   |   3
+ 2 |   |   6
+   | 1 |   3
+   | 2 |   3
+   | 3 |   3
+(5 rows)
+
+explain (costs off)
+  select a, b, sum(v.x)
+    from (values (1),(2)) v(x), gstest_data(v.x)
+   group by grouping sets (a,b)
+   order by 3, 1, 2;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Sort
+   Sort Key: (sum("*VALUES*".column1)), gstest_data.a, gstest_data.b
+   ->  HashAggregate
+         Hash Key: gstest_data.a
+         Hash Key: gstest_data.b
+         ->  Nested Loop
+               ->  Values Scan on "*VALUES*"
+               ->  Function Scan on gstest_data
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select *
+  from (values (1),(2)) v(x),
+       lateral (select a, b, sum(v.x) from gstest_data(v.x) group by grouping sets (a,b)) s;
+ERROR:  aggregate functions are not allowed in FROM clause of their own query level
+LINE 3:        lateral (select a, b, sum(v.x) from gstest_data(v.x) ...
+                                     ^
+explain (costs off)
+  select *
+    from (values (1),(2)) v(x),
+         lateral (select a, b, sum(v.x) from gstest_data(v.x) group by grouping sets (a,b)) s;
+ERROR:  aggregate functions are not allowed in FROM clause of their own query level
+LINE 4:          lateral (select a, b, sum(v.x) from gstest_data(v.x...
+                                       ^
+-- Tests for chained aggregates
+select a, b, grouping(a,b), sum(v), count(*), max(v)
+  from gstest1 group by grouping sets ((a,b),(a+1,b+1),(a+2,b+2)) order by 3,6;
+ a | b | grouping | sum | count | max 
+---+---+----------+-----+-------+-----
+ 1 | 1 |        0 |  21 |     2 |  11
+ 1 | 2 |        0 |  25 |     2 |  13
+ 1 | 3 |        0 |  14 |     1 |  14
+ 2 | 3 |        0 |  15 |     1 |  15
+ 3 | 3 |        0 |  16 |     1 |  16
+ 3 | 4 |        0 |  17 |     1 |  17
+ 4 | 1 |        0 |  37 |     2 |  19
+   |   |        3 |  21 |     2 |  11
+   |   |        3 |  21 |     2 |  11
+   |   |        3 |  25 |     2 |  13
+   |   |        3 |  25 |     2 |  13
+   |   |        3 |  14 |     1 |  14
+   |   |        3 |  14 |     1 |  14
+   |   |        3 |  15 |     1 |  15
+   |   |        3 |  15 |     1 |  15
+   |   |        3 |  16 |     1 |  16
+   |   |        3 |  16 |     1 |  16
+   |   |        3 |  17 |     1 |  17
+   |   |        3 |  17 |     1 |  17
+   |   |        3 |  37 |     2 |  19
+   |   |        3 |  37 |     2 |  19
+(21 rows)
+
+explain (costs off)
+  select a, b, grouping(a,b), sum(v), count(*), max(v)
+    from gstest1 group by grouping sets ((a,b),(a+1,b+1),(a+2,b+2)) order by 3,6;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (GROUPING("*VALUES*".column1, "*VALUES*".column2)), (max("*VALUES*".column3))
+   ->  HashAggregate
+         Hash Key: "*VALUES*".column1, "*VALUES*".column2
+         Hash Key: ("*VALUES*".column1 + 1), ("*VALUES*".column2 + 1)
+         Hash Key: ("*VALUES*".column1 + 2), ("*VALUES*".column2 + 2)
+         ->  Values Scan on "*VALUES*"
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select a, b, sum(c), sum(sum(c)) over (order by a,b) as rsum
+  from gstest2 group by cube (a,b) order by rsum, a, b;
+ a | b | sum | rsum 
+---+---+-----+------
+ 1 | 1 |   8 |    8
+ 1 | 2 |   2 |   10
+ 1 |   |  10 |   20
+ 2 | 2 |   2 |   22
+ 2 |   |   2 |   24
+   | 1 |   8 |   32
+   | 2 |   4 |   36
+   |   |  12 |   48
+(8 rows)
+
+explain (costs off)
+  select a, b, sum(c), sum(sum(c)) over (order by a,b) as rsum
+    from gstest2 group by cube (a,b) order by rsum, a, b;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Sort
+   Sort Key: (sum((sum(c))) OVER (?)), a, b
+   ->  WindowAgg
+         Order By: a, b
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Merge Key: a, b
+               ->  Sort
+                     Sort Key: a, b
+                     ->  Finalize HashAggregate
+                           Group Key: a, b, (GROUPINGSET_ID())
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: a, b, (GROUPINGSET_ID())
+                                 ->  Partial MixedAggregate
+                                       Hash Key: a, b
+                                       Hash Key: a
+                                       Hash Key: b
+                                       Group Key: ()
+                                       ->  Seq Scan on gstest2
+ Optimizer: Postgres query optimizer
+(19 rows)
+
+select a, b, sum(v.x)
+  from (values (1),(2)) v(x), gstest_data(v.x)
+ group by cube (a,b) order by a,b;
+ a | b | sum 
+---+---+-----
+ 1 | 1 |   1
+ 1 | 2 |   1
+ 1 | 3 |   1
+ 1 |   |   3
+ 2 | 1 |   2
+ 2 | 2 |   2
+ 2 | 3 |   2
+ 2 |   |   6
+   | 1 |   3
+   | 2 |   3
+   | 3 |   3
+   |   |   9
+(12 rows)
+
+explain (costs off)
+  select a, b, sum(v.x)
+    from (values (1),(2)) v(x), gstest_data(v.x)
+   group by cube (a,b) order by a,b;
+                   QUERY PLAN                   
+------------------------------------------------
+ Sort
+   Sort Key: gstest_data.a, gstest_data.b
+   ->  MixedAggregate
+         Hash Key: gstest_data.a, gstest_data.b
+         Hash Key: gstest_data.a
+         Hash Key: gstest_data.b
+         Group Key: ()
+         ->  Nested Loop
+               ->  Values Scan on "*VALUES*"
+               ->  Function Scan on gstest_data
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+-- More rescan tests
+-- start_ignore
+-- GPDB_95_MERGE_FIXME: the lateral query with grouping sets do not make right plans
+select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, count(*) from onek group by cube(four,ten)) s on true order by v.a,four,ten;
+ a | a | four | ten | count 
+---+---+------+-----+-------
+ 1 | 1 |    0 |   0 |    50
+ 1 | 1 |    0 |   2 |    50
+ 1 | 1 |    0 |   4 |    50
+ 1 | 1 |    0 |   6 |    50
+ 1 | 1 |    0 |   8 |    50
+ 1 | 1 |    0 |     |   250
+ 1 | 1 |    1 |   1 |    50
+ 1 | 1 |    1 |   3 |    50
+ 1 | 1 |    1 |   5 |    50
+ 1 | 1 |    1 |   7 |    50
+ 1 | 1 |    1 |   9 |    50
+ 1 | 1 |    1 |     |   250
+ 1 | 1 |    2 |   0 |    50
+ 1 | 1 |    2 |   2 |    50
+ 1 | 1 |    2 |   4 |    50
+ 1 | 1 |    2 |   6 |    50
+ 1 | 1 |    2 |   8 |    50
+ 1 | 1 |    2 |     |   250
+ 1 | 1 |    3 |   1 |    50
+ 1 | 1 |    3 |   3 |    50
+ 1 | 1 |    3 |   5 |    50
+ 1 | 1 |    3 |   7 |    50
+ 1 | 1 |    3 |   9 |    50
+ 1 | 1 |    3 |     |   250
+ 1 | 1 |      |   0 |   100
+ 1 | 1 |      |   1 |   100
+ 1 | 1 |      |   2 |   100
+ 1 | 1 |      |   3 |   100
+ 1 | 1 |      |   4 |   100
+ 1 | 1 |      |   5 |   100
+ 1 | 1 |      |   6 |   100
+ 1 | 1 |      |   7 |   100
+ 1 | 1 |      |   8 |   100
+ 1 | 1 |      |   9 |   100
+ 1 | 1 |      |     |  1000
+ 2 | 2 |    0 |   0 |    50
+ 2 | 2 |    0 |   2 |    50
+ 2 | 2 |    0 |   4 |    50
+ 2 | 2 |    0 |   6 |    50
+ 2 | 2 |    0 |   8 |    50
+ 2 | 2 |    0 |     |   250
+ 2 | 2 |    1 |   1 |    50
+ 2 | 2 |    1 |   3 |    50
+ 2 | 2 |    1 |   5 |    50
+ 2 | 2 |    1 |   7 |    50
+ 2 | 2 |    1 |   9 |    50
+ 2 | 2 |    1 |     |   250
+ 2 | 2 |    2 |   0 |    50
+ 2 | 2 |    2 |   2 |    50
+ 2 | 2 |    2 |   4 |    50
+ 2 | 2 |    2 |   6 |    50
+ 2 | 2 |    2 |   8 |    50
+ 2 | 2 |    2 |     |   250
+ 2 | 2 |    3 |   1 |    50
+ 2 | 2 |    3 |   3 |    50
+ 2 | 2 |    3 |   5 |    50
+ 2 | 2 |    3 |   7 |    50
+ 2 | 2 |    3 |   9 |    50
+ 2 | 2 |    3 |     |   250
+ 2 | 2 |      |   0 |   100
+ 2 | 2 |      |   1 |   100
+ 2 | 2 |      |   2 |   100
+ 2 | 2 |      |   3 |   100
+ 2 | 2 |      |   4 |   100
+ 2 | 2 |      |   5 |   100
+ 2 | 2 |      |   6 |   100
+ 2 | 2 |      |   7 |   100
+ 2 | 2 |      |   8 |   100
+ 2 | 2 |      |   9 |   100
+ 2 | 2 |      |     |  1000
+(70 rows)
+
+-- end_ignore
+select array(select row(v.a,s1.*) from (select two,four, count(*) from onek group by cube(two,four) order by two,four) s1) from (values (1),(2)) v(a);
+                                                                        array                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"(1,0,0,250)","(1,0,2,250)","(1,0,,500)","(1,1,1,250)","(1,1,3,250)","(1,1,,500)","(1,,0,250)","(1,,1,250)","(1,,2,250)","(1,,3,250)","(1,,,1000)"}
+ {"(2,0,0,250)","(2,0,2,250)","(2,0,,500)","(2,1,1,250)","(2,1,3,250)","(2,1,,500)","(2,,0,250)","(2,,1,250)","(2,,2,250)","(2,,3,250)","(2,,,1000)"}
+(2 rows)
+
+-- Rescan logic changes when there are no empty grouping sets, so test
+-- that too:
+select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, count(*) from onek group by grouping sets(four,ten)) s on true order by v.a,four,ten;
+ a | a | four | ten | count 
+---+---+------+-----+-------
+ 1 | 1 |    0 |     |   250
+ 1 | 1 |    1 |     |   250
+ 1 | 1 |    2 |     |   250
+ 1 | 1 |    3 |     |   250
+ 1 | 1 |      |   0 |   100
+ 1 | 1 |      |   1 |   100
+ 1 | 1 |      |   2 |   100
+ 1 | 1 |      |   3 |   100
+ 1 | 1 |      |   4 |   100
+ 1 | 1 |      |   5 |   100
+ 1 | 1 |      |   6 |   100
+ 1 | 1 |      |   7 |   100
+ 1 | 1 |      |   8 |   100
+ 1 | 1 |      |   9 |   100
+ 2 | 2 |    0 |     |   250
+ 2 | 2 |    1 |     |   250
+ 2 | 2 |    2 |     |   250
+ 2 | 2 |    3 |     |   250
+ 2 | 2 |      |   0 |   100
+ 2 | 2 |      |   1 |   100
+ 2 | 2 |      |   2 |   100
+ 2 | 2 |      |   3 |   100
+ 2 | 2 |      |   4 |   100
+ 2 | 2 |      |   5 |   100
+ 2 | 2 |      |   6 |   100
+ 2 | 2 |      |   7 |   100
+ 2 | 2 |      |   8 |   100
+ 2 | 2 |      |   9 |   100
+(28 rows)
+
+select array(select row(v.a,s1.*) from (select two,four, count(*) from onek group by grouping sets(two,four) order by two,four) s1) from (values (1),(2)) v(a);
+                                      array                                      
+---------------------------------------------------------------------------------
+ {"(1,0,,500)","(1,1,,500)","(1,,0,250)","(1,,1,250)","(1,,2,250)","(1,,3,250)"}
+ {"(2,0,,500)","(2,1,,500)","(2,,0,250)","(2,,1,250)","(2,,2,250)","(2,,3,250)"}
+(2 rows)
+
+-- test the knapsack
+set enable_indexscan = false;
+set work_mem = '64kB';
+WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+explain (costs off)
+  select unique1,
+         count(two), count(four), count(ten),
+         count(hundred), count(thousand), count(twothousand),
+         count(*)
+    from tenk1 group by grouping sets (unique1,twothousand,thousand,hundred,ten,four,two);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Seq Scan on tenk1
+         ->  Append
+               ->  Finalize GroupAggregate
+                     Group Key: share0_ref2.two
+                     ->  Sort
+                           Sort Key: share0_ref2.two
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: share0_ref2.two
+                                 ->  Streaming Partial HashAggregate
+                                       Group Key: share0_ref2.two
+                                       ->  Shared Scan (share slice:id 2:0)
+               ->  Finalize HashAggregate
+                     Group Key: share0_ref3.four
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: share0_ref3.four
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: share0_ref3.four
+                                 ->  Shared Scan (share slice:id 3:0)
+               ->  Finalize HashAggregate
+                     Group Key: share0_ref4.ten
+                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                           Hash Key: share0_ref4.ten
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: share0_ref4.ten
+                                 ->  Shared Scan (share slice:id 4:0)
+               ->  Finalize HashAggregate
+                     Group Key: share0_ref5.hundred
+                     ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                           Hash Key: share0_ref5.hundred
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: share0_ref5.hundred
+                                 ->  Shared Scan (share slice:id 5:0)
+               ->  Finalize HashAggregate
+                     Group Key: share0_ref6.thousand
+                     ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                           Hash Key: share0_ref6.thousand
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: share0_ref6.thousand
+                                 ->  Shared Scan (share slice:id 6:0)
+               ->  HashAggregate
+                     Group Key: share0_ref7.twothousand
+                     ->  Redistribute Motion 3:3  (slice7; segments: 3)
+                           Hash Key: share0_ref7.twothousand
+                           ->  Result
+                                 ->  Shared Scan (share slice:id 7:0)
+               ->  HashAggregate
+                     Group Key: share0_ref8.unique1
+                     ->  Shared Scan (share slice:id 1:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(52 rows)
+
+explain (costs off)
+  select unique1,
+         count(two), count(four), count(ten),
+         count(hundred), count(thousand), count(twothousand),
+         count(*)
+    from tenk1 group by grouping sets (unique1,hundred,ten,four,two);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Seq Scan on tenk1
+         ->  Append
+               ->  Finalize GroupAggregate
+                     Group Key: share0_ref2.two
+                     ->  Sort
+                           Sort Key: share0_ref2.two
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: share0_ref2.two
+                                 ->  Streaming Partial HashAggregate
+                                       Group Key: share0_ref2.two
+                                       ->  Shared Scan (share slice:id 2:0)
+               ->  Finalize HashAggregate
+                     Group Key: share0_ref3.four
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: share0_ref3.four
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: share0_ref3.four
+                                 ->  Shared Scan (share slice:id 3:0)
+               ->  Finalize HashAggregate
+                     Group Key: share0_ref4.ten
+                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                           Hash Key: share0_ref4.ten
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: share0_ref4.ten
+                                 ->  Shared Scan (share slice:id 4:0)
+               ->  Finalize HashAggregate
+                     Group Key: share0_ref5.hundred
+                     ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                           Hash Key: share0_ref5.hundred
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: share0_ref5.hundred
+                                 ->  Shared Scan (share slice:id 5:0)
+               ->  HashAggregate
+                     Group Key: share0_ref6.unique1
+                     ->  Shared Scan (share slice:id 1:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(39 rows)
+
+set work_mem = '384kB';
+WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+explain (costs off)
+  select unique1,
+         count(two), count(four), count(ten),
+         count(hundred), count(thousand), count(twothousand),
+         count(*)
+    from tenk1 group by grouping sets (unique1,twothousand,thousand,hundred,ten,four,two);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Seq Scan on tenk1
+         ->  Append
+               ->  Finalize GroupAggregate
+                     Group Key: share0_ref2.two
+                     ->  Sort
+                           Sort Key: share0_ref2.two
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: share0_ref2.two
+                                 ->  Streaming Partial HashAggregate
+                                       Group Key: share0_ref2.two
+                                       ->  Shared Scan (share slice:id 2:0)
+               ->  Finalize HashAggregate
+                     Group Key: share0_ref3.four
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: share0_ref3.four
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: share0_ref3.four
+                                 ->  Shared Scan (share slice:id 3:0)
+               ->  Finalize HashAggregate
+                     Group Key: share0_ref4.ten
+                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                           Hash Key: share0_ref4.ten
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: share0_ref4.ten
+                                 ->  Shared Scan (share slice:id 4:0)
+               ->  Finalize HashAggregate
+                     Group Key: share0_ref5.hundred
+                     ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                           Hash Key: share0_ref5.hundred
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: share0_ref5.hundred
+                                 ->  Shared Scan (share slice:id 5:0)
+               ->  Finalize HashAggregate
+                     Group Key: share0_ref6.thousand
+                     ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                           Hash Key: share0_ref6.thousand
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: share0_ref6.thousand
+                                 ->  Shared Scan (share slice:id 6:0)
+               ->  HashAggregate
+                     Group Key: share0_ref7.twothousand
+                     ->  Redistribute Motion 3:3  (slice7; segments: 3)
+                           Hash Key: share0_ref7.twothousand
+                           ->  Result
+                                 ->  Shared Scan (share slice:id 7:0)
+               ->  HashAggregate
+                     Group Key: share0_ref8.unique1
+                     ->  Shared Scan (share slice:id 1:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(52 rows)
+
+-- check collation-sensitive matching between grouping expressions
+-- (similar to a check for aggregates, but there are additional code
+-- paths for GROUPING, so check again here)
+select v||'a', case grouping(v||'a') when 1 then 1 else 0 end, count(*)
+  from unnest(array[1,1], array['a','b']) u(i,v)
+ group by rollup(i, v||'a') order by 1,3;
+ ?column? | case | count 
+----------+------+-------
+ aa       |    0 |     1
+ ba       |    0 |     1
+          |    1 |     2
+          |    1 |     2
+(4 rows)
+
+select v||'a', case when grouping(v||'a') = 1 then 1 else 0 end, count(*)
+  from unnest(array[1,1], array['a','b']) u(i,v)
+ group by rollup(i, v||'a') order by 1,3;
+ ?column? | case | count 
+----------+------+-------
+ aa       |    0 |     1
+ ba       |    0 |     1
+          |    1 |     2
+          |    1 |     2
+(4 rows)
+
+--
+-- Compare results between plans using sorting and plans using hash
+-- aggregation. Force spilling in both cases by setting work_mem low
+-- and turning on enable_groupingsets_hash_disk.
+--
+SET enable_groupingsets_hash_disk = true;
+SET work_mem='64kB';
+WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+-- Produce results with sorting.
+set enable_hashagg = false;
+set jit_above_cost = 0;
+explain (costs off)
+select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
+  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
+   from generate_series(0,199999) g) s
+group by cube (g1000,g100,g10);
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ GroupAggregate
+   Group Key: ((g.g % 1000)), ((g.g % 100)), ((g.g % 10))
+   Group Key: ((g.g % 1000)), ((g.g % 100))
+   Group Key: ((g.g % 1000))
+   Group Key: ()
+   Sort Key: ((g.g % 100)), ((g.g % 10))
+     Group Key: ((g.g % 100)), ((g.g % 10))
+     Group Key: ((g.g % 100))
+   Sort Key: ((g.g % 10)), ((g.g % 1000))
+     Group Key: ((g.g % 10)), ((g.g % 1000))
+     Group Key: ((g.g % 10))
+   ->  Sort
+         Sort Key: ((g.g % 1000)), ((g.g % 100)), ((g.g % 10))
+         ->  Function Scan on generate_series g
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+create table gs_group_1 as
+select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
+  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
+   from generate_series(0,199999) g) s
+group by cube (g1000,g100,g10);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'g1000' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set jit_above_cost to default;
+create table gs_group_2 as
+select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
+  (select g/20 as g1000, g/200 as g100, g/2000 as g10, g
+   from generate_series(0,19999) g) s
+group by cube (g1000,g100,g10);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'g1000' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table gs_group_3 as
+select g100, g10, array_agg(g) as a, count(*) as c, max(g::text) as m from
+  (select g/200 as g100, g/2000 as g10, g
+   from generate_series(0,19999) g) s
+group by grouping sets (g100,g10);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+-- Produce results with hash aggregation.
+set enable_hashagg = true;
+set enable_sort = false;
+set work_mem='64kB';
+WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+set jit_above_cost = 0;
+explain (costs off)
+select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
+  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
+   from generate_series(0,199999) g) s
+group by cube (g1000,g100,g10);
+                    QUERY PLAN                     
+---------------------------------------------------
+ MixedAggregate
+   Hash Key: (g.g % 1000), (g.g % 100), (g.g % 10)
+   Hash Key: (g.g % 1000), (g.g % 100)
+   Hash Key: (g.g % 1000)
+   Hash Key: (g.g % 100), (g.g % 10)
+   Hash Key: (g.g % 100)
+   Hash Key: (g.g % 10), (g.g % 1000)
+   Hash Key: (g.g % 10)
+   Group Key: ()
+   ->  Function Scan on generate_series g
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+create table gs_hash_1 as
+select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
+  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
+   from generate_series(0,199999) g) s
+group by cube (g1000,g100,g10);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'g1000' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set jit_above_cost to default;
+create table gs_hash_2 as
+select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
+  (select g/20 as g1000, g/200 as g100, g/2000 as g10, g
+   from generate_series(0,19999) g) s
+group by cube (g1000,g100,g10);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'g1000' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table gs_hash_3 as
+select g100, g10, array_agg(g) as a, count(*) as c, max(g::text) as m from
+  (select g/200 as g100, g/2000 as g10, g
+   from generate_series(0,19999) g) s
+group by grouping sets (g100,g10);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+set enable_sort = true;
+set work_mem to default;
+WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+-- GPDB_12_MERGE_FIXME: the following comparison query has an ORCA plan that
+-- relies on "IS NOT DISTINCT FROM" Hash Join, a variant that we likely have
+-- lost during the merge with upstream Postgres 12. Disable ORCA for this query
+SET optimizer TO off;
+-- Compare results
+(select * from gs_hash_1 except select * from gs_group_1)
+  union all
+(select * from gs_group_1 except select * from gs_hash_1);
+ g1000 | g100 | g10 | sum | count | max 
+-------+------+-----+-----+-------+-----
+(0 rows)
+
+(select * from gs_hash_2 except select * from gs_group_2)
+  union all
+(select * from gs_group_2 except select * from gs_hash_2);
+ g1000 | g100 | g10 | sum | count | max 
+-------+------+-----+-----+-------+-----
+(0 rows)
+
+(select g100,g10,unnest(a),c,m from gs_hash_3 except
+  select g100,g10,unnest(a),c,m from gs_group_3)
+    union all
+(select g100,g10,unnest(a),c,m from gs_group_3 except
+  select g100,g10,unnest(a),c,m from gs_hash_3);
+ g100 | g10 | unnest | c | m 
+------+-----+--------+---+---
+(0 rows)
+
+RESET optimizer;
+drop table gs_group_1;
+drop table gs_group_2;
+drop table gs_group_3;
+drop table gs_hash_1;
+drop table gs_hash_2;
+drop table gs_hash_3;
+SET enable_groupingsets_hash_disk TO DEFAULT;
+-- end

--- a/src/test/regress/expected/olap_plans_optimizer.out
+++ b/src/test/regress/expected/olap_plans_optimizer.out
@@ -194,24 +194,34 @@ set gp_motion_cost_per_row=1.0;
 -- was supported.
 set enable_hashagg=off;
 explain select a, b, c, sum(d) from olap_test group by grouping sets((a, b), (a), (b, c));
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=509.52..1056.87 rows=267 width=20)
-   Group Key: a, b, c, (GROUPINGSET_ID())
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=509.52..1044.19 rows=801 width=20)
-         Merge Key: a, b, c, (GROUPINGSET_ID())
-         ->  Sort  (cost=509.52..510.19 rows=267 width=20)
-               Sort Key: a, b, c, (GROUPINGSET_ID())
-               ->  Partial GroupAggregate  (cost=234.38..498.76 rows=267 width=20)
-                     Group Key: a, b
-                     Group Key: a
-                     Sort Key: b, c
-                       Group Key: b, c
-                     ->  Sort  (cost=234.38..242.71 rows=3333 width=16)
-                           Sort Key: a, b
-                           ->  Seq Scan on olap_test  (cost=0.00..39.33 rows=3333 width=16)
- Optimizer: Postgres query optimizer
-(14 rows)
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1726.53 rows=152 width=20)
+   ->  Sequence  (cost=0.00..1726.51 rows=51 width=20)
+         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.19 rows=3334 width=1)
+               ->  Seq Scan on olap_test  (cost=0.00..431.08 rows=3334 width=16)
+         ->  Append  (cost=0.00..1295.33 rows=51 width=20)
+               ->  Finalize HashAggregate  (cost=0.00..431.94 rows=44 width=16)
+                     Group Key: share0_ref2.b, share0_ref2.c
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.93 rows=44 width=16)
+                           Hash Key: share0_ref2.b, share0_ref2.c
+                           ->  Streaming Partial HashAggregate  (cost=0.00..431.92 rows=44 width=16)
+                                 Group Key: share0_ref2.b, share0_ref2.c
+                                 ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.10 rows=3334 width=12)
+               ->  Finalize GroupAggregate  (cost=0.00..431.48 rows=1 width=12)
+                     Group Key: share0_ref3.a
+                     ->  Sort  (cost=0.00..431.48 rows=1 width=12)
+                           Sort Key: share0_ref3.a
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.48 rows=1 width=12)
+                                 Hash Key: share0_ref3.a
+                                 ->  Streaming Partial HashAggregate  (cost=0.00..431.48 rows=1 width=12)
+                                       Group Key: share0_ref3.a
+                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.06 rows=3334 width=8)
+               ->  HashAggregate  (cost=0.00..431.91 rows=7 width=16)
+                     Group Key: share0_ref4.a, share0_ref4.b
+                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.10 rows=3334 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(25 rows)
 
 select a, b, c, sum(d) from olap_test group by grouping sets((a, b), (a), (b, c));
  a | b  | c  |   sum    
@@ -257,16 +267,33 @@ reset enable_hashagg;
 -- If the query produces a relatively large number of groups in comparison to
 -- the number of input rows, one-stage aggregation will be picked.
 explain select a, b, d, sum(d) from olap_test group by grouping sets((a, b), (a), (b, d));
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- HashAggregate  (cost=392.00..617.36 rows=10036 width=20)
-   Hash Key: a, b
-   Hash Key: a
-   Hash Key: b, d
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..317.00 rows=10000 width=12)
-         ->  Seq Scan on olap_test  (cost=0.00..117.00 rows=3334 width=12)
- Optimizer: Postgres query optimizer
-(11 rows)
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1727.49 rows=10022 width=20)
+   ->  Sequence  (cost=0.00..1726.74 rows=3341 width=20)
+         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.16 rows=3334 width=1)
+               ->  Seq Scan on olap_test  (cost=0.00..431.08 rows=3334 width=12)
+         ->  Append  (cost=0.00..1295.51 rows=3341 width=20)
+               ->  HashAggregate  (cost=0.00..431.99 rows=3334 width=16)
+                     Group Key: share0_ref2.b, share0_ref2.d
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.15 rows=3334 width=8)
+                           Hash Key: share0_ref2.b, share0_ref2.d
+                           ->  Result  (cost=0.00..431.06 rows=3334 width=8)
+                                 ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.06 rows=3334 width=8)
+               ->  Finalize GroupAggregate  (cost=0.00..431.48 rows=1 width=12)
+                     Group Key: share0_ref3.a
+                     ->  Sort  (cost=0.00..431.48 rows=1 width=12)
+                           Sort Key: share0_ref3.a
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.48 rows=1 width=12)
+                                 Hash Key: share0_ref3.a
+                                 ->  Streaming Partial HashAggregate  (cost=0.00..431.48 rows=1 width=12)
+                                       Group Key: share0_ref3.a
+                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.06 rows=3334 width=8)
+               ->  HashAggregate  (cost=0.00..431.91 rows=7 width=16)
+                     Group Key: share0_ref4.a, share0_ref4.b
+                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.10 rows=3334 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(24 rows)
 
 -- do not execute this query as it would produce too many tuples.
 -- Test that when the second-stage Agg doesn't try to preserve the
@@ -279,28 +306,35 @@ explain select a, b, d, sum(d) from olap_test group by grouping sets((a, b), (a)
 -- from the Merge Key.
 set enable_hashagg=off;
 explain select a, b, c, sum(d) from olap_test group by grouping sets((a, b), (a), (b, c)) limit 200;
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=777.19..912.19 rows=200 width=20)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=777.19..1182.19 rows=600 width=20)
-         Merge Key: a, b, c
-         ->  Limit  (cost=777.19..782.19 rows=200 width=20)
-               ->  Finalize GroupAggregate  (cost=776.52..783.20 rows=267 width=20)
-                     Group Key: a, b, c, (GROUPINGSET_ID())
-                     ->  Sort  (cost=776.52..777.19 rows=267 width=20)
-                           Sort Key: a, b, c, (GROUPINGSET_ID())
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=234.38..765.76 rows=267 width=20)
-                                 Hash Key: a, b, c, (GROUPINGSET_ID())
-                                 ->  Partial GroupAggregate  (cost=234.38..498.76 rows=267 width=20)
-                                       Group Key: a, b
-                                       Group Key: a
-                                       Sort Key: b, c
-                                         Group Key: b, c
-                                       ->  Sort  (cost=234.38..242.71 rows=3333 width=16)
-                                             Sort Key: a, b
-                                             ->  Seq Scan on olap_test  (cost=0.00..39.33 rows=3333 width=16)
- Optimizer: Postgres query optimizer
-(19 rows)
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1726.53 rows=152 width=20)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1726.53 rows=152 width=20)
+         ->  Sequence  (cost=0.00..1726.51 rows=51 width=20)
+               ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.19 rows=3334 width=1)
+                     ->  Seq Scan on olap_test  (cost=0.00..431.08 rows=3334 width=16)
+               ->  Append  (cost=0.00..1295.33 rows=51 width=20)
+                     ->  Finalize HashAggregate  (cost=0.00..431.94 rows=44 width=16)
+                           Group Key: share0_ref2.b, share0_ref2.c
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.93 rows=44 width=16)
+                                 Hash Key: share0_ref2.b, share0_ref2.c
+                                 ->  Streaming Partial HashAggregate  (cost=0.00..431.92 rows=44 width=16)
+                                       Group Key: share0_ref2.b, share0_ref2.c
+                                       ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.10 rows=3334 width=12)
+                     ->  Finalize GroupAggregate  (cost=0.00..431.48 rows=1 width=12)
+                           Group Key: share0_ref3.a
+                           ->  Sort  (cost=0.00..431.48 rows=1 width=12)
+                                 Sort Key: share0_ref3.a
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.48 rows=1 width=12)
+                                       Hash Key: share0_ref3.a
+                                       ->  Streaming Partial HashAggregate  (cost=0.00..431.48 rows=1 width=12)
+                                             Group Key: share0_ref3.a
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.06 rows=3334 width=8)
+                     ->  HashAggregate  (cost=0.00..431.91 rows=7 width=16)
+                           Group Key: share0_ref4.a, share0_ref4.b
+                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.10 rows=3334 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(26 rows)
 
 reset enable_hashagg;
 --

--- a/src/test/regress/expected/orca_groupingsets_fallbacks.out
+++ b/src/test/regress/expected/orca_groupingsets_fallbacks.out
@@ -1,0 +1,144 @@
+--
+-- One purpose of these tests is to make sure that ORCA can gracefully fall
+-- back for these queries. To detect that, turn optimizer_trace_fallback on,
+-- and watch for "falling back to planner" messages.
+--
+set optimizer_trace_fallback='on';
+create temp table gstest1 (a int, b int, c int, d int, v int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into gstest1 values (1, 5, 10, 0, 100);
+insert into gstest1 values (1, 42, 20, 7, 200);
+insert into gstest1 values (2, 5, 30, 21, 300);
+insert into gstest1 values (2, 42, 40, 53, 400);
+-- Orca falls back due to Cube
+select a, b, c, sum(v) from gstest1 group by cube(a, b, c);
+ a | b  | c  | sum  
+---+----+----+------
+ 1 |  5 | 10 |  100
+ 1 |  5 |    |  100
+ 1 | 42 | 20 |  200
+ 1 | 42 |    |  200
+ 1 |    |    |  300
+ 2 |  5 | 30 |  300
+ 2 |  5 |    |  300
+ 2 | 42 | 40 |  400
+ 2 | 42 |    |  400
+ 2 |    |    |  700
+   |    |    | 1000
+   |    | 30 |  300
+   |    | 10 |  100
+   |    | 40 |  400
+   |    | 20 |  200
+ 2 |    | 30 |  300
+ 1 |    | 20 |  200
+ 2 |    | 40 |  400
+ 1 |    | 10 |  100
+   |  5 |    |  400
+   | 42 |    |  600
+   |  5 | 30 |  300
+   | 42 | 20 |  200
+   | 42 | 40 |  400
+   |  5 | 10 |  100
+(25 rows)
+
+-- Orca falls back due to multiple grouping sets specifications
+select sum(v), b, a, c from gstest1 group by c, grouping sets ((a, b), ());
+ sum | b  | a | c  
+-----+----+---+----
+ 400 | 42 | 2 | 40
+ 300 |  5 | 2 | 30
+ 200 | 42 | 1 | 20
+ 300 |    |   | 30
+ 400 |    |   | 40
+ 200 |    |   | 20
+ 100 |  5 | 1 | 10
+ 100 |    |   | 10
+(8 rows)
+
+select sum(v), b, a, c, d from gstest1 group by grouping sets(a, b), rollup(c, d);
+ sum | b  | a | c  | d  
+-----+----+---+----+----
+ 100 |    | 1 | 10 |  0
+ 100 |    | 1 | 10 |   
+ 200 |    | 1 | 20 |  7
+ 200 |    | 1 | 20 |   
+ 300 |    | 1 |    |   
+ 300 |    | 2 | 30 | 21
+ 300 |    | 2 | 30 |   
+ 400 |    | 2 | 40 | 53
+ 400 |    | 2 | 40 |   
+ 700 |    | 2 |    |   
+ 100 |  5 |   | 10 |  0
+ 100 |  5 |   | 10 |   
+ 300 |  5 |   | 30 | 21
+ 300 |  5 |   | 30 |   
+ 400 |  5 |   |    |   
+ 200 | 42 |   | 20 |  7
+ 200 | 42 |   | 20 |   
+ 400 | 42 |   | 40 | 53
+ 400 | 42 |   | 40 |   
+ 600 | 42 |   |    |   
+(20 rows)
+
+-- Orca falls back due to nested grouping sets
+select sum(v), b, a, c, d from gstest1 group by grouping sets(a, b, rollup(c, d));
+ sum  | b  | a | c  | d  
+------+----+---+----+----
+ 1000 |    |   |    |   
+  300 |    | 1 |    |   
+  700 |    | 2 |    |   
+  400 |  5 |   |    |   
+  600 | 42 |   |    |   
+  100 |    |   | 10 |  0
+  400 |    |   | 40 | 53
+  300 |    |   | 30 | 21
+  200 |    |   | 20 |  7
+  300 |    |   | 30 |   
+  100 |    |   | 10 |   
+  400 |    |   | 40 |   
+  200 |    |   | 20 |   
+(13 rows)
+
+-- Orca falls back when all grouping sets contain the primary key and the target
+-- list contains a column that does not appear in any grouping set
+create temp table gstest2 (a int primary key, b int, c int, d int, v int);
+insert into gstest2 values (1, 1, 1, 1, 1);
+insert into gstest2 values (2, 2, 2, 2, 1);
+select d from gstest2 group by grouping sets ((a,b), (a));
+ d 
+---
+ 2
+ 2
+ 1
+ 1
+(4 rows)
+
+-- Orca falls back due to HAVING clause with outer references
+select v.c, (select count(*) from gstest1 group by () having v.c) from (values (false),(true)) v(c);
+ c | count 
+---+-------
+ f |      
+ t |     4
+(2 rows)
+
+-- Orca falls back due to grouping function with multiple arguments
+select a, b, grouping(a,b), sum(v), count(*), max(v) from gstest1 group by rollup (a,b);
+ a | b  | grouping | sum  | count | max 
+---+----+----------+------+-------+-----
+ 1 |  5 |        0 |  100 |     1 | 100
+ 1 | 42 |        0 |  200 |     1 | 200
+ 1 |    |        1 |  300 |     2 | 200
+ 2 |  5 |        0 |  300 |     1 | 300
+ 2 | 42 |        0 |  400 |     1 | 400
+ 2 |    |        1 |  700 |     2 | 400
+   |    |        3 | 1000 |     4 | 400
+(7 rows)
+
+-- Orca falls back due to grouping function with outer references
+select (select grouping(a) from (values(1)) v2(c)) from (values(1, 2)) v1(a, b) group by (a, b);
+ grouping 
+----------
+        0
+(1 row)
+

--- a/src/test/regress/expected/orca_groupingsets_fallbacks_optimizer.out
+++ b/src/test/regress/expected/orca_groupingsets_fallbacks_optimizer.out
@@ -1,0 +1,160 @@
+--
+-- One purpose of these tests is to make sure that ORCA can gracefully fall
+-- back for these queries. To detect that, turn optimizer_trace_fallback on,
+-- and watch for "falling back to planner" messages.
+--
+set optimizer_trace_fallback='on';
+create temp table gstest1 (a int, b int, c int, d int, v int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into gstest1 values (1, 5, 10, 0, 100);
+insert into gstest1 values (1, 42, 20, 7, 200);
+insert into gstest1 values (2, 5, 30, 21, 300);
+insert into gstest1 values (2, 42, 40, 53, 400);
+-- Orca falls back due to Cube
+select a, b, c, sum(v) from gstest1 group by cube(a, b, c);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Cube
+ a | b  | c  | sum  
+---+----+----+------
+ 1 |  5 | 10 |  100
+ 1 |  5 |    |  100
+ 1 | 42 | 20 |  200
+ 1 | 42 |    |  200
+ 1 |    |    |  300
+ 2 |  5 | 30 |  300
+ 2 |  5 |    |  300
+ 2 | 42 | 40 |  400
+ 2 | 42 |    |  400
+ 2 |    |    |  700
+   |    |    | 1000
+   |    | 30 |  300
+   |    | 10 |  100
+   |    | 40 |  400
+   |    | 20 |  200
+ 2 |    | 30 |  300
+ 1 |    | 20 |  200
+ 2 |    | 40 |  400
+ 1 |    | 10 |  100
+   |  5 |    |  400
+   | 42 |    |  600
+   |  5 | 30 |  300
+   | 42 | 20 |  200
+   | 42 | 40 |  400
+   |  5 | 10 |  100
+(25 rows)
+
+-- Orca falls back due to multiple grouping sets specifications
+select sum(v), b, a, c from gstest1 group by c, grouping sets ((a, b), ());
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple grouping sets specifications
+ sum | b  | a | c  
+-----+----+---+----
+ 400 | 42 | 2 | 40
+ 300 |  5 | 2 | 30
+ 200 | 42 | 1 | 20
+ 300 |    |   | 30
+ 400 |    |   | 40
+ 200 |    |   | 20
+ 100 |  5 | 1 | 10
+ 100 |    |   | 10
+(8 rows)
+
+select sum(v), b, a, c, d from gstest1 group by grouping sets(a, b), rollup(c, d);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple grouping sets specifications
+ sum | b  | a | c  | d  
+-----+----+---+----+----
+ 100 |    | 1 | 10 |  0
+ 100 |    | 1 | 10 |   
+ 200 |    | 1 | 20 |  7
+ 200 |    | 1 | 20 |   
+ 300 |    | 1 |    |   
+ 300 |    | 2 | 30 | 21
+ 300 |    | 2 | 30 |   
+ 400 |    | 2 | 40 | 53
+ 400 |    | 2 | 40 |   
+ 700 |    | 2 |    |   
+ 100 |  5 |   | 10 |  0
+ 100 |  5 |   | 10 |   
+ 300 |  5 |   | 30 | 21
+ 300 |  5 |   | 30 |   
+ 400 |  5 |   |    |   
+ 200 | 42 |   | 20 |  7
+ 200 | 42 |   | 20 |   
+ 400 | 42 |   | 40 | 53
+ 400 | 42 |   | 40 |   
+ 600 | 42 |   |    |   
+(20 rows)
+
+-- Orca falls back due to nested grouping sets
+select sum(v), b, a, c, d from gstest1 group by grouping sets(a, b, rollup(c, d));
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: nested grouping set
+ sum  | b  | a | c  | d  
+------+----+---+----+----
+ 1000 |    |   |    |   
+  300 |    | 1 |    |   
+  700 |    | 2 |    |   
+  400 |  5 |   |    |   
+  600 | 42 |   |    |   
+  100 |    |   | 10 |  0
+  400 |    |   | 40 | 53
+  300 |    |   | 30 | 21
+  200 |    |   | 20 |  7
+  300 |    |   | 30 |   
+  100 |    |   | 10 |   
+  400 |    |   | 40 |   
+  200 |    |   | 20 |   
+(13 rows)
+
+-- Orca falls back when all grouping sets contain the primary key and the target
+-- list contains a column that does not appear in any grouping set
+create temp table gstest2 (a int primary key, b int, c int, d int, v int);
+insert into gstest2 values (1, 1, 1, 1, 1);
+insert into gstest2 values (2, 2, 2, 2, 1);
+select d from gstest2 group by grouping sets ((a,b), (a));
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
+ d 
+---
+ 2
+ 2
+ 1
+ 1
+(4 rows)
+
+-- Orca falls back due to HAVING clause with outer references
+select v.c, (select count(*) from gstest1 group by () having v.c) from (values (false),(true)) v(c);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 2 :location -1} :resno 1 :resname count :ressortgroupref 0 :resorigtbl 0 :resorigcol 0 :resjunk false} not supported in DXL
+ c | count 
+---+-------
+ f |      
+ t |     4
+(2 rows)
+
+-- Orca falls back due to grouping function with multiple arguments
+select a, b, grouping(a,b), sum(v), count(*), max(v) from gstest1 group by rollup (a,b);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Grouping function with multiple arguments
+ a | b  | grouping | sum  | count | max 
+---+----+----------+------+-------+-----
+ 1 |  5 |        0 |  100 |     1 | 100
+ 1 | 42 |        0 |  200 |     1 | 200
+ 1 |    |        1 |  300 |     2 | 200
+ 2 |  5 |        0 |  300 |     1 | 300
+ 2 | 42 |        0 |  400 |     1 | 400
+ 2 |    |        1 |  700 |     2 | 400
+   |    |        3 | 1000 |     4 | 400
+(7 rows)
+
+-- Orca falls back due to grouping function with outer references
+select (select grouping(a) from (values(1)) v2(c)) from (values(1, 2)) v1(a, b) group by (a, b);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Grouping function with outer references
+ grouping 
+----------
+        0
+(1 row)
+

--- a/src/test/regress/expected/qp_olap_group2_optimizer.out
+++ b/src/test/regress/expected/qp_olap_group2_optimizer.out
@@ -7,8 +7,6 @@
 set optimizer_trace_fallback='on';
 -- Query 1
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -30,8 +28,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 2
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -61,8 +57,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 3
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -85,8 +79,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 4
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -102,8 +94,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 5
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -119,8 +109,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 6
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -152,8 +140,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 7
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -175,8 +161,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 8
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -206,8 +190,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 9
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -230,8 +212,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 10
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -247,8 +227,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 11
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -264,8 +242,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 12
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -297,8 +273,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 13
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -320,8 +294,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 14
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -351,8 +323,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 15
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -375,8 +345,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 16
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -392,8 +360,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 17
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -409,8 +375,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 18
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -575,8 +539,6 @@ SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY R
 
 -- Query 25
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -598,8 +560,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 26
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -629,8 +589,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 27
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -653,8 +611,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 28
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -670,8 +626,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 29
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -687,8 +641,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 30
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -720,8 +672,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 31
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -743,8 +693,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 32
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -774,8 +722,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 33
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -798,8 +744,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 34
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -815,8 +759,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 35
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -832,8 +774,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 36
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -865,8 +805,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 37
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -888,8 +826,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 38
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -919,8 +855,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 39
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -943,8 +877,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 40
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -960,8 +892,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 41
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -977,8 +907,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 42
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -1143,8 +1071,6 @@ SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY R
 
 -- Query 49
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1166,8 +1092,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 50
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1197,8 +1121,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 51
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1221,8 +1143,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 52
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1238,8 +1158,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 53
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1255,8 +1173,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 54
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1288,8 +1204,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 55
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  2
@@ -1311,8 +1225,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 56
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  2
@@ -1342,8 +1254,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 57
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1366,8 +1276,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 58
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1383,8 +1291,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 59
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1400,8 +1306,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 60
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1433,8 +1337,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 61
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1456,8 +1358,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 62
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1487,8 +1387,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 63
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1511,8 +1409,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 64
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1528,8 +1424,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 65
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1545,8 +1439,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 66
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1578,8 +1470,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 67
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1601,8 +1491,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 68
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1632,8 +1520,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 69
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1656,8 +1542,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 70
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1673,8 +1557,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 71
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1690,8 +1572,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 72
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1723,8 +1603,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 73
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1746,8 +1624,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 74
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1777,8 +1653,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 75
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1801,8 +1675,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 76
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1818,8 +1690,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 77
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1835,8 +1705,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 78
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1868,8 +1736,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 79
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1891,8 +1757,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 80
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1922,8 +1786,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 81
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1946,8 +1808,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 82
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1963,8 +1823,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 83
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1980,8 +1838,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 84
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -2013,8 +1869,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 85
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  1
@@ -2036,8 +1890,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 86
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  1
@@ -2067,8 +1919,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 87
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  0
@@ -2091,8 +1941,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 88
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  0
@@ -2108,8 +1956,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 89
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  0
@@ -2125,8 +1971,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 90
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  0
@@ -2158,8 +2002,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 91
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -2181,8 +2023,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 92
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -2212,8 +2052,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 93
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -2236,8 +2074,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 94
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -2253,8 +2089,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 95
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -2270,8 +2104,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 96
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -2303,8 +2135,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 97
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2326,8 +2156,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 98
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2357,8 +2185,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 99
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2381,8 +2207,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 100
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2398,8 +2222,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 101
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2415,8 +2237,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 102
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2448,8 +2268,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 103
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2471,8 +2289,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 104
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2502,8 +2318,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 105
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2526,8 +2340,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 106
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2543,8 +2355,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 107
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2560,8 +2370,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 108
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2593,8 +2401,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 109
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -2616,8 +2422,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 110
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -2647,8 +2451,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 111
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -2671,8 +2473,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 112
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -2688,8 +2488,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 113
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -2705,8 +2503,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 114
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -2738,8 +2534,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 115
 SELECT GROUPING(product.pname) as g1, sale.pn as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname,sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2  
 ----+-----
   0 | 100
@@ -2754,8 +2548,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 116
 SELECT GROUPING(sale.pn) as g1, sale.pn as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname,sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2  
 ----+-----
   0 | 100
@@ -2770,8 +2562,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 117
 SELECT GROUPING(sale.pn) + 1 as g1, sale.pn as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname,sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2  
 ----+-----
   1 | 100
@@ -2800,8 +2590,6 @@ SELECT SUM(sale.pn) as g1, sale.pn as g2 FROM product, sale WHERE product.pn=sal
 
 -- Query 119
 SELECT GROUPING(product.pname) as g1, 'CONST' as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname,sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2   
 ----+-------
   0 | CONST
@@ -2816,8 +2604,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 120
 SELECT GROUPING(sale.pn) as g1, 'CONST' as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname,sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2   
 ----+-------
   0 | CONST
@@ -2832,8 +2618,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 121
 SELECT GROUPING(sale.pn) + 1 as g1, 'CONST' as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname,sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2   
 ----+-------
   1 | CONST
@@ -2862,8 +2646,6 @@ SELECT SUM(sale.pn) as g1, 'CONST' as g2 FROM product, sale WHERE product.pn=sal
 
 -- Query 123
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.cn,product.pname,sale.pn ORDER BY sale.cn;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -2882,8 +2664,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 124
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.cn,product.pname,sale.pn ORDER BY sale.cn;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -2902,8 +2682,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 125
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.cn,product.pname,sale.pn ORDER BY sale.cn;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -2941,8 +2719,6 @@ select 'a',* from (SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn
 
 -- Query 127
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname, sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -2957,8 +2733,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 128
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname, sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -2973,8 +2747,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 129
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname, sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -2989,8 +2761,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 130
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname, sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -3005,8 +2775,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 131
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname, sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -3021,8 +2789,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 132
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname, sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -3037,8 +2803,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 133
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname, sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  0
@@ -3053,8 +2817,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 134
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname, sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -3069,8 +2831,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 135
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname, sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -3085,8 +2845,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 136
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname, sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -3101,8 +2859,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 137
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY product.pname, sale.pn ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -3117,8 +2873,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 138
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.pn, product.pname ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -3133,8 +2887,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 139
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.pn, product.pname ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -3149,8 +2901,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 140
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.pn, product.pname ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -3165,8 +2915,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 141
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.pn, product.pname ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -3181,8 +2929,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 142
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.pn, product.pname ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -3197,8 +2943,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 143
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.pn, product.pname ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -3213,8 +2957,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 144
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.pn, product.pname ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  0
@@ -3229,8 +2971,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 145
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.pn, product.pname ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -3245,8 +2985,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 146
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.pn, product.pname ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -3261,8 +2999,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 147
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.pn, product.pname ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -3277,8 +3013,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 148
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY sale.pn, product.pname ORDER BY g1,g2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -3293,8 +3027,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 149
 SELECT sale.pn, GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3316,8 +3048,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 150
 SELECT sale.pn, GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3347,8 +3077,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 151
 SELECT sale.pn, GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3371,8 +3099,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 152
 SELECT sale.pn, GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3388,8 +3114,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 153
 SELECT sale.pn, GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3405,8 +3129,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 154
 SELECT sale.pn, GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3438,8 +3160,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 155
 SELECT sale.pn, GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3461,8 +3181,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 156
 SELECT sale.pn, GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3492,8 +3210,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 157
 SELECT sale.pn, GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3516,8 +3232,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 158
 SELECT sale.pn, GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3533,8 +3247,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 159
 SELECT sale.pn, GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3550,8 +3262,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 160
 SELECT sale.pn, GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3583,8 +3293,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 161
 SELECT sale.pn, GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3606,8 +3314,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 162
 SELECT sale.pn, GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3637,8 +3343,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 163
 SELECT sale.pn, GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3661,8 +3365,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 164
 SELECT sale.pn, GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3678,8 +3380,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 165
 SELECT sale.pn, GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3695,8 +3395,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 
 -- Query 166
 SELECT sale.pn, GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3862,8 +3560,6 @@ SELECT sale.pn, SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn G
 -- Query 173
 -- order 1
 select 'a', * from ((SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1) UNION (SELECT sale.pn FROM sale)) as a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 200
@@ -3881,8 +3577,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 174
 -- order 1
 select 'a', * from ((SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1) UNION (SELECT sale.pn FROM sale) )a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 200
@@ -3900,8 +3594,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 175
 -- order 1
 select 'a', * from ((SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1) UNION (SELECT sale.pn FROM sale) )a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 200
@@ -3919,8 +3611,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 176
 -- order 1
 select 'a', * from ((SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1) UNION (SELECT sale.pn FROM sale) )a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 200
@@ -3938,8 +3628,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 177
 -- order 1
 select 'a', * from ((SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 800
@@ -3957,8 +3645,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 178
 -- order 1
 select 'a', * from ((SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 200
@@ -3976,8 +3662,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 179
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 200
@@ -3995,8 +3679,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 180
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 200
@@ -4014,8 +3696,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 181
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 200
@@ -4032,8 +3712,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 182
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 800
@@ -4051,8 +3729,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 183
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 200
@@ -4070,8 +3746,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 184
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 200
@@ -4089,8 +3763,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 185
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 400
@@ -4108,8 +3780,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 186
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 400
@@ -4127,8 +3797,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 187
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 400
@@ -4145,8 +3813,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 188
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 200
@@ -4164,8 +3830,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 189
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 200
@@ -4183,8 +3847,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 190
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1  
 ----------+-----
  a        | 200
@@ -4303,8 +3965,6 @@ select 'a', * from ((SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.
 -- Query 197
 -- order 1
 select 'a', * from ((SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1) UNION (SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  1
@@ -4314,8 +3974,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 198
 -- order 1
 select 'a', * from ((SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1) UNION (SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  1
@@ -4325,8 +3983,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 199
 -- order 1
 select 'a', * from ((SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1) UNION (SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  0
@@ -4336,8 +3992,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 200
 -- order 1
 select 'a', * from ((SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1) UNION (SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  0
@@ -4347,8 +4001,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 201
 -- order 1
 select 'a', * from ((SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1) UNION (SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  1
@@ -4358,8 +4010,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 202
 -- order 1
 select 'a', * from ((SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1) UNION (SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  1
@@ -4369,8 +4019,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 203
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1) UNION (SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  1
@@ -4380,8 +4028,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 204
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1) UNION (SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  1
@@ -4391,8 +4037,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 205
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1) UNION (SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  0
@@ -4401,8 +4045,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 206
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1) UNION (SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  0
@@ -4412,8 +4054,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 207
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1) UNION (SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  0
@@ -4423,8 +4063,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 208
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1) UNION (SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  1
@@ -4434,8 +4072,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 209
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1) UNION (SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  2
@@ -4445,8 +4081,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 210
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1) UNION (SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  2
@@ -4456,8 +4090,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 211
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1) UNION (SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  1
@@ -4466,8 +4098,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 212
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1) UNION (SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  1
@@ -4477,8 +4107,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 213
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1) UNION (SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  2
@@ -4488,8 +4116,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 214
 -- order 1
 select 'a', * from ((SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1) UNION (SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: GROUPINGFUNC
  ?column? | g1 
 ----------+----
  a        |  1

--- a/src/test/regress/expected/qp_olap_group2_optimizer.out
+++ b/src/test/regress/expected/qp_olap_group2_optimizer.out
@@ -8,7 +8,7 @@ set optimizer_trace_fallback='on';
 -- Query 1
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -31,7 +31,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 2
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -62,7 +62,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 3
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -86,7 +86,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 4
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -103,7 +103,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 5
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -120,7 +120,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 6
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -153,7 +153,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 7
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -176,7 +176,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 8
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -207,7 +207,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 9
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -231,7 +231,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 10
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -248,7 +248,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 11
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -265,7 +265,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 12
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -298,7 +298,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 13
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -321,7 +321,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 14
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -352,7 +352,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 15
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -376,7 +376,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 16
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -393,7 +393,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 17
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -410,7 +410,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 18
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -442,8 +442,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 19
 SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
   g1  
 ------
   200
@@ -465,8 +463,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 20
 SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
   g1  
 ------
   200
@@ -496,8 +492,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 21
 SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
   g1  
 ------
   200
@@ -520,8 +514,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 22
 SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
   g1  
 ------
   200
@@ -537,8 +529,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 23
 SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
   g1  
 ------
   200
@@ -554,8 +544,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 24
 SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
   g1  
 ------
   200
@@ -588,7 +576,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 25
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -611,7 +599,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 26
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -642,7 +630,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 27
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -666,7 +654,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 28
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -683,7 +671,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 29
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -700,7 +688,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 30
 SELECT GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -733,7 +721,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 31
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -756,7 +744,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 32
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -787,7 +775,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 33
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -811,7 +799,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 34
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -828,7 +816,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 35
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -845,7 +833,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 36
 SELECT GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   0
@@ -878,7 +866,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 37
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -901,7 +889,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 38
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -932,7 +920,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 39
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -956,7 +944,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 40
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -973,7 +961,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 41
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -990,7 +978,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 42
 SELECT GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY sale.pn, product.pname;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 
 ----
   1
@@ -1022,8 +1010,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 43
 SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
   g1  
 ------
   200
@@ -1045,8 +1031,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 44
 SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
   g1  
 ------
   200
@@ -1076,8 +1060,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 45
 SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
   g1  
 ------
   200
@@ -1100,8 +1082,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 46
 SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
   g1  
 ------
   200
@@ -1117,8 +1097,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 47
 SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
   g1  
 ------
   200
@@ -1134,8 +1112,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 48
 SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY sale.pn, product.pname;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
   g1  
 ------
   200
@@ -1168,7 +1144,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 49
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1191,7 +1167,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 50
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1222,7 +1198,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 51
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1246,7 +1222,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 52
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1263,7 +1239,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 53
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1280,7 +1256,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 54
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1313,7 +1289,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 55
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  2
@@ -1336,7 +1312,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 56
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  2
@@ -1367,7 +1343,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 57
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1391,7 +1367,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 58
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1408,7 +1384,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 59
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1425,7 +1401,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 60
 SELECT GROUPING(product.pname) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1458,7 +1434,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 61
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1481,7 +1457,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 62
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1512,7 +1488,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 63
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1536,7 +1512,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 64
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1553,7 +1529,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 65
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1570,7 +1546,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 66
 SELECT GROUPING(product.pname) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1603,7 +1579,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 67
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1626,7 +1602,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 68
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1657,7 +1633,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 69
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1681,7 +1657,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 70
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1698,7 +1674,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 71
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1715,7 +1691,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 72
 SELECT GROUPING(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  0
@@ -1748,7 +1724,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 73
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1771,7 +1747,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 74
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1802,7 +1778,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 75
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1826,7 +1802,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 76
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1843,7 +1819,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 77
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1860,7 +1836,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 78
 SELECT GROUPING(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   0 |  1
@@ -1893,7 +1869,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 79
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1916,7 +1892,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 80
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1947,7 +1923,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 81
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1971,7 +1947,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 82
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -1988,7 +1964,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 83
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -2005,7 +1981,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 84
 SELECT GROUPING(sale.pn) as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   0 |  200
@@ -2038,7 +2014,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 85
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  1
@@ -2061,7 +2037,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 86
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  1
@@ -2092,7 +2068,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 87
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  0
@@ -2116,7 +2092,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 88
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  0
@@ -2133,7 +2109,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 89
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  0
@@ -2150,7 +2126,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 90
 SELECT GROUPING(sale.pn) + 1 as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 | g2 
 ----+----
   1 |  0
@@ -2183,7 +2159,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 91
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -2206,7 +2182,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 92
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -2237,7 +2213,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 93
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -2261,7 +2237,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 94
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -2278,7 +2254,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 95
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -2295,7 +2271,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 96
 SELECT GROUPING(sale.pn) + 1 as g1, SUM(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  g1 |  g2  
 ----+------
   1 |  200
@@ -2328,7 +2304,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 97
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2351,7 +2327,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 98
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2382,7 +2358,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 99
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2406,7 +2382,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 100
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2423,7 +2399,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 101
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2440,7 +2416,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 102
 SELECT SUM(sale.pn) as g1, GROUPING(product.pname) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2473,7 +2449,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 103
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2496,7 +2472,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 104
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2527,7 +2503,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 105
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2551,7 +2527,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 106
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2568,7 +2544,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 107
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2585,7 +2561,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 108
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  0
@@ -2618,7 +2594,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 109
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -2641,7 +2617,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 110
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -2672,7 +2648,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 111
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -2696,7 +2672,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 112
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -2713,7 +2689,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 113
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -2730,7 +2706,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 114
 SELECT SUM(sale.pn) as g1, GROUPING(sale.pn) + 1 as g2 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1,g2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
   g1  | g2 
 ------+----
   200 |  1
@@ -3318,7 +3294,7 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 149
 SELECT sale.pn, GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3341,7 +3317,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 150
 SELECT sale.pn, GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3372,7 +3348,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 151
 SELECT sale.pn, GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3396,7 +3372,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 152
 SELECT sale.pn, GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3413,7 +3389,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 153
 SELECT sale.pn, GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3430,7 +3406,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 154
 SELECT sale.pn, GROUPING(product.pname) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3463,7 +3439,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 155
 SELECT sale.pn, GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3486,7 +3462,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 156
 SELECT sale.pn, GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3517,7 +3493,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 157
 SELECT sale.pn, GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3541,7 +3517,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 158
 SELECT sale.pn, GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3558,7 +3534,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 159
 SELECT sale.pn, GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3575,7 +3551,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 160
 SELECT sale.pn, GROUPING(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  0
@@ -3608,7 +3584,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 161
 SELECT sale.pn, GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3631,7 +3607,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 162
 SELECT sale.pn, GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3662,7 +3638,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 163
 SELECT sale.pn, GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3686,7 +3662,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 164
 SELECT sale.pn, GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3703,7 +3679,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 165
 SELECT sale.pn, GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3720,7 +3696,7 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 166
 SELECT sale.pn, GROUPING(sale.pn) + 1 as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY 1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
+DETAIL:  Feature not supported: GROUPINGFUNC
  pn  | g1 
 -----+----
  100 |  1
@@ -3752,8 +3728,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 167
 SELECT sale.pn, SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  pn  |  g1  
 -----+------
  100 |  200
@@ -3775,8 +3749,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 168
 SELECT sale.pn, SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  pn  |  g1  
 -----+------
  100 |  200
@@ -3806,8 +3778,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 169
 SELECT sale.pn, SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  pn  |  g1  
 -----+------
  100 |  200
@@ -3830,8 +3800,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 170
 SELECT sale.pn, SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  pn  |  g1  
 -----+------
  100 |  200
@@ -3847,8 +3815,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 171
 SELECT sale.pn, SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  pn  |  g1  
 -----+------
  100 |  200
@@ -3864,8 +3830,6 @@ DETAIL:  Feature not supported: Grouping Sets
 
 -- Query 172
 SELECT sale.pn, SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY 1,2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  pn  |  g1  
 -----+------
  100 |  200
@@ -4238,8 +4202,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 191
 -- order 1
 select 'a', * from ((SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  ?column? |  g1  
 ----------+------
  a        |  400
@@ -4257,8 +4219,6 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 192
 -- order 1
 select 'a', * from ((SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  ?column? |  g1  
 ----------+------
  a        |  400
@@ -4276,8 +4236,6 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 193
 -- order 1
 select 'a', * from ((SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  ?column? |  g1  
 ----------+------
  a        |  400
@@ -4294,8 +4252,6 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 194
 -- order 1
 select 'a', * from ((SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  ?column? |  g1  
 ----------+------
  a        |  800
@@ -4313,8 +4269,6 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 195
 -- order 1
 select 'a', * from ((SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  ?column? |  g1  
 ----------+------
  a        |  200
@@ -4332,8 +4286,6 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 196
 -- order 1
 select 'a', * from ((SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1) UNION (SELECT sale.pn FROM sale))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  ?column? |  g1  
 ----------+------
  a        |  200
@@ -4547,8 +4499,6 @@ DETAIL:  Feature not supported: GROUPINGFUNC
 -- Query 215
 -- order 1
 select 'a', * from ((SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1) UNION (SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  ?column? |  g1  
 ----------+------
  a        |  200
@@ -4564,8 +4514,6 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 216
 -- order 1
 select 'a', * from ((SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1) UNION (SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS (sale.pn, product.pname, sale.pn) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  ?column? |  g1  
 ----------+------
  a        |  200
@@ -4581,8 +4529,6 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 217
 -- order 1
 select 'a', * from ((SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1) UNION (SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY GROUPING SETS ((sale.pn) ,(product.pname, sale.pn)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  ?column? |  g1  
 ----------+------
  a        |  400
@@ -4597,8 +4543,6 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 218
 -- order 1
 select 'a', * from ((SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1) UNION (SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  ?column? |  g1  
 ----------+------
  a        |  200
@@ -4614,8 +4558,6 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 219
 -- order 1
 select 'a', * from ((SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1) UNION (SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn,product.pname,sale.pn)) ORDER BY g1)) a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  ?column? |  g1  
 ----------+------
  a        |  400
@@ -4631,8 +4573,6 @@ DETAIL:  Feature not supported: Grouping Sets
 -- Query 220
 -- order 1
 select 'a', * from ((SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1) UNION (SELECT SUM(sale.pn) as g1 FROM product, sale WHERE product.pn=sale.pn GROUP BY ROLLUP((sale.pn),(product.pname),(sale.pn)) ORDER BY g1))a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Grouping Sets
  ?column? |  g1  
 ----------+------
  a        |  200

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -41,7 +41,7 @@ test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp li
 # below test(s) inject faults so each of them need to be in a separate group
 test: gpcopy
 
-test: orca_static_pruning
+test: orca_static_pruning orca_groupingsets_fallbacks
 test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format olap_plans misc_jiras
 # below test(s) inject faults so each of them need to be in a separate group
 test: guc_gp

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -236,6 +236,8 @@ select a, count(*) c from orca.r group by grouping sets ((),(a), (a,b)) order by
 select 1 from orca.r group by ();
 select a,1 from orca.r group by rollup(a);
 
+select distinct grouping(a) + grouping(b) from orca.m group by rollup(a,b);
+
 -- arrays
 select array[array[a,b]], array[b] from orca.r;
 
@@ -706,7 +708,7 @@ select max(a) from foo group by (select e from bar where bar.e = foo.a);
 -- nested subquery in group by
 select max(a) from foo group by (select g from jazz where foo.a = (select max(a) from foo where c = 1 group by b));
 
--- group by inside groupby inside group by ;S
+-- group by inside groupby inside group by
 select max(a) from foo group by (select min(g) from jazz where foo.a = (select max(g) from jazz group by h) group by h);
 
 -- cte subquery in group by

--- a/src/test/regress/sql/orca_groupingsets_fallbacks.sql
+++ b/src/test/regress/sql/orca_groupingsets_fallbacks.sql
@@ -1,0 +1,38 @@
+--
+-- One purpose of these tests is to make sure that ORCA can gracefully fall
+-- back for these queries. To detect that, turn optimizer_trace_fallback on,
+-- and watch for "falling back to planner" messages.
+--
+set optimizer_trace_fallback='on';
+
+create temp table gstest1 (a int, b int, c int, d int, v int);
+insert into gstest1 values (1, 5, 10, 0, 100);
+insert into gstest1 values (1, 42, 20, 7, 200);
+insert into gstest1 values (2, 5, 30, 21, 300);
+insert into gstest1 values (2, 42, 40, 53, 400);
+
+-- Orca falls back due to Cube
+select a, b, c, sum(v) from gstest1 group by cube(a, b, c);
+
+-- Orca falls back due to multiple grouping sets specifications
+select sum(v), b, a, c from gstest1 group by c, grouping sets ((a, b), ());
+select sum(v), b, a, c, d from gstest1 group by grouping sets(a, b), rollup(c, d);
+
+-- Orca falls back due to nested grouping sets
+select sum(v), b, a, c, d from gstest1 group by grouping sets(a, b, rollup(c, d));
+
+-- Orca falls back when all grouping sets contain the primary key and the target
+-- list contains a column that does not appear in any grouping set
+create temp table gstest2 (a int primary key, b int, c int, d int, v int);
+insert into gstest2 values (1, 1, 1, 1, 1);
+insert into gstest2 values (2, 2, 2, 2, 1);
+select d from gstest2 group by grouping sets ((a,b), (a));
+
+-- Orca falls back due to HAVING clause with outer references
+select v.c, (select count(*) from gstest1 group by () having v.c) from (values (false),(true)) v(c);
+
+-- Orca falls back due to grouping function with multiple arguments
+select a, b, grouping(a,b), sum(v), count(*), max(v) from gstest1 group by rollup (a,b);
+-- Orca falls back due to grouping function with outer references
+select (select grouping(a) from (values(1)) v2(c)) from (values(1, 2)) v1(a, b) group by (a, b);
+


### PR DESCRIPTION
This PR mostly contains two parts:
1. Re-enable GROUPING SETS and ROLLUP support in ORCA (a746b5bd4e52aaf7b4e633ec64b5cf2d577a3087)
2. Re-enable GroupingFunc support in ORCA (9582c89158cf2ca66da1bfba41c486dca5766806)

Both features were disabled in ORCA during the Postgres 9.5 merge by commit https://github.com/greenplum-db/gpdb-postgres-merge/commit/3d0e2f2e5c91ba90ee44189a10f9af4561525f27. 

The rest of the commits are house keeping: bug fix, adding FIXME and README, for exiting features in previously released GPDB versions.

Please review individual commits for details.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
