### PR TITLE
mask all signal in the udp pthreads

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1370,16 +1370,7 @@ ic_set_pthread_sigmasks(sigset_t *old_sigs)
 	sigset_t sigs;
 	int		 err;
 
-	sigemptyset(&sigs);
-
-	/* make our thread ignore these signals (which should allow that
-	 * they be delivered to the main thread) */
-	sigaddset(&sigs, SIGHUP);
-	sigaddset(&sigs, SIGINT);
-	sigaddset(&sigs, SIGTERM);
-	sigaddset(&sigs, SIGALRM);
-	sigaddset(&sigs, SIGUSR1);
-	sigaddset(&sigs, SIGUSR2);
+	sigfillset(&sigs);
 
 	err = pthread_sigmask(SIG_BLOCK, &sigs, old_sigs);
 	if (err != 0)


### PR DESCRIPTION
In some cases, some signals (like SIGQUIT) that should only be processed by the main thread of the postmaster may be dispatched to rxThread. So we should and it is safe to block all signals in the udp pthreads.

Fix #11006
