### PR TITLE
Use a Mixin for repeated definitions of DbgPrint

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCTEMap.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCTEMap.h
@@ -134,7 +134,7 @@ private:
 
 		// print function
 		IOstream &
-		OsPrint(IOstream &os) const override
+		OsPrint(IOstream &os) const
 		{
 			os << m_id << (EctProducer == m_ect ? "p" : "c");
 			if (NULL != m_pdpplan)
@@ -211,7 +211,7 @@ public:
 											  const CCTEReq *pcter) const;
 
 	// print function
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 	// combine the two given maps and return the resulting map
 	static CCTEMap *PcmCombine(CMemoryPool *mp, const CCTEMap &cmFirst,

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCTEReq.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCTEReq.h
@@ -106,7 +106,7 @@ private:
 		BOOL Equals(CCTEReqEntry *pcre) const;
 
 		// print function
-		IOstream &OsPrint(IOstream &os) const override;
+		IOstream &OsPrint(IOstream &os) const;
 
 	};	// class CCTEReqEntry
 
@@ -195,7 +195,7 @@ public:
 	CDrvdPropPlan *Pdpplan(ULONG ulCteId) const;
 
 	// print function
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 };	// class CCTEMap
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
@@ -15,6 +15,7 @@
 #include "gpos/common/CDynamicPtrArray.h"
 #include "gpos/common/CHashMap.h"
 #include "gpos/common/CList.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/metadata/CName.h"
 #include "naucrates/md/IMDType.h"
@@ -51,7 +52,7 @@ typedef CHashMapIter<ULONG, CColRef, gpos::HashValue<ULONG>,
 //		factory object
 //
 //---------------------------------------------------------------------------
-class CColRef
+class CColRef : public gpos::DbgPrintMixin<CColRef>
 {
 public:
 	enum EUsedStatus
@@ -226,10 +227,6 @@ public:
 	{
 		m_mdid_table = mdid_table;
 	}
-
-#ifdef GPOS_DEBUG
-	void DbgPrint() const;
-#endif	// GPOS_DEBUG
 
 };	// class CColRef
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRefSet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRefSet.h
@@ -124,7 +124,7 @@ public:
 	ULONG HashValue();
 
 	// debug print
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 	IOstream &OsPrint(IOstream &os, ULONG ulLenMax) const;
 
 	// extract all column ids

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
@@ -259,6 +259,7 @@ public:
 												CConstraintArray *pdrgpcnstr,
 												CColRef *colref,
 												BOOL fExclusive);
+	virtual gpos::IOstream &OsPrint(gpos::IOstream &os) const = 0;
 
 };	// class CConstraint
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CCostContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CCostContext.h
@@ -298,7 +298,7 @@ public:
 	}
 
 	// debug print
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 };	// class CCostContext
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdProp.h
@@ -102,6 +102,7 @@ public:
 		return true;
 	}
 
+	virtual gpos::IOstream &OsPrint(gpos::IOstream &os) const = 0;
 };	// class CDrvdProp
 
 // shorthand for printing

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropCtxtPlan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropCtxtPlan.h
@@ -58,7 +58,7 @@ public:
 	~CDrvdPropCtxtPlan() override;
 
 	// print
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 	// return the plan properties of CTE producer with given id
 	CDrvdPropPlan *PdpplanCTEProducer(ULONG ulCTEId) const;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CEnfdProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CEnfdProp.h
@@ -123,6 +123,7 @@ public:
 			   CEnfdProp::EpetUnnecessary == epet;
 	}
 
+	virtual gpos::IOstream &OsPrint(gpos::IOstream &os) const = 0;
 };	// class CEnfdProp
 
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionProp.h
@@ -80,7 +80,7 @@ public:
 	BOOL NeedsSingletonExecution() const;
 
 	// print
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 };	// class CFunctionProp
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionalDependency.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CFunctionalDependency.h
@@ -89,7 +89,7 @@ public:
 	}
 
 	// print
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 	// hash function
 	static ULONG HashValue(const CFunctionalDependencyArray *pdrgpfd);

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CKeyCollection.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CKeyCollection.h
@@ -80,7 +80,7 @@ public:
 	}
 
 	// print
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 };	// class CKeyCollection
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/COptimizationContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/COptimizationContext.h
@@ -273,7 +273,7 @@ public:
 	}
 
 	// debug print
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 	IOstream &OsPrintWithPrefix(IOstream &os, const CHAR *szPrefix) const;
 
 	// check equality of optimization contexts

--- a/src/backend/gporca/libgpopt/include/gpopt/base/COrderSpec.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/COrderSpec.h
@@ -13,11 +13,11 @@
 #define GPOPT_COrderSpec_H
 
 #include "gpos/base.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/base/CColRef.h"
 #include "gpopt/base/CPropSpec.h"
 #include "naucrates/md/IMDId.h"
-
 
 namespace gpopt
 {
@@ -64,7 +64,7 @@ private:
 	//			3. definition of NULL treatment
 	//
 	//---------------------------------------------------------------------------
-	class COrderExpression
+	class COrderExpression : public gpos::DbgPrintMixin<COrderExpression>
 	{
 	private:
 		// MD id of sort operator
@@ -112,11 +112,6 @@ private:
 
 		// print
 		IOstream &OsPrint(IOstream &os) const;
-
-#ifdef GPOS_DEBUG
-		// debug print for interactive debugging sessions only
-		void DbgPrint() const;
-#endif	// GPOS_DEBUG
 
 	};	// class COrderExpression
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPartInfo.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPartInfo.h
@@ -99,7 +99,7 @@ private:
 		}
 
 		// print function
-		IOstream &OsPrint(IOstream &os) const override;
+		IOstream &OsPrint(IOstream &os) const;
 
 		// copy part info entry into given memory pool
 		CPartInfoEntry *PpartinfoentryCopy(CMemoryPool *mp);
@@ -156,7 +156,7 @@ public:
 										 CColRefArray *pdrgpcrDest) const;
 
 	// print
-	IOstream &OsPrint(IOstream &) const override;
+	IOstream &OsPrint(IOstream &) const;
 
 	// combine two part info objects
 	static CPartInfo *PpartinfoCombine(CMemoryPool *mp, CPartInfo *ppartinfoFst,

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPartKeys.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPartKeys.h
@@ -81,7 +81,7 @@ public:
 							  UlongToColRefMap *colref_mapping) const;
 
 	// print
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 	// copy array of part keys into given memory pool
 	static CPartKeysArray *PdrgppartkeysCopy(

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPropConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPropConstraint.h
@@ -93,7 +93,7 @@ public:
 		CPropConstraint *constraintsForOuterRefs) const;
 
 	// print
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 };	// class CPropConstraint
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CPropSpec.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CPropSpec.h
@@ -70,6 +70,8 @@ public:
 	// property type
 	virtual EPropSpecType Epst() const = 0;
 
+	virtual gpos::IOstream &OsPrint(gpos::IOstream &os) const = 0;
+
 };	// class CPropSpec
 
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CQueryContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CQueryContext.h
@@ -12,6 +12,7 @@
 #define GPOPT_CQueryContext_H
 
 #include "gpos/base.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/base/CReqdPropPlan.h"
 #include "gpopt/base/CReqdPropRelational.h"
@@ -50,13 +51,6 @@ using namespace gpos;
 class CQueryContext
 {
 private:
-#ifdef GPOS_DEBUG
-	// FIXME: m_mp is really only used by DbgPrint, consider an alternative to
-	// supply memory pool to that method
-	// memory pool
-	CMemoryPool *m_mp;
-#endif
-
 	// required plan properties in optimizer's produced plan
 	CReqdPropPlan *m_prpp;
 
@@ -145,8 +139,6 @@ public:
 #ifdef GPOS_DEBUG
 	// debug print
 	IOstream &OsPrint(IOstream &) const;
-
-	void DbgPrint() const;
 #endif	// GPOS_DEBUG
 
 	// walk the expression and add the mapping between computed column

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CRange.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CRange.h
@@ -201,7 +201,7 @@ public:
 	}
 
 	// print
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 };	// class CRange
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CReqdProp.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CReqdProp.h
@@ -105,6 +105,8 @@ public:
 						 CReqdProp *prpInput, ULONG child_index,
 						 CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq) = 0;
 
+	virtual gpos::IOstream &OsPrint(gpos::IOstream &os) const = 0;
+
 };	// class CReqdProp
 
 // shorthand for printing

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CWindowFrame.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CWindowFrame.h
@@ -171,7 +171,7 @@ public:
 	}
 
 	// print
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 	// matching function over frame arrays
 	static BOOL Equals(const CWindowFrameArray *pdrgpwfFirst,

--- a/src/backend/gporca/libgpopt/include/gpopt/cost/ICostModelParams.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/cost/ICostModelParams.h
@@ -131,6 +131,8 @@ public:
 	virtual BOOL Equals(ICostModelParams *pcm) const = 0;
 
 	virtual const CHAR *SzNameLookup(ULONG id) const = 0;
+
+	virtual gpos::IOstream &OsPrint(gpos::IOstream &os) const = 0;
 };
 }  // namespace gpopt
 

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CColumnDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CColumnDescriptor.h
@@ -127,7 +127,7 @@ public:
 		m_is_dist_col = true;
 	}
 
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 };	// class CColumnDescriptor
 }  // namespace gpopt

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CIndexDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CIndexDescriptor.h
@@ -120,7 +120,7 @@ public:
 										const CTableDescriptor *ptabdesc,
 										const IMDIndex *pmdindex);
 
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 };	// class CIndexDescriptor
 }  // namespace gpopt

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CPartConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CPartConstraint.h
@@ -172,7 +172,7 @@ public:
 		CMemoryPool *mp, UlongToColRefMap *colref_mapping, BOOL must_exist);
 
 	// print
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 	// construct a disjunction of the two constraints
 	static CPartConstraint *PpartcnstrDisjunction(

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -224,7 +224,7 @@ public:
 	ULONG UlPos(const CColumnDescriptor *,
 				const CColumnDescriptorArray *) const;
 
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 	// returns number of indices
 	ULONG IndexCount();

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
@@ -14,6 +14,7 @@
 #include "gpos/base.h"
 #include "gpos/common/CDynamicPtrArray.h"
 #include "gpos/common/CRefCount.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/base/CColRef.h"
 #include "gpopt/base/CCostContext.h"
@@ -53,7 +54,7 @@ using namespace gpnaucrates;
 //		Simply dynamic array for pointer types
 //
 //---------------------------------------------------------------------------
-class CExpression : public CRefCount
+class CExpression : public CRefCount, public gpos::DbgPrintMixin<CExpression>
 {
 	friend class CExpressionHandle;
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
@@ -245,7 +245,7 @@ public:
 	BOOL HasOuterRefs();
 
 	// print driver
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 	// print driver, customized for expressions
 	IOstream &OsPrintExpression(IOstream &os, const CPrintPrefix * = NULL,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/COperator.h
@@ -351,7 +351,7 @@ public:
 		CMemoryPool *mp, UlongToColRefMap *colref_mapping, BOOL must_exist) = 0;
 
 	// print
-	IOstream &OsPrint(IOstream &os) const override;
+	virtual IOstream &OsPrint(IOstream &os) const;
 
 };	// class COperator
 

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroup.h
@@ -612,7 +612,7 @@ public:
 	static BOOL FDuplicateGroups(CGroup *pgroupFst, CGroup *pgroupSnd);
 
 	// print function
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 	// slink for group list in memo
 	SLink m_link;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
@@ -71,13 +71,6 @@ public:
 		ShtCC;
 
 private:
-	// FIXME: this is ONLY used by DbgPrint. Find an alternative way to supply
-	// memory pool to that method
-#ifdef GPOS_DEBUG
-	// memory pool
-	CMemoryPool *m_mp;
-#endif
-
 	// definition of context hash table accessor
 	typedef CSyncHashtableAccessByKey<CCostContext,	 // entry
 									  OPTCTXT_PTR>
@@ -183,11 +176,7 @@ private:
 
 	//private dummy ctor; used for creating invalid gexpr
 	CGroupExpression()
-		:
-#ifdef GPOS_DEBUG
-		  m_mp(NULL),
-#endif
-		  m_id(GPOPT_INVALID_GEXPR_ID),
+		: m_id(GPOPT_INVALID_GEXPR_ID),
 		  m_pop(NULL),
 		  m_pdrgpgroup(NULL),
 		  m_pdrgpgroupSorted(NULL),

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
@@ -407,7 +407,7 @@ public:
 									   BOOL fComputeRootStats = true);
 
 	// print driver
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 	IOstream &OsPrintWithPrefix(IOstream &os, const CHAR *prefix) const;
 
 	// link for list in Group

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CMemo.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CMemo.h
@@ -15,6 +15,7 @@
 #include "gpos/common/CRefCount.h"
 #include "gpos/common/CSyncHashtable.h"
 #include "gpos/common/CSyncList.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/search/CGroupExpression.h"
 
@@ -41,7 +42,7 @@ using namespace gpos;
 //		Dynamic programming table
 //
 //---------------------------------------------------------------------------
-class CMemo
+class CMemo : public gpos::DbgPrintMixin<CMemo>
 {
 private:
 	// definition of hash table key accessor
@@ -175,8 +176,6 @@ public:
 	// get group by id
 	CGroup *Pgroup(ULONG id);
 
-	// debug print for interactive debugging sessions only
-	void DbgPrint();
 #endif	// GPOS_DEBUG
 
 };	// class CMemo

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrder.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrder.h
@@ -76,7 +76,7 @@ public:
 		~SEdge() override;
 
 		// print routine
-		IOstream &OsPrint(IOstream &os) const override;
+		IOstream &OsPrint(IOstream &os) const;
 	};
 
 
@@ -181,7 +181,7 @@ public:
 		}
 
 		// print routine
-		IOstream &OsPrint(IOstream &os) const override;
+		IOstream &OsPrint(IOstream &os) const;
 	};
 
 protected:

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDP.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDP.h
@@ -14,6 +14,7 @@
 #include "gpos/base.h"
 #include "gpos/common/CBitSet.h"
 #include "gpos/common/CHashMap.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/io/IOstream.h"
 
 #include "gpopt/base/CUtils.h"
@@ -33,7 +34,7 @@ using namespace gpos;
 //		Helper class for creating join orders using dynamic programming
 //
 //---------------------------------------------------------------------------
-class CJoinOrderDP : public CJoinOrder
+class CJoinOrderDP : public CJoinOrder, public gpos::DbgPrintMixin<CJoinOrderDP>
 {
 private:
 	//---------------------------------------------------------------------------
@@ -190,9 +191,6 @@ public:
 	// print function
 	IOstream &OsPrint(IOstream &) const;
 
-#ifdef GPOS_DEBUG
-	void DbgPrint();
-#endif
 
 };	// class CJoinOrderDP
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -14,6 +14,7 @@
 #include "gpos/base.h"
 #include "gpos/common/CBitSet.h"
 #include "gpos/common/CHashMap.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/io/IOstream.h"
 
 #include "gpopt/base/CKHeap.h"
@@ -44,7 +45,8 @@ using namespace gpos;
 //				a result expression, each of these sets will be associated
 //				with a CGroup in MEMO.
 //---------------------------------------------------------------------------
-class CJoinOrderDPv2 : public CJoinOrder
+class CJoinOrderDPv2 : public CJoinOrder,
+					   public gpos::DbgPrintMixin<CJoinOrderDPv2>
 {
 private:
 	// Data structures for DPv2 join enumeration:
@@ -559,10 +561,6 @@ public:
 	IOstream &OsPrint(IOstream &) const;
 
 	IOstream &OsPrintProperty(IOstream &, SExpressionProperties &) const;
-
-#ifdef GPOS_DEBUG
-	void DbgPrint();
-#endif
 
 };	// class CJoinOrderDPv2
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
@@ -289,7 +289,7 @@ public:
 	virtual EXformPromise Exfp(CExpressionHandle &exprhdl) const = 0;
 
 	// print
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 #ifdef GPOS_DEBUG
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformResult.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformResult.h
@@ -59,7 +59,7 @@ public:
 	CExpression *PexprNext();
 
 	// print function
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 };	// class CXformResult
 

--- a/src/backend/gporca/libgpopt/src/base/CColRef.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColRef.cpp
@@ -176,15 +176,3 @@ CColRef::Equals(const CColRef2dArray *pdrgdrgpcr1,
 
 	return true;
 }
-
-#ifdef GPOS_DEBUG
-void
-CColRef::DbgPrint() const
-{
-	CMemoryPool *pmp = COptCtxt::PoctxtFromTLS()->Pmp();
-	CAutoTrace at(pmp);
-	(void) this->OsPrint(at.Os());
-}
-#endif	// GPOS_DEBUG
-
-// EOF

--- a/src/backend/gporca/libgpopt/src/base/CColRef.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColRef.cpp
@@ -93,6 +93,8 @@ CColRef::HashValue(const CColRef *colref)
 }
 
 
+FORCE_GENERATE_DBGSTR(gpopt::CColRef);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CColRef::OsPrint

--- a/src/backend/gporca/libgpopt/src/base/COrderSpec.cpp
+++ b/src/backend/gporca/libgpopt/src/base/COrderSpec.cpp
@@ -75,6 +75,8 @@ COrderSpec::COrderExpression::Matches(const COrderExpression *poe) const
 }
 
 
+FORCE_GENERATE_DBGSTR(gpopt::COrderSpec::COrderExpression);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		COrderSpec::COrderExpression::OsPrint

--- a/src/backend/gporca/libgpopt/src/base/COrderSpec.cpp
+++ b/src/backend/gporca/libgpopt/src/base/COrderSpec.cpp
@@ -95,15 +95,6 @@ COrderSpec::COrderExpression::OsPrint(IOstream &os) const
 	return os;
 }
 
-#ifdef GPOS_DEBUG
-void
-COrderSpec::COrderExpression::DbgPrint() const
-{
-	CMemoryPool *mp = COptCtxt::PoctxtFromTLS()->Pmp();
-	CAutoTrace at(mp);
-	(void) this->OsPrint(at.Os());
-}
-#endif	// GPOS_DEBUG
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/base/CQueryContext.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CQueryContext.cpp
@@ -34,11 +34,7 @@ using namespace gpopt;
 CQueryContext::CQueryContext(CMemoryPool *mp, CExpression *pexpr,
 							 CReqdPropPlan *prpp, CColRefArray *colref_array,
 							 CMDNameArray *pdrgpmdname, BOOL fDeriveStats)
-	:
-#ifdef GPOS_DEBUG
-	  m_mp(mp),
-#endif
-	  m_prpp(prpp),
+	: m_prpp(prpp),
 	  m_pdrgpcr(colref_array),
 	  m_pdrgpcrSystemCols(NULL),
 	  m_pdrgpmdname(pdrgpmdname),
@@ -270,13 +266,6 @@ IOstream &
 CQueryContext::OsPrint(IOstream &os) const
 {
 	return os << *m_pexpr << std::endl << *m_prpp;
-}
-
-void
-CQueryContext::DbgPrint() const
-{
-	CAutoTrace at(m_mp);
-	(void) this->OsPrint(at.Os());
 }
 #endif	// GPOS_DEBUG
 

--- a/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
@@ -37,7 +37,6 @@
 #include "naucrates/statistics/CStatistics.h"
 #include "naucrates/traceflags/traceflags.h"
 
-
 using namespace gpnaucrates;
 using namespace gpopt;
 
@@ -1122,6 +1121,8 @@ CExpression::DbgPrintWithProperties() const
 }
 
 #endif	// GPOS_DEBUG
+
+FORCE_GENERATE_DBGSTR(gpopt::CExpression);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
@@ -48,11 +48,7 @@ CGroupExpression::CGroupExpression(CMemoryPool *mp, COperator *pop,
 								   CXform::EXformId exfid,
 								   CGroupExpression *pgexprOrigin,
 								   BOOL fIntermediate)
-	:
-#ifdef GPOS_DEBUG
-	  m_mp(mp),
-#endif
-	  m_id(GPOPT_INVALID_GEXPR_ID),
+	: m_id(GPOPT_INVALID_GEXPR_ID),
 	  m_pgexprDuplicate(NULL),
 	  m_pop(pop),
 	  m_pdrgpgroup(pdrgpgroup),
@@ -1212,7 +1208,7 @@ void
 CGroupExpression::DbgPrintWithProperties()
 {
 	CAutoTraceFlag atf(EopttracePrintGroupProperties, true);
-	CAutoTrace at(m_mp);
+	CAutoTrace at(CTask::Self()->Pmp());
 	(void) this->OsPrint(at.Os());
 }
 #endif	// GPOS_DEBUG

--- a/src/backend/gporca/libgpopt/src/search/CMemo.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CMemo.cpp
@@ -806,14 +806,3 @@ CMemo::UlGrpExprs()
 
 	return ulGExprs;
 }
-
-#ifdef GPOS_DEBUG
-void
-CMemo::DbgPrint()
-{
-	CAutoTrace at(m_mp);
-	(void) this->OsPrint(at.Os());
-}
-#endif	// GPOS_DEBUG
-
-// EOF

--- a/src/backend/gporca/libgpopt/src/search/CMemo.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CMemo.cpp
@@ -610,6 +610,8 @@ CMemo::Trace()
 }
 
 
+FORCE_GENERATE_DBGSTR(gpopt::CMemo);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CMemo::OsPrint

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDP.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDP.cpp
@@ -969,16 +969,3 @@ CJoinOrderDP::OsPrint(IOstream &os) const
 
 	return os;
 }
-
-
-#ifdef GPOS_DEBUG
-void
-CJoinOrderDP::DbgPrint()
-{
-	CAutoTrace at(m_mp);
-
-	OsPrint(at.Os());
-}
-#endif
-
-// EOF

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDP.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDP.cpp
@@ -913,6 +913,8 @@ CJoinOrderDP::PexprExpand()
 }
 
 
+FORCE_GENERATE_DBGSTR(gpopt::CJoinOrderDP);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CJoinOrderDP::OsPrint

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
@@ -32,7 +32,6 @@
 #include "naucrates/md/IMDRelStats.h"
 #include "naucrates/statistics/CJoinStatsProcessor.h"
 
-
 using namespace gpopt;
 
 // how many expressions will we return at the end of the DP phase?
@@ -1800,6 +1799,8 @@ CJoinOrderDPv2::LevelIsFull(ULONG level)
 	return li->m_top_k_groups->IsLimitExceeded();
 }
 
+
+FORCE_GENERATE_DBGSTR(gpopt::CJoinOrderDPv2);
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
@@ -1974,17 +1974,3 @@ CJoinOrderDPv2::OsPrintProperty(IOstream &os,
 
 	return os;
 }
-
-
-#ifdef GPOS_DEBUG
-void
-CJoinOrderDPv2::DbgPrint()
-{
-	CAutoTrace at(m_mp);
-
-	OsPrint(at.Os());
-}
-#endif
-
-
-// EOF

--- a/src/backend/gporca/libgpos/include/gpos/common/CBitSet.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CBitSet.h
@@ -153,7 +153,7 @@ public:
 	}
 
 	// print function
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 };	// class CBitSet
 

--- a/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
@@ -128,11 +128,6 @@ public:
 		}
 	}
 
-#ifdef GPOS_DEBUG
-	// debug print for interactive debugging sessions only
-	void DbgPrint() const;
-#endif	// GPOS_DEBUG
-
 	// print function
 	virtual IOstream &
 	OsPrint(IOstream &os) const

--- a/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
@@ -128,14 +128,6 @@ public:
 		}
 	}
 
-	// print function
-	virtual IOstream &
-	OsPrint(IOstream &os) const
-	{
-		return os;
-	}
-
-
 };	// class CRefCount
 }  // namespace gpos
 

--- a/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
@@ -6,7 +6,9 @@
 #define GPDB_DbgPrintMixin_H
 
 #include "gpos/error/CAutoTrace.h"
+#include "gpos/io/COstreamStdString.h"
 #include "gpos/task/CTask.h"
+
 namespace gpos
 {
 template <class T>
@@ -19,6 +21,14 @@ struct DbgPrintMixin
 	{
 		CAutoTrace at(CTask::Self()->Pmp());
 		static_cast<const T *>(this)->OsPrint(at.Os());
+	}
+
+	std::wstring
+	DbgStr() const __attribute__((used))
+	{
+		COstreamStdString oss;
+		static_cast<const T *>(this)->OsPrint(oss);
+		return oss.Str();
 	}
 #endif
 };

--- a/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
@@ -1,0 +1,27 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (c) 2020-Present VMware, Inc. or its affiliates
+//---------------------------------------------------------------------------
+#ifndef GPDB_DbgPrintMixin_H
+#define GPDB_DbgPrintMixin_H
+
+#include "gpos/error/CAutoTrace.h"
+#include "gpos/task/CTask.h"
+namespace gpos
+{
+template <class T>
+struct DbgPrintMixin
+{
+#ifdef GPOS_DEBUG
+	// debug print for interactive debugging sessions only
+	void
+	DbgPrint() const __attribute__((used))
+	{
+		CAutoTrace at(CTask::Self()->Pmp());
+		static_cast<const T *>(this)->OsPrint(at.Os());
+	}
+#endif
+};
+}  // namespace gpos
+
+#endif

--- a/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/DbgPrintMixin.h
@@ -2,8 +2,8 @@
 //	Greenplum Database
 //	Copyright (c) 2020-Present VMware, Inc. or its affiliates
 //---------------------------------------------------------------------------
-#ifndef GPDB_DbgPrintMixin_H
-#define GPDB_DbgPrintMixin_H
+#ifndef GPOS_DbgPrintMixin_H
+#define GPOS_DbgPrintMixin_H
 
 #include "gpos/error/CAutoTrace.h"
 #include "gpos/io/COstreamStdString.h"
@@ -11,20 +11,36 @@
 
 namespace gpos
 {
+/// A Mixin class that adds debug printing to a type.
+///
+/// To use it to add DbgStr() and friends to a type U, simply add this as a
+/// public base:
+/// \code
+/// namespace ns {
+/// class U : public gpos::DbgPrintMixin<U> { ... };
+/// }
+/// \endcode
+///
+/// Also drop this snippet into the U.cpp file at the top level:
+///
+/// \code FORCE_GENERATE_DBGSTR(ns::U); \endcode
+///
+/// The FORCE_GENERATE_DBGSTR macro ensures code generation for the unused
+/// functions so that we can call them in a debugger
 template <class T>
 struct DbgPrintMixin
 {
 #ifdef GPOS_DEBUG
 	// debug print for interactive debugging sessions only
 	void
-	DbgPrint() const __attribute__((used))
+	DbgPrint() const
 	{
 		CAutoTrace at(CTask::Self()->Pmp());
 		static_cast<const T *>(this)->OsPrint(at.Os());
 	}
 
 	std::wstring
-	DbgStr() const __attribute__((used))
+	DbgStr() const GPOS_UNUSED
 	{
 		COstreamStdString oss;
 		static_cast<const T *>(this)->OsPrint(oss);
@@ -33,5 +49,30 @@ struct DbgPrintMixin
 #endif
 };
 }  // namespace gpos
+
+// DbgStr() is designed to be unused until evaluated in a debugger. The "used"
+// attribute usually does the trick to convince a mainstream compiler (GCC and
+// upstream LLVM Clang) to generate code for DbgStr(). There are two issues with
+// the "used" attribute, however:
+//
+// 1. It slows down compilation. Every translation unit that includes the
+// declaration of a derived class will take a hit generating DbgPrint() and
+// DbgStr(). But we really only need one copy of them. This is a fairly minor
+// issue.
+//
+// 2. Not so minor, However, is that AppleClang insists to omit code generation
+// for unused functions in a class template (this is borderline bug, and there
+// isn't a flag to disable such a "feature").
+//
+// The best remedy is for each derived type, explicitly instantiate the base
+// template in the translation unit. This forces code generation even in Apple
+// Clang, and it speeds up compilation because we only emit code for each
+// explicit instantiation once.
+#if defined(GPOS_DEBUG)
+#define FORCE_GENERATE_DBGSTR(Type) template struct ::gpos::DbgPrintMixin<Type>
+#else
+#define FORCE_GENERATE_DBGSTR(Type) static_assert(true, "")
+#endif
+
 
 #endif

--- a/src/backend/gporca/libgpos/include/gpos/io/COstreamStdString.h
+++ b/src/backend/gporca/libgpos/include/gpos/io/COstreamStdString.h
@@ -1,0 +1,26 @@
+//---------------------------------------------------------------------------
+// Greenplum Database
+// Copyright (c) 2020 VMware, Inc. or its affiliates
+//---------------------------------------------------------------------------
+#ifndef COstreamStdString_H
+#define COstreamStdString_H
+
+#include <sstream>
+#include <string>
+
+#include "gpos/io/COstreamBasic.h"
+
+namespace gpos
+{
+class COstreamStdString : public gpos::COstreamBasic
+{
+public:
+	COstreamStdString();
+	std::wstring Str() const;
+
+private:
+	std::wostringstream m_oss;
+};
+}  // namespace gpos
+
+#endif

--- a/src/backend/gporca/libgpos/src/common/CRefCount.cpp
+++ b/src/backend/gporca/libgpos/src/common/CRefCount.cpp
@@ -15,16 +15,3 @@
 #include "gpos/task/CTask.h"
 
 using namespace gpos;
-
-#ifdef GPOS_DEBUG
-// debug print for interactive debugging sessions only
-void
-CRefCount::DbgPrint() const
-{
-	CAutoTrace at(CTask::Self()->Pmp());
-
-	OsPrint(at.Os());
-}
-#endif	// GPOS_DEBUG
-
-// EOF

--- a/src/backend/gporca/libgpos/src/io/COstreamStdString.cpp
+++ b/src/backend/gporca/libgpos/src/io/COstreamStdString.cpp
@@ -1,0 +1,20 @@
+//---------------------------------------------------------------------------
+// Greenplum Database
+// Copyright (c) 2020 VMware, Inc. or its affiliates
+//---------------------------------------------------------------------------
+
+#include "gpos/io/COstreamStdString.h"
+
+namespace gpos
+{
+COstreamStdString::COstreamStdString() : COstreamBasic(&m_oss)
+{
+}
+
+std::wstring
+COstreamStdString::Str() const
+{
+	return m_oss.str();
+}
+
+}  // namespace gpos

--- a/src/backend/gporca/libgpos/src/io/Makefile
+++ b/src/backend/gporca/libgpos/src/io/Makefile
@@ -15,6 +15,7 @@ OBJS        = CFileDescriptor.o \
               CFileWriter.o \
               COstream.o \
               COstreamBasic.o \
+              COstreamStdString.o \
               COstreamString.o \
               ioutils.o
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/base/IDatum.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/base/IDatum.h
@@ -140,6 +140,7 @@ public:
 	// check if the given pair of datums are stats comparable
 	virtual BOOL StatsAreComparable(const IDatum *datum) const;
 
+	virtual gpos::IOstream &OsPrint(gpos::IOstream &os) const = 0;
 };	// class IDatum
 
 // array of idatums

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
@@ -161,6 +161,8 @@ public:
 	{
 		return NULL != mdid && mdid->IsValid();
 	}
+
+	virtual gpos::IOstream &OsPrint(gpos::IOstream &os) const = 0;
 };
 
 // common structures over metadata id elements

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CBucket.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CBucket.h
@@ -13,6 +13,7 @@
 #define GPNAUCRATES_CBucket_H
 
 #include "gpos/base.h"
+#include "gpos/common/DbgPrintMixin.h"
 #include "gpos/error/CAutoTrace.h"
 #include "gpos/task/CTask.h"
 
@@ -42,7 +43,7 @@ typedef CDynamicPtrArray<CBucket, CleanupDelete> CBucketArray;
 //
 //---------------------------------------------------------------------------
 
-class CBucket : public IBucket
+class CBucket : public IBucket, public gpos::DbgPrintMixin<CBucket>
 {
 private:
 	// lower bound of bucket
@@ -165,10 +166,6 @@ public:
 
 	// print function
 	IOstream &OsPrint(IOstream &os) const;
-
-#ifdef GPOS_DEBUG
-	void DbgPrint() const;
-#endif
 
 	// construct new bucket with lower bound greater than given point
 	CBucket *MakeBucketGreaterThan(CMemoryPool *mp, CPoint *point) const;

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
@@ -12,6 +12,7 @@
 #define GPNAUCRATES_CHistogram_H
 
 #include "gpos/base.h"
+#include "gpos/common/DbgPrintMixin.h"
 
 #include "gpopt/base/CKHeap.h"
 #include "naucrates/statistics/CBucket.h"
@@ -37,7 +38,7 @@ typedef CDynamicPtrArray<CDouble, CleanupDelete> CDoubleArray;
 //	@doc:
 //
 //---------------------------------------------------------------------------
-class CHistogram
+class CHistogram : public gpos::DbgPrintMixin<CHistogram>
 {
 	// hash map from column id to a histogram
 	typedef CHashMap<ULONG, CHistogram, gpos::HashValue<ULONG>,
@@ -343,10 +344,6 @@ public:
 
 	// print function
 	IOstream &OsPrint(IOstream &os) const;
-
-#ifdef GPOS_DEBUG
-	void DbgPrint() const;
-#endif
 
 	// total frequency from buckets and null fraction
 	CDouble GetFrequency() const;

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CPoint.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CPoint.h
@@ -80,7 +80,7 @@ public:
 	CDouble Width(const CPoint *, BOOL include_lower, BOOL include_upper) const;
 
 	// print function
-	IOstream &OsPrint(IOstream &os) const override;
+	IOstream &OsPrint(IOstream &os) const;
 
 	// d'tor
 	~CPoint() override

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/IStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/IStatistics.h
@@ -185,7 +185,7 @@ public:
 	virtual CColRefSet *GetColRefSet(CMemoryPool *mp) const = 0;
 
 	// print function
-	IOstream &OsPrint(IOstream &os) const override = 0;
+	virtual IOstream &OsPrint(IOstream &os) const = 0;
 
 	// generate the DXL representation of the statistics object
 	virtual CDXLStatsDerivedRelation *GetDxlStatsDrvdRelation(

--- a/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
@@ -240,15 +240,6 @@ CBucket::OsPrint(IOstream &os) const
 	return os;
 }
 
-#ifdef GPOS_DEBUG
-void
-CBucket::DbgPrint() const
-{
-	CAutoTrace at(CTask::Self()->Pmp());
-	OsPrint(at.Os());
-}
-#endif
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CBucket::MakeBucketGreaterThan

--- a/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
@@ -198,6 +198,8 @@ CBucket::GetOverlapPercentage(const CPoint *point, BOOL include_point) const
 	return CDouble(std::min(res.Get(), DOUBLE(1.0)));
 }
 
+FORCE_GENERATE_DBGSTR(gpnaucrates::CBucket);
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CBucket::OsPrint

--- a/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
@@ -117,6 +117,8 @@ CHistogram::SetNullFrequency(CDouble null_freq)
 	m_null_freq = null_freq;
 }
 
+FORCE_GENERATE_DBGSTR(gpnaucrates::CHistogram);
+
 //	print function
 IOstream &
 CHistogram::OsPrint(IOstream &os) const

--- a/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
@@ -153,15 +153,6 @@ CHistogram::OsPrint(IOstream &os) const
 	return os;
 }
 
-#ifdef GPOS_DEBUG
-void
-CHistogram::DbgPrint() const
-{
-	CAutoTrace at(CTask::Self()->Pmp());
-	OsPrint(at.Os());
-}
-#endif
-
 // check if histogram is empty
 BOOL
 CHistogram::IsEmpty() const


### PR DESCRIPTION
I'm finally ready for this to be reviewed. Specific areas of feedback I'm looking for (others are also welcome):

1. GDB by default prints newlines in a `std::wstring` as `\n`. GDB has a very nice API for making pretty printers. Is it a showstopper to ship this without GDB/LLDB scripts?
2. I'm a bit upset by having to repeat ourselves a bit with the `FORCE_GENERATE` macro. Is it just me? It's not really necessary in GCC and upstream LLVM/Clang. It's only needed to support the fork of clang in Xcode.
