### PR TITLE
[6X backport]: Pin PR resource to v0.21 to avoid Github abuse rate limit

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -7,6 +7,7 @@ resource_types:
   type: registry-image
   source:
     repository: teliaoss/github-pr-resource
+    tag: v0.21.0
 - name: gcs
   type: registry-image
   source:


### PR DESCRIPTION
Backport of https://github.com/greenplum-db/gpdb/pull/11045

We started hitting this on Thursday, and there's been ongoing report from the community about this as well. While upstream is figuring out a long term solution [1], we've been advised [2] to pin to the previous release (v0.21.0) to avoid being blocked for hours at once.

[1]: https://github.com/telia-oss/github-pr-resource/pull/238
[2]: https://github.com/telia-oss/github-pr-resource/pull/238#issuecomment-714830491

(cherry picked from commit f4bf9be689bbcb7b703af527f1520fb5b2d26803)