### PR TITLE
Fix gprecoverseg hba

### DIFF
--- a/gpMgmt/bin/gppylib/operations/Makefile
+++ b/gpMgmt/bin/gppylib/operations/Makefile
@@ -7,7 +7,7 @@ PROGRAMS= initstandby.py test_utils_helper.py
 
 DATA= __init__.py buildMirrorSegments.py deletesystem.py package.py \
 	rebalanceSegments.py reload.py segment_reconfigurer.py startSegments.py \
-	unix.py utils.py
+	unix.py update_pg_hba_conf.py utils.py
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(libdir)/python/gppylib/operations'

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -6,7 +6,7 @@ import time
 
 from gppylib.mainUtils import *
 
-from gppylib.utils import checkNotNone, appendNewEntriesToHbaFile
+from gppylib.utils import checkNotNone
 from gppylib.db import dbconn
 from gppylib import gparray, gplog
 from gppylib.commands import unix

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_update_pg_hba_conf.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_update_pg_hba_conf.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+#
+# Copyright (c) Greenplum Inc 2008. All Rights Reserved.
+#
+from mock import patch, Mock
+
+from gppylib.gparray import Segment, GpArray
+from gppylib.operations.update_pg_hba_conf import config_primaries_for_replication
+from test.unit.gp_unittest import GpTestCase, run_tests
+
+
+class UpdatePgHBAConfTests(GpTestCase):
+    def setUp(self):
+        def _setup_gparray():
+            master = Segment.initFromString(
+                "1|-1|p|p|s|u|mdw|mdw|5432|/data/master")
+            standby = Segment.initFromString(
+                "6|-1|m|m|s|u|sdw3|sdw3|5433|/data/standby")
+            primary0 = Segment.initFromString(
+                "2|0|p|p|s|u|sdw1|sdw1|40000|/data/primary0")
+            primary1 = Segment.initFromString(
+                "3|1|p|p|s|u|sdw2|sdw2|40001|/data/primary1")
+            mirror0 = Segment.initFromString(
+                "4|0|m|m|s|u|sdw2|sdw2|50000|/data/mirror0")
+            mirror1 = Segment.initFromString(
+                "5|1|m|m|s|u|sdw1|sdw1|50001|/data/mirror1")
+            return GpArray([master, standby, primary0, primary1, mirror0, mirror1])
+
+        self.gparray = _setup_gparray()
+        self.apply_patches([
+            patch('gppylib.operations.update_pg_hba_conf.logger', return_value=Mock(spec=['log', 'info', 'debug', 'error'])),
+        ])
+        self.logger = self.get_mock_from_apply_patch('logger')
+
+    @patch('gppylib.operations.update_pg_hba_conf.Command')
+    @patch('gppylib.operations.update_pg_hba_conf.gp.IfAddrs.list_addrs', return_value=['192.168.2.1', '192.168.1.1'])
+    def test_pghbaconf_updated_successfully(self, mock_cmd, mock_list_addrs):
+        config_primaries_for_replication(self.gparray, False)
+        self.logger.info.assert_any_call("Starting to modify pg_hba.conf on primary segments to allow replication connections")
+        self.logger.info.assert_any_call("Successfully modified pg_hba.conf on primary segments to allow replication connections")
+
+    @patch('gppylib.operations.update_pg_hba_conf.Command', side_effect=Exception("boom"))
+    @patch('gppylib.operations.update_pg_hba_conf.gp.IfAddrs.list_addrs', return_value=['192.168.2.1', '192.168.1.1'])
+    def test_pghbaconf_updated_fails(self, mock1, mock2):
+        with self.assertRaisesRegexp(Exception, "boom"):
+            config_primaries_for_replication(self.gparray, False)
+        self.logger.info.assert_any_call("Starting to modify pg_hba.conf on primary segments to allow replication connections")
+        self.logger.error.assert_any_call("Failed while modifying pg_hba.conf on primary segments to allow replication connections: boom")

--- a/gpMgmt/bin/gppylib/operations/update_pg_hba_conf.py
+++ b/gpMgmt/bin/gppylib/operations/update_pg_hba_conf.py
@@ -1,0 +1,58 @@
+import os
+import socket
+
+from gppylib import gplog
+from gppylib.commands.base import Command
+from gppylib.commands import base, gp, unix
+
+logger = gplog.get_default_logger()
+
+
+def config_primaries_for_replication(gpArray, hba_hostnames):
+    logger.info("Starting to modify pg_hba.conf on primary segments to allow replication connections")
+
+    try:
+        for segmentPair in gpArray.getSegmentList():
+            # Start with an empty string so that the later .join prepends a newline to the first entry
+            entries = ['']
+            # Add the samehost replication entry to support single-host development
+            entries.append('host  replication {username} samehost trust'.format(username=unix.getUserName()))
+            if hba_hostnames:
+                mirror_hostname, _, _ = socket.gethostbyaddr(segmentPair.mirrorDB.getSegmentHostName())
+                entries.append("host all {username} {hostname} trust".format(username=unix.getUserName(), hostname=mirror_hostname))
+                entries.append("host replication {username} {hostname} trust".format(username=unix.getUserName(), hostname=mirror_hostname))
+                primary_hostname, _, _ = socket.gethostbyaddr(segmentPair.primaryDB.getSegmentHostName())
+                if mirror_hostname != primary_hostname:
+                    entries.append("host replication {username} {hostname} trust".format(username=unix.getUserName(), hostname=primary_hostname))
+            else:
+                mirror_ips = gp.IfAddrs.list_addrs(segmentPair.mirrorDB.getSegmentHostName())
+                for ip in mirror_ips:
+                    cidr_suffix = '/128' if ':' in ip else '/32'
+                    cidr = ip + cidr_suffix
+                    hba_line_entry = "host all {username} {cidr} trust".format(username=unix.getUserName(), cidr=cidr)
+                    entries.append(hba_line_entry)
+                mirror_hostname = segmentPair.mirrorDB.getSegmentHostName()
+                segment_pair_ips = gp.IfAddrs.list_addrs(mirror_hostname)
+                primary_hostname = segmentPair.primaryDB.getSegmentHostName()
+                if mirror_hostname != primary_hostname:
+                    segment_pair_ips.extend(gp.IfAddrs.list_addrs(primary_hostname))
+                for ip in segment_pair_ips:
+                    cidr_suffix = '/128' if ':' in ip else '/32'
+                    cidr = ip + cidr_suffix
+                    hba_line_entry = "host replication {username} {cidr} trust".format(username=unix.getUserName(), cidr=cidr)
+                    entries.append(hba_line_entry)
+            cmdStr = ". {gphome}/greenplum_path.sh; echo '{entries}' >> {datadir}/pg_hba.conf; pg_ctl -D {datadir} reload".format(
+                gphome=os.environ["GPHOME"],
+                entries="\n".join(entries),
+                datadir=segmentPair.primaryDB.datadir)
+            logger.debug(cmdStr)
+            cmd = Command(name="append to pg_hba.conf", cmdStr=cmdStr, ctxt=base.REMOTE, remoteHost=segmentPair.primaryDB.hostname)
+            cmd.run(validateAfter=True)
+
+    except Exception as e:
+        logger.error("Failed while modifying pg_hba.conf on primary segments to allow replication connections: %s" % str(e))
+        raise
+
+    else:
+        logger.info("Successfully modified pg_hba.conf on primary segments to allow replication connections")
+        

--- a/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
+++ b/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
@@ -19,6 +19,7 @@ from gppylib.db import catalog, dbconn
 from gppylib.gpparseopts import OptParser, OptChecker
 from gppylib.operations.startSegments import *
 from gppylib.operations.buildMirrorSegments import *
+from gppylib.operations.update_pg_hba_conf import config_primaries_for_replication
 from gppylib.programs import programIoUtils
 from gppylib.system import configurationInterface as configInterface
 from gppylib.system.environment import GpMasterEnvironment
@@ -499,54 +500,6 @@ class GpAddMirrorsProgram:
         else:
             logger.info("Heap checksum setting consistent across cluster")
 
-    def config_primaries_for_replication(self, gpArray):
-        logger.info("Starting to modify pg_hba.conf on primary segments to allow replication connections")
-
-        try:
-            for segmentPair in gpArray.getSegmentList():
-                # Start with an empty string so that the later .join prepends a newline to the first entry
-                entries = ['']
-                # Add the samehost replication entry to support single-host development
-                entries.append('host  replication {username} samehost trust'.format(username=unix.getUserName()))
-                if self.__options.hba_hostnames:
-                    mirror_hostname, _, _ = socket.gethostbyaddr(segmentPair.mirrorDB.getSegmentHostName())
-                    entries.append("host all {username} {hostname} trust".format(username=unix.getUserName(), hostname=mirror_hostname))
-                    entries.append("host replication {username} {hostname} trust".format(username=unix.getUserName(), hostname=mirror_hostname))
-                    primary_hostname, _, _ = socket.gethostbyaddr(segmentPair.primaryDB.getSegmentHostName())
-                    if mirror_hostname != primary_hostname:
-                        entries.append("host replication {username} {hostname} trust".format(username=unix.getUserName(), hostname=primary_hostname))
-                else:
-                    mirror_ips = unix.InterfaceAddrs.remote('get mirror ips', segmentPair.mirrorDB.getSegmentHostName())
-                    for ip in mirror_ips:
-                        cidr_suffix = '/128' if ':' in ip else '/32'
-                        cidr = ip + cidr_suffix
-                        hba_line_entry = "host all {username} {cidr} trust".format(username=unix.getUserName(), cidr=cidr)
-                        entries.append(hba_line_entry)
-                    mirror_hostname = segmentPair.mirrorDB.getSegmentHostName()
-                    segment_pair_ips = gp.IfAddrs.list_addrs(mirror_hostname)
-                    primary_hostname = segmentPair.primaryDB.getSegmentHostName()
-                    if mirror_hostname != primary_hostname:
-                        segment_pair_ips.extend(gp.IfAddrs.list_addrs(primary_hostname))
-                    for ip in segment_pair_ips:
-                        cidr_suffix = '/128' if ':' in ip else '/32'
-                        cidr = ip + cidr_suffix
-                        hba_line_entry = "host replication {username} {cidr} trust".format(username=unix.getUserName(), cidr=cidr)
-                        entries.append(hba_line_entry)
-                cmdStr = ". {gphome}/greenplum_path.sh; echo '{entries}' >> {datadir}/pg_hba.conf; pg_ctl -D {datadir} reload".format(
-                    gphome=os.environ["GPHOME"],
-                    entries="\n".join(entries),
-                    datadir=segmentPair.primaryDB.datadir)
-                logger.debug(cmdStr)
-                cmd = Command(name="append to pg_hba.conf", cmdStr=cmdStr, ctxt=base.REMOTE, remoteHost=segmentPair.primaryDB.hostname)
-                cmd.run(validateAfter=True)
-
-        except Exception, e:
-            logger.error("Failed while modifying pg_hba.conf on primary segments to allow replication connections: %s" % str(e))
-            raise
-
-        else:
-            logger.info("Successfully modified pg_hba.conf on primary segments to allow replication connections")
-
 
     def run(self):
         if self.__options.parallelDegree < 1 or self.__options.parallelDegree > 64:
@@ -584,7 +537,7 @@ class GpAddMirrorsProgram:
                 if not userinput.ask_yesno(None, "\nContinue with add mirrors procedure", 'N'):
                     raise UserAbortedException()
 
-            self.config_primaries_for_replication(gpArray)
+            config_primaries_for_replication(gpArray, self.__options.hba_hostnames)
             if not mirrorBuilder.buildMirrors("add", gpEnv, gpArray):
                 return 1
 

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -29,6 +29,7 @@ from gppylib.gpparseopts import OptParser, OptChecker
 from gppylib.operations.startSegments import *
 from gppylib.operations.buildMirrorSegments import *
 from gppylib.operations.rebalanceSegments import GpSegmentRebalanceOperation
+from gppylib.operations.update_pg_hba_conf import config_primaries_for_replication
 from gppylib.programs import programIoUtils
 from gppylib.system import configurationInterface as configInterface
 from gppylib.system.environment import GpMasterEnvironment
@@ -663,6 +664,7 @@ class GpRecoverSegmentProgram:
             if new_hosts:
                 self.syncPackages(new_hosts)
 
+            config_primaries_for_replication(gpArray, self.__options.hba_hostnames)
             if not mirrorBuilder.buildMirrors("recover", gpEnv, gpArray):
                 sys.exit(1)
 
@@ -771,6 +773,8 @@ class GpRecoverSegmentProgram:
                          help="Max # of workers to use for building recovery segments.  [default: %default]")
         addTo.add_option("-r", None, default=False, action='store_true',
                          dest='rebalanceSegments', help='Rebalance synchronized segments.')
+        addTo.add_option('', '--hba-hostnames', action='store_true', dest='hba_hostnames',
+                         help='use hostnames instead of CIDR in pg_hba.conf')
 
         parser.set_defaults()
         return parser

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
@@ -121,29 +121,6 @@ class GpAddMirrorsTest(GpTestCase):
 
         self.assertIn("45000", result[0])
 
-    @patch('gppylib.programs.clsAddMirrors.Command')
-    @patch('gppylib.programs.clsAddMirrors.unix.InterfaceAddrs.remote', return_value=['192.168.2.1', '192.168.1.1'])
-    @patch('gppylib.programs.clsAddMirrors.gp.IfAddrs.list_addrs', return_value=['192.168.2.1', '192.168.1.1'])
-    def test_pghbaconf_updated_successfully(self, mock1, mock2, mock3):
-        sys.argv = ['gpaddmirrors', '-i', '/tmp/nonexistent/file']
-        options, _ = self.parser.parse_args()
-        self.subject = GpAddMirrorsProgram(options)
-        self.subject.config_primaries_for_replication(self.gparrayMock)
-        self.mock_logger.info.assert_any_call("Starting to modify pg_hba.conf on primary segments to allow replication connections")
-        self.mock_logger.info.assert_any_call("Successfully modified pg_hba.conf on primary segments to allow replication connections")
-
-    @patch('gppylib.programs.clsAddMirrors.Command', side_effect=Exception("boom"))
-    @patch('gppylib.programs.clsAddMirrors.unix.InterfaceAddrs.remote', return_value=['192.168.2.1', '192.168.1.1'])
-    @patch('gppylib.programs.clsAddMirrors.gp.IfAddrs.list_addrs', return_value=['192.168.2.1', '192.168.1.1'])
-    def test_pghbaconf_updated_fails(self, mock1, mock2, mock3):
-        sys.argv = ['gpaddmirrors', '-i', '/tmp/nonexistent/file']
-        options, _ = self.parser.parse_args()
-        self.subject = GpAddMirrorsProgram(options)
-        with self.assertRaisesRegexp(Exception, "boom"):
-            self.subject.config_primaries_for_replication(self.gparrayMock)
-        self.mock_logger.info.assert_any_call("Starting to modify pg_hba.conf on primary segments to allow replication connections")
-        self.mock_logger.error.assert_any_call("Failed while modifying pg_hba.conf on primary segments to allow replication connections: boom")
-
     def test_datadir_interview(self):
         self.raw_input_mock.side_effect = ["/tmp/datadirs/mirror1", "/tmp/datadirs/mirror2", "/tmp/datadirs/mirror3"]
         sys.argv = ['gpaddmirrors', '-p', '5000']

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -30,6 +30,7 @@ class Options:
         self.persistent_check = None
         self.quiet = None
         self.interactive = False
+        self.hba_hostnames = False
 
 
 class GpRecoversegTestCase(GpTestCase):

--- a/gpMgmt/bin/gppylib/utils.py
+++ b/gpMgmt/bin/gppylib/utils.py
@@ -351,49 +351,6 @@ def parseKeyColonValueLines(str):
 def sortedDictByKey(di):
     return  [ (k,di[k]) for k in sorted(di.keys())]
 
-def appendNewEntriesToHbaFile(fileName, segments):
-    """
-    Will raise Exception if there is a problem updating the hba file
-    """
-
-    try:
-        #
-        # Get the list of lines that already exist...we won't write those again
-        #
-        # Replace runs of whitespace with single space to improve deduping
-        #
-        def lineToCanonical(s):
-            s = re.sub("\s", " ", s) # first reduce whitespace runs to single space
-            s = re.sub(" $", "", s) # remove trailing space
-            s = re.sub("^ ", "", s) # remove leading space
-            return s
-        existingLineMap = {}
-        for line in readAllLinesFromFile(fileName):
-            existingLineMap[lineToCanonical(line)] = True
-
-        fp = open(fileName, 'a')
-        try:
-            for newSeg in segments:
-                address = newSeg.getSegmentAddress()
-                addrinfo = socket.getaddrinfo(address, None)
-                ipaddrlist = list(set([ (ai[0], ai[4][0]) for ai in addrinfo]))
-                haveWrittenCommentHeader = False
-                for addr in ipaddrlist:
-                    newLine = 'host\tall\tall\t%s/%s\ttrust' % (addr[1], '32' if addr[0] == socket.AF_INET else '128')
-                    newLineCanonical = lineToCanonical(newLine)
-                    if newLineCanonical not in existingLineMap:
-                        if not haveWrittenCommentHeader:
-                            fp.write('# %s\n' % address)
-                            haveWrittenCommentHeader = True
-                        fp.write(newLine)
-                        fp.write('\n')
-                        existingLineMap[newLineCanonical] = True
-        finally:
-            fp.close()
-    except IOError, msg:
-        raise Exception('Failed to open %s' % fileName)
-    except Exception, msg:
-        raise Exception('Failed to add new segments to template %s' % fileName)
 
 class TableLogger:
 

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -232,6 +232,11 @@ Do not show pg_basebackup progress. Useful when writing to a
 file. Defaults to showing the progress.
 
 
+--hba-hostnames
+
+Optional. use hostnames instead of CIDR in pg_hba.conf
+
+
 -v
 
 Sets logging output to verbose.

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -279,3 +279,27 @@ Feature: gprecoverseg tests
           And the segments are synchronized
           And the tablespace is valid
           And the other tablespace is valid
+
+    @concourse_cluster
+    Scenario: moving mirror to a different host must work
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "mirror" segment on a remote host is saved
+          And the information of the corresponding primary segment on a remote host is saved
+         When user kills a "mirror" process with the saved information
+          And user can start transactions
+         Then the saved "mirror" segment is marked down in config
+         When the user runs "gprecoverseg -a -p mdw"
+         Then gprecoverseg should return a return code of 0
+         When user kills a "primary" process with the saved information
+          And user can start transactions
+         Then the saved "primary" segment is marked down in config
+         When the user runs "gprecoverseg -a"
+         Then gprecoverseg should return a return code of 0
+          And all the segments are running
+          And the segments are synchronized
+         When the user runs "gprecoverseg -ra"
+         Then gprecoverseg should return a return code of 0
+          And all the segments are running
+          And the segments are synchronized


### PR DESCRIPTION
When a down mirror segment is moved to a new host using gprecoverseg Full, the replication/connections entries for the new mirror are not appended to the primary pg_hba.conf due to which gprecoverseg fails. This commits updates the code to add the entries of the new mirror to the primary pg_hba.conf 