### PR TITLE
Fix writeable CTE assign reader gang to writer slice.

### DIFF
--- a/src/test/regress/expected/insert.out
+++ b/src/test/regress/expected/insert.out
@@ -576,11 +576,18 @@ alter table mlparted4 drop a;
 alter table mlparted4 add a int not null;
 alter table mlparted4 set distributed by (a);
 alter table mlparted attach partition mlparted4 for values from (1, 30) to (1, 40);
--- this upstream query doesn't work on GPDB at the moment.
 with ins (a, b, c) as
   (insert into mlparted (b, a) select s.a, 1 from generate_series(2, 39) s(a) returning tableoid::regclass, *)
   select a, b, min(c), max(c) from ins group by a, b order by 1;
-ERROR:  INSERT/UPDATE/DELETE must be executed by a writer segworker group
+     a      | b | min | max 
+------------+---+-----+-----
+ mlparted11 | 1 |   2 |   4
+ mlparted12 | 1 |   5 |   9
+ mlparted2  | 1 |  10 |  19
+ mlparted3  | 1 |  20 |  29
+ mlparted4  | 1 |  30 |  39
+(5 rows)
+
 alter table mlparted add c text;
 create table mlparted5 (c text, a int not null, b int not null) partition by list (c);
 alter table mlparted5 set distributed by (a);

--- a/src/test/regress/sql/insert.sql
+++ b/src/test/regress/sql/insert.sql
@@ -373,7 +373,6 @@ alter table mlparted4 drop a;
 alter table mlparted4 add a int not null;
 alter table mlparted4 set distributed by (a);
 alter table mlparted attach partition mlparted4 for values from (1, 30) to (1, 40);
--- this upstream query doesn't work on GPDB at the moment.
 with ins (a, b, c) as
   (insert into mlparted (b, a) select s.a, 1 from generate_series(2, 39) s(a) returning tableoid::regclass, *)
   select a, b, min(c), max(c) from ins group by a, b order by 1;


### PR DESCRIPTION
For the gang allocation, we assert the first allocated gang always be the
writer gang. And when recycle, the writer QE aliways be putted at the
top of free list.

Normally, the writer slice will be assign writer gang first when iterate the
slice table. But this is not true for writable CTE (with only one writer gang).
For below statement:
```
explain (slicetable) WITH updated AS (update tbl set rank = 6 where id = 5 returning
rank) select * from tbl where rank in (select rank from updated);
                        QUERY PLAN
--------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  Seq Scan on tbl
         Filter: (hashed SubPlan 1)
         SubPlan 1
           ->  Broadcast Motion 1:3  (slice2; segments: 1)
                 ->  Update on tbl
                       ->  Seq Scan on tbl
                             Filter: (id = 5)
 Slice 0: Dispatcher; root 0; parent -1; gang size 0
 Slice 1: Reader; root 0; parent 0; gang size 3
 Slice 2: Primary Writer; root 0; parent 1; gang size 1
```
If we sill assigns writer gang to Slice 1 here, the writer process will execute
on reader gang. So, find the writer slice and assign writer gang first.

This fixes the issue https://github.com/greenplum-db/gpdb/issues/11024

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
