### PR TITLE
[6X backport] Fix dangling pointer issue when refreshing a matview relation

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -301,8 +301,15 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	/*
 	 * The stored query was rewritten at the time of the MV definition, but
 	 * has not been scribbled on by the planner.
+	 *
+	 * GPDB: using original query directly may cause dangling pointers if
+	 * shared-inval-queue is overflow, which will cause rebuild the matview
+	 * relation. when rebuilding matview relation(relcache), it is found
+	 * that oldRel->rule(parentStmtType = PARENTSTMTTYPE_REFRESH_MATVIEW)
+	 * is not equal to newRel->rule(parentStmtType = PARENTSTMTTYPE_NONE),
+	 * caused oldRel->rule(dataQuery) to be released
 	 */
-	dataQuery = (Query *) linitial(actions);
+	dataQuery = copyObject((Query *) linitial(actions));
 	Assert(IsA(dataQuery, Query));
 
 	dataQuery->parentStmtType = PARENTSTMTTYPE_REFRESH_MATVIEW;


### PR DESCRIPTION
019-12-04 23:16:23.075209 CST,"gpadmin","regression",p30552,th-790954624,"[local]",,2019-12-04 23:16:03 CST,8192,con143,cmd54,seg-1,,,x8192,sx1,"ERROR","XX000","unrecognized node type: 0 (copyfuncs.c:6424)",,,,,,"REFRESH MATERIALIZED VIEW m_aocs WITH NO DATA;",0,,"copyfuncs.c",6273,"Stack trace:
1    0xaf1f9c postgres errstart (elog.c:561)
2    0xaf4b83 postgres elog_finish (elog.c:1734)
3    0x7b15f7 postgres copyObject (copyfuncs.c:6424)
4    0x6c6ad1 postgres ExecRefreshMatView (matview.c:409)
5    0x997841 postgres <symbol not found> (utility.c:1743)
6    0x9969f4 postgres standard_ProcessUtility (utility.c:1071)
7    0x993bc5 postgres <symbol not found> (palloc.h:176)
8    0x9945c5 postgres <symbol not found> (pquery.c:1552)
9    0x995a21 postgres PortalRun (pquery.c:1022)
10   0x9908d4 postgres <symbol not found> (postgres.c:1791)
11   0x99359b postgres PostgresMain (postgres.c:5123)
12   0x541c32 postgres <symbol not found> (postmaster.c:4445)
13   0x87dcea postgres PostmasterMain (postmaster.c:1519)
14   0x543fbb postgres main (discriminator 1)
15   0x7f4ccb783505 libc.so.6 __libc_start_main + 0xf5
16   0x54485f postgres <symbol not found> + 0x54485f

Root cause
1 Save the rule (query tree with parentStmtType = PARENTSTMTTYPE_NONE) in the pg_rewrite table when creating a matview relation.
In ExecRefreshMatView function
2 Use dataQuery pointer to get the rule (query tree) of matview relation data(relcache)
3 Set dataQuery->parentStmtType = PARENTSTMTTYPE_REFRESH_MATVIEW
4 QD may receive a reset message(shared-inval-queue overflow) when make_new_heap is called,causing QD to rebuild the entire relcache of the backend, including the matview relation
When rebuilding matview relation(relcache), it is found that oldRel->rule(parentStmtType = PARENTSTMTTYPE_REFRESH_MATVIEW) is not equal to newRel->rule(parentStmtType = PARENTSTMTTYPE_NONE), caused oldRel->rule(dataQuery) to be released
5 refresh_matview_datafill using dataQuery will report an error

(cherry picked from commit 474088cb426035964914a88d9b91f5660ab4ec70)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
