### PR TITLE
Mock cmd.get_stdout() to fix test regression

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_buildmirrorsegments.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_buildmirrorsegments.py
@@ -25,7 +25,8 @@ class GpMirrorListToBuildTestCase(GpTestCase):
             patch('gppylib.commands.base.Command.run', return_value=Mock()),
             patch('gppylib.commands.base.Command.get_return_code', return_value=0),
             # Mock all pg_rewind commands to be not successful
-            patch('gppylib.commands.base.Command.was_successful', return_value=False)
+            patch('gppylib.commands.base.Command.was_successful', return_value=False),
+            patch('gppylib.commands.base.Command.get_stdout', return_value='Mocking results')
         ])
         from gppylib.operations.buildMirrorSegments import GpMirrorListToBuild
         # WorkerPool is the only valid parameter required in this test


### PR DESCRIPTION
Otherwise, it will raise an exception "command not run yet".
