### PR TITLE
Backport #9583 to 6X_STABLE: Use palloc() in CdbDispatchCommand

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1405,7 +1405,7 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 		pfree(waitGxids);
 
 	if (results)
-		free(results);
+		pfree(results);
 
 	return (numOfFailed == 0);
 }

--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -799,13 +799,7 @@ cdbdisp_returnResults(CdbDispatchResults *primaryResults, CdbPgResults *cdb_pgre
 	for (i = 0; i < primaryResults->resultCount; ++i)
 		nslots += cdbdisp_numPGresult(&primaryResults->resultArray[i]);
 
-
-	cdb_pgresults->pg_results = (struct pg_result **) calloc(nslots, sizeof(struct pg_result *));
-
-	if (!cdb_pgresults->pg_results)
-		ereport(ERROR, (errcode(ERRCODE_OUT_OF_MEMORY),
-						errmsg
-						("cdbdisp_returnResults failed: out of memory")));
+	cdb_pgresults->pg_results = (struct pg_result **) palloc0(nslots * sizeof(struct pg_result *));
 
 	/*
 	 * Collect results from primary gang.
@@ -900,6 +894,12 @@ cdbdisp_clearCdbPgResults(CdbPgResults *cdb_pgresults)
 
 	for (i = 0; i < cdb_pgresults->numResults; i++)
 		PQclear(cdb_pgresults->pg_results[i]);
+
+	if (cdb_pgresults->pg_results)
+	{
+		pfree(cdb_pgresults->pg_results);
+		cdb_pgresults->pg_results = NULL;
+	}
 
 	cdb_pgresults->numResults = 0;
 }

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -679,7 +679,7 @@ pg_lock_status(PG_FUNCTION_ARGS)
 		for (i = 0; i < mystatus->numsegresults; i++)
 			PQclear(mystatus->segresults[i]);
 
-		free(mystatus->segresults);
+		pfree(mystatus->segresults);
 	}
 
 	SRF_RETURN_DONE(funcctx);


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/commit/c7e81969eb9f6e698204a19f3c6b0416544491f4. The problem it solves is described in https://github.com/greenplum-db/gpdb/pull/9583; it affects not only master, but [6X_STABLE](https://github.com/greenplum-db/gpdb/tree/db74df9fbe82383703e46328816626b77eca4039), and [5X_STABLE](https://github.com/greenplum-db/gpdb/tree/9b690a9e936e0bbfdbfd1b1181b39f6b92c9e2bb) as well.

I just `cherry-pick`ed the original commit without conflicts; it seems the code in question did not undergo significant changes since 5X.

### Extra notes

I have also checked if there are any other usages of `CdbDispatchCommand()` where `free` should be replaced with `pfree`, as done [in `doDispatchDtxProtocolCommand()`](https://github.com/greenplum-db/gpdb/pull/11080/files#diff-9305f2126a44f407d91597abcbe20f63a320caec26038b931488c7b943ed6d0aR1408). I have *not* found such usages, but found some other points that may be of interest:
1. [These](https://github.com/greenplum-db/gpdb/blob/db74df9fbe82383703e46328816626b77eca4039/src/backend/cdb/cdbdtxrecovery.c#L272) `CdbPgResults` are not cleared, unless an exception happens: https://github.com/greenplum-db/gpdb/blob/db74df9fbe82383703e46328816626b77eca4039/src/backend/cdb/cdbdtxrecovery.c#L272
2. [This](https://github.com/greenplum-db/gpdb/blob/db74df9fbe82383703e46328816626b77eca4039/src/backend/commands/indexcmds.c#L138) `elog(ERROR)` is called without clearing `CdbPgResults` (note the preceding `elog(ERROR)` does call `cdbdisp_clearCdbPgResults()`): https://github.com/greenplum-db/gpdb/blob/db74df9fbe82383703e46328816626b77eca4039/src/backend/commands/indexcmds.c#L138
    * The same behaviour: https://github.com/greenplum-db/gpdb/blob/db74df9fbe82383703e46328816626b77eca4039/src/backend/utils/gdd/gddfuncs.c#L186
3. Sometimes `cdbdisp_clearCdbPgResults()` is *not* called after the caller of `CdbDispatchCommand()` determines `CdbPgResults.numResults` is `0`. Currently, this does not lead to a memory leak, but this may lead to it in the future, if `CdbDispatchCommand()` implementation changes: https://github.com/greenplum-db/gpdb/blob/db74df9fbe82383703e46328816626b77eca4039/src/backend/utils/gdd/gddfuncs.c#L166
    * The same behaviour: https://github.com/greenplum-db/gpdb/blob/db74df9fbe82383703e46328816626b77eca4039/src/backend/utils/resgroup/resgroup_helper.c#L435

IMHO, if these should be fixed, this can be done in a separate PR.
