### PR TITLE
docs - add info about postgres_fdw module

### DIFF
--- a/gpdb-doc/dita/admin_guide/external/g-devel-fdw.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-devel-fdw.xml
@@ -12,7 +12,7 @@
       wrapper must handle that, too.</p>
     <p>The foreign-data wrappers included in the Greenplum Database open source
       github repository are good references when trying to write your own.
-      You may want to examine the
+      You may want to examine the source code for the
       <codeph><xref href="https://github.com/greenplum-db/gpdb/tree/master/contrib/file_fdw" scope="external">file_fdw</xref></codeph>
       and <codeph><xref href="https://github.com/greenplum-db/gpdb/tree/master/contrib/postgres_fdw" scope="external">postgres_fdw</xref></codeph>
       modules in the <codeph>contrib/</codeph> directory. The

--- a/gpdb-doc/dita/admin_guide/external/g-foreign.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-foreign.xml
@@ -11,6 +11,9 @@
       A foreign-data wrapper is a library that communicates with a remote
       data source. This library hides the source-specific connection and data
       access details.</p>
+    <p>The Greenplum Database distribution includes the
+      <xref href="../../ref_guide/modules/postgres_fdw.xml" format="dita" scope="peer">postgres_fdw</xref>
+       foreign data wrapper.</p>
     <note>Most PostgreSQL foreign-data wrappers should work with Greenplum
       Database. However, PostgreSQL foreign-data wrappers connect only through 
       the Greenplum Database master and do not access the Greenplum Database 
@@ -32,10 +35,11 @@
       source. This information can be provided by a <i>user mapping</i>,
       which can provide additional data such as a user name and password
       based on the current Greenplum Database role.</p>
-    <p>For additional information, refer to
+    <p>For additional information, refer to the
        <codeph><xref href="../../ref_guide/sql_commands/CREATE_FOREIGN_DATA_WRAPPER.xml#topic1"/></codeph>,
        <codeph><xref href="../../ref_guide/sql_commands/CREATE_SERVER.xml#topic1"/></codeph>,
        <codeph><xref href="../../ref_guide/sql_commands/CREATE_USER_MAPPING.xml#topic1"/></codeph>,
-        and <codeph><xref href="../../ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml#topic1"/></codeph>.</p>
+        and <codeph><xref href="../../ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml#topic1"/></codeph>
+        SQL reference pages.</p>
   </body>
 </topic>

--- a/gpdb-doc/dita/install_guide/install_modules.xml
+++ b/gpdb-doc/dita/install_guide/install_modules.xml
@@ -46,6 +46,8 @@
                   format="dita">pageinspect</xref></li>
               <li><xref href="../ref_guide/modules/pgcrypto.xml" type="topic" scope="peer"
                   format="dita">pgcrypto</xref></li>
+              <li><xref href="../ref_guide/modules/postgres_fdw.xml" type="topic" scope="peer"
+                  format="dita">postgres_fdw</xref></li>
               <li><xref href="../ref_guide/modules/sslinfo.xml" type="topic" scope="peer"
                   format="dita">sslinfo</xref></li>
             </ul>

--- a/gpdb-doc/dita/ref_guide/modules/intro.xml
+++ b/gpdb-doc/dita/ref_guide/modules/intro.xml
@@ -41,6 +41,10 @@
        <li><codeph><xref href="pgcrypto.xml" format="dita"
              >pgcrypto</xref></codeph> - Provides cryptographic functions for Greenplum
          Database.</li>
+       <li><codeph><xref href="postgres_fdw.xml" format="dita"
+             >postgres_fdw</xref></codeph> - Provides a foreign data wrapper (FDW)
+         for accessing data stored in an external PostgreSQL or Greenplum
+         database.</li>
       <li><codeph><xref href="sslinfo.xml" format="dita">sslinfo</xref></codeph> - Provides
         information about the SSL certificate that the current client provided when connecting to
         Greenplum.</li>

--- a/gpdb-doc/dita/ref_guide/modules/modules.ditamap
+++ b/gpdb-doc/dita/ref_guide/modules/modules.ditamap
@@ -12,6 +12,7 @@
     <topicref href="orafce_ref.xml"/>
     <topicref href="pageinspect.xml"/>
     <topicref href="pgcrypto.xml"/>
+    <topicref href="postgres_fdw.xml"/>
     <topicref href="sslinfo.xml"/>
   </topicref>
 </map>

--- a/gpdb-doc/dita/ref_guide/modules/postgres_fdw.xml
+++ b/gpdb-doc/dita/ref_guide/modules/postgres_fdw.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic1">
+  <title>postgres_fdw</title>
+  <body>
+    <p>The <codeph>postgres_fdw</codeph> module is a foreign data wrapper (FDW) 
+      that you can use to access data stored in a remote PostgreSQL or Greenplum
+      database.</p>
+    <p>The Greenplum Database <codeph>postgres_fdw</codeph> module is a modified
+      version of the PostgreSQL <codeph>postgres_fdw</codeph> module. The module
+      behaves as described in the PostgreSQL
+      <xref href="https://www.postgresql.org/docs/9.4/postgres-fdw.html" format="html"
+        scope="external">postgres_fdw</xref> documentation when you use it to
+      access a remote PostgreSQL database. <note>There are some restrictions and
+      limitations when you use this foreign data wrapper module to access
+      Greenplum Database, described below.</note></p>
+  </body>
+  <topic id="topic_reg">
+    <title>Installing and Registering the Module</title>
+    <body>
+      <p>The <codeph>postgres_fdw</codeph> module is installed when you install
+        Greenplum Database. Before you can use the foreign data wrapper, you
+        must register the <codeph>postgres_fdw</codeph> extension in each
+        database in which you want to use the foreign data wrapper.
+        <ph otherprops="pivotal">Refer to <xref href="../../install_guide/install_modules.xml"
+          format="dita" scope="peer">Installing Additional Supplied Modules</xref>
+        for more information.</ph></p>
+    </body>
+  </topic>
+  <topic id="topic_gp_limit">
+    <title>Greenplum Database Limitations</title>
+    <body>
+      <p>When you use the foreign data wrapper to access Greenplum Database,
+        <codeph>postgres_fdw</codeph> has the following limitations:</p>
+        <ul>
+          <li>The <codeph>ctid</codeph> is not guaranteed to uniquely identify
+            the physical location of a row within its table. For example, the
+            following statements may return incorrect results when the foreign
+            table references a Greenplum Database table:
+            <codeblock>INSERT INTO rem1(f2) VALUES ('test') RETURNING ctid;
+SELECT * FROM ft1, t1 WHERE t1.ctid = '(0,2)'; </codeblock></li>
+          <li><codeph>postgres_fdw</codeph> does not support local or remote
+            triggers when you use it to access a foreign table that references
+            a Greenplum Database table.</li>
+          <li><codeph>UPDATE</codeph> or <codeph>DELETE</codeph> operations on
+            a foreign table that references a Greenplum table are not guaranteed
+            to work correctly.</li>
+        </ul>
+    </body>
+  </topic>
+  <topic id="topic_info">
+    <title>Additional Module Documentation</title>
+    <body>
+      <p>Refer to the <xref href="https://www.postgresql.org/docs/9.4/postgres-fdw.html" format="html"
+        scope="external">postgres_fdw</xref> PostgreSQL documentation for detailed
+        information about this module.</p>
+    </body>
+  </topic>
+</topic>


### PR DESCRIPTION
add some docs for the postgres_fdw module; explicitly calling out greenplum limitations and xref'ing to postgres docs for the core info.

doc review site link:  http://docs-lisa-postgres_fdw.cfapps.io/7-0/ref_guide/modules/postgres_fdw.html
