### PR TITLE
[6X backport] Harden analyzedb

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -702,8 +702,9 @@ class AnalyzeDb(Operation):
                 prev_ao_state_dict[schema_table] = new_modcount
 
             # update last op for tables that are successfully analyzed
-            last_op_info = curr_last_op_dict[schema_table]  # {'CREATE':'<entry>', 'ALTER':'<entry>', ...}
-            prev_last_op_dict[schema_table] = last_op_info
+            if schema_table in curr_last_op_dict:
+                last_op_info = curr_last_op_dict[schema_table]  # {'CREATE':'<entry>', 'ALTER':'<entry>', ...}
+                prev_last_op_dict[schema_table] = last_op_info
 
             # update column dict
             if is_full or schema_table in dirty_partitions or schema_table not in prev_col_dict or '-1' in \


### PR DESCRIPTION
Commit 4bbbb3810eb043af521dd60e738aaa2538cf30d4 introduced some hardening
around concurrent drop and recreate of tables while analyzedb is running but it
failed to take into account the code around updating the last operation
performed. This commit fixes it.

(cherry picked from commit 6949ecfb1a90c92db63c7c26463f3a9110d3fa12)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
