### PR TITLE
gpinitsystem -I should respect master dbid != 1

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1210,12 +1210,12 @@ CREATE_QD_DB () {
 		LOG_MSG "[INFO]:-Setting Master instance check point segments"
 
 		LOG_MSG "[INFO]:-Setting Master instance content id"
-		SED_PG_CONF ${GP_DIR}/$PG_CONF "$CONTENT_ID_TXT" "gp_contentid=-1" 0
-		ERROR_CHK $? "set gp_contentid=-1 in ${GP_DIR}/$PG_CONF" 1
+		SED_PG_CONF ${GP_DIR}/$PG_CONF "$CONTENT_ID_TXT" "gp_contentid=$GP_CONTENT" 0
+		ERROR_CHK $? "set gp_contentid=$GP_CONTENT in ${GP_DIR}/$PG_CONF" 1
 
 		LOG_MSG "[INFO]:-Setting Master instance db id"
-		SED_PG_CONF ${GP_DIR}/$PG_INTERNAL_CONF "$DBID_TXT" "gp_dbid=1" 0
-		ERROR_CHK $? "set gp_dbid=1 in ${GP_DIR}/$PG_INTERNAL_CONF" 1
+		SED_PG_CONF ${GP_DIR}/$PG_INTERNAL_CONF "$DBID_TXT" "gp_dbid=$GP_DBID" 0
+		ERROR_CHK $? "set gp_dbid=$GP_DBID in ${GP_DIR}/$PG_INTERNAL_CONF" 1
 
 		if [  x"" != x"$PG_CONF_ADD_FILE" ]; then
 				LOG_MSG "[INFO]:-Processing additional configuration parameters"

--- a/src/include/catalog/gp_segment_configuration.h
+++ b/src/include/catalog/gp_segment_configuration.h
@@ -23,9 +23,7 @@
  */
 #define GpSegmentConfigRelationName		"gp_segment_configuration"
 
-#define MASTER_DBID 1
 #define MASTER_CONTENT_ID (-1)
-#define InvalidDbid 0
 
 #define GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY 'p'
 #define GP_SEGMENT_CONFIGURATION_ROLE_MIRROR 'm'

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -872,8 +872,6 @@ PG_FUNCTION_INFO_V1(gp_fts_probe_stats);
 Datum
 gp_fts_probe_stats(PG_FUNCTION_ARGS)
 {
-	Assert(GpIdentity.dbid == MASTER_DBID);
-
 	TupleDesc	tupdesc;
 	int32		start_count = 0;
 	int32		done_count = 0;


### PR DESCRIPTION
Looking at GP documents, there is no indication that master dbid
must be 1. However, when CREATE_QD_DB, gpinitsystem always writes
"gp_dbid=1" into file `internal.auto.conf` even if we specify:

```
mdw~5432~/data/master/gpseg-1~2~-1
 OR
mdw~5432~/data/master/gpseg-1~0~-1
```

But catalog gp_segment_configuration can have the correct master
dbid value (2 or 0), the mismatch causes gpinitsystem hang.
Users can run into such problem for their first time to use
gpinitsystem -I.

Here we test dbid 0, because PostmasterMain() will simply check
dbid >= 0 (non-utility mode), it says:

> This value must be >= 0, or >= -1 in utility mode

It seems 0 is a valid value.

Changes:

- use specified master dbid field when CREATE_QD_DB.
- remove unused macros MASTER_DBID, InvalidDbid in C sources.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
