### PR TITLE
6X: gprecoverseg: log the error if pg_rewind fails

### DIFF
--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -397,6 +397,7 @@ class GpMirrorListToBuild:
             if not cmd.was_successful():
                 dbid = int(cmd.name.split(':')[1].strip())
                 self.__logger.debug("%s failed" % cmd.name)
+                self.__logger.warning(cmd.get_stdout())
                 self.__logger.warning("Incremental recovery failed for dbid %d. You must use gprecoverseg -F to recover the segment." % dbid)
                 rewindFailedSegments.append(rewindInfo[dbid].targetSegment)
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_buildmirrorsegments.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_buildmirrorsegments.py
@@ -25,7 +25,8 @@ class GpMirrorListToBuildTestCase(GpTestCase):
             patch('gppylib.commands.base.Command.run', return_value=Mock()),
             patch('gppylib.commands.base.Command.get_return_code', return_value=0),
             # Mock all pg_rewind commands to be not successful
-            patch('gppylib.commands.base.Command.was_successful', return_value=False)
+            patch('gppylib.commands.base.Command.was_successful', return_value=False),
+            patch('gppylib.commands.base.Command.get_stdout', return_value='Mocking results')
         ])
         from gppylib.operations.buildMirrorSegments import GpMirrorListToBuild
         # WorkerPool is the only valid parameter required in this test


### PR DESCRIPTION
It didn't log the error message before if pg_rewind fails, fix that to make
DBA/field/developer's life eaisier.

Before this:
```
20201022:15:19:10:011118 gprecoverseg:earth:adam-[INFO]:-Running pg_rewind on required mirrors
20201022:15:19:12:011118 gprecoverseg:earth:adam-[WARNING]:-Incremental recovery failed for dbid 2. You must use gprecoverseg -F to recover the segment.
20201022:15:19:12:011118 gprecoverseg:earth:adam-[INFO]:-Starting mirrors
20201022:15:19:12:011118 gprecoverseg:earth:adam-[INFO]:-era is 0406b847bf226356_201022151031
```

After this:
```
20201022:15:33:31:019577 gprecoverseg:earth:adam-[INFO]:-Running pg_rewind on required mirrors
20201022:15:33:31:019577 gprecoverseg:earth:adam-[WARNING]:-pg_rewind: fatal: could not find common ancestor of the source and target cluster's timelines
20201022:15:33:31:019577 gprecoverseg:earth:adam-[WARNING]:-Incremental recovery failed for dbid 2. You must use gprecoverseg -F to recover the segment.
20201022:15:33:31:019577 gprecoverseg:earth:adam-[INFO]:-Starting mirrors
20201022:15:33:31:019577 gprecoverseg:earth:adam-[INFO]:-era is 0406b847bf226356_201022151031
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
