### PR TITLE
[5X backport]: Pin PR resource to v0.21 to avoid Github abuse rate limit

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -3,6 +3,7 @@ resource_types:
     type: registry-image
     source:
       repository: teliaoss/github-pr-resource
+      tag: v0.21.0
 
   - name: gcs
     type: registry-image


### PR DESCRIPTION
6X backport: https://github.com/greenplum-db/gpdb/pull/11065 master backport: https://github.com/greenplum-db/gpdb/pull/11045

We started hitting this on Thursday, and there's been ongoing report from the community about this as well. While upstream is figuring out a long term solution [1], we've been advised [2] to pin to the previous release (v0.21.0) to avoid being blocked for hours at once.

[1]: telia-oss/github-pr-resource#238
[2]: telia-oss/github-pr-resource#238 (comment)

Co-authored-by: Jesse Zhang <sbjesse@gmail.com>
