### PR TITLE
Enable postgres_fdw test in icw test of gpdb pipeline

### DIFF
--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -34,6 +34,7 @@ function gen_env(){
 		fi
 		cd "\${1}/gpdb_src"
 		source gpAux/gpdemo/gpdemo-env.sh
+		export TEST_PGFDW=1
 		make -s ${MAKE_TEST_COMMAND}
 	EOF
 

--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -16,7 +16,7 @@ DATA = postgres_fdw--1.0.sql
 
 REGRESS =
 ifeq ($(TEST_PGFDW),1)
-REGRESS += postgres_fdw
+REGRESS += gp2pg_postgres_fdw
 endif
 REGRESS_OPTS = --load-extension=$(EXTENSION)
 

--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -14,8 +14,13 @@ SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdyn
 EXTENSION = postgres_fdw
 DATA = postgres_fdw--1.0.sql
 
+ifdef TEST_PGFDW
 REGRESS = gp2pg_postgres_fdw
 REGRESS_OPTS = --load-extension=$(EXTENSION)
+installcheck: prep_postgres
+clean: clean_postgres
+endif
+
 
 # the db name is hard-coded in the tests
 override USE_MODULE_DB =
@@ -37,9 +42,6 @@ endif
 # both the below PG_PORT and the port in test/sql/postgres_fdw.sql
 # which is the option of foreign server
 export PG_PORT=5432
-
-installcheck: prep_postgres
-clean: clean_postgres
 
 prep_postgres:
 	./postgres_setup.bash

--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -14,12 +14,12 @@ SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdyn
 EXTENSION = postgres_fdw
 DATA = postgres_fdw--1.0.sql
 
-ifdef TEST_PGFDW
-REGRESS = gp2pg_postgres_fdw
-REGRESS_OPTS = --load-extension=$(EXTENSION)
-installcheck: prep_postgres
-clean: clean_postgres
+REGRESS =
+ifeq ($(TEST_PGFDW),1)
+REGRESS += postgres_fdw
 endif
+REGRESS_OPTS = --load-extension=$(EXTENSION)
+
 
 
 # the db name is hard-coded in the tests
@@ -37,15 +37,18 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
-# For test
+# For postgres_fdw test
 # If you want to change the PG_PORT, please update
 # both the below PG_PORT and the port in test/sql/postgres_fdw.sql
 # which is the option of foreign server
-export PG_PORT=5432
 
+ifeq ($(TEST_PGFDW),1)
+installcheck: prep_postgres
+clean: clean_postgres
+export PG_PORT=5432
 prep_postgres:
 	./postgres_setup.bash
 clean_postgres:
 	./postgres_clean.bash
-
 .PHONY: prep_postgres clean_postgres
+endif


### PR DESCRIPTION
postgres_fdw test is disabled by default, and it's
enabled in gpdb pipelines.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
