### PR TITLE
Give cdblegacyhash_bpchar proc its own prosrc

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302009141
+#define CATALOG_VERSION_NO	302010201
 
 #endif

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -11380,7 +11380,7 @@
    proname => 'cdblegacyhash_text', prorettype => 'int4', proargtypes => 'text', prosrc => 'cdblegacyhash_text' },
 
 { oid => 6148, descr => 'Legacy cdbhash function',
-   proname => 'cdblegacyhash_bpchar', prorettype => 'int4', proargtypes => 'bpchar', prosrc => 'cdblegacyhash_text' },
+   proname => 'cdblegacyhash_bpchar', prorettype => 'int4', proargtypes => 'bpchar', prosrc => 'cdblegacyhash_bpchar' },
 
 { oid => 6149, descr => 'Legacy cdbhash function',
    proname => 'cdblegacyhash_bytea', prorettype => 'int4', proargtypes => 'bytea', prosrc => 'cdblegacyhash_bytea' },


### PR DESCRIPTION
Currently, when inserting into a table distributed by a bpchar using
the legacy bpchar hash operator, the row goes through jump consistent
hashing instead of lazy modular hashing. This is because the
cdblegacyhash_bpchar funcid is missing from the
isLegacyCdbHashFunction check function which determines if an
attribute is using a legacy hash function or not. The funcids
currently in that check function come from the auto-generated
fmgroids.h header file which only creates a DEFINE for the
pg_proc.prosrc field. Unfortunately, cdblegacyhash_bpchar is left out
because its prosrc is cdblegacyhash_text.

To fix this issue, we should simply give the cdblegacy_bpchar proc its
own prosrc instead of reusing cdblegacyhash_text and add the new
autogenerated funcid DEFINE to the isLegacyCdbHashFunction check
function. We shouldn't really do anything more since these are legacy
hash operators that will presumably disappear in due time.

This issue was reported by github user cobolbaby in the gpbackup
repository while the user was migrating GPDB 5X tables to GPDB 6X:
https://github.com/greenplum-db/gpbackup/issues/425