### PR TITLE
Enlarge the GUC disable_cost's default value for Greenplum.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -147,6 +147,13 @@ typedef struct
 								 * clauses per Window */
 } WindowClauseSortData;
 
+typedef struct
+{
+	RollupData *unhashed_rollup;
+	List       *new_rollups;
+	AggStrategy strat;
+} split_rollup_data;
+
 /* Local functions */
 static Node *preprocess_expression(PlannerInfo *root, Node *expr, int kind);
 static void preprocess_qual_conditions(PlannerInfo *root, Node *jtnode);
@@ -277,6 +284,10 @@ static Path *create_preliminary_limit_path(PlannerInfo *root, RelOptInfo *rel,
 static Path *create_scatter_path(PlannerInfo *root, List *scatterClause, Path *path);
 
 static Oid getSimplyUpdatableRel(Query *query);
+
+static split_rollup_data *make_new_rollups_for_hash_grouping_set(PlannerInfo *root,
+																 Path *path,
+																 grouping_sets_data *gd);
 
 /*****************************************************************************
  *
@@ -4847,16 +4858,9 @@ consider_groupingsets_paths(PlannerInfo *root,
 	 */
 	if (!is_sorted)
 	{
-		List	   *new_rollups = NIL;
-		RollupData *unhashed_rollup = NULL;
-		List	   *sets_data;
-		List	   *empty_sets_data = NIL;
-		List	   *empty_sets = NIL;
-		ListCell   *lc;
-		ListCell   *l_start = list_head(gd->rollups);
-		AggStrategy strat = AGG_HASHED;
-		double		hashsize;
-		double		exclude_groups = 0.0;
+		split_rollup_data      *srd;
+		double		            hashsize;
+		double		            exclude_groups = 0.0;
 
 		Assert(can_hash);
 
@@ -4878,33 +4882,13 @@ consider_groupingsets_paths(PlannerInfo *root,
 		else
 			dNumGroups = dNumGroupsTotal;
 
-		/*
-		 * If the input is coincidentally sorted usefully (which can happen
-		 * even if is_sorted is false, since that only means that our caller
-		 * has set up the sorting for us), then save some hashtable space by
-		 * making use of that. But we need to watch out for degenerate cases:
-		 *
-		 * 1) If there are any empty grouping sets, then group_pathkeys might
-		 * be NIL if all non-empty grouping sets are unsortable. In this case,
-		 * there will be a rollup containing only empty groups, and the
-		 * pathkeys_contained_in test is vacuously true; this is ok.
-		 *
-		 * XXX: the above relies on the fact that group_pathkeys is generated
-		 * from the first rollup. If we add the ability to consider multiple
-		 * sort orders for grouping input, this assumption might fail.
-		 *
-		 * 2) If there are no empty sets and only unsortable sets, then the
-		 * rollups list will be empty (and thus l_start == NULL), and
-		 * group_pathkeys will be NIL; we must ensure that the vacuously-true
-		 * pathkeys_contain_in test doesn't cause us to crash.
-		 */
-		if (l_start != NULL &&
-			pathkeys_contained_in(root->group_pathkeys, path->pathkeys))
-		{
-			unhashed_rollup = lfirst_node(RollupData, l_start);
-			exclude_groups = unhashed_rollup->numGroups;
-			l_start = lnext(l_start);
-		}
+		srd = make_new_rollups_for_hash_grouping_set(root, path, gd);
+
+		if (srd == NULL)
+			return;
+
+		if (srd->unhashed_rollup)
+			exclude_groups = srd->unhashed_rollup->numGroups;
 
 		hashsize = estimate_hashagg_tablesize(path,
 											  agg_costs,
@@ -4920,92 +4904,6 @@ consider_groupingsets_paths(PlannerInfo *root,
 			return;				/* nope, won't fit */
 
 		/*
-		 * We need to burst the existing rollups list into individual grouping
-		 * sets and recompute a groupClause for each set.
-		 */
-		sets_data = list_copy(gd->unsortable_sets);
-
-		for_each_cell(lc, l_start)
-		{
-			RollupData *rollup = lfirst_node(RollupData, lc);
-
-			/*
-			 * If we find an unhashable rollup that's not been skipped by the
-			 * "actually sorted" check above, we can't cope; we'd need sorted
-			 * input (with a different sort order) but we can't get that here.
-			 * So bail out; we'll get a valid path from the is_sorted case
-			 * instead.
-			 *
-			 * The mere presence of empty grouping sets doesn't make a rollup
-			 * unhashable (see preprocess_grouping_sets), we handle those
-			 * specially below.
-			 */
-			if (!rollup->hashable)
-				return;
-			else
-				sets_data = list_concat(sets_data, list_copy(rollup->gsets_data));
-		}
-		foreach(lc, sets_data)
-		{
-			GroupingSetData *gs = lfirst_node(GroupingSetData, lc);
-			List	   *gset = gs->set;
-			RollupData *rollup;
-
-			if (gset == NIL)
-			{
-				/* Empty grouping sets can't be hashed. */
-				empty_sets_data = lappend(empty_sets_data, gs);
-				empty_sets = lappend(empty_sets, NIL);
-			}
-			else
-			{
-				rollup = makeNode(RollupData);
-
-				rollup->groupClause = preprocess_groupclause(root, gset);
-				rollup->gsets_data = list_make1(gs);
-				rollup->gsets = remap_to_groupclause_idx(rollup->groupClause,
-														 rollup->gsets_data,
-														 gd->tleref_to_colnum_map);
-				rollup->numGroups = gs->numGroups;
-				rollup->hashable = true;
-				rollup->is_hashed = true;
-				new_rollups = lappend(new_rollups, rollup);
-			}
-		}
-
-		/*
-		 * If we didn't find anything nonempty to hash, then bail.  We'll
-		 * generate a path from the is_sorted case.
-		 */
-		if (new_rollups == NIL)
-			return;
-
-		/*
-		 * If there were empty grouping sets they should have been in the
-		 * first rollup.
-		 */
-		Assert(!unhashed_rollup || !empty_sets);
-
-		if (unhashed_rollup)
-		{
-			new_rollups = lappend(new_rollups, unhashed_rollup);
-			strat = AGG_MIXED;
-		}
-		else if (empty_sets)
-		{
-			RollupData *rollup = makeNode(RollupData);
-
-			rollup->groupClause = NIL;
-			rollup->gsets_data = empty_sets_data;
-			rollup->gsets = empty_sets;
-			rollup->numGroups = list_length(empty_sets);
-			rollup->hashable = false;
-			rollup->is_hashed = false;
-			new_rollups = lappend(new_rollups, rollup);
-			strat = AGG_MIXED;
-		}
-
-		/*
 		 * Unless the input happens to be suitable distributed, we
 		 * need to redistribute it.
 		 */
@@ -5014,7 +4912,7 @@ consider_groupingsets_paths(PlannerInfo *root,
 											   path,
 											   path->pathtarget,
 											   parse->groupClause,
-											   new_rollups);
+											   srd->new_rollups);
 
 		// GPDB_12_MERGE_FIXME: fix computation of dNumGroups
 #if 0
@@ -5036,8 +4934,8 @@ consider_groupingsets_paths(PlannerInfo *root,
 										  path,
 										  AGGSPLIT_SIMPLE,
 										  (List *) parse->havingQual,
-										  strat,
-										  new_rollups,
+										  srd->strat,
+										  srd->new_rollups,
 										  agg_costs,
 										  dNumGroups));
 		return;
@@ -7645,7 +7543,7 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 											 grouped_rel->reltarget,
 											 parse->groupClause ? AGG_SORTED : AGG_PLAIN,
 											 AGGSPLIT_FINAL_DESERIAL,
-                                             false,
+											 false,
 											 parse->groupClause,
 											 havingQual,
 											 agg_final_costs,
@@ -7864,9 +7762,24 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 		}
 
 		can_mpp_hash = (parse->groupClause != NIL &&
-			parse->groupingSets == NIL &&
-			agg_costs->numPureOrderedAggs == 0 &&
-			grouping_is_hashable(parse->groupClause));
+						agg_costs->numPureOrderedAggs == 0 &&
+						grouping_is_hashable(parse->groupClause));
+
+		AggStrategy   strat = AGG_HASHED;
+		List         *new_rollups = NIL;
+
+		if (can_mpp_hash)
+		{
+			split_rollup_data    *srd;
+
+			srd = make_new_rollups_for_hash_grouping_set(root, NULL, gd);
+
+			if (srd != NULL)
+			{
+				new_rollups = srd->new_rollups;
+				strat = srd->strat;
+			}
+		}
 
 		cdb_create_twostage_grouping_paths(root,
 										   input_rel,
@@ -7874,13 +7787,15 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 										   grouped_rel->reltarget,
 										   partially_grouped_target,
 										   havingQual,
-                                           ((extra->flags & GROUPING_CAN_USE_SORT) != 0), /* can_sort */
+										   can_sort,
 										   can_mpp_hash,
 										   dNumGroupsTotal,
 										   agg_costs,
 										   &extra->agg_partial_costs,
 										   &extra->agg_final_costs,
-										   gd ? gd->rollups : NIL);
+										   gd ? gd->rollups : NIL,
+										   new_rollups,
+										   strat);
 	}
 }
 
@@ -8718,4 +8633,142 @@ group_by_has_partkey(RelOptInfo *input_rel,
 	}
 
 	return true;
+}
+
+static split_rollup_data *
+make_new_rollups_for_hash_grouping_set(PlannerInfo        *root,
+									   Path               *path,
+									   grouping_sets_data *gd)
+{
+	split_rollup_data      *srd = NULL;
+	List	               *new_rollups = NIL;
+	RollupData             *unhashed_rollup = NULL;
+	List	               *sets_data;
+	List	               *empty_sets_data = NIL;
+	List	               *empty_sets = NIL;
+	ListCell               *lc;
+	ListCell               *l_start;
+	AggStrategy             strat = AGG_HASHED;
+
+	if (gd == NULL)
+		return NULL;
+
+	l_start = list_head(gd->rollups);
+
+	/*
+	 * If the input is coincidentally sorted usefully (which can happen
+	 * even if is_sorted is false, since that only means that our caller
+	 * has set up the sorting for us), then save some hashtable space by
+	 * making use of that. But we need to watch out for degenerate cases:
+	 *
+	 * 1) If there are any empty grouping sets, then group_pathkeys might
+	 * be NIL if all non-empty grouping sets are unsortable. In this case,
+	 * there will be a rollup containing only empty groups, and the
+	 * pathkeys_contained_in test is vacuously true; this is ok.
+	 *
+	 * XXX: the above relies on the fact that group_pathkeys is generated
+	 * from the first rollup. If we add the ability to consider multiple
+	 * sort orders for grouping input, this assumption might fail.
+	 *
+	 * 2) If there are no empty sets and only unsortable sets, then the
+	 * rollups list will be empty (and thus l_start == NULL), and
+	 * group_pathkeys will be NIL; we must ensure that the vacuously-true
+	 * pathkeys_contain_in test doesn't cause us to crash.
+	 */
+	if (l_start != NULL &&
+		path != NULL &&
+		pathkeys_contained_in(root->group_pathkeys, path->pathkeys))
+	{
+		unhashed_rollup = lfirst_node(RollupData, l_start);
+		l_start = lnext(l_start);
+	}
+
+	sets_data = list_copy(gd->unsortable_sets);
+
+	for_each_cell(lc, l_start)
+	{
+		RollupData *rollup = lfirst_node(RollupData, lc);
+
+		/*
+		 * If we find an unhashable rollup that's not been skipped by the
+		 * "actually sorted" check above, we can't cope; we'd need sorted
+		 * input (with a different sort order) but we can't get that here.
+		 * So bail out; we'll get a valid path from the is_sorted case
+		 * instead.
+		 *
+		 * The mere presence of empty grouping sets doesn't make a rollup
+		 * unhashable (see preprocess_grouping_sets), we handle those
+		 * specially below.
+		 */
+		if (!rollup->hashable)
+			return NULL;
+		else
+			sets_data = list_concat(sets_data, list_copy(rollup->gsets_data));
+	}
+	foreach(lc, sets_data)
+	{
+		GroupingSetData *gs = lfirst_node(GroupingSetData, lc);
+		List	   *gset = gs->set;
+		RollupData *rollup;
+
+		if (gset == NIL)
+		{
+			/* Empty grouping sets can't be hashed. */
+			empty_sets_data = lappend(empty_sets_data, gs);
+			empty_sets = lappend(empty_sets, NIL);
+		}
+		else
+		{
+			rollup = makeNode(RollupData);
+
+			rollup->groupClause = preprocess_groupclause(root, gset);
+			rollup->gsets_data = list_make1(gs);
+			rollup->gsets = remap_to_groupclause_idx(rollup->groupClause,
+													 rollup->gsets_data,
+													 gd->tleref_to_colnum_map);
+			rollup->numGroups = gs->numGroups;
+			rollup->hashable = true;
+			rollup->is_hashed = true;
+			new_rollups = lappend(new_rollups, rollup);
+		}
+	}
+
+	/*
+	 * If we didn't find anything nonempty to hash, then bail.  We'll
+	 * generate a path from the is_sorted case.
+	 */
+	if (new_rollups == NIL)
+		return NULL;
+
+	/*
+	 * If there were empty grouping sets they should have been in the
+	 * first rollup.
+	 */
+	Assert(!unhashed_rollup || !empty_sets);
+
+	if (unhashed_rollup)
+	{
+		new_rollups = lappend(new_rollups, unhashed_rollup);
+		strat = AGG_MIXED;
+	}
+	else if (empty_sets)
+	{
+		RollupData *rollup = makeNode(RollupData);
+
+		rollup->groupClause = NIL;
+		rollup->gsets_data = empty_sets_data;
+		rollup->gsets = empty_sets;
+		rollup->numGroups = list_length(empty_sets);
+		rollup->hashable = false;
+		rollup->is_hashed = false;
+		new_rollups = lappend(new_rollups, rollup);
+		strat = AGG_MIXED;
+	}
+
+	srd = (split_rollup_data *) palloc0(sizeof(*srd));
+	srd->strat = strat;
+	srd->new_rollups = new_rollups;
+	srd->unhashed_rollup = unhashed_rollup;
+
+	return srd;
 }

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3980,7 +3980,7 @@ struct config_real ConfigureNamesReal_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&disable_cost,
-		1.0e10, 1.0e10, 1.0e30,
+		1.0e30, 1.0e10, 1.0e30,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/cdb/cdbgroupingpaths.h
+++ b/src/include/cdb/cdbgroupingpaths.h
@@ -28,7 +28,9 @@ extern void cdb_create_twostage_grouping_paths(PlannerInfo *root,
 											   const AggClauseCosts *agg_costs,
 											   const AggClauseCosts *agg_partial_costs,
 											   const AggClauseCosts *agg_final_costs,
-											   List *rollups);
+											   List *rollups,
+											   List *new_rollups,
+											   AggStrategy strat);
 
 extern Path *cdb_prepare_path_for_sorted_agg(PlannerInfo *root,
 											 bool is_sorted,

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -1146,14 +1146,16 @@ explain (costs off) select * from t1 group by a,b,c,d;
 
 -- No removal can happen if the complete PK is not present in GROUP BY
 explain (costs off) select a,c from t1 group by a,c,d;
-                   QUERY PLAN                   
-------------------------------------------------
- Finalize HashAggregate
-   Group Key: a, c, d
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial HashAggregate
-               Group Key: a, c, d
-               ->  Seq Scan on t1
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Finalize HashAggregate
+         Group Key: a, c, d
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: a, c, d
+               ->  Partial HashAggregate
+                     Group Key: a, c, d
+                     ->  Seq Scan on t1
  Optimizer: Postgres query optimizer
 (7 rows)
 

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1678,23 +1678,25 @@ ANALYZE pagg_tab2;
 -- should have Redistribute Motion above the FULL JOIN
 EXPLAIN (COSTS OFF)
 SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x ORDER BY 1 NULLS LAST;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: a.x
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Merge Key: a.x
-         ->  Sort
-               Sort Key: a.x
-               ->  Partial HashAggregate
-                     Group Key: a.x
-                     ->  Hash Full Join
-                           Hash Cond: (a.x = b.y)
-                           ->  Seq Scan on pagg_tab1 a
-                           ->  Hash
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                       Hash Key: b.y
-                                       ->  Seq Scan on pagg_tab2 b
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: a.x
+   ->  Sort
+         Sort Key: a.x
+         ->  Finalize HashAggregate
+               Group Key: a.x
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: a.x
+                     ->  Partial HashAggregate
+                           Group Key: a.x
+                           ->  Hash Full Join
+                                 Hash Cond: (a.x = b.y)
+                                 ->  Seq Scan on pagg_tab1 a
+                                 ->  Hash
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                             Hash Key: b.y
+                                             ->  Seq Scan on pagg_tab2 b
  Optimizer: Postgres query optimizer
 (16 rows)
 

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -738,14 +738,13 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 (3 rows)
 
 explain (costs off) select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
-                       QUERY PLAN                        
----------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: gp_segment_id
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Merge Key: gp_segment_id
-         ->  Sort
-               Sort Key: gp_segment_id
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Finalize HashAggregate
+         Group Key: gp_segment_id
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: gp_segment_id
                ->  Partial HashAggregate
                      Group Key: gp_segment_id
                      ->  Seq Scan on t_test_dd_via_segid
@@ -753,6 +752,7 @@ explain (costs off) select gp_segment_id, count(*) from t_test_dd_via_segid grou
 (10 rows)
 
 select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
+INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  gp_segment_id | count 
 ---------------+-------

--- a/src/test/regress/expected/eagerfree.out
+++ b/src/test/regress/expected/eagerfree.out
@@ -38,23 +38,26 @@ select d, count(*) from smallt group by d;
 (20 rows)
 
 explain analyze select d, count(*) from smallt group by d;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
- Finalize HashAggregate  (cost=5.54..5.75 rows=21 width=12) (actual time=0.771..0.776 rows=20 loops=1)
-   Group Key: d
-   Peak Memory Usage: 24 kB
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1.50..5.27 rows=54 width=12) (actual time=0.226..0.753 rows=20 loops=1)
-         ->  Partial HashAggregate  (cost=1.50..1.68 rows=18 width=12) (actual time=0.033..0.035 rows=10 loops=1)
-               Group Key: d
-               Peak Memory Usage: 0 kB
-               ->  Seq Scan on smallt  (cost=0.00..1.33 rows=33 width=4) (actual time=0.008..0.014 rows=50 loops=1)
- Planning Time: 0.112 ms
-   (slice0)    Executor memory: 37K bytes.  Work_mem: 24K bytes max.
-   (slice1)    Executor memory: 22K bytes avg x 3 workers, 23K bytes max (seg0).  Work_mem: 24K bytes max.
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.56..5.03 rows=21 width=12) (actual time=1.756..1.764 rows=20 loops=1)
+   ->  Finalize HashAggregate  (cost=3.56..3.63 rows=7 width=12) (actual time=1.663..1.666 rows=7 loops=1)
+         Group Key: d
+         Peak Memory Usage: 0 kB
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.50..3.47 rows=18 width=12) (actual time=0.395..1.643 rows=7 loops=1)
+               Hash Key: d
+               ->  Partial HashAggregate  (cost=1.50..1.68 rows=18 width=12) (actual time=0.058..0.061 rows=10 loops=1)
+                     Group Key: d
+                     Peak Memory Usage: 0 kB
+                     ->  Seq Scan on smallt  (cost=0.00..1.33 rows=33 width=4) (actual time=0.017..0.024 rows=50 loops=1)
+ Planning Time: 0.306 ms
+   (slice0)    Executor memory: 40K bytes.
+   (slice1)    Executor memory: 19K bytes avg x 3 workers, 19K bytes max (seg1).  Work_mem: 24K bytes max.
+   (slice2)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).  Work_mem: 24K bytes max.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution Time: 1.056 ms
-(14 rows)
+ Execution Time: 2.695 ms
+(17 rows)
 
 set statement_mem=2560;
 select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;
@@ -166,44 +169,40 @@ where t1.d = t2.d;
 explain analyze select t1.*, t2.* from
 (select d, count(*) from smallt group by d) as t1, (select d, sum(i) from smallt group by d) as t2
 where t1.d = t2.d;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=7.70..19.67 rows=63 width=24) (actual time=11.994..13.558 rows=20 loops=1)
-   ->  Nested Loop  (cost=7.70..15.47 rows=21 width=24) (actual time=8.535..8.556 rows=7 loops=1)
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=7.13..9.56 rows=21 width=24) (actual time=1.607..2.287 rows=20 loops=1)
+   ->  Nested Loop  (cost=7.13..8.16 rows=7 width=24) (actual time=1.790..1.809 rows=7 loops=1)
          Join Filter: (smallt.d = smallt_1.d)
          Rows Removed by Join Filter: 21
-         ->  Finalize GroupAggregate  (cost=3.85..4.19 rows=21 width=12) (actual time=8.510..8.516 rows=7 loops=1)
+         ->  Finalize HashAggregate  (cost=3.56..3.63 rows=7 width=12) (actual time=1.302..1.306 rows=7 loops=1)
                Group Key: smallt.d
-               ->  Sort  (cost=3.85..3.89 rows=18 width=12) (actual time=8.501..8.503 rows=7 loops=1)
-                     Sort Key: smallt.d
-                     Sort Method:  quicksort  Memory: 150kB
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.50..3.47 rows=18 width=12) (actual time=0.867..8.491 rows=7 loops=1)
-                           Hash Key: smallt.d
-                           ->  Partial HashAggregate  (cost=1.50..1.68 rows=18 width=12) (actual time=0.037..0.040 rows=10 loops=1)
-                                 Group Key: smallt.d
-                                 Peak Memory Usage: 0 kB
-                                 ->  Seq Scan on smallt  (cost=0.00..1.33 rows=33 width=4) (actual time=0.010..0.016 rows=50 loops=1)
-         ->  Materialize  (cost=3.85..4.51 rows=21 width=12) (actual time=0.003..0.004 rows=4 loops=7)
-               ->  Finalize GroupAggregate  (cost=3.85..4.19 rows=21 width=12) (actual time=0.017..0.021 rows=7 loops=1)
+               Peak Memory Usage: 0 kB
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.50..3.47 rows=18 width=12) (actual time=0.659..1.284 rows=7 loops=1)
+                     Hash Key: smallt.d
+                     ->  Partial HashAggregate  (cost=1.50..1.68 rows=18 width=12) (actual time=0.055..0.058 rows=10 loops=1)
+                           Group Key: smallt.d
+                           Peak Memory Usage: 0 kB
+                           ->  Seq Scan on smallt  (cost=0.00..1.33 rows=33 width=4) (actual time=0.015..0.022 rows=50 loops=1)
+         ->  Materialize  (cost=3.56..3.74 rows=7 width=12) (actual time=0.069..0.070 rows=4 loops=7)
+               ->  Finalize HashAggregate  (cost=3.56..3.63 rows=7 width=12) (actual time=0.480..0.482 rows=7 loops=1)
                      Group Key: smallt_1.d
-                     ->  Sort  (cost=3.85..3.89 rows=18 width=12) (actual time=0.013..0.014 rows=7 loops=1)
-                           Sort Key: smallt_1.d
-                           Sort Method:  quicksort  Memory: 150kB
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=1.50..3.47 rows=18 width=12) (actual time=0.004..0.006 rows=7 loops=1)
-                                 Hash Key: smallt_1.d
-                                 ->  Partial HashAggregate  (cost=1.50..1.68 rows=18 width=12) (actual time=0.040..0.042 rows=10 loops=1)
-                                       Group Key: smallt_1.d
-                                       Peak Memory Usage: 0 kB
-                                       ->  Seq Scan on smallt smallt_1  (cost=0.00..1.33 rows=33 width=8) (actual time=0.015..0.020 rows=50 loops=1)
- Planning Time: 0.229 ms
-   (slice0)    Executor memory: 87K bytes.
-   (slice1)    Executor memory: 82K bytes avg x 3 workers, 82K bytes max (seg1).  Work_mem: 26K bytes max.
+                     Peak Memory Usage: 0 kB
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=1.50..3.47 rows=18 width=12) (actual time=0.003..0.470 rows=7 loops=1)
+                           Hash Key: smallt_1.d
+                           ->  Partial HashAggregate  (cost=1.50..1.68 rows=18 width=12) (actual time=0.084..0.090 rows=10 loops=1)
+                                 Group Key: smallt_1.d
+                                 Peak Memory Usage: 0 kB
+                                 ->  Seq Scan on smallt smallt_1  (cost=0.00..1.33 rows=33 width=8) (actual time=0.022..0.033 rows=50 loops=1)
+ Planning Time: 0.645 ms
+   (slice0)    Executor memory: 80K bytes.
+   (slice1)    Executor memory: 56K bytes avg x 3 workers, 56K bytes max (seg1).  Work_mem: 24K bytes max.
    (slice2)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).  Work_mem: 24K bytes max.
    (slice3)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).  Work_mem: 24K bytes max.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution Time: 14.134 ms
-(35 rows)
+ Execution Time: 3.142 ms
+(31 rows)
 
 set enable_nestloop=off;
 set enable_hashjoin=on;
@@ -235,24 +234,26 @@ explain analyze select t1.*, t2.* from
 where t1.i = t2.i;
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=9.00..10.92 rows=10 width=24) (actual time=0.691..0.711 rows=10 loops=1)
-   ->  Nested Loop  (cost=9.00..10.92 rows=4 width=24) (actual time=0.263..0.341 rows=5 loops=1)
-         Join Filter: public.smallt.i = public.smallt.i
-         ->  HashAggregate  (cost=4.50..4.60 rows=4 width=12) (actual time=0.062..0.076 rows=5 loops=1)
-               Group Key: public.smallt.i
-               (seg1)   Hash chain length 1.0 avg, 1 max, using 5 of 32 buckets; total 0 expansions.
-               ->  Seq Scan on smallt  (cost=0.00..4.00 rows=34 width=4) (actual time=0.006..0.024 rows=50 loops=1)
-         ->  Materialize  (cost=4.50..4.75 rows=4 width=12) (actual time=0.033..0.034 rows=4 loops=6)
-               ->  HashAggregate  (cost=4.50..4.60 rows=4 width=12) (actual time=0.080..0.102 rows=5 loops=1)
-                     Group Key: public.smallt.i
-                     (seg1)   Hash chain length 1.0 avg, 1 max, using 5 of 32 buckets; total 0 expansions.
-                     ->  Seq Scan on smallt smallt_1  (cost=0.00..4.00 rows=34 width=4) (actual time=0.012..0.030 rows=50 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 278K bytes avg x 3 workers, 278K bytes max (seg0).
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.00..3.98 rows=10 width=24) (actual time=0.448..0.454 rows=10 loops=1)
+   ->  Nested Loop  (cost=3.00..3.31 rows=3 width=24) (actual time=0.108..0.120 rows=5 loops=1)
+         Join Filter: (smallt.i = smallt_1.i)
+         Rows Removed by Join Filter: 10
+         ->  HashAggregate  (cost=1.50..1.53 rows=3 width=12) (actual time=0.066..0.068 rows=5 loops=1)
+               Group Key: smallt.i
+               Peak Memory Usage: 0 kB
+               ->  Seq Scan on smallt  (cost=0.00..1.33 rows=33 width=4) (actual time=0.025..0.032 rows=50 loops=1)
+         ->  Materialize  (cost=1.50..1.58 rows=3 width=12) (actual time=0.008..0.009 rows=3 loops=5)
+               ->  HashAggregate  (cost=1.50..1.53 rows=3 width=12) (actual time=0.036..0.038 rows=5 loops=1)
+                     Group Key: smallt_1.i
+                     Peak Memory Usage: 0 kB
+                     ->  Seq Scan on smallt smallt_1  (cost=0.00..1.33 rows=33 width=4) (actual time=0.003..0.010 rows=50 loops=1)
+ Planning Time: 0.591 ms
+   (slice0)    Executor memory: 48K bytes.
+   (slice1)    Executor memory: 61K bytes avg x 3 workers, 61K bytes max (seg0).  Work_mem: 24K bytes max.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Total runtime: 1.614 ms
-(17 rows)
+ Execution Time: 1.119 ms
+(19 rows)
 
 set enable_nestloop=off;
 set enable_hashjoin=on;

--- a/src/test/regress/expected/gangsize.out
+++ b/src/test/regress/expected/gangsize.out
@@ -52,56 +52,64 @@ INFO:  (slice 4) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 1) Dispatch command to SINGLE content
 INFO:  (slice 3) Dispatch command to SINGLE content
 select replicate_3_3.d, replicate_2_1.d, avg(random_2_0.c), max(hash_3_3_2.a) from ((((random_2_0 left join replicate_2_1 on random_2_0.c <= replicate_2_1.d) full join hash_3_3_2 on random_2_0.a > hash_3_3_2.d) full join replicate_3_3 on hash_3_3_2.a >= replicate_3_3.b) right join hash_2_3_4 on random_2_0.a = hash_2_3_4.b) left join replicate_2_5 on random_2_0.a > replicate_2_5.b group by replicate_3_3.d, replicate_2_1.d order by 1,2;
-INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 4) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 4) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 5) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 3) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 2) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
 select hash_3_3_2.b, replicate_2_1.c, max(replicate_3_3.d), avg(random_2_0.a) from (random_2_0 right join (replicate_2_1 left join hash_3_3_2 on replicate_2_1.b <> hash_3_3_2.b) on random_2_0.a <> hash_3_3_2.a) right join ((replicate_3_3 inner join hash_2_3_4 on replicate_3_3.b < hash_2_3_4.c) left join replicate_2_5 on hash_2_3_4.b < replicate_2_5.d) on hash_3_3_2.a > hash_2_3_4.b group by hash_3_3_2.b, replicate_2_1.c order by 1,2;
 INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 4) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 2) Dispatch command to SINGLE content
 select replicate_2_1.c, random_2_0.c, sum(replicate_3_3.a), max(replicate_2_5.c) from (random_2_0 left join replicate_2_1 on random_2_0.d <= replicate_2_1.b) right join (hash_3_3_2 inner join (replicate_3_3 inner join (hash_2_3_4 right join replicate_2_5 on hash_2_3_4.b <> replicate_2_5.a) on replicate_3_3.b = hash_2_3_4.b) on hash_3_3_2.a <> replicate_2_5.a) on replicate_2_1.c <> replicate_3_3.c group by replicate_2_1.c, random_2_0.c order by 1,2;
-INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 5) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 4) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 6) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 3) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 2) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 4) Dispatch command to SINGLE content
+INFO:  (slice 5) Dispatch command to SINGLE content
 select hash_2_3_4.d, replicate_2_1.b, sum(random_2_0.a), count(replicate_2_5.d) from ((random_2_0 left join replicate_2_1 on random_2_0.b = replicate_2_1.b) right join (hash_3_3_2 full join replicate_3_3 on hash_3_3_2.b <= replicate_3_3.d) on replicate_2_1.c > hash_3_3_2.b) inner join (hash_2_3_4 right join replicate_2_5 on hash_2_3_4.a < replicate_2_5.d) on replicate_2_1.b < replicate_2_5.d group by hash_2_3_4.d, replicate_2_1.b order by 1,2;
 INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 4) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 2) Dispatch command to PARTIAL contents: 0 1
 select replicate_3_3.d, random_2_0.c, count(hash_3_3_2.d), count(hash_2_3_4.b) from ((random_2_0 full join (replicate_2_1 right join hash_3_3_2 on replicate_2_1.b > hash_3_3_2.c) on random_2_0.b >= hash_3_3_2.a) inner join replicate_3_3 on hash_3_3_2.d < replicate_3_3.a) left join (hash_2_3_4 full join replicate_2_5 on hash_2_3_4.a <> replicate_2_5.a) on random_2_0.d = hash_2_3_4.c group by replicate_3_3.d, random_2_0.c order by 1,2;
-INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 4) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 4) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 5) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 2) Dispatch command to SINGLE content
+INFO:  (slice 6) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 2) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 3) Dispatch command to SINGLE content
 select random_2_0.d, replicate_2_1.a, max(hash_3_3_2.b), count(replicate_2_5.b) from (random_2_0 left join replicate_2_1 on random_2_0.c <> replicate_2_1.b) inner join (hash_3_3_2 full join ((replicate_3_3 inner join hash_2_3_4 on replicate_3_3.d <> hash_2_3_4.d) left join replicate_2_5 on hash_2_3_4.d < replicate_2_5.b) on hash_3_3_2.c > hash_2_3_4.b) on random_2_0.b < replicate_2_5.d group by random_2_0.d, replicate_2_1.a order by 1,2;
-INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 4) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 3) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 2) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
 select replicate_2_5.c, hash_3_3_2.c, sum(replicate_3_3.c), max(hash_2_3_4.c) from ((random_2_0 inner join replicate_2_1 on random_2_0.a = replicate_2_1.d) right join hash_3_3_2 on replicate_2_1.c <> hash_3_3_2.c) left join ((replicate_3_3 inner join hash_2_3_4 on replicate_3_3.d <= hash_2_3_4.c) right join replicate_2_5 on replicate_3_3.d > replicate_2_5.b) on hash_3_3_2.b = hash_2_3_4.b group by replicate_2_5.c, hash_3_3_2.c order by 1,2;
-INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 4) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 3) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 5) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 2) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 4) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
 select hash_3_3_2.a, replicate_3_3.b, max(random_2_0.c), sum(replicate_2_1.a) from random_2_0 full join (replicate_2_1 inner join ((hash_3_3_2 inner join (replicate_3_3 inner join hash_2_3_4 on replicate_3_3.d >= hash_2_3_4.d) on hash_3_3_2.c >= replicate_3_3.d) inner join replicate_2_5 on replicate_3_3.b <= replicate_2_5.d) on replicate_2_1.c > replicate_3_3.a) on random_2_0.d = hash_3_3_2.d group by hash_3_3_2.a, replicate_3_3.b order by 1,2;
-INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
-INFO:  (slice 4) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 4) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 5) Dispatch command to PARTIAL contents: 0 1
+INFO:  (slice 3) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 2) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
 select replicate_2_1.d, random_2_0.c, sum(hash_3_3_2.d), max(replicate_3_3.d) from (random_2_0 right join (replicate_2_1 inner join hash_3_3_2 on replicate_2_1.d >= hash_3_3_2.c) on random_2_0.c <= hash_3_3_2.c) inner join ((replicate_3_3 full join hash_2_3_4 on replicate_3_3.d <= hash_2_3_4.b) left join replicate_2_5 on replicate_3_3.d <= replicate_2_5.b) on random_2_0.b > replicate_2_5.b group by replicate_2_1.d, random_2_0.c order by 1,2;
-INFO:  (slice 4) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 5) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 3) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 2) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 3) Dispatch command to SINGLE content
+INFO:  (slice 4) Dispatch command to SINGLE content
 select replicate_3_3.d, hash_3_3_2.a, avg(replicate_2_5.d), max(replicate_2_1.d) from random_2_0 right join ((replicate_2_1 right join hash_3_3_2 on replicate_2_1.b <= hash_3_3_2.a) inner join (replicate_3_3 right join (hash_2_3_4 right join replicate_2_5 on hash_2_3_4.c = replicate_2_5.d) on replicate_3_3.b >= hash_2_3_4.c) on hash_3_3_2.b <> hash_2_3_4.c) on random_2_0.c >= hash_2_3_4.b group by replicate_3_3.d, hash_3_3_2.a order by 1,2;
-INFO:  (slice 4) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 5) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 3) Dispatch command to PARTIAL contents: 0 1
 INFO:  (slice 2) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
-INFO:  (slice 3) Dispatch command to SINGLE content
+INFO:  (slice 4) Dispatch command to SINGLE content
 select hash_2_3_4.c, replicate_2_1.b, sum(replicate_3_3.b), avg(replicate_2_5.a) from random_2_0 left join (replicate_2_1 right join ((hash_3_3_2 left join replicate_3_3 on hash_3_3_2.d >= replicate_3_3.b) right join (hash_2_3_4 right join replicate_2_5 on hash_2_3_4.d <> replicate_2_5.d) on replicate_3_3.d <= replicate_2_5.a) on replicate_2_1.b <= replicate_2_5.d) on random_2_0.a < replicate_3_3.a group by hash_2_3_4.c, replicate_2_1.b order by 1,2;
 INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1

--- a/src/test/regress/expected/gp_aggregates_costs.out
+++ b/src/test/regress/expected/gp_aggregates_costs.out
@@ -13,16 +13,18 @@ set statement_mem= '1800 kB';
 -- There are only 2000 distinct values of 'c' in the table, which fits
 -- comfortably in an in-memory hash table.
 explain select avg(b) from cost_agg_t1 group by c;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Finalize HashAggregate  (cost=5579.00..5604.00 rows=2000 width=36)
-   Group Key: c
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=5449.00..5549.00 rows=6000 width=36)
-         ->  Partial HashAggregate  (cost=5449.00..5469.00 rows=2000 width=36)
-               Group Key: c
-               ->  Seq Scan on cost_agg_t1  (cost=0.00..3782.33 rows=333333 width=8)
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=5519.00..5554.00 rows=2000 width=36)
+   ->  Finalize HashAggregate  (cost=5519.00..5527.33 rows=667 width=36)
+         Group Key: c
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=5449.00..5509.00 rows=2000 width=36)
+               Hash Key: c
+               ->  Partial HashAggregate  (cost=5449.00..5469.00 rows=2000 width=36)
+                     Group Key: c
+                     ->  Seq Scan on cost_agg_t1  (cost=0.00..3782.33 rows=333333 width=8)
  Optimizer: Postgres query optimizer
-(7 rows)
+(9 rows)
 
 -- In the other table, there are 300000 distinct values of 'c', which doesn't
 -- fit in statement_mem. The planner chooses to do a single-phase agg for this.
@@ -34,32 +36,35 @@ explain select avg(b) from cost_agg_t1 group by c;
 explain select avg(b) from cost_agg_t2 group by c;
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=12115.67..17035.13 rows=281112 width=36)
-   ->  HashAggregate  (cost=12115.67..13286.97 rows=93704 width=36)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=12115.67..17309.12 rows=296769 width=36)
+   ->  HashAggregate  (cost=12115.67..13352.20 rows=98923 width=36)
          Group Key: c
+         Planned Partitions: 8
          ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..10449.00 rows=333333 width=8)
                Hash Key: c
                ->  Seq Scan on cost_agg_t2  (cost=0.00..3782.33 rows=333333 width=8)
  Optimizer: Postgres query optimizer
-(7 rows)
+(8 rows)
 
 -- But if there are a lot more duplicate values, the two-stage plan becomes
 -- cheaper again, even though it doesn't git in memory and has to spill.
 insert into cost_agg_t2 select i, random() * 99999,1 from generate_series(1, 200000) i;
 analyze cost_agg_t2;
 explain select avg(b) from cost_agg_t2 group by c;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
- Finalize HashAggregate  (cost=13092.74..14363.89 rows=101692 width=36)
-   Group Key: c
-   Planned Partitions: 8
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=6538.00..11580.11 rows=302526 width=36)
-         ->  Partial HashAggregate  (cost=6538.00..7546.42 rows=100842 width=36)
-               Group Key: c
-               Planned Partitions: 8
-               ->  Seq Scan on cost_agg_t2  (cost=0.00..4538.00 rows=400000 width=8)
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10113.08..11916.68 rows=103063 width=36)
+   ->  Finalize HashAggregate  (cost=10113.08..10542.51 rows=34354 width=36)
+         Group Key: c
+         Planned Partitions: 8
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=6538.00..9602.35 rows=102145 width=36)
+               Hash Key: c
+               ->  Partial HashAggregate  (cost=6538.00..7559.45 rows=102145 width=36)
+                     Group Key: c
+                     Planned Partitions: 8
+                     ->  Seq Scan on cost_agg_t2  (cost=0.00..4538.00 rows=400000 width=8)
  Optimizer: Postgres query optimizer
-(9 rows)
+(11 rows)
 
 drop table cost_agg_t1;
 drop table cost_agg_t2;

--- a/src/test/regress/expected/gp_hashagg.out
+++ b/src/test/regress/expected/gp_hashagg.out
@@ -143,19 +143,22 @@ GROUP BY b
 HAVING max(c) = '31'
 $$ AS qry \gset
 EXPLAIN (COSTS OFF, VERBOSE) :qry;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Finalize HashAggregate
-   Output: sum(a) FILTER (WHERE false), b
-   Group Key: test_combinefn_null.b
-   Filter: (max(test_combinefn_null.c) = '31'::bpchar)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: b, (PARTIAL sum(a) FILTER (WHERE false)), (PARTIAL max(c))
-         ->  Partial HashAggregate
-               Output: b, PARTIAL sum(a) FILTER (WHERE false), PARTIAL max(c)
-               Group Key: test_combinefn_null.b
-               ->  Seq Scan on public.test_combinefn_null
-                     Output: a, b, c
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(a) FILTER (WHERE false)), b
+   ->  Finalize HashAggregate
+         Output: sum(a) FILTER (WHERE false), b
+         Group Key: test_combinefn_null.b
+         Filter: (max(test_combinefn_null.c) = '31'::bpchar)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: b, (PARTIAL sum(a) FILTER (WHERE false)), (PARTIAL max(c))
+               Hash Key: b
+               ->  Partial HashAggregate
+                     Output: b, PARTIAL sum(a) FILTER (WHERE false), PARTIAL max(c)
+                     Group Key: test_combinefn_null.b
+                     ->  Seq Scan on public.test_combinefn_null
+                           Output: a, b, c
  Optimizer: Postgres query optimizer
  Settings: enable_indexscan=off, enable_seqscan=on, enable_sort=off, optimizer=off
 (13 rows)
@@ -175,19 +178,22 @@ GROUP BY b
 HAVING max(c) = '31'
 $$ AS qry \gset
 EXPLAIN (COSTS OFF, VERBOSE) :qry;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
- Finalize HashAggregate
-   Output: var_pop((a)::integer) FILTER (WHERE false), b
-   Group Key: test_combinefn_null.b
-   Filter: (max(test_combinefn_null.c) = '31'::bpchar)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: b, (PARTIAL var_pop((a)::integer) FILTER (WHERE false)), (PARTIAL max(c))
-         ->  Partial HashAggregate
-               Output: b, PARTIAL var_pop((a)::integer) FILTER (WHERE false), PARTIAL max(c)
-               Group Key: test_combinefn_null.b
-               ->  Seq Scan on public.test_combinefn_null
-                     Output: a, b, c
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (var_pop((a)::integer) FILTER (WHERE false)), b
+   ->  Finalize HashAggregate
+         Output: var_pop((a)::integer) FILTER (WHERE false), b
+         Group Key: test_combinefn_null.b
+         Filter: (max(test_combinefn_null.c) = '31'::bpchar)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: b, (PARTIAL var_pop((a)::integer) FILTER (WHERE false)), (PARTIAL max(c))
+               Hash Key: b
+               ->  Partial HashAggregate
+                     Output: b, PARTIAL var_pop((a)::integer) FILTER (WHERE false), PARTIAL max(c)
+                     Group Key: test_combinefn_null.b
+                     ->  Seq Scan on public.test_combinefn_null
+                           Output: a, b, c
  Optimizer: Postgres query optimizer
  Settings: enable_indexscan=off, enable_seqscan=on, enable_sort=off, optimizer=off
 (13 rows)
@@ -207,19 +213,22 @@ GROUP BY b
 HAVING max(c) = '31'
 $$ AS qry \gset
 EXPLAIN (COSTS OFF, VERBOSE) :qry;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Finalize HashAggregate
-   Output: sum((a)::numeric) FILTER (WHERE false), b
-   Group Key: test_combinefn_null.b
-   Filter: (max(test_combinefn_null.c) = '31'::bpchar)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: b, (PARTIAL sum((a)::numeric) FILTER (WHERE false)), (PARTIAL max(c))
-         ->  Partial HashAggregate
-               Output: b, PARTIAL sum((a)::numeric) FILTER (WHERE false), PARTIAL max(c)
-               Group Key: test_combinefn_null.b
-               ->  Seq Scan on public.test_combinefn_null
-                     Output: a, b, c
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum((a)::numeric) FILTER (WHERE false)), b
+   ->  Finalize HashAggregate
+         Output: sum((a)::numeric) FILTER (WHERE false), b
+         Group Key: test_combinefn_null.b
+         Filter: (max(test_combinefn_null.c) = '31'::bpchar)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: b, (PARTIAL sum((a)::numeric) FILTER (WHERE false)), (PARTIAL max(c))
+               Hash Key: b
+               ->  Partial HashAggregate
+                     Output: b, PARTIAL sum((a)::numeric) FILTER (WHERE false), PARTIAL max(c)
+                     Group Key: test_combinefn_null.b
+                     ->  Seq Scan on public.test_combinefn_null
+                           Output: a, b, c
  Optimizer: Postgres query optimizer
  Settings: enable_indexscan=off, enable_seqscan=on, enable_sort=off, optimizer=off
 (13 rows)
@@ -239,19 +248,22 @@ GROUP BY b
 HAVING max(c) = '31'
 $$ AS qry \gset
 EXPLAIN (COSTS OFF, VERBOSE) :qry;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
- Finalize HashAggregate
-   Output: var_pop((a)::numeric) FILTER (WHERE false), b
-   Group Key: test_combinefn_null.b
-   Filter: (max(test_combinefn_null.c) = '31'::bpchar)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: b, (PARTIAL var_pop((a)::numeric) FILTER (WHERE false)), (PARTIAL max(c))
-         ->  Partial HashAggregate
-               Output: b, PARTIAL var_pop((a)::numeric) FILTER (WHERE false), PARTIAL max(c)
-               Group Key: test_combinefn_null.b
-               ->  Seq Scan on public.test_combinefn_null
-                     Output: a, b, c
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (var_pop((a)::numeric) FILTER (WHERE false)), b
+   ->  Finalize HashAggregate
+         Output: var_pop((a)::numeric) FILTER (WHERE false), b
+         Group Key: test_combinefn_null.b
+         Filter: (max(test_combinefn_null.c) = '31'::bpchar)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: b, (PARTIAL var_pop((a)::numeric) FILTER (WHERE false)), (PARTIAL max(c))
+               Hash Key: b
+               ->  Partial HashAggregate
+                     Output: b, PARTIAL var_pop((a)::numeric) FILTER (WHERE false), PARTIAL max(c)
+                     Group Key: test_combinefn_null.b
+                     ->  Seq Scan on public.test_combinefn_null
+                           Output: a, b, c
  Optimizer: Postgres query optimizer
  Settings: enable_indexscan=off, enable_seqscan=on, enable_sort=off, optimizer=off
 (13 rows)

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10231,26 +10231,28 @@ WHERE tq.sym = tt.symbol AND
       tt.event_ts <  tq.end_ts
 GROUP BY 1
 ORDER BY 1 asc ;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=39942.80..40017.80 rows=1000 width=16)
-   Group Key: ((((tt.event_ts / 100000) / 5) * 5))
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=39942.80..39985.30 rows=3000 width=16)
-         Merge Key: ((((tt.event_ts / 100000) / 5) * 5))
-         ->  Sort  (cost=39942.80..39945.30 rows=1000 width=16)
-               Sort Key: ((((tt.event_ts / 100000) / 5) * 5))
-               ->  Partial HashAggregate  (cost=39875.47..39892.97 rows=1000 width=16)
-                     Group Key: (((tt.event_ts / 100000) / 5) * 5)
-                     ->  Hash Join  (cost=202.00..39819.05 rows=11283 width=8)
-                           Hash Cond: ((tq.sym)::bpchar = tt.symbol)
-                           Join Filter: ((tt.event_ts >= tq.ets) AND (tt.event_ts < tq.end_ts) AND (plusone(tq.bid_price) < tt.trade_price))
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..544.00 rows=13600 width=98)
-                                 Hash Key: tq.sym
-                                 ->  Append  (cost=0.00..272.00 rows=13600 width=98)
-                                       ->  Seq Scan on my_tq_agg_opt_part_1_prt_p1 tq  (cost=0.00..102.00 rows=6800 width=98)
-                                       ->  Seq Scan on my_tq_agg_opt_part_1_prt_p2 tq_1  (cost=0.00..102.00 rows=6800 width=98)
-                           ->  Hash  (cost=108.67..108.67 rows=7467 width=108)
-                                 ->  Seq Scan on my_tt_agg_opt tt  (cost=0.00..108.67 rows=7467 width=108)
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=39937.77..39951.93 rows=1000 width=16)
+   Merge Key: ((((tt.event_ts / 100000) / 5) * 5))
+   ->  Sort  (cost=39937.77..39938.60 rows=333 width=16)
+         Sort Key: ((((tt.event_ts / 100000) / 5) * 5))
+         ->  Finalize HashAggregate  (cost=39917.97..39923.80 rows=333 width=16)
+               Group Key: ((((tt.event_ts / 100000) / 5) * 5))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=39875.47..39912.97 rows=1000 width=16)
+                     Hash Key: ((((tt.event_ts / 100000) / 5) * 5))
+                     ->  Partial HashAggregate  (cost=39875.47..39892.97 rows=1000 width=16)
+                           Group Key: (((tt.event_ts / 100000) / 5) * 5)
+                           ->  Hash Join  (cost=202.00..39819.05 rows=11283 width=8)
+                                 Hash Cond: ((tq.sym)::bpchar = tt.symbol)
+                                 Join Filter: ((tt.event_ts >= tq.ets) AND (tt.event_ts < tq.end_ts) AND (plusone(tq.bid_price) < tt.trade_price))
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..544.00 rows=13600 width=98)
+                                       Hash Key: tq.sym
+                                       ->  Append  (cost=0.00..272.00 rows=13600 width=98)
+                                             ->  Seq Scan on my_tq_agg_opt_part_1_prt_p1 tq  (cost=0.00..102.00 rows=6800 width=98)
+                                             ->  Seq Scan on my_tq_agg_opt_part_1_prt_p2 tq_1  (cost=0.00..102.00 rows=6800 width=98)
+                                 ->  Hash  (cost=108.67..108.67 rows=7467 width=108)
+                                       ->  Seq Scan on my_tt_agg_opt tt  (cost=0.00..108.67 rows=7467 width=108)
  Optimizer: Postgres query optimizer
 (19 rows)
 
@@ -10638,16 +10640,20 @@ set log_statement='none';
 set log_min_duration_statement=-1;
 set client_min_messages='log';
 explain select count(*) from foo group by cube(a,b);
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- MixedAggregate  (cost=0.00..3297.11 rows=10611 width=16)
-   Hash Key: a, b
-   Hash Key: a
-   Hash Key: b
-   Group Key: ()
-   Planned Partitions: 4
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
-         ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1319.44..1496.29 rows=10611 width=16)
+   ->  Finalize HashAggregate  (cost=1319.44..1354.81 rows=3537 width=16)
+         Group Key: a, b, (GROUPINGSET_ID())
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1213.33 rows=10611 width=16)
+               Hash Key: a, b, (GROUPINGSET_ID())
+               ->  Partial MixedAggregate  (cost=0.00..1001.11 rows=10611 width=16)
+                     Hash Key: a, b
+                     Hash Key: a
+                     Hash Key: b
+                     Group Key: ()
+                     Planned Partitions: 4
+                     ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
  Optimizer: Postgres query optimizer
 (9 rows)
 
@@ -12896,12 +12902,13 @@ select * from foo join (select min_a, count(*) as cnt from (select min(a) as min
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: (grby1.min_a = foo.a)
-         ->  HashAggregate
-               Group Key: grby1.min_a
+         Hash Cond: ((min(tbitmap.a)) = foo.a)
+         ->  Finalize HashAggregate
+               Group Key: (min(tbitmap.a))
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: grby1.min_a
-                     ->  Subquery Scan on grby1
+                     Hash Key: (min(tbitmap.a))
+                     ->  Partial HashAggregate
+                           Group Key: min(tbitmap.a)
                            ->  HashAggregate
                                  Group Key: tbitmap.b
                                  ->  Redistribute Motion 3:3  (slice3; segments: 3)

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10567,26 +10567,28 @@ GROUP BY 1
 ORDER BY 1 asc ;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  No plan has been computed for required properties
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=39942.80..40017.80 rows=1000 width=16)
-   Group Key: ((((tt.event_ts / 100000) / 5) * 5))
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=39942.80..39985.30 rows=3000 width=16)
-         Merge Key: ((((tt.event_ts / 100000) / 5) * 5))
-         ->  Sort  (cost=39942.80..39945.30 rows=1000 width=16)
-               Sort Key: ((((tt.event_ts / 100000) / 5) * 5))
-               ->  Partial HashAggregate  (cost=39875.47..39892.97 rows=1000 width=16)
-                     Group Key: (((tt.event_ts / 100000) / 5) * 5)
-                     ->  Hash Join  (cost=202.00..39819.05 rows=11283 width=8)
-                           Hash Cond: ((tq.sym)::bpchar = tt.symbol)
-                           Join Filter: ((tt.event_ts >= tq.ets) AND (tt.event_ts < tq.end_ts) AND (plusone(tq.bid_price) < tt.trade_price))
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..544.00 rows=13600 width=98)
-                                 Hash Key: tq.sym
-                                 ->  Append  (cost=0.00..272.00 rows=13600 width=98)
-                                       ->  Seq Scan on my_tq_agg_opt_part_1_prt_p1 tq  (cost=0.00..102.00 rows=6800 width=98)
-                                       ->  Seq Scan on my_tq_agg_opt_part_1_prt_p2 tq_1  (cost=0.00..102.00 rows=6800 width=98)
-                           ->  Hash  (cost=108.67..108.67 rows=7467 width=108)
-                                 ->  Seq Scan on my_tt_agg_opt tt  (cost=0.00..108.67 rows=7467 width=108)
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=39937.77..39951.93 rows=1000 width=16)
+   Merge Key: ((((tt.event_ts / 100000) / 5) * 5))
+   ->  Sort  (cost=39937.77..39938.60 rows=333 width=16)
+         Sort Key: ((((tt.event_ts / 100000) / 5) * 5))
+         ->  Finalize HashAggregate  (cost=39917.97..39923.80 rows=333 width=16)
+               Group Key: ((((tt.event_ts / 100000) / 5) * 5))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=39875.47..39912.97 rows=1000 width=16)
+                     Hash Key: ((((tt.event_ts / 100000) / 5) * 5))
+                     ->  Partial HashAggregate  (cost=39875.47..39892.97 rows=1000 width=16)
+                           Group Key: (((tt.event_ts / 100000) / 5) * 5)
+                           ->  Hash Join  (cost=202.00..39819.05 rows=11283 width=8)
+                                 Hash Cond: ((tq.sym)::bpchar = tt.symbol)
+                                 Join Filter: ((tt.event_ts >= tq.ets) AND (tt.event_ts < tq.end_ts) AND (plusone(tq.bid_price) < tt.trade_price))
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..544.00 rows=13600 width=98)
+                                       Hash Key: tq.sym
+                                       ->  Append  (cost=0.00..272.00 rows=13600 width=98)
+                                             ->  Seq Scan on my_tq_agg_opt_part_1_prt_p1 tq  (cost=0.00..102.00 rows=6800 width=98)
+                                             ->  Seq Scan on my_tq_agg_opt_part_1_prt_p2 tq_1  (cost=0.00..102.00 rows=6800 width=98)
+                                 ->  Hash  (cost=108.67..108.67 rows=7467 width=108)
+                                       ->  Seq Scan on my_tt_agg_opt tt  (cost=0.00..108.67 rows=7467 width=108)
  Optimizer: Postgres query optimizer
 (19 rows)
 
@@ -10988,16 +10990,20 @@ explain select count(*) from foo group by cube(a,b);
 LOG:  2019-05-31 15:13:50:374760 PDT,THD000,NOTICE,"Feature not supported: Grouping Sets",
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Grouping Sets
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- MixedAggregate  (cost=0.00..4511.11 rows=10611 width=16)
-   Hash Key: a, b
-   Hash Key: a
-   Hash Key: b
-   Group Key: ()
-   Planned Partitions: 4
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2683.00 rows=86100 width=8)
-         ->  Seq Scan on foo  (cost=0.00..961.00 rows=28700 width=8)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1319.44..1496.29 rows=10611 width=16)
+   ->  Finalize HashAggregate  (cost=1319.44..1354.81 rows=3537 width=16)
+         Group Key: a, b, (GROUPINGSET_ID())
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1213.33 rows=10611 width=16)
+               Hash Key: a, b, (GROUPINGSET_ID())
+               ->  Partial MixedAggregate  (cost=0.00..1001.11 rows=10611 width=16)
+                     Hash Key: a, b
+                     Hash Key: a
+                     Hash Key: b
+                     Group Key: ()
+                     Planned Partitions: 4
+                     ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
  Optimizer: Postgres query optimizer
 (15 rows)
 

--- a/src/test/regress/expected/groupingsets.out
+++ b/src/test/regress/expected/groupingsets.out
@@ -1233,15 +1233,19 @@ select a, b, sum(v), count(*) from gstest_empty group by grouping sets ((a,b),()
 
 explain (costs off)
   select a, b, sum(v), count(*) from gstest_empty group by grouping sets ((a,b),(),(),());
-                   QUERY PLAN                   
-------------------------------------------------
- MixedAggregate
-   Hash Key: a, b
-   Group Key: ()
-   Group Key: ()
-   Group Key: ()
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on gstest_empty
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Finalize HashAggregate
+         Group Key: a, b, (GROUPINGSET_ID())
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: a, b, (GROUPINGSET_ID())
+               ->  Partial MixedAggregate
+                     Hash Key: a, b
+                     Group Key: ()
+                     Group Key: ()
+                     Group Key: ()
+                     ->  Seq Scan on gstest_empty
  Optimizer: Postgres query optimizer
 (8 rows)
 
@@ -1596,23 +1600,22 @@ explain (costs off)
          count(hundred), count(thousand), count(twothousand),
          count(*)
     from tenk1 group by grouping sets (unique1,twothousand,thousand,hundred,ten,four,two);
-                   QUERY PLAN                   
-------------------------------------------------
- MixedAggregate
-   Hash Key: two
-   Hash Key: four
-   Hash Key: ten
-   Hash Key: hundred
-   Group Key: unique1
-   Sort Key: twothousand
-     Group Key: twothousand
-   Sort Key: thousand
-     Group Key: thousand
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Merge Key: unique1
-         ->  Sort
-               Sort Key: unique1
-               ->  Seq Scan on tenk1
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Finalize HashAggregate
+         Group Key: unique1, twothousand, thousand, hundred, ten, four, two, (GROUPINGSET_ID())
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: unique1, twothousand, thousand, hundred, ten, four, two, (GROUPINGSET_ID())
+               ->  Partial HashAggregate
+                     Hash Key: unique1
+                     Hash Key: twothousand
+                     Hash Key: thousand
+                     Hash Key: hundred
+                     Hash Key: ten
+                     Hash Key: four
+                     Hash Key: two
+                     ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
 (16 rows)
 
@@ -1646,22 +1649,22 @@ explain (costs off)
          count(hundred), count(thousand), count(twothousand),
          count(*)
     from tenk1 group by grouping sets (unique1,twothousand,thousand,hundred,ten,four,two);
-                   QUERY PLAN                   
-------------------------------------------------
- MixedAggregate
-   Hash Key: two
-   Hash Key: four
-   Hash Key: ten
-   Hash Key: hundred
-   Hash Key: thousand
-   Group Key: unique1
-   Sort Key: twothousand
-     Group Key: twothousand
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Merge Key: unique1
-         ->  Sort
-               Sort Key: unique1
-               ->  Seq Scan on tenk1
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Finalize HashAggregate
+         Group Key: unique1, twothousand, thousand, hundred, ten, four, two, (GROUPINGSET_ID())
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: unique1, twothousand, thousand, hundred, ten, four, two, (GROUPINGSET_ID())
+               ->  Partial HashAggregate
+                     Hash Key: unique1
+                     Hash Key: twothousand
+                     Hash Key: thousand
+                     Hash Key: hundred
+                     Hash Key: ten
+                     Hash Key: four
+                     Hash Key: two
+                     ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
 (15 rows)
 

--- a/src/test/regress/expected/indexjoin.out
+++ b/src/test/regress/expected/indexjoin.out
@@ -27,25 +27,27 @@ WHERE tq.sym = tt.symbol AND
       tt.event_ts <  tq.end_ts
 GROUP BY 1
 ORDER BY 1 asc ;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=1262.14..1293.11 rows=413 width=16)
-   Group Key: ((((tt.event_ts / 100000) / 5) * 5))
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1262.14..1279.69 rows=1239 width=16)
-         Merge Key: ((((tt.event_ts / 100000) / 5) * 5))
-         ->  Sort  (cost=1262.14..1263.17 rows=413 width=16)
-               Sort Key: ((((tt.event_ts / 100000) / 5) * 5))
-               ->  Partial HashAggregate  (cost=1236.97..1244.19 rows=413 width=16)
-                     Group Key: (((tt.event_ts / 100000) / 5) * 5)
-                     ->  Hash Join  (cost=17.20..1161.31 rows=15131 width=8)
-                           Hash Cond: (tt.symbol = (tq.sym)::bpchar)
-                           Join Filter: ((tt.event_ts >= tq.ets) AND (tt.event_ts < tq.end_ts))
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..8.00 rows=420 width=25)
-                                 ->  Seq Scan on my_tt_agg_small tt  (cost=0.00..2.40 rows=140 width=25)
-                           ->  Hash  (cost=8.76..8.76 rows=676 width=20)
-                                 ->  Seq Scan on my_tq_agg_small tq  (cost=0.00..8.76 rows=676 width=20)
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1261.82..1267.67 rows=413 width=16)
+   Merge Key: ((((tt.event_ts / 100000) / 5) * 5))
+   ->  Sort  (cost=1261.82..1262.16 rows=138 width=16)
+         Sort Key: ((((tt.event_ts / 100000) / 5) * 5))
+         ->  Finalize HashAggregate  (cost=1254.52..1256.93 rows=138 width=16)
+               Group Key: ((((tt.event_ts / 100000) / 5) * 5))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1236.97..1252.45 rows=413 width=16)
+                     Hash Key: ((((tt.event_ts / 100000) / 5) * 5))
+                     ->  Partial HashAggregate  (cost=1236.97..1244.19 rows=413 width=16)
+                           Group Key: (((tt.event_ts / 100000) / 5) * 5)
+                           ->  Hash Join  (cost=17.20..1161.31 rows=15131 width=8)
+                                 Hash Cond: (tt.symbol = (tq.sym)::bpchar)
+                                 Join Filter: ((tt.event_ts >= tq.ets) AND (tt.event_ts < tq.end_ts))
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..8.00 rows=420 width=25)
+                                       ->  Seq Scan on my_tt_agg_small tt  (cost=0.00..2.40 rows=140 width=25)
+                                 ->  Hash  (cost=8.76..8.76 rows=676 width=20)
+                                       ->  Seq Scan on my_tq_agg_small tq  (cost=0.00..8.76 rows=676 width=20)
  Optimizer: Postgres query optimizer
-(16 rows)
+(18 rows)
 
 SELECT (tt.event_ts / 100000) / 5 * 5 as fivemin, COUNT(*)
 FROM my_tt_agg_small tt, my_tq_agg_small tq

--- a/src/test/regress/expected/limit_gp.out
+++ b/src/test/regress/expected/limit_gp.out
@@ -123,38 +123,44 @@ explain select * from t_volatile_limit order by i limit 2 offset (random()*5);
 (7 rows)
 
 explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a, sum(b) limit (random()+3);
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Limit  (cost=589.33..590.08 rows=100 width=12)
-   ->  Unique  (cost=589.33..596.83 rows=1000 width=12)
-         Group Key: a, (sum(b))
-         ->  Sort  (cost=589.33..591.83 rows=1000 width=12)
-               Sort Key: a, (sum(b))
-               ->  Finalize HashAggregate  (cost=529.50..539.50 rows=1000 width=12)
-                     Group Key: a
-                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=464.50..514.50 rows=3000 width=12)
-                           ->  Partial HashAggregate  (cost=464.50..474.50 rows=1000 width=12)
-                                 Group Key: a
-                                 ->  Seq Scan on t_volatile_limit_1  (cost=0.00..321.00 rows=28700 width=8)
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=516.80..518.38 rows=100 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=516.80..532.63 rows=1000 width=12)
+         Merge Key: a, (sum(b))
+         ->  Unique  (cost=516.80..519.30 rows=333 width=12)
+               Group Key: a, (sum(b))
+               ->  Sort  (cost=516.80..517.63 rows=333 width=12)
+                     Sort Key: a, (sum(b))
+                     ->  Finalize HashAggregate  (cost=499.50..502.83 rows=333 width=12)
+                           Group Key: a
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=464.50..494.50 rows=1000 width=12)
+                                 Hash Key: a
+                                 ->  Partial HashAggregate  (cost=464.50..474.50 rows=1000 width=12)
+                                       Group Key: a
+                                       ->  Seq Scan on t_volatile_limit_1  (cost=0.00..321.00 rows=28700 width=8)
  Optimizer: Postgres query optimizer
-(12 rows)
+(15 rows)
 
 explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a, sum(b) limit 2 offset (random()*2);
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Limit  (cost=590.08..590.09 rows=2 width=12)
-   ->  Unique  (cost=589.33..596.83 rows=1000 width=12)
-         Group Key: a, (sum(b))
-         ->  Sort  (cost=589.33..591.83 rows=1000 width=12)
-               Sort Key: a, (sum(b))
-               ->  Finalize HashAggregate  (cost=529.50..539.50 rows=1000 width=12)
-                     Group Key: a
-                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=464.50..514.50 rows=3000 width=12)
-                           ->  Partial HashAggregate  (cost=464.50..474.50 rows=1000 width=12)
-                                 Group Key: a
-                                 ->  Seq Scan on t_volatile_limit_1  (cost=0.00..321.00 rows=28700 width=8)
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=518.38..518.42 rows=2 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=516.80..532.63 rows=1000 width=12)
+         Merge Key: a, (sum(b))
+         ->  Unique  (cost=516.80..519.30 rows=333 width=12)
+               Group Key: a, (sum(b))
+               ->  Sort  (cost=516.80..517.63 rows=333 width=12)
+                     Sort Key: a, (sum(b))
+                     ->  Finalize HashAggregate  (cost=499.50..502.83 rows=333 width=12)
+                           Group Key: a
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=464.50..494.50 rows=1000 width=12)
+                                 Hash Key: a
+                                 ->  Partial HashAggregate  (cost=464.50..474.50 rows=1000 width=12)
+                                       Group Key: a
+                                       ->  Seq Scan on t_volatile_limit_1  (cost=0.00..321.00 rows=28700 width=8)
  Optimizer: Postgres query optimizer
-(12 rows)
+(15 rows)
 
 drop table t_volatile_limit;
 drop table t_volatile_limit_1;

--- a/src/test/regress/expected/olap_plans.out
+++ b/src/test/regress/expected/olap_plans.out
@@ -79,19 +79,18 @@ select a, b, c, sum(d) from olap_test group by a, b, c;
 
 -- If it's not a superset, redistribution is needed.
 explain select a, sum(d) from olap_test group by a;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=56.05..56.26 rows=3 width=12)
-   Group Key: a
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=56.05..56.18 rows=9 width=12)
-         Merge Key: a
-         ->  Sort  (cost=56.05..56.06 rows=3 width=12)
-               Sort Key: a
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=56.11..56.16 rows=3 width=12)
+   ->  Finalize HashAggregate  (cost=56.11..56.12 rows=1 width=12)
+         Group Key: a
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=56.00..56.09 rows=3 width=12)
+               Hash Key: a
                ->  Partial HashAggregate  (cost=56.00..56.03 rows=3 width=12)
                      Group Key: a
                      ->  Seq Scan on olap_test  (cost=0.00..39.33 rows=3333 width=8)
  Optimizer: Postgres query optimizer
-(10 rows)
+(9 rows)
 
 select a, sum(d) from olap_test group by a;
  a |   sum    
@@ -312,40 +311,36 @@ reset enable_hashagg;
 create table foo_ctas(a int, b int) distributed randomly;
 insert into foo_ctas select g%5, g%2 from generate_series(1, 100) g;
 explain create table bar_ctas as select * from foo_ctas group by a, b distributed by (b);
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=11.59..11.76 rows=10 width=8)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Finalize HashAggregate  (cost=11.47..11.51 rows=3 width=8)
    Group Key: a, b
-   ->  Sort  (cost=11.59..11.61 rows=10 width=8)
-         Sort Key: a, b
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1.50..11.42 rows=10 width=8)
-               Hash Key: b
-               ->  Partial HashAggregate  (cost=1.50..1.60 rows=10 width=8)
-                     Group Key: a, b
-                     ->  Seq Scan on foo_ctas  (cost=0.00..1.33 rows=33 width=8)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1.50..11.42 rows=10 width=8)
+         Hash Key: b
+         ->  Partial HashAggregate  (cost=1.50..1.60 rows=10 width=8)
+               Group Key: a, b
+               ->  Seq Scan on foo_ctas  (cost=0.00..1.33 rows=33 width=8)
  Optimizer: Postgres query optimizer
-(10 rows)
+(8 rows)
 
 create table bar_ctas as select * from foo_ctas group by a, b distributed by (b);
 -- Currently, the planner misses this optimization with INSERT, so this
 -- needs an extra Redistribute Motion.
 explain insert into bar_ctas select * from foo_ctas group by a, b;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Insert on bar_ctas  (cost=11.59..21.86 rows=10 width=8)
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=11.59..21.86 rows=10 width=8)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Insert on bar_ctas  (cost=11.47..14.87 rows=3 width=8)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=11.47..14.87 rows=3 width=8)
          Hash Key: foo_ctas.b
-         ->  Finalize GroupAggregate  (cost=11.59..11.76 rows=10 width=8)
+         ->  Finalize HashAggregate  (cost=11.47..11.51 rows=3 width=8)
                Group Key: foo_ctas.a, foo_ctas.b
-               ->  Sort  (cost=11.59..11.61 rows=10 width=8)
-                     Sort Key: foo_ctas.a, foo_ctas.b
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.50..11.42 rows=10 width=8)
-                           Hash Key: foo_ctas.a, foo_ctas.b
-                           ->  Partial HashAggregate  (cost=1.50..1.60 rows=10 width=8)
-                                 Group Key: foo_ctas.a, foo_ctas.b
-                                 ->  Seq Scan on foo_ctas  (cost=0.00..1.33 rows=33 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.50..11.42 rows=10 width=8)
+                     Hash Key: foo_ctas.a, foo_ctas.b
+                     ->  Partial HashAggregate  (cost=1.50..1.60 rows=10 width=8)
+                           Group Key: foo_ctas.a, foo_ctas.b
+                           ->  Seq Scan on foo_ctas  (cost=0.00..1.33 rows=33 width=8)
  Optimizer: Postgres query optimizer
-(13 rows)
+(11 rows)
 
 drop table foo_ctas;
 drop table bar_ctas;

--- a/src/test/regress/expected/partition_aggregate.out
+++ b/src/test/regress/expected/partition_aggregate.out
@@ -20,45 +20,39 @@ ANALYZE pagg_tab;
 -- When GROUP BY clause matches; full aggregation is performed for each partition.
 EXPLAIN (COSTS OFF)
 SELECT c, sum(a), avg(b), count(*), min(a), max(b) FROM pagg_tab GROUP BY c HAVING avg(d) < 15 ORDER BY 1, 2, 3;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: pagg_tab_p1.c, (sum(pagg_tab_p1.a)), (avg(pagg_tab_p1.b))
    ->  Sort
          Sort Key: pagg_tab_p1.c, (sum(pagg_tab_p1.a)), (avg(pagg_tab_p1.b))
          ->  Append
-               ->  Finalize GroupAggregate
+               ->  Finalize HashAggregate
                      Group Key: pagg_tab_p1.c
                      Filter: (avg(pagg_tab_p1.d) < '15'::numeric)
-                     ->  Sort
-                           Sort Key: pagg_tab_p1.c
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                 Hash Key: pagg_tab_p1.c
-                                 ->  Partial HashAggregate
-                                       Group Key: pagg_tab_p1.c
-                                       ->  Seq Scan on pagg_tab_p1
-               ->  Finalize GroupAggregate
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: pagg_tab_p1.c
+                           ->  Partial HashAggregate
+                                 Group Key: pagg_tab_p1.c
+                                 ->  Seq Scan on pagg_tab_p1
+               ->  Finalize HashAggregate
                      Group Key: pagg_tab_p2.c
                      Filter: (avg(pagg_tab_p2.d) < '15'::numeric)
-                     ->  Sort
-                           Sort Key: pagg_tab_p2.c
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: pagg_tab_p2.c
-                                 ->  Partial HashAggregate
-                                       Group Key: pagg_tab_p2.c
-                                       ->  Seq Scan on pagg_tab_p2
-               ->  Finalize GroupAggregate
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: pagg_tab_p2.c
+                           ->  Partial HashAggregate
+                                 Group Key: pagg_tab_p2.c
+                                 ->  Seq Scan on pagg_tab_p2
+               ->  Finalize HashAggregate
                      Group Key: pagg_tab_p3.c
                      Filter: (avg(pagg_tab_p3.d) < '15'::numeric)
-                     ->  Sort
-                           Sort Key: pagg_tab_p3.c
-                           ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                 Hash Key: pagg_tab_p3.c
-                                 ->  Partial HashAggregate
-                                       Group Key: pagg_tab_p3.c
-                                       ->  Seq Scan on pagg_tab_p3
+                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                           Hash Key: pagg_tab_p3.c
+                           ->  Partial HashAggregate
+                                 Group Key: pagg_tab_p3.c
+                                 ->  Seq Scan on pagg_tab_p3
  Optimizer: Postgres query optimizer
-(36 rows)
+(30 rows)
 
 SELECT c, sum(a), avg(b), count(*), min(a), max(b) FROM pagg_tab GROUP BY c HAVING avg(d) < 15 ORDER BY 1, 2, 3;
   c   | sum  |         avg         | count | min | max 
@@ -387,29 +381,25 @@ RESET enable_hashagg;
 -- ROLLUP, partitionwise aggregation does not apply
 EXPLAIN (COSTS OFF)
 SELECT c, sum(a) FROM pagg_tab GROUP BY rollup(c) ORDER BY 1, 2;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: pagg_tab_p1.c, (sum(pagg_tab_p1.a))
    ->  Sort
          Sort Key: pagg_tab_p1.c, (sum(pagg_tab_p1.a))
-         ->  Finalize GroupAggregate
+         ->  Finalize HashAggregate
                Group Key: pagg_tab_p1.c, (GROUPINGSET_ID())
-               ->  Sort
-                     Sort Key: pagg_tab_p1.c, (GROUPINGSET_ID())
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: pagg_tab_p1.c, (GROUPINGSET_ID())
-                           ->  Partial GroupAggregate
-                                 Group Key: pagg_tab_p1.c
-                                 Group Key: ()
-                                 ->  Sort
-                                       Sort Key: pagg_tab_p1.c
-                                       ->  Append
-                                             ->  Seq Scan on pagg_tab_p1
-                                             ->  Seq Scan on pagg_tab_p2
-                                             ->  Seq Scan on pagg_tab_p3
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: pagg_tab_p1.c, (GROUPINGSET_ID())
+                     ->  Partial MixedAggregate
+                           Hash Key: pagg_tab_p1.c
+                           Group Key: ()
+                           ->  Append
+                                 ->  Seq Scan on pagg_tab_p1
+                                 ->  Seq Scan on pagg_tab_p2
+                                 ->  Seq Scan on pagg_tab_p3
  Optimizer: Postgres query optimizer
-(20 rows)
+(16 rows)
 
 -- ORDERED SET within the aggregate.
 -- Full aggregation; since all the rows that belong to the same group come

--- a/src/test/regress/expected/partition_aggregate_optimizer.out
+++ b/src/test/regress/expected/partition_aggregate_optimizer.out
@@ -25,45 +25,39 @@ ANALYZE pagg_tab;
 -- When GROUP BY clause matches; full aggregation is performed for each partition.
 EXPLAIN (COSTS OFF)
 SELECT c, sum(a), avg(b), count(*), min(a), max(b) FROM pagg_tab GROUP BY c HAVING avg(d) < 15 ORDER BY 1, 2, 3;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: pagg_tab_p1.c, (sum(pagg_tab_p1.a)), (avg(pagg_tab_p1.b))
    ->  Sort
          Sort Key: pagg_tab_p1.c, (sum(pagg_tab_p1.a)), (avg(pagg_tab_p1.b))
          ->  Append
-               ->  Finalize GroupAggregate
+               ->  Finalize HashAggregate
                      Group Key: pagg_tab_p1.c
                      Filter: (avg(pagg_tab_p1.d) < '15'::numeric)
-                     ->  Sort
-                           Sort Key: pagg_tab_p1.c
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                 Hash Key: pagg_tab_p1.c
-                                 ->  Partial HashAggregate
-                                       Group Key: pagg_tab_p1.c
-                                       ->  Seq Scan on pagg_tab_p1
-               ->  Finalize GroupAggregate
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: pagg_tab_p1.c
+                           ->  Partial HashAggregate
+                                 Group Key: pagg_tab_p1.c
+                                 ->  Seq Scan on pagg_tab_p1
+               ->  Finalize HashAggregate
                      Group Key: pagg_tab_p2.c
                      Filter: (avg(pagg_tab_p2.d) < '15'::numeric)
-                     ->  Sort
-                           Sort Key: pagg_tab_p2.c
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: pagg_tab_p2.c
-                                 ->  Partial HashAggregate
-                                       Group Key: pagg_tab_p2.c
-                                       ->  Seq Scan on pagg_tab_p2
-               ->  Finalize GroupAggregate
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: pagg_tab_p2.c
+                           ->  Partial HashAggregate
+                                 Group Key: pagg_tab_p2.c
+                                 ->  Seq Scan on pagg_tab_p2
+               ->  Finalize HashAggregate
                      Group Key: pagg_tab_p3.c
                      Filter: (avg(pagg_tab_p3.d) < '15'::numeric)
-                     ->  Sort
-                           Sort Key: pagg_tab_p3.c
-                           ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                 Hash Key: pagg_tab_p3.c
-                                 ->  Partial HashAggregate
-                                       Group Key: pagg_tab_p3.c
-                                       ->  Seq Scan on pagg_tab_p3
+                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                           Hash Key: pagg_tab_p3.c
+                           ->  Partial HashAggregate
+                                 Group Key: pagg_tab_p3.c
+                                 ->  Seq Scan on pagg_tab_p3
  Optimizer: Postgres query optimizer
-(36 rows)
+(30 rows)
 
 SELECT c, sum(a), avg(b), count(*), min(a), max(b) FROM pagg_tab GROUP BY c HAVING avg(d) < 15 ORDER BY 1, 2, 3;
   c   | sum  |         avg         | count | min | max 
@@ -402,29 +396,25 @@ RESET enable_hashagg;
 -- ROLLUP, partitionwise aggregation does not apply
 EXPLAIN (COSTS OFF)
 SELECT c, sum(a) FROM pagg_tab GROUP BY rollup(c) ORDER BY 1, 2;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: pagg_tab_p1.c, (sum(pagg_tab_p1.a))
    ->  Sort
          Sort Key: pagg_tab_p1.c, (sum(pagg_tab_p1.a))
-         ->  Finalize GroupAggregate
+         ->  Finalize HashAggregate
                Group Key: pagg_tab_p1.c, (GROUPINGSET_ID())
-               ->  Sort
-                     Sort Key: pagg_tab_p1.c, (GROUPINGSET_ID())
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: pagg_tab_p1.c, (GROUPINGSET_ID())
-                           ->  Partial GroupAggregate
-                                 Group Key: pagg_tab_p1.c
-                                 Group Key: ()
-                                 ->  Sort
-                                       Sort Key: pagg_tab_p1.c
-                                       ->  Append
-                                             ->  Seq Scan on pagg_tab_p1
-                                             ->  Seq Scan on pagg_tab_p2
-                                             ->  Seq Scan on pagg_tab_p3
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: pagg_tab_p1.c, (GROUPINGSET_ID())
+                     ->  Partial MixedAggregate
+                           Hash Key: pagg_tab_p1.c
+                           Group Key: ()
+                           ->  Append
+                                 ->  Seq Scan on pagg_tab_p1
+                                 ->  Seq Scan on pagg_tab_p2
+                                 ->  Seq Scan on pagg_tab_p3
  Optimizer: Postgres query optimizer
-(20 rows)
+(16 rows)
 
 -- ORDERED SET within the aggregate.
 -- Full aggregation; since all the rows that belong to the same group come

--- a/src/test/regress/expected/partition_join.out
+++ b/src/test/regress/expected/partition_join.out
@@ -1639,40 +1639,42 @@ ALTER TABLE plt2 ATTACH PARTITION plt2_p3 DEFAULT;
 ANALYZE plt2;
 EXPLAIN (COSTS OFF)
 SELECT avg(t1.a), avg(t2.b), t1.c, t2.c FROM plt1 t1 RIGHT JOIN plt2 t2 ON t1.c = t2.c WHERE t1.a % 25 = 0 GROUP BY t1.c, t2.c ORDER BY t1.c, t2.c;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Finalize GroupAggregate
-   Group Key: t1.c, t2.c
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Merge Key: t1.c
-         ->  Sort
-               Sort Key: t1.c
-               ->  Partial HashAggregate
-                     Group Key: t1.c, t2.c
-                     ->  Append
-                           ->  Hash Join
-                                 Hash Cond: (t2.c = t1.c)
-                                 ->  Seq Scan on plt2_p1 t2
-                                 ->  Hash
-                                       ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                             ->  Seq Scan on plt1_p1 t1
-                                                   Filter: ((a % 25) = 0)
-                           ->  Hash Join
-                                 Hash Cond: (t2_1.c = t1_1.c)
-                                 ->  Seq Scan on plt2_p2 t2_1
-                                 ->  Hash
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                             ->  Seq Scan on plt1_p2 t1_1
-                                                   Filter: ((a % 25) = 0)
-                           ->  Hash Join
-                                 Hash Cond: (t2_2.c = t1_2.c)
-                                 ->  Seq Scan on plt2_p3 t2_2
-                                 ->  Hash
-                                       ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                             ->  Seq Scan on plt1_p3 t1_2
-                                                   Filter: ((a % 25) = 0)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: t1.c
+   ->  Sort
+         Sort Key: t1.c
+         ->  Finalize HashAggregate
+               Group Key: t1.c, t2.c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: t1.c, t1.c
+                     ->  Partial HashAggregate
+                           Group Key: t1.c, t2.c
+                           ->  Append
+                                 ->  Hash Join
+                                       Hash Cond: (t2.c = t1.c)
+                                       ->  Seq Scan on plt2_p1 t2
+                                       ->  Hash
+                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                                   ->  Seq Scan on plt1_p1 t1
+                                                         Filter: ((a % 25) = 0)
+                                 ->  Hash Join
+                                       Hash Cond: (t2_1.c = t1_1.c)
+                                       ->  Seq Scan on plt2_p2 t2_1
+                                       ->  Hash
+                                             ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                   ->  Seq Scan on plt1_p2 t1_1
+                                                         Filter: ((a % 25) = 0)
+                                 ->  Hash Join
+                                       Hash Cond: (t2_2.c = t1_2.c)
+                                       ->  Seq Scan on plt2_p3 t2_2
+                                       ->  Hash
+                                             ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                                   ->  Seq Scan on plt1_p3 t1_2
+                                                         Filter: ((a % 25) = 0)
  Optimizer: Postgres query optimizer
-(31 rows)
+(33 rows)
 
 --
 -- multiple levels of partitioning

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -3634,20 +3634,17 @@ select i as a, i as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a
 (2 rows)
 
 explain select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=10000002790.97..10000002940.97 rows=2000 width=8)
-   Group Key: (GROUPINGSET_ID()), j, j
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=10000002790.97..10000002875.97 rows=6000 width=8)
-         Merge Key: (GROUPINGSET_ID()), j
-         ->  Sort  (cost=10000002790.97..10000002795.97 rows=2000 width=8)
-               Sort Key: (GROUPINGSET_ID()), j
-               ->  Partial GroupAggregate  (cost=10000002446.06..10000002681.31 rows=2000 width=8)
-                     Group Key: j, j
-                     Group Key: j
-                     ->  Sort  (cost=10000002446.06..10000002517.81 rows=28700 width=8)
-                           Sort Key: j
-                           ->  Seq Scan on tbl7553_test  (cost=10000000000.00..10000000321.00 rows=28700 width=8)
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000611.25..10000000644.58 rows=2000 width=8)
+   ->  Finalize HashAggregate  (cost=10000000611.25..10000000617.92 rows=667 width=8)
+         Group Key: j, j, (GROUPINGSET_ID())
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000464.50..10000000596.25 rows=2000 width=8)
+               Hash Key: j, j, (GROUPINGSET_ID())
+               ->  Partial HashAggregate  (cost=10000000464.50..10000000556.25 rows=2000 width=8)
+                     Hash Key: j, j
+                     Hash Key: j
+                     ->  Seq Scan on tbl7553_test  (cost=10000000000.00..10000000321.00 rows=28700 width=8)
  Optimizer: Postgres query optimizer
 (13 rows)
 
@@ -4762,14 +4759,16 @@ then 'MO' else 'foo' end
 case when ir_call_type_group_code in ('H', 'VH', 'PCB') then 'Thailland'
 else 'Unidentify' end
 ;
-                                                                                                                             QUERY PLAN                                                                                                                              
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize HashAggregate  (cost=284.32..306.82 rows=1000 width=96)
-   Group Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=75.08..270.74 rows=2714 width=102)
-         ->  Partial HashAggregate  (cost=75.08..89.79 rows=905 width=102)
-               Group Key: CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END, CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END
-               ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..65.42 rows=1933 width=102)
+                                                                                                                                QUERY PLAN                                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=184.79..258.96 rows=1000 width=96)
+   ->  Finalize HashAggregate  (cost=184.79..192.29 rows=333 width=96)
+         Group Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=75.08..180.27 rows=905 width=102)
+               Hash Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
+               ->  Partial HashAggregate  (cost=75.08..89.79 rows=905 width=102)
+                     Group Key: CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END, CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END
+                     ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..65.42 rows=1933 width=102)
  Optimizer: Postgres query optimizer
 (7 rows)
 

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -3626,20 +3626,17 @@ select i as a, i as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a
 (2 rows)
 
 explain select j as a, j as b from qp_misc_jiras.tbl7553_test group by grouping sets( (a, b), (a)); 
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Finalize GroupAggregate  (cost=10000002790.97..10000002940.97 rows=2000 width=8)
-   Group Key: j, j, (GROUPINGSET_ID())
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=10000002790.97..10000002875.97 rows=6000 width=8)
-         Merge Key: j, (GROUPINGSET_ID())
-         ->  Sort  (cost=10000002790.97..10000002795.97 rows=2000 width=8)
-               Sort Key: j, (GROUPINGSET_ID())
-               ->  Partial GroupAggregate  (cost=10000002446.06..10000002681.31 rows=2000 width=8)
-                     Group Key: j, j
-                     Group Key: j
-                     ->  Sort  (cost=10000002446.06..10000002517.81 rows=28700 width=8)
-                           Sort Key: j
-                           ->  Seq Scan on tbl7553_test  (cost=10000000000.00..10000000321.00 rows=28700 width=8)
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000611.25..10000000644.58 rows=2000 width=8)
+   ->  Finalize HashAggregate  (cost=10000000611.25..10000000617.92 rows=667 width=8)
+         Group Key: j, j, (GROUPINGSET_ID())
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000464.50..10000000596.25 rows=2000 width=8)
+               Hash Key: j, j, (GROUPINGSET_ID())
+               ->  Partial HashAggregate  (cost=10000000464.50..10000000556.25 rows=2000 width=8)
+                     Hash Key: j, j
+                     Hash Key: j
+                     ->  Seq Scan on tbl7553_test  (cost=10000000000.00..10000000321.00 rows=28700 width=8)
  Optimizer: Postgres query optimizer
 (16 rows)
 

--- a/src/test/regress/expected/select_distinct.out
+++ b/src/test/regress/expected/select_distinct.out
@@ -130,31 +130,28 @@ SELECT DISTINCT p.age FROM person* p ORDER BY age using >;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT count(*) FROM
   (SELECT DISTINCT two, four, two FROM tenk1) ss;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Finalize Aggregate
    Output: count(*)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Output: (PARTIAL count(*))
          ->  Partial Aggregate
                Output: PARTIAL count(*)
-               ->  Finalize GroupAggregate
+               ->  Finalize HashAggregate
                      Output: tenk1.two, tenk1.four, tenk1.two
                      Group Key: tenk1.two, tenk1.four, tenk1.two
-                     ->  Sort
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Output: tenk1.two, tenk1.four, tenk1.two
-                           Sort Key: tenk1.two, tenk1.four
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: tenk1.two, tenk1.four, tenk1.two
+                           ->  Partial HashAggregate
                                  Output: tenk1.two, tenk1.four, tenk1.two
-                                 Hash Key: tenk1.two, tenk1.four, tenk1.two
-                                 ->  Partial HashAggregate
+                                 Group Key: tenk1.two, tenk1.four, tenk1.two
+                                 ->  Seq Scan on public.tenk1
                                        Output: tenk1.two, tenk1.four, tenk1.two
-                                       Group Key: tenk1.two, tenk1.four, tenk1.two
-                                       ->  Seq Scan on public.tenk1
-                                             Output: tenk1.two, tenk1.four, tenk1.two
  Optimizer: Postgres query optimizer
  Settings: optimizer=off
-(22 rows)
+(19 rows)
 
 SELECT count(*) FROM
   (SELECT DISTINCT two, four, two FROM tenk1) ss;

--- a/src/test/regress/expected/select_parallel.out
+++ b/src/test/regress/expected/select_parallel.out
@@ -258,14 +258,16 @@ select sp_parallel_restricted(unique1) from tenk1
 -- test parallel plan when group by expression is in target list.
 explain (costs off)
 	select length(stringu1) from tenk1 group by length(stringu1);
-                    QUERY PLAN                     
----------------------------------------------------
- Finalize HashAggregate
-   Group Key: (length((stringu1)::text))
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial HashAggregate
-               Group Key: length((stringu1)::text)
-               ->  Seq Scan on tenk1
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Finalize HashAggregate
+         Group Key: (length((stringu1)::text))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: (length((stringu1)::text))
+               ->  Partial HashAggregate
+                     Group Key: length((stringu1)::text)
+                     ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
 (7 rows)
 
@@ -277,17 +279,19 @@ select length(stringu1) from tenk1 group by length(stringu1);
 
 explain (costs off)
 	select stringu1, count(*) from tenk1 group by stringu1 order by stringu1;
-                   QUERY PLAN                   
-------------------------------------------------
- Finalize GroupAggregate
-   Group Key: stringu1
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Merge Key: stringu1
-         ->  Sort
-               Sort Key: stringu1
-               ->  Partial HashAggregate
-                     Group Key: stringu1
-                     ->  Seq Scan on tenk1
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: stringu1
+   ->  Sort
+         Sort Key: stringu1
+         ->  Finalize HashAggregate
+               Group Key: stringu1
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: stringu1
+                     ->  Partial HashAggregate
+                           Group Key: stringu1
+                           ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
 (10 rows)
 

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -261,14 +261,16 @@ select sp_parallel_restricted(unique1) from tenk1
 -- test parallel plan when group by expression is in target list.
 explain (costs off)
 	select length(stringu1) from tenk1 group by length(stringu1);
-                    QUERY PLAN                     
----------------------------------------------------
- Finalize HashAggregate
-   Group Key: (length((stringu1)::text))
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial HashAggregate
-               Group Key: length((stringu1)::text)
-               ->  Seq Scan on tenk1
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Finalize HashAggregate
+         Group Key: (length((stringu1)::text))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: (length((stringu1)::text))
+               ->  Partial HashAggregate
+                     Group Key: length((stringu1)::text)
+                     ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
 (7 rows)
 

--- a/src/test/regress/expected/window.out
+++ b/src/test/regress/expected/window.out
@@ -624,17 +624,19 @@ explain (costs off)
 select first_value(max(x)) over (), y
   from (select unique1 as x, ten+four as y from tenk1) ss
   group by y;
-                       QUERY PLAN                        
----------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  WindowAgg
-   ->  Finalize HashAggregate
-         Group Key: ((tenk1.ten + tenk1.four))
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               ->  Partial HashAggregate
-                     Group Key: (tenk1.ten + tenk1.four)
-                     ->  Seq Scan on tenk1
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Finalize HashAggregate
+               Group Key: ((tenk1.ten + tenk1.four))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: ((tenk1.ten + tenk1.four))
+                     ->  Partial HashAggregate
+                           Group Key: (tenk1.ten + tenk1.four)
+                           ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
-(8 rows)
+(10 rows)
 
 -- test non-default frame specifications
 SELECT four, ten,

--- a/src/test/regress/expected/write_parallel.out
+++ b/src/test/regress/expected/write_parallel.out
@@ -17,76 +17,76 @@ set max_parallel_workers_per_gather=4;
 --
 explain (costs off) create table parallel_write as
     select length(stringu1) from tenk1 group by length(stringu1);
-                         QUERY PLAN                         
-------------------------------------------------------------
- Finalize GroupAggregate
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'length' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+                      QUERY PLAN                      
+------------------------------------------------------
+ Finalize HashAggregate
    Group Key: (length((stringu1)::text))
-   ->  Sort
-         Sort Key: (length((stringu1)::text))
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: (length((stringu1)::text))
-               ->  Partial HashAggregate
-                     Group Key: length((stringu1)::text)
-                     ->  Seq Scan on tenk1
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Hash Key: (length((stringu1)::text))
+         ->  Partial HashAggregate
+               Group Key: length((stringu1)::text)
+               ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
-(10 rows)
+(8 rows)
 
 create table parallel_write as
     select length(stringu1) from tenk1 group by length(stringu1);
 drop table parallel_write;
 explain (costs off) select length(stringu1) into parallel_write
     from tenk1 group by length(stringu1);
-                         QUERY PLAN                         
-------------------------------------------------------------
- Finalize GroupAggregate
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'length' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+                      QUERY PLAN                      
+------------------------------------------------------
+ Finalize HashAggregate
    Group Key: (length((stringu1)::text))
-   ->  Sort
-         Sort Key: (length((stringu1)::text))
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: (length((stringu1)::text))
-               ->  Partial HashAggregate
-                     Group Key: length((stringu1)::text)
-                     ->  Seq Scan on tenk1
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Hash Key: (length((stringu1)::text))
+         ->  Partial HashAggregate
+               Group Key: length((stringu1)::text)
+               ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
-(10 rows)
+(8 rows)
 
 select length(stringu1) into parallel_write
     from tenk1 group by length(stringu1);
 drop table parallel_write;
 explain (costs off) create materialized view parallel_mat_view as
     select length(stringu1) from tenk1 group by length(stringu1);
-                         QUERY PLAN                         
-------------------------------------------------------------
- Finalize GroupAggregate
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'length' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+                      QUERY PLAN                      
+------------------------------------------------------
+ Finalize HashAggregate
    Group Key: (length((stringu1)::text))
-   ->  Sort
-         Sort Key: (length((stringu1)::text))
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: (length((stringu1)::text))
-               ->  Partial HashAggregate
-                     Group Key: length((stringu1)::text)
-                     ->  Seq Scan on tenk1
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Hash Key: (length((stringu1)::text))
+         ->  Partial HashAggregate
+               Group Key: length((stringu1)::text)
+               ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
-(10 rows)
+(8 rows)
 
 create materialized view parallel_mat_view as
     select length(stringu1) from tenk1 group by length(stringu1);
 drop materialized view parallel_mat_view;
 prepare prep_stmt as select length(stringu1) from tenk1 group by length(stringu1);
 explain (costs off) create table parallel_write as execute prep_stmt;
-                         QUERY PLAN                         
-------------------------------------------------------------
- Finalize GroupAggregate
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'length' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+                      QUERY PLAN                      
+------------------------------------------------------
+ Finalize HashAggregate
    Group Key: (length((stringu1)::text))
-   ->  Sort
-         Sort Key: (length((stringu1)::text))
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: (length((stringu1)::text))
-               ->  Partial HashAggregate
-                     Group Key: length((stringu1)::text)
-                     ->  Seq Scan on tenk1
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Hash Key: (length((stringu1)::text))
+         ->  Partial HashAggregate
+               Group Key: length((stringu1)::text)
+               ->  Seq Scan on tenk1
  Optimizer: Postgres query optimizer
-(10 rows)
+(8 rows)
 
 create table parallel_write as execute prep_stmt;
 drop table parallel_write;


### PR DESCRIPTION
Disable_cost is added to path's cost when corresponding GUC
is set off. Greenplum is MPP database, the old value might be
too small.

I encounter this problem when I was working with performance issue
for TPCDS 1TBytes data query 104. Planner generates mergejoin join
even if enable_mergejoin is set off, which leads to the query cannot
finish for a long time. After I enlarge the disable_cost, we can get
hash join plan, and the query finishes soon. I also test with the same
amount of data under Postgres12, it also generates merge join with
enable_mergejoin = off.

See previous closede pr https://github.com/greenplum-db/gpdb/pull/8954.
And also refer to the upstream thread:
https://www.postgresql.org/message-id/CAO0i4_SSPV9TVxbbTRVLOnCyewopcc147fBZy%3Df2ABk15eHS%2Bg%40mail.gmail.com