### PR TITLE
ic-proxy: refresh peer connections and listeners on address/port changes

### DIFF
--- a/src/backend/cdb/motion/ic_proxy.h
+++ b/src/backend/cdb/motion/ic_proxy.h
@@ -55,4 +55,37 @@ ic_proxy_build_server_sock_path(char *buf, size_t bufsize)
 			 PostPortNumber, PostmasterPid);
 }
 
+/*
+ * Free a list.
+ *
+ * The difference with list_free() is we always return NIL.
+ */
+static inline List *
+ic_proxy_list_free(List *list)
+{
+	list_free(list);
+	return NIL;
+}
+
+/*
+ * Free a list and the cells.
+ *
+ * The cells must be allocated with the ic_proxy_alloc() / ic_proxy_new()
+ * allocators.
+ *
+ * Always return NIL.
+ */
+static inline List *
+ic_proxy_list_free_deep(List *list)
+{
+	ListCell   *cell;
+
+	foreach(cell, list)
+	{
+		ic_proxy_free(lfirst(cell));
+	}
+
+	return ic_proxy_list_free(list);
+}
+
 #endif   /* IC_PROXY_H */

--- a/src/backend/cdb/motion/ic_proxy_addr.c
+++ b/src/backend/cdb/motion/ic_proxy_addr.c
@@ -98,7 +98,7 @@ ic_proxy_addr_on_getaddrinfo(uv_getaddrinfo_t *req,
 			}
 #endif /* IC_PROXY_LOG_LEVEL <= LOG */
 
-			memcpy(&addr->addr, iter->ai_addr, iter->ai_addrlen);
+			memcpy(&addr->sockaddr, iter->ai_addr, iter->ai_addrlen);
 			ic_proxy_addrs = lappend(ic_proxy_addrs, addr);
 			break;
 		}
@@ -226,14 +226,14 @@ ic_proxy_get_my_addr(void)
 int
 ic_proxy_addr_get_port(const ICProxyAddr *addr)
 {
-	if (addr->addr.ss_family == AF_INET)
+	if (addr->sockaddr.ss_family == AF_INET)
 		return ntohs(((struct sockaddr_in *) addr)->sin_port);
-	else if (addr->addr.ss_family == AF_INET6)
+	else if (addr->sockaddr.ss_family == AF_INET6)
 		return ntohs(((struct sockaddr_in6 *) addr)->sin6_port);
 
 	ic_proxy_log(WARNING,
 				 "ic-proxy-addr: invalid address family %d for seg%d,dbid%d",
-				 addr->addr.ss_family, addr->content, addr->dbid);
+				 addr->sockaddr.ss_family, addr->content, addr->dbid);
 	return -1;
 }
 
@@ -255,8 +255,8 @@ ic_proxy_addr_get_port(const ICProxyAddr *addr)
  * error code.
  */
 int
-ic_proxy_extract_addr(const struct sockaddr *addr,
-					  char *name, size_t namelen, int *port, int *family)
+ic_proxy_extract_sockaddr(const struct sockaddr *addr,
+						  char *name, size_t namelen, int *port, int *family)
 {
 	int			ret;
 

--- a/src/backend/cdb/motion/ic_proxy_addr.h
+++ b/src/backend/cdb/motion/ic_proxy_addr.h
@@ -43,6 +43,13 @@ struct ICProxyAddr
  * List<ICProxyAddr *>
  */
 extern List		   *ic_proxy_addrs;
+extern List		   *ic_proxy_prev_addrs;
+
+/*
+ * List<unowned ICProxyAddr *>
+ */
+extern List		   *ic_proxy_removed_addrs;
+extern List		   *ic_proxy_added_addrs;
 
 
 extern void ic_proxy_reload_addresses(uv_loop_t *loop);

--- a/src/backend/cdb/motion/ic_proxy_addr.h
+++ b/src/backend/cdb/motion/ic_proxy_addr.h
@@ -18,7 +18,7 @@ typedef struct ICProxyAddr ICProxyAddr;
 
 struct ICProxyAddr
 {
-	struct sockaddr_storage addr;
+	struct sockaddr_storage sockaddr;
 
 	int			dbid;
 	int			content;
@@ -48,9 +48,9 @@ extern List		   *ic_proxy_addrs;
 extern void ic_proxy_reload_addresses(uv_loop_t *loop);
 extern const ICProxyAddr *ic_proxy_get_my_addr(void);
 extern int ic_proxy_addr_get_port(const ICProxyAddr *addr);
-extern int ic_proxy_extract_addr(const struct sockaddr *addr,
-								 char *name, size_t namelen,
-								 int *port, int *family);
+extern int ic_proxy_extract_sockaddr(const struct sockaddr *addr,
+									 char *name, size_t namelen,
+									 int *port, int *family);
 
 
 #endif   /* IC_PROXY_ADDR_H */

--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -177,7 +177,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 	uv_tcp_init(loop, listener);
 	uv_tcp_nodelay(listener, true);
 
-	ret = uv_tcp_bind(listener, (struct sockaddr *) &addr->addr, 0);
+	ret = uv_tcp_bind(listener, (struct sockaddr *) &addr->sockaddr, 0);
 	if (ret < 0)
 	{
 		ic_proxy_log(WARNING, "ic-proxy-server: tcp: fail to bind: %s",

--- a/src/backend/cdb/motion/ic_proxy_peer.c
+++ b/src/backend/cdb/motion/ic_proxy_peer.c
@@ -814,6 +814,27 @@ ic_proxy_peer_connect(ICProxyPeer *peer, struct sockaddr_in *dest)
 }
 
 /*
+ * Disconnect a peer.
+ *
+ * The peer can be in any state, the caller only needs to ensure not to call
+ * this function from a peer callback.
+ */
+void
+ic_proxy_peer_disconnect(ICProxyPeer *peer)
+{
+	/* No such a peer yet */
+	if (!peer)
+		return;
+
+	/* No connection is made or being made */
+	if (!(peer->state & IC_PROXY_PEER_STATE_CONNECTING))
+		return;
+
+	ic_proxy_log(LOG, "%s: disconnecting", peer->name);
+	ic_proxy_peer_shutdown(peer);
+}
+
+/*
  * Send a packet to a remote peer.
  */
 void

--- a/src/backend/cdb/motion/ic_proxy_peer.c
+++ b/src/backend/cdb/motion/ic_proxy_peer.c
@@ -134,14 +134,14 @@ ic_proxy_peer_update_name(ICProxyPeer *peer)
 	 * happens.
 	 */
 	uv_tcp_getsockname(&peer->tcp, (struct sockaddr *) &peeraddr, &addrlen);
-	ic_proxy_extract_addr((struct sockaddr *) &peeraddr,
-						  sockname, sizeof(sockname),
-						  &sockport, NULL /* family */);
+	ic_proxy_extract_sockaddr((struct sockaddr *) &peeraddr,
+							  sockname, sizeof(sockname),
+							  &sockport, NULL /* family */);
 
 	uv_tcp_getpeername(&peer->tcp, (struct sockaddr *) &peeraddr, &addrlen);
-	ic_proxy_extract_addr((struct sockaddr *) &peeraddr,
-						  peername, sizeof(peername),
-						  &peerport, NULL /* family */);
+	ic_proxy_extract_sockaddr((struct sockaddr *) &peeraddr,
+							  peername, sizeof(peername),
+							  &peerport, NULL /* family */);
 
 	snprintf(peer->name, sizeof(peer->name), "peer%s[seg%hd,dbid%hu %s:%d->%s:%d]",
 			 (peer->state & IC_PROXY_PEER_STATE_LEGACY) ? ".legacy" : "",

--- a/src/backend/cdb/motion/ic_proxy_server.h
+++ b/src/backend/cdb/motion/ic_proxy_server.h
@@ -127,6 +127,7 @@ extern ICProxyPeer *ic_proxy_peer_new(uv_loop_t *loop,
 extern void ic_proxy_peer_free(ICProxyPeer *peer);
 extern void ic_proxy_peer_read_hello(ICProxyPeer *peer);
 extern void ic_proxy_peer_connect(ICProxyPeer *peer, struct sockaddr_in *dest);
+extern void ic_proxy_peer_disconnect(ICProxyPeer *peer);
 extern void ic_proxy_peer_route_data(ICProxyPeer *peer, ICProxyPkt *pkt,
 									 ic_proxy_sent_cb callback, void *opaque);
 extern ICProxyPeer *ic_proxy_peer_lookup(int16 content, uint16 dbid);


### PR DESCRIPTION
The peer addresses are specified with the GUC
gp_interconnect_proxy_addresses, it can be reloaded on SIGHUP, we used
to only care about the newly added ones, however it is also possible for
the user to modify them, or even remove some of them.

So now we add the logic to classify the addresses after parsing the GUC,
we can tell whether an address is added, removed, or modified.

The peer connections and / or the listeners are refreshed accordingly.

----

Tests are not included, it's not easy to automate the verification.

But we can verify the effect manually, simply update the GUC `gp_interconnect_proxy_addresses` and reload with `gpstop -u`, then monitor the `netstat -nlt` output.

Also note that, ic-proxy header files are all private, they are not under `src/include` and are not included in the gpdb packages, so changes to them will not cause API/ABI breaks.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community