### PR TITLE
Fix resgroup unusable if its dropping failed

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -320,7 +320,15 @@ DropResourceGroup(DropResourceGroupStmt *stmt)
 
 	/* check before dispatch to segment */
 	if (IsResGroupActivated())
+	{
+		/* Argument of callback function should be allocated in heap region */
+		callbackCtx = (ResourceGroupCallbackContext *)
+			MemoryContextAlloc(TopMemoryContext, sizeof(*callbackCtx));
+		callbackCtx->groupid = groupid;
+		RegisterXactCallbackOnce(dropResgroupCallback, callbackCtx);
+
 		ResGroupCheckForDrop(groupid, stmt->name);
+	}
 
 	/*
 	 * Check to see if any roles are in this resource group.
@@ -353,15 +361,6 @@ DropResourceGroup(DropResourceGroupStmt *stmt)
 									DF_NEED_TWO_PHASE,
 									NIL,
 									NULL);
-	}
-
-	if (IsResGroupActivated())
-	{
-		/* Argument of callback function should be allocated in heap region */
-		callbackCtx = (ResourceGroupCallbackContext *)
-			MemoryContextAlloc(TopMemoryContext, sizeof(*callbackCtx));
-		callbackCtx->groupid = groupid;
-		RegisterXactCallbackOnce(dropResgroupCallback, callbackCtx);
 	}
 }
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3438,6 +3438,9 @@ slotGetId(const ResGroupSlotData *slot)
 static void
 lockResGroupForDrop(ResGroupData *group)
 {
+	if (group->lockedForDrop)
+		return;
+
 	Assert(LWLockHeldByMeInMode(ResGroupLock, LW_EXCLUSIVE));
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 	Assert(group->nRunning == 0);
@@ -3448,6 +3451,9 @@ lockResGroupForDrop(ResGroupData *group)
 static void
 unlockResGroupForDrop(ResGroupData *group)
 {
+	if (!group->lockedForDrop)
+		return;
+
 	Assert(LWLockHeldByMeInMode(ResGroupLock, LW_EXCLUSIVE));
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 	Assert(group->nRunning == 0);


### PR DESCRIPTION
In function DropResourceGroup(), group->lockedForDrop is set
to true by calling ResGroupCheckForDrop, however, it can only
be set to false inside dropResgroupCallback. This callback is
registered at the ending of function DropResourceGroup. If an
error occured between them, group->lockedForDrop would be true
forever.

Fix it by putting the register process ahead of the lock call.
To prevent Assert(group->nRunning* > 0) if ResGroupCheckForDrop
throws an error, return directly if group->lockedForDrop did
not change.

See:

```
gpconfig -c gp_resource_manager -v group
gpstop -r -a

psql
# CREATE RESOURCE GROUP resg_test WITH (
                CPU_RATE_LIMIT=20,
                MEMORY_LIMIT=20,
                CONCURRENCY=50,
                MEMORY_SHARED_QUOTA=80,
                MEMORY_SPILL_RATIO=20,
                MEMORY_AUDITOR=vmtracker
        );
# CREATE USER user_test PASSWORD '123456' RESOURCE GROUP resg_test;
# DROP RESOURCE GROUP resg_test;

psql -U user_test
> \d -- hang
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
