### PR TITLE
[5X backport] demo_cluster.sh: remove GPSEARCH

### DIFF
--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -162,8 +162,6 @@ if [ -z "${GPHOME}" ]; then
     echo "  file in your Greenplum installation directory."
     echo ""
     exit 1
-else
-    GPSEARCH=$GPHOME
 fi
 
 cat <<-EOF
@@ -194,16 +192,16 @@ cat <<-EOF
 
 EOF
 
-GPPATH=`find $GPSEARCH -name gp_dump| tail -1`
+GPPATH=`find -H $GPHOME -name gp_dump| tail -1`
 RETVAL=$?
 
 if [ "$RETVAL" -ne 0 ]; then
-    echo "Error attempting to find Greenplum executables in $GPSEARCH"
+    echo "Error attempting to find Greenplum executables in $GPHOME"
     exit 1
 fi
 
 if [ ! -x "$GPPATH" ]; then
-    echo "No executables found for Greenplum installation in $GPSEARCH"
+    echo "No executables found for Greenplum installation in $GPHOME"
     exit 1
 fi
 GPPATH=`dirname $GPPATH`


### PR DESCRIPTION
master fix https://github.com/greenplum-db/gpdb/pull/10330  and 5X backport https://github.com/greenplum-db/gpdb/pull/11016

Use GPHOME directly. There is no need for GPSEARCH.

This enables demo_cluster.sh to handle symlinks which is useful when GPDB is installed using RPMs and a demo cluster is desired.

(cherry picked from commit 6932195ab2faa7fa5835e2c231314dabd3daf7bf)

[Test pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/demo_cluster_symlinks_5X)