### PR TITLE
Fix a shell issue of empty string

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -148,7 +148,7 @@ pylint:
 
 $(MOCK_BIN):
 	@echo "--- mock for platform $(UBUNTU_PLATFORM)"
-	@if [ $(UBUNTU_PLATFORM) = "Ubuntu" ]; then\
+	@if [ "$(UBUNTU_PLATFORM)" = "Ubuntu" ]; then\
        pip install mock;\
      else\
        mkdir -p $(PYTHONSRC_INSTALL_SITE) && \


### PR DESCRIPTION
If the $(UBUNTU_PLATFORM) is an empty string, the test command will fail,
double quotes it to fix.

```
--- mock for platform
/bin/sh: line 0: [: =: unary operator expected
```