### PR TITLE
Make greenplum-path.sh compatible with more shells

### DIFF
--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -1,7 +1,24 @@
 #!/usr/bin/env bash
 
 cat <<"EOF"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+if test -n "$ZSH_VERSION"; then
+    # zsh
+    SCRIPT_PATH="${(%):-%x}"
+elif test -n "$BASH_VERSION"; then
+    # bash
+    SCRIPT_PATH="${BASH_SOURCE[0]}"
+else
+    # Unknown shell, hope below works.
+    # Tested with dash
+    result=$(lsof -p $$ -Fn | tail --lines=1 | xargs --max-args=2 | cut --delimiter=' ' --fields=2)
+    SCRIPT_PATH=${result#n}
+fi
+
+if test -z "$SCRIPT_PATH"; then
+    echo "The shell cannot be identified. \$GPHOME may not be set correctly." >&2
+fi
+SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" >/dev/null 2>&1 && pwd)"
+
 if [ ! -L "${SCRIPT_DIR}" ]; then
 	GPDB_DIR=$(basename "${SCRIPT_DIR}")
 else


### PR DESCRIPTION
zsh doesn't have BASH_SOURCE. "${(%):-%x}" is the similar replacement
    for zsh.
    Also try to support other shells with some command combinations.
    Tested with bash/zsh/dash.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
