### PR TITLE
Fix source greenplum_path.sh error with set -u

### DIFF
--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 cat <<"EOF"
-if test -n "$ZSH_VERSION"; then
+if test -n "${ZSH_VERSION:-}"; then
     # zsh
     SCRIPT_PATH="${(%):-%x}"
-elif test -n "$BASH_VERSION"; then
+elif test -n "${BASH_VERSION:-}"; then
     # bash
     SCRIPT_PATH="${BASH_SOURCE[0]}"
 else


### PR DESCRIPTION
The error was introduced by dc96f66789.
If `set -u` was called before sourcing greenplum_path.sh with bash, an
error `ZSH_VERSION: unbound variable` would be reported.
To solve the issue, use shell syntax `{:-}` which will output an empty
value if the variable doesn't exist.

Tested with zsh, bash and dash.

See example of CI failure at:
https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master/jobs/icw_planner_centos7/builds/1609

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
