### PR TITLE
Fix `Explain Analyze` crash and wrong result when Memory Accounting

### DIFF
--- a/src/backend/utils/mmgr/memaccounting.c
+++ b/src/backend/utils/mmgr/memaccounting.c
@@ -450,6 +450,7 @@ void
 MemoryAccounting_CombinedAccountArrayToExplain(void *accountArrayBytes,
 		MemoryAccountIdType accountCount, void *explainstate)
 {
+	Assert(NULL != accountArrayBytes);
 	MemoryAccount *combinedArray = (MemoryAccount *) accountArrayBytes;
 	ExplainState *es = (ExplainState *) explainstate;
 	/* 1 extra account pointer to reserve for undefined account */


### PR DESCRIPTION
With the commit 6dd2759a (#6096), GPDB supports creating gang only
on the necessary segments for each slice. But little piece of code
in expain_gp.c supposes gang segments are index-continuous:

```
create table test(id int);
insert into test select generate_series(1, 10000);

select id from test where gp_segment_id=1 limit 1; -- e.g. id 50
select id from test where gp_segment_id=2 limit 1; -- e.g. id 111
select id from test where gp_segment_id=5 limit 1; -- e.g. id 43

set explain_memory_verbosity =detail;

explain analyze select * from test where id=50 or id=111;
| Gather Motion 2:1  (slice1; segments: 2)
|  slice 1, seg 0 -- right: seg 1
|  slice 1, seg 1 -- right: seg 2

explain analyze SELECT * FROM test WHERE id=50 or id=43;
| **CRASH**
```
See the usage of CdbExplain_SliceSummary::workers and
CdbExplain_NodeSummary::insts; but the latter has no
problem, whether it intended it or not, by:

```
for (i = 0; i < ns->ninst; i++)
  if (nsi->bnotes < nsi->enotes)

for (i = 0; i < ns->ninst; i++)
  if (INSTR_TIME_IS_ZERO(nsi->firststart))
```

This fix looks not pretty but works.

NOTE: master branch has removd Memory Accounting (#9065)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
