### PR TITLE
Fix GROUPING SETS of multiple empty sets

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -473,7 +473,7 @@ cdb_grouping_planner(PlannerInfo *root,
 	Plan	   *result_plan = NULL;
 	List	   *sub_tlist = NIL;
 	bool		has_groups = root->parse->groupClause != NIL;
-	bool		has_aggs = agg_costs->numAggs > 0;
+	bool		has_aggs = agg_costs->numAggs > 0 || group_context->pretend_has_agg;
 	bool		has_ordered_aggs = agg_costs->numPureOrderedAggs > 0;
 	ListCell   *lc;
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1715,6 +1715,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 	List	   *distinct_dist_exprs = NIL;
 	List	   *distinct_dist_opfamilies = NIL;
 	bool		must_gather;
+	bool		pretend_has_agg = false;
 
 	double		motion_cost_per_row =
 	(gp_motion_cost_per_row > 0.0) ?
@@ -1888,6 +1889,9 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		{
 			list_free(parse->groupClause);
 			parse->groupClause = NIL;
+
+			if (canonical_grpsets->ngrpsets > 0)
+				pretend_has_agg = true;
 		}
 
 		grpext = is_grouping_extension(canonical_grpsets);
@@ -2210,6 +2214,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 			group_context.p_dNumGroups = &dNumGroups;
 			group_context.pcurrent_pathkeys = &current_pathkeys;
 			group_context.querynode_changed = &querynode_changed;
+			group_context.pretend_has_agg = pretend_has_agg;
 
 			result_plan = cdb_grouping_planner(root,
 											   &agg_costs,

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -62,6 +62,8 @@ typedef struct GroupContext
 	double *p_dNumGroups;
 	List **pcurrent_pathkeys;
 	bool *querynode_changed;
+
+	bool	pretend_has_agg;
 } GroupContext;
 
 /* GUC parameters */

--- a/src/test/regress/expected/aggregate_with_groupingsets.out
+++ b/src/test/regress/expected/aggregate_with_groupingsets.out
@@ -84,17 +84,9 @@ ORDER BY type, s_quant;
       | Bed   |     300
 (6 rows)
 
---
--- Reset settings
---
-reset optimizer;
 ---
 --- Planning for sub-queries that have grouping sets
 ---
---
--- Turn off GPORCA
---
-set optimizer to off;
 explain (costs off) WITH table1 AS (
 	SELECT 2 AS city_id, 5 AS cnt
 	UNION ALL
@@ -146,6 +138,28 @@ WHERE location_id = 1;
                                  ->  Result
  Optimizer: Postgres query optimizer
 (23 rows)
+
+--
+-- Select constant from GROUPING SETS of multiple empty sets
+--
+explain (costs off)
+select 1 from foo group by grouping sets ((), ());
+                      QUERY PLAN                      
+------------------------------------------------------
+ Repeat
+   ->  Aggregate
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Aggregate
+                     ->  Seq Scan on foo
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select 1 from foo group by grouping sets ((), ());
+ ?column? 
+----------
+        1
+        1
+(2 rows)
 
 --
 -- Reset settings

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -4322,27 +4322,7 @@ select 1 from orca.r group by ();
  ?column? 
 ----------
         1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-        1
-(21 rows)
+(1 row)
 
 select a,1 from orca.r group by rollup(a);
  a  | ?column? 

--- a/src/test/regress/sql/aggregate_with_groupingsets.sql
+++ b/src/test/regress/sql/aggregate_with_groupingsets.sql
@@ -67,20 +67,10 @@ FROM (
 GROUP BY GROUPING SETS((type), (prod))
 ORDER BY type, s_quant;
 
---
--- Reset settings
---
-reset optimizer;
-
 
 ---
 --- Planning for sub-queries that have grouping sets
 ---
-
---
--- Turn off GPORCA
---
-set optimizer to off;
 
 explain (costs off) WITH table1 AS (
 	SELECT 2 AS city_id, 5 AS cnt
@@ -107,6 +97,14 @@ FROM (
 SELECT *
 FROM fin
 WHERE location_id = 1;
+
+
+--
+-- Select constant from GROUPING SETS of multiple empty sets
+--
+explain (costs off)
+select 1 from foo group by grouping sets ((), ());
+select 1 from foo group by grouping sets ((), ());
 
 --
 -- Reset settings


### PR DESCRIPTION
Currently if GROUPING SETS are empty sets, we will clean up
parse->groupClause and treat it as having no groups. If meanwhile there
are no aggregates in tlist or havingQual, the query would be planned as
if there are no GROUPING SETS, which is not correct.

This patch is just a workaround by petending the query has aggregates
when it finds the GROUPING SETS are empty sets.

Fix issue #11003

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
