### PR TITLE
gpstart: testing of improve handling of down segment hosts

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -51,6 +51,7 @@ def impl(context):
 
         subprocess.check_call(['gpstart', '-am'])
         _run_sql("""
+            SET allow_system_table_mods='true';
             UPDATE gp_segment_configuration
                SET hostname = master.hostname,
                     address = master.address
@@ -60,10 +61,10 @@ def impl(context):
                       WHERE content = -1 and role = 'p'
                    ) master
              WHERE content = -1 AND role = 'm'
-        """, opts=opts)
+        """, {'gp_role': 'utility'})
         subprocess.check_call(['gpstop', '-am'])
 
-        context.add_cleanup(cleanup, context)
+    context.add_cleanup(cleanup, context)
 
 def _handle_sigpipe():
     """


### PR DESCRIPTION
The tests in commit be5d11e2286 contained a typo that caused the changes
in the Scenario "gpstart starts even if the standby host is unreachable"
to not properly cleanup after itself.  Though the test feature still
passes, this leaves a bug to be found later when more tests are added.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
