### PR TITLE
Track shared file set by workfile

### DIFF
--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -355,7 +355,7 @@ MakeNewSharedSegment(BufFile *buffile, int segment)
  * unrelated SharedFileSet objects.
  */
 BufFile *
-BufFileCreateShared(SharedFileSet *fileset, const char *name)
+BufFileCreateShared(SharedFileSet *fileset, const char *name, workfile_set *work_set)
 {
 	BufFile    *file;
 
@@ -365,6 +365,14 @@ BufFileCreateShared(SharedFileSet *fileset, const char *name)
 	file->files = (File *) palloc(sizeof(File));
 	file->files[0] = MakeNewSharedSegment(file, 0);
 	file->readOnly = false;
+	/*
+	 * Register the file as a "work file", so that the Greenplum workfile
+	 * limits apply to it.
+	 */
+	file->work_set = work_set;
+
+	FileSetIsWorkfile(file->files[0]);
+	RegisterFileWithSet(file->files[0], work_set);
 
 	return file;
 }

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -1961,9 +1961,6 @@ FileClose(File file)
 		else
 			stat_errno = 0;
 
-		if (vfdP->fdstate & FD_WORKFILE)
-			WorkFileDeleted(file, true);
-
 		/* in any case do the unlink */
 		if (unlink(vfdP->fileName))
 			elog(DEBUG1, "could not unlink file \"%s\": %m", vfdP->fileName);
@@ -1981,6 +1978,10 @@ FileClose(File file)
 	/* Unregister it from the resource owner */
 	if (vfdP->resowner)
 		ResourceOwnerForgetFile(vfdP->resowner, file);
+
+	/* Unregister it from the workfile set */
+	if (vfdP->fdstate & FD_WORKFILE)
+		WorkFileDeleted(file, true);
 
 	/*
 	 * Return the Vfd slot to the free list

--- a/src/backend/utils/sort/logtape.c
+++ b/src/backend/utils/sort/logtape.c
@@ -706,17 +706,15 @@ LogicalTapeSetCreate(int ntapes, TapeShare *shared, SharedFileSet *fileset,
 	else if (fileset)
 	{
 		char		filename[MAXPGPATH];
+		workfile_set *work_set;
 
 		pg_itoa(worker, filename);
-		lts->pfile = BufFileCreateShared(fileset, filename);
+		work_set = workfile_mgr_create_set("LogicalTape", filename, false /* hold pin */);
+		lts->pfile = BufFileCreateShared(fileset, filename, work_set);
 	}
 	else
 	{
-		/*
-		 * GPDB_12_MERGE_FIXME: This is also used for Hash Aggs, not just
-		 * Sorts.
-		 */
-		lts->pfile = BufFileCreateTemp("Sort", false);
+		lts->pfile = BufFileCreateTemp("LogicalTape", false);
 	}
 
 	return lts;

--- a/src/backend/utils/sort/sharedtuplestore.c
+++ b/src/backend/utils/sort/sharedtuplestore.c
@@ -314,10 +314,12 @@ sts_puttuple(SharedTuplestoreAccessor *accessor, void *meta_data,
 	{
 		SharedTuplestoreParticipant *participant;
 		char		name[MAXPGPATH];
+		workfile_set	*work_set;
 
 		/* Create one.  Only this backend will write into it. */
 		sts_filename(name, accessor, accessor->participant);
-		accessor->write_file = BufFileCreateShared(accessor->fileset, name);
+		work_set = workfile_mgr_create_set("SharedTupleStore", name, false /* hold pin */);
+		accessor->write_file = BufFileCreateShared(accessor->fileset, name, work_set);
 
 		/* Set up the shared state for this backend's file. */
 		participant = &accessor->sts->participants[accessor->participant];

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -1694,7 +1694,6 @@ tuplestore_make_shared(Tuplestorestate *state, SharedFileSet *fileset, const cha
 {
 	ResourceOwner oldowner;
 
-	// GPDB_12_MERGE_FIXME: how should SharedFileSets and workfile sets interact?
 	state->work_set = workfile_mgr_create_set("SharedTupleStore", filename, true /* hold pin */);
 
 	Assert(state->status == TSS_INMEM);
@@ -1716,7 +1715,7 @@ tuplestore_make_shared(Tuplestorestate *state, SharedFileSet *fileset, const cha
 	oldowner = CurrentResourceOwner;
 	CurrentResourceOwner = state->resowner;
 
-	state->myfile = BufFileCreateShared(fileset, filename);
+	state->myfile = BufFileCreateShared(fileset, filename, state->work_set);
 	CurrentResourceOwner = oldowner;
 
 	/*

--- a/src/include/storage/buffile.h
+++ b/src/include/storage/buffile.h
@@ -29,6 +29,7 @@
 #define BUFFILE_H
 
 #include "storage/sharedfileset.h"
+#include "utils/workfile_mgr.h"
 
 /* BufFile is an opaque type whose details are not known outside buffile.c. */
 
@@ -52,7 +53,7 @@ extern int	BufFileSeekBlock(BufFile *file, int64 blknum);
 extern int64 BufFileSize(BufFile *file);
 extern long BufFileAppend(BufFile *target, BufFile *source);
 
-extern BufFile *BufFileCreateShared(SharedFileSet *fileset, const char *name);
+extern BufFile *BufFileCreateShared(SharedFileSet *fileset, const char *name, struct workfile_set *work_set);
 extern void BufFileExportShared(BufFile *file);
 extern BufFile *BufFileOpenShared(SharedFileSet *fileset, const char *name);
 extern void BufFileDeleteShared(SharedFileSet *fileset, const char *name);


### PR DESCRIPTION
Track temporary files that can be shared by multiple backends, so the
gp_toolkit views and gp_* limits apply to these.

Update the signature of BufFileCreateShared() to not expose BufFile and
merge in the future won't miss the work_set.