### PR TITLE
Reset wrote_xlog in pg_conn to avoid keeping old value.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -915,7 +915,17 @@ processResults(CdbDispatchResult *dispatchResult)
 		}
 
 		if (segdbDesc->conn->wrote_xlog)
+		{
 			MarkTopTransactionWriteXLogOnExecutor();
+
+			/*
+			 * Reset the worte_xlog here. Since if the received pgresult not process
+			 * the xlog write message('x' message sends from QE in ReadyForQuery),
+			 * the value may still refer to previous dispatch statement. Which may
+			 * always mark current top transaction has wrote xlog on executor.
+			 */
+			segdbDesc->conn->wrote_xlog = false;
+		}
 
 		/*
 		 * Attach the PGresult object to the CdbDispatchResult object.


### PR DESCRIPTION
On QD, it tracks whether QE wrote_xlog in the libpq connection.
The logic is, if QE writes xlog, it'll send a libpq msg to QD. But the
msg is sent in ReadyForQuery. So, before QE execute this function, the
QE may already send back results to QD. Then when QD process this
message, it does not read the new wrote_xlog value. This makes the
connection still contains the previous dispatch wrote_xlog value,
which will affect whether choosing one-phase commit.

The issue only happens when the QE flush the libpq msg before the
ReadyForQuery function, hard to find a case to cover it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
