### PR TITLE
Fix stats bucket logic for Double values in UNION queries in Orca

### DIFF
--- a/src/backend/gporca/libnaucrates/src/base/IDatum.cpp
+++ b/src/backend/gporca/libnaucrates/src/base/IDatum.cpp
@@ -110,7 +110,8 @@ IDatum::StatsAreLessThan(const IDatum *datum) const
 
 	CDouble d1 = this->GetDoubleMapping();
 	CDouble d2 = datum->GetDoubleMapping();
-	return d1 < d2;
+	CDouble diff = d2 - d1;
+	return diff > CStatistics::Epsilon;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
@@ -186,6 +186,14 @@ CBucket::GetOverlapPercentage(const CPoint *point, BOOL include_point) const
 	CDouble res = 1 / distance_upper;
 	res = res * distance_middle;
 
+	// TODO: When calculating the overlap percentage for doubles, we're
+	// using a different method than when calculating the frequency. This
+	// causes the frequency of singleton Double buckets to be inconsistent
+	// -- the frequency of the split bucket exceeds the frequency of the
+	// original bucket.  Instead, we should have a consistent method of
+	// calculating singleton frequency, either through NDV or assuming a
+	// small epsilon (using the NDV in GetOverlapPercentage is probably
+	// safer)
 	return CDouble(std::min(res.Get(), DOUBLE(1.0)));
 }
 
@@ -1195,9 +1203,6 @@ CBucket::SplitAndMergeBuckets(
 													 true /*include_lower*/);
 			this_overlap =
 				this->GetOverlapPercentage(minUpper, false /*include_point*/);
-			GPOS_ASSERT(this_overlap * this->GetFrequency() +
-							upper_third->GetFrequency() <=
-						this->GetFrequency() + CStatistics::Epsilon);
 		}
 		else
 		{
@@ -1206,9 +1211,6 @@ CBucket::SplitAndMergeBuckets(
 				mp, minUpper, true /*include_lower*/);
 			bucket_other_overlap = bucket_other->GetOverlapPercentage(
 				minUpper, false /*include_point*/);
-			GPOS_ASSERT(bucket_other_overlap * bucket_other->GetFrequency() +
-							upper_third->GetFrequency() <=
-						bucket_other->GetFrequency() + CStatistics::Epsilon);
 		}
 	}
 	else
@@ -1222,9 +1224,6 @@ CBucket::SplitAndMergeBuckets(
 													 true /*include_lower*/);
 			this_overlap =
 				this->GetOverlapPercentage(minUpper, false /*include_point*/);
-			GPOS_ASSERT(this_overlap * this->GetFrequency() +
-							upper_third->GetFrequency() <=
-						this->GetFrequency() + CStatistics::Epsilon);
 		}
 		else if (bucket_other->IsUpperClosed() && !this->IsUpperClosed())
 		{
@@ -1232,9 +1231,6 @@ CBucket::SplitAndMergeBuckets(
 				mp, minUpper, true /*include_lower*/);
 			bucket_other_overlap = bucket_other->GetOverlapPercentage(
 				minUpper, false /*include_point*/);
-			GPOS_ASSERT(bucket_other_overlap * bucket_other->GetFrequency() +
-							upper_third->GetFrequency() <=
-						bucket_other->GetFrequency() + CStatistics::Epsilon);
 		}
 		// the buckets are completely identical
 		// [1,5) & [1,5) OR (1,5] & (1,5] OR [1,5] & [1,5]

--- a/src/backend/gporca/server/include/unittest/dxl/base/CDatumTest.h
+++ b/src/backend/gporca/server/include/unittest/dxl/base/CDatumTest.h
@@ -53,6 +53,14 @@ public:
 
 	static GPOS_RESULT EresUnittest_Basics();
 
+	static GPOS_RESULT StatsComparisonDoubleLessThan();
+
+	static GPOS_RESULT StatsComparisonDoubleEqualWithinEpsilon();
+
+	static GPOS_RESULT StatsComparisonIntLessThan();
+
+	static GPOS_RESULT StatsComparisonIntEqual();
+
 };	// class CDatumTest
 }  // namespace gpnaucrates
 

--- a/src/backend/gporca/server/include/unittest/dxl/statistics/CBucketTest.h
+++ b/src/backend/gporca/server/include/unittest/dxl/statistics/CBucketTest.h
@@ -99,6 +99,13 @@ public:
 
 	static GPOS_RESULT EresUnittest_CBucketMergeCommutativityUnionAll();
 
+	static GPOS_RESULT EresUnittest_CBucketMergeCommutativityDoubleDatum();
+
+	static GPOS_RESULT
+	EresUnittest_CBucketMergeCommutativityDoubleDatumSameLowerBounds();
+
+	static GPOS_RESULT
+	EresUnittest_CBucketMergeCommutativityDoubleDatumSameUpperBounds();
 };	// class CBucketTest
 }  // namespace gpnaucrates
 

--- a/src/backend/gporca/server/include/unittest/dxl/statistics/CCardinalityTestUtils.h
+++ b/src/backend/gporca/server/include/unittest/dxl/statistics/CCardinalityTestUtils.h
@@ -65,6 +65,9 @@ public:
 								 CWStringDynamic *pstrEncodedValue,
 								 CDouble value);
 
+	// helper function to generate a point of double datatype
+	static CPoint *PpointDouble(CMemoryPool *mp, OID oid, CDouble value);
+
 	// helper method to print statistics object
 	static void PrintStats(CMemoryPool *mp, const CStatistics *stats);
 

--- a/src/backend/gporca/server/include/unittest/dxl/statistics/CHistogramTest.h
+++ b/src/backend/gporca/server/include/unittest/dxl/statistics/CHistogramTest.h
@@ -48,6 +48,8 @@ public:
 	// merge basic tests
 	static GPOS_RESULT EresUnittest_MergeUnion();
 
+	// merge union test with double values differing by less than epsilon
+	static GPOS_RESULT EresUnittest_MergeUnionDoubleLessThanEpsilon();
 };	// class CHistogramTest
 }  // namespace gpnaucrates
 

--- a/src/backend/gporca/server/include/unittest/gpopt/CTestUtils.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/CTestUtils.h
@@ -614,6 +614,9 @@ public:
 									  CWStringDynamic *pstrEncodedValue,
 									  LINT value);
 
+	// Create a datum with a given type and double value
+	static IDatum *CreateDoubleDatum(CMemoryPool *mp, CMDAccessor *md_accessor,
+									 IMDId *mdid_type, CDouble value);
 	// create an interval for generic data types
 	// does not take ownership of mdid_type
 	static CConstraintInterval *PciGenericInterval(

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -3853,6 +3853,39 @@ CTestUtils::CreateGenericDatum(CMemoryPool *mp, CMDAccessor *md_accessor,
 }
 
 //---------------------------------------------------------------------------
+//	@function:
+//		CTestUtils::CreateDoubleDatum
+//
+//	@doc:
+//		Create a datum with a given type and double value
+//
+//---------------------------------------------------------------------------
+IDatum *
+CTestUtils::CreateDoubleDatum(CMemoryPool *mp, CMDAccessor *md_accessor,
+							  IMDId *mdid_type, CDouble value)
+{
+	GPOS_ASSERT(NULL != md_accessor);
+
+	GPOS_ASSERT(!mdid_type->Equals(&CMDIdGPDB::m_mdid_numeric));
+	const IMDType *pmdtype = md_accessor->RetrieveType(mdid_type);
+	ULONG ulbaSize = 0;
+	CWStringDynamic *pstrW =
+		GPOS_NEW(mp) CWStringDynamic(mp, GPOS_WSZ_LIT("AAAABXc="));
+	BYTE *data = CDXLUtils::DecodeByteArrayFromString(mp, pstrW, &ulbaSize);
+	CDXLDatumGeneric *dxl_datum = NULL;
+
+	dxl_datum = GPOS_NEW(mp) CDXLDatumStatsDoubleMappable(
+		mp, mdid_type, default_type_modifier, false /*is_const_null*/, data,
+		ulbaSize, CDouble(value));
+
+
+	IDatum *datum = pmdtype->GetDatumForDXLDatum(mp, dxl_datum);
+	dxl_datum->Release();
+	GPOS_DELETE(pstrW);
+	return datum;
+}
+
+//---------------------------------------------------------------------------
 //      @function:
 //              CConstraintTest::PciGenericInterval
 //
@@ -3887,8 +3920,6 @@ CTestUtils::PciGenericInterval(CMemoryPool *mp, CMDAccessor *md_accessor,
 	return GPOS_NEW(mp)
 		CConstraintInterval(mp, colref, pdrgprng, false /*is_null*/);
 }
-
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CTestUtils::PexprScalarCmpIdentToConstant

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CCardinalityTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CCardinalityTestUtils.cpp
@@ -196,6 +196,19 @@ CCardinalityTestUtils::PpointNumeric(CMemoryPool *mp,
 	return point;
 }
 
+// helper function to generate a point from an encoded value of specific datatype
+CPoint *
+CCardinalityTestUtils::PpointDouble(CMemoryPool *mp, OID oid, CDouble value)
+{
+	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
+
+	IMDId *mdid = GPOS_NEW(mp) CMDIdGPDB(oid);
+	IDatum *datum = CTestUtils::CreateDoubleDatum(mp, md_accessor, mdid, value);
+	CPoint *point = GPOS_NEW(mp) CPoint(datum);
+
+	return point;
+}
+
 // helper function to print the bucket object
 void
 CCardinalityTestUtils::PrintBucket(CMemoryPool *mp, const char *pcPrefix,


### PR DESCRIPTION
This is a direct backport of https://github.com/greenplum-db/gpdb/pull/10994

When merging statistics buckets for UNION and UNION ALL queries
involving a column that maps to Double (eg: floats, numeric, time
related types), we could end up in an infinite loop. This occurred if
the bucket boundaries that we compared were within a very small value,
defined in Orca as Epsilon. While we considered that two values were
equal if they were within Epsilon, we didn't when computing whether
datum1 < datum2. Therefore we'd get into a situation where a datum
could be both equal to and less than another datum, which the logic
wasn't able to handle.

The fix is to make sure we have a hard boundary of when we consider a
datum less than another datum by including the epsilon logic in all
datum comparisons. Now, 2 datums are equal if they are within epsilon,
but datum1 is less than datum 2 only if datum1 < datum2 - epsilon.

Also add some tests since we didn't have any tests for types that mapped
to Double.