### PR TITLE
Fix CLOSE_WAIT leaks when Gang recycling

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -289,10 +289,10 @@ cdbconn_disconnect(SegmentDatabaseDescriptor *segdbDesc)
 			if (!sent)
 				elog(LOG, "Unable to cancel: %s", strlen(errbuf) == 0 ? "cannot allocate PGCancel" : errbuf);
 		}
-
-		PQfinish(segdbDesc->conn);
-		segdbDesc->conn = NULL;
 	}
+
+	PQfinish(segdbDesc->conn);
+	segdbDesc->conn = NULL;
 }
 
 /*


### PR DESCRIPTION
Postgresql libpq document:

> Note that when PQconnectStart or PQconnectStartParams returns a
> non-null pointer, you must call PQfinish when you are finished
> with it, in order to dispose of the structure and any associated
> memory blocks. **This must be done even if the connection attempt
> fails or is abandoned**.

However, cdbconn_disconnect() function did not call PQfinish when
CONNECTION_BAD, it can cause socket leaks (CLOSE_WAIT state).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
