### PR TITLE
fix gprecoverseg

### DIFF
--- a/gpMgmt/bin/gppylib/operations/Makefile
+++ b/gpMgmt/bin/gppylib/operations/Makefile
@@ -7,7 +7,7 @@ PROGRAMS= initstandby.py test_utils_helper.py
 
 DATA= __init__.py buildMirrorSegments.py deletesystem.py package.py \
 	rebalanceSegments.py reload.py segment_reconfigurer.py startSegments.py \
-	unix.py utils.py
+	unix.py update_pg_hba_conf.py utils.py
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(libdir)/python/gppylib/operations'

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -167,6 +167,7 @@ class buildMirrorSegmentsTestCase(GpTestCase):
         with self.assertRaisesRegex(Exception, r"Segment dbid's 2 and 1 on host samehost cannot have the same data directory '/data'"):
             self.buildMirrorSegs.checkForPortAndDirectoryConflicts(gpArray)
 
+
 class SegmentProgressTestCase(GpTestCase):
     """
     Test case for GpMirrorListToBuild._join_and_show_segment_progress().

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_update_pg_hba_conf.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_update_pg_hba_conf.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Greenplum Inc 2008. All Rights Reserved.
+#
+from mock import patch, MagicMock, Mock
+
+from gppylib.gparray import Segment, GpArray
+from gppylib.operations.update_pg_hba_conf import config_primaries_for_replication
+from test.unit.gp_unittest import GpTestCase, run_tests
+
+
+class UpdatePgHBAConfTests(GpTestCase):
+    def setUp(self):
+        def _setup_gparray():
+            master = Segment.initFromString(
+                "1|-1|p|p|s|u|mdw|mdw|5432|/data/master")
+            standby = Segment.initFromString(
+                "6|-1|m|m|s|u|sdw3|sdw3|5433|/data/standby")
+            primary0 = Segment.initFromString(
+                "2|0|p|p|s|u|sdw1|sdw1|40000|/data/primary0")
+            primary1 = Segment.initFromString(
+                "3|1|p|p|s|u|sdw2|sdw2|40001|/data/primary1")
+            mirror0 = Segment.initFromString(
+                "4|0|m|m|s|u|sdw2|sdw2|50000|/data/mirror0")
+            mirror1 = Segment.initFromString(
+                "5|1|m|m|s|u|sdw1|sdw1|50001|/data/mirror1")
+            return GpArray([master, standby, primary0, primary1, mirror0, mirror1])
+
+        self.gparray = _setup_gparray()
+        self.apply_patches([
+            patch('gppylib.operations.update_pg_hba_conf.logger', return_value=Mock(spec=['log', 'info', 'debug', 'error'])),
+        ])
+        self.logger = self.get_mock_from_apply_patch('logger')
+
+    @patch('gppylib.operations.update_pg_hba_conf.Command')
+    @patch('gppylib.operations.update_pg_hba_conf.gp.IfAddrs.list_addrs', return_value=['192.168.2.1', '192.168.1.1'])
+    def test_pghbaconf_updated_successfully(self, mock_cmd, mock_list_addrs):
+        config_primaries_for_replication(self.gparray, False)
+        self.logger.info.assert_any_call("Starting to modify pg_hba.conf on primary segments to allow replication connections")
+        self.logger.info.assert_any_call("Successfully modified pg_hba.conf on primary segments to allow replication connections")
+
+    @patch('gppylib.operations.update_pg_hba_conf.Command', side_effect=Exception("boom"))
+    @patch('gppylib.operations.update_pg_hba_conf.gp.IfAddrs.list_addrs', return_value=['192.168.2.1', '192.168.1.1'])
+    def test_pghbaconf_updated_fails(self, mock1, mock2):
+        with self.assertRaisesRegex(Exception, "boom"):
+            config_primaries_for_replication(self.gparray, False)
+        self.logger.info.assert_any_call("Starting to modify pg_hba.conf on primary segments to allow replication connections")
+        self.logger.error.assert_any_call("Failed while modifying pg_hba.conf on primary segments to allow replication connections: boom")
+

--- a/gpMgmt/bin/gppylib/operations/update_pg_hba_conf.py
+++ b/gpMgmt/bin/gppylib/operations/update_pg_hba_conf.py
@@ -1,0 +1,58 @@
+import os
+import socket
+
+from gppylib import gplog
+from gppylib.commands.base import Command
+from gppylib.commands import base, gp, unix
+
+logger = gplog.get_default_logger()
+
+
+def config_primaries_for_replication(gpArray, hba_hostnames):
+    logger.info("Starting to modify pg_hba.conf on primary segments to allow replication connections")
+
+    try:
+        for segmentPair in gpArray.getSegmentList():
+            # Start with an empty string so that the later .join prepends a newline to the first entry
+            entries = ['']
+            # Add the samehost replication entry to support single-host development
+            entries.append('host  replication {username} samehost trust'.format(username=unix.getUserName()))
+            if hba_hostnames:
+                mirror_hostname, _, _ = socket.gethostbyaddr(segmentPair.mirrorDB.getSegmentHostName())
+                entries.append("host all {username} {hostname} trust".format(username=unix.getUserName(), hostname=mirror_hostname))
+                entries.append("host replication {username} {hostname} trust".format(username=unix.getUserName(), hostname=mirror_hostname))
+                primary_hostname, _, _ = socket.gethostbyaddr(segmentPair.primaryDB.getSegmentHostName())
+                if mirror_hostname != primary_hostname:
+                    entries.append("host replication {username} {hostname} trust".format(username=unix.getUserName(), hostname=primary_hostname))
+            else:
+                mirror_ips = gp.IfAddrs.list_addrs(segmentPair.mirrorDB.getSegmentHostName())
+                for ip in mirror_ips:
+                    cidr_suffix = '/128' if ':' in ip else '/32'
+                    cidr = ip + cidr_suffix
+                    hba_line_entry = "host all {username} {cidr} trust".format(username=unix.getUserName(), cidr=cidr)
+                    entries.append(hba_line_entry)
+                mirror_hostname = segmentPair.mirrorDB.getSegmentHostName()
+                segment_pair_ips = gp.IfAddrs.list_addrs(mirror_hostname)
+                primary_hostname = segmentPair.primaryDB.getSegmentHostName()
+                if mirror_hostname != primary_hostname:
+                    segment_pair_ips.extend(gp.IfAddrs.list_addrs(primary_hostname))
+                for ip in segment_pair_ips:
+                    cidr_suffix = '/128' if ':' in ip else '/32'
+                    cidr = ip + cidr_suffix
+                    hba_line_entry = "host replication {username} {cidr} trust".format(username=unix.getUserName(), cidr=cidr)
+                    entries.append(hba_line_entry)
+            cmdStr = ". {gphome}/greenplum_path.sh; echo '{entries}' >> {datadir}/pg_hba.conf; pg_ctl -D {datadir} reload".format(
+                gphome=os.environ["GPHOME"],
+                entries="\n".join(entries),
+                datadir=segmentPair.primaryDB.datadir)
+            logger.debug(cmdStr)
+            cmd = Command(name="append to pg_hba.conf", cmdStr=cmdStr, ctxt=base.REMOTE, remoteHost=segmentPair.primaryDB.hostname)
+            cmd.run(validateAfter=True)
+
+    except Exception as e:
+        logger.error("Failed while modifying pg_hba.conf on primary segments to allow replication connections: %s" % str(e))
+        raise
+
+    else:
+        logger.info("Successfully modified pg_hba.conf on primary segments to allow replication connections")
+

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -347,7 +347,7 @@ class GpRecoverSegmentProgram:
                 if isStandardArray:
                     # We have a standard array configuration, so we'll try to use the same
                     # interface naming convention.  If this doesn't work, we'll correct it
-                    # below on name lookup
+                    # below during ping failure
                     segInterface = segAddress[segAddress.rfind('-'):]
                     destAddress = recoverHostMap[segHostname] + segInterface
                     destHostname = recoverHostMap[segHostname]
@@ -361,36 +361,14 @@ class GpRecoverSegmentProgram:
                 # Save off the new host/address for this address.
                 recoverAddressMap[segAddress] = (destHostname, destAddress)
 
-            # Now that we've generated the mapping, look up all the addresses to make
-            # sure they are resolvable.
-            interfaces = [address for (_ignore, address) in list(recoverAddressMap.values())]
-            interfaceLookup = GpInterfaceToHostNameCache(self.__pool, interfaces, [None] * len(interfaces))
-
             for key in list(recoverAddressMap.keys()):
                 (newHostname, newAddress) = recoverAddressMap[key]
                 try:
-                    addressHostnameLookup = interfaceLookup.getHostName(newAddress)
-                    # Lookup failed so use hostname passed in for everything.
-                    if addressHostnameLookup is None:
-                        interfaceHostnameWarnings.append(
-                            "Lookup of %s failed.  Using %s for both hostname and address." % (newAddress, newHostname))
-                        newAddress = newHostname
+                    unix.Ping.local("ping new address", newAddress)
                 except:
-                    # Catch all exceptions.  We will use hostname instead of address
-                    # that we generated.
-                    interfaceHostnameWarnings.append(
-                        "Lookup of %s failed.  Using %s for both hostname and address." % (newAddress, newHostname))
+                    # new address created is invalid, so instead use same hostname for address
+                    self.logger.info("Ping of %s failed, Using %s for both hostname and address.", newAddress, newHostname)
                     newAddress = newHostname
-
-                # if we've updated the address to use the hostname because of lookup failure
-                # make sure the hostname is resolvable and up
-                if newHostname == newAddress:
-                    try:
-                        unix.Ping.local("ping new hostname", newHostname)
-                    except:
-                        raise Exception("Ping of host %s failed." % newHostname)
-
-                # Save changes in map
                 recoverAddressMap[key] = (newHostname, newAddress)
 
             if len(self.__options.newRecoverHosts) != recoverHostIdx:

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -31,6 +31,7 @@ from gppylib.gpparseopts import OptParser, OptChecker
 from gppylib.operations.startSegments import *
 from gppylib.operations.buildMirrorSegments import *
 from gppylib.operations.rebalanceSegments import GpSegmentRebalanceOperation
+from gppylib.operations.update_pg_hba_conf import config_primaries_for_replication
 from gppylib.programs import programIoUtils
 from gppylib.system import configurationInterface as configInterface
 from gppylib.system.environment import GpMasterEnvironment
@@ -640,6 +641,7 @@ class GpRecoverSegmentProgram:
             if new_hosts:
                 self.syncPackages(new_hosts)
 
+            config_primaries_for_replication(gpArray, self.__options.hba_hostnames)
             if not mirrorBuilder.buildMirrors("recover", gpEnv, gpArray):
                 sys.exit(1)
 
@@ -750,6 +752,8 @@ class GpRecoverSegmentProgram:
                          help="Max # of workers to use for building recovery segments.  [default: %default]")
         addTo.add_option("-r", None, default=False, action='store_true',
                          dest='rebalanceSegments', help='Rebalance synchronized segments.')
+        addTo.add_option('', '--hba-hostnames', action='store_true', dest='hba_hostnames',
+                         help='use hostnames instead of CIDR in pg_hba.conf')
 
         parser.set_defaults()
         return parser

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpaddmirrors.py
@@ -122,27 +122,6 @@ class GpAddMirrorsTest(GpTestCase):
 
         self.assertIn("45000", result[0])
 
-    @patch('gppylib.programs.clsAddMirrors.Command')
-    @patch('gppylib.programs.clsAddMirrors.gp.IfAddrs.list_addrs', return_value=['192.168.2.1', '192.168.1.1'])
-    def test_pghbaconf_updated_successfully(self, mock1, mock2):
-        sys.argv = ['gpaddmirrors', '-i', '/tmp/nonexistent/file']
-        options, _ = self.parser.parse_args()
-        self.subject = GpAddMirrorsProgram(options)
-        self.subject.config_primaries_for_replication(self.gparrayMock)
-        self.mock_logger.info.assert_any_call("Starting to modify pg_hba.conf on primary segments to allow replication connections")
-        self.mock_logger.info.assert_any_call("Successfully modified pg_hba.conf on primary segments to allow replication connections")
-
-    @patch('gppylib.programs.clsAddMirrors.Command', side_effect=Exception("boom"))
-    @patch('gppylib.programs.clsAddMirrors.gp.IfAddrs.list_addrs', return_value=['192.168.2.1', '192.168.1.1'])
-    def test_pghbaconf_updated_fails(self, mock1, mock2):
-        sys.argv = ['gpaddmirrors', '-i', '/tmp/nonexistent/file']
-        options, _ = self.parser.parse_args()
-        self.subject = GpAddMirrorsProgram(options)
-        with self.assertRaisesRegex(Exception, "boom"):
-            self.subject.config_primaries_for_replication(self.gparrayMock)
-        self.mock_logger.info.assert_any_call("Starting to modify pg_hba.conf on primary segments to allow replication connections")
-        self.mock_logger.error.assert_any_call("Failed while modifying pg_hba.conf on primary segments to allow replication connections: boom")
-
     def test_datadir_interview(self):
         self.input_mock.side_effect = ["/tmp/datadirs/mirror1", "/tmp/datadirs/mirror2", "/tmp/datadirs/mirror3"]
         sys.argv = ['gpaddmirrors', '-p', '5000']

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -30,6 +30,7 @@ class Options:
         self.persistent_check = None
         self.quiet = None
         self.interactive = False
+        self.hba_hostnames = False
 
 
 class GpRecoversegTestCase(GpTestCase):

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -232,6 +232,11 @@ Do not show pg_basebackup progress. Useful when writing to a
 file. Defaults to showing the progress.
 
 
+--hba-hostnames
+
+Optional. use hostnames instead of CIDR in pg_hba.conf
+
+
 -v
 
 Sets logging output to verbose.

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -281,3 +281,27 @@ Feature: gprecoverseg tests
           And the segments are synchronized
           And the tablespace is valid
           And the other tablespace is valid
+
+  @concourse_cluster
+  Scenario: moving mirror to a different host must work
+      Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And the information of a "mirror" segment on a remote host is saved
+        And the information of the corresponding primary segment on a remote host is saved
+       When user kills a "mirror" process with the saved information
+        And user can start transactions
+       Then the saved "mirror" segment is marked down in config
+       When the user runs "gprecoverseg -a -p mdw"
+       Then gprecoverseg should return a return code of 0
+       When user kills a "primary" process with the saved information
+        And user can start transactions
+       Then the saved "primary" segment is marked down in config
+       When the user runs "gprecoverseg -a"
+       Then gprecoverseg should return a return code of 0
+        And all the segments are running
+        And the segments are synchronized
+       When the user runs "gprecoverseg -ra"
+       Then gprecoverseg should return a return code of 0
+        And all the segments are running
+        And the segments are synchronized


### PR DESCRIPTION
When a down mirror segment is moved to a new host using gprecoverseg Full, the replication/connections entries for the new mirror are not appended to the primary pg_hba.conf due to which gprecoverseg fails. This commits updates the code to add the entries of the new mirror to the primary pg_hba.conf