### PR TITLE
Improve symlink resolution to find the greenplum-path script

### DIFF
--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 
 cat <<"EOF"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-if [ ! -L "${SCRIPT_DIR}" ]; then
-	GPDB_DIR=$(basename "${SCRIPT_DIR}")
-else
-	GPDB_DIR=$(basename "$(readlink "${SCRIPT_DIR}")")
-fi
+WORKING_DIR="$(pwd)"
+
+# Follow symlinks to find the real script
+cd "$(dirname "$0")" || exit 1
+script_file=$(pwd)/$(basename "$0")
+while [[ -L "$script_file" ]]; do
+  script_file=$(readlink "$script_file")
+  cd "$(dirname "$script_file")" || exit 1
+  script_file=$(pwd)/$(basename "$script_file")
+done
+
+SCRIPT_DIR="$( (cd "$( dirname "${script_file}" )" && pwd -P) )"
+cd "$WORKING_DIR" || exit 1
+
+GPDB_DIR=$(basename "${SCRIPT_DIR}")
 GPHOME=$(dirname "${SCRIPT_DIR}")/"${GPDB_DIR}"
 EOF
 


### PR DESCRIPTION
I ran into issues when running a `make create-demo-cluster` and it turns
out that the script resolution was not working correctly (possibly
related to zsh). This improves the logic to resolve the script directory
in `greenplum-path.sh`
