### PR TITLE
docs - remove duplicate left nav entry

### DIFF
--- a/gpdb-doc/dita/analytics/analytics.ditamap
+++ b/gpdb-doc/dita/analytics/analytics.ditamap
@@ -17,8 +17,6 @@
     </topicref>
     <topicref href="text.xml" navtitle="Text Analytics and Search" otherprops="pivotal"
         linking="none"/>
-    <topicref href="text.xml" navtitle="Text Analytics and Search" otherprops="pivotal"
-        linking="none"/>
     <topicref href="intro.xml" navtitle="Procedural Languages" linking="none">
         <topicref href="pl_container.xml" navtitle="PL/Container" linking="none">
             <topicref href="pl_container.xml#about_pl_container" linking="none"/>


### PR DESCRIPTION
remove duplicate entry in the left navigation pane.

should be backported to 6X_STABLE
