### PR TITLE
Add Orca costing of index only scan

### DIFF
--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -33,16 +33,16 @@ def ResultIter(cursor, arraysize=1000):
 def getVersion(envOpts):
     cmd = subprocess.Popen('psql --pset footer -Atqc "select version()" template1', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=envOpts)
     if cmd.wait() is not 0:
-        sys.stderr.write('\nError while trying to find HAWQ/GPDB version.\n\n' + cmd.communicate()[1] + '\n\n')
+        sys.stderr.write('\nError while trying to find HAWQ/GPDB version.\n\n' + cmd.communicate()[1].decode('ascii') + '\n\n')
         sys.exit(1)
-    return cmd.communicate()[0]
+    return cmd.communicate()[0].decode('ascii')
 
 
 def dumpSchema(connectionInfo, envOpts):
     dump_cmd = 'pg_dump -h {host} -p {port} -U {user} -s -x -O {database}'.format(**connectionInfo)
     p = subprocess.Popen(dump_cmd, shell=True, stderr=subprocess.PIPE, env=envOpts)
     if p.wait() is not 0:
-        sys.stderr.write('\nError while dumping schema.\n\n' + p.communicate()[1] + '\n\n')
+        sys.stderr.write('\nError while dumping schema.\n\n' + p.communicate()[1].decode('ascii') + '\n\n')
         sys.exit(1)
 
 
@@ -50,12 +50,12 @@ def dumpGlobals(connectionInfo, envOpts):
     dump_cmd = 'pg_dumpall -h {host} -p {port} -U {user} -l {database} -g'.format(**connectionInfo)
     p = subprocess.Popen(dump_cmd, shell=True, stderr=subprocess.PIPE, env=envOpts)
     if p.wait() is not 0:
-        sys.stderr.write('\nError while dumping globals.\n\n' + p.communicate()[1] + '\n\n')
+        sys.stderr.write('\nError while dumping globals.\n\n' + p.communicate()[1].decode('ascii') + '\n\n')
         sys.exit(1)
 
 
 def dumpTupleCount(cur):
-    stmt = "SELECT pgc.relname, pgn.nspname, pgc.relpages, pgc.reltuples FROM pg_class pgc, pg_namespace pgn WHERE pgc.relnamespace = pgn.oid and pgn.nspname NOT IN " + \
+    stmt = "SELECT pgc.relname, pgn.nspname, pgc.relpages, pgc.reltuples, pgc.relallvisible FROM pg_class pgc, pg_namespace pgn WHERE pgc.relnamespace = pgn.oid and pgn.nspname NOT IN " + \
         sysnslist
     setStmt = '-- Table: {1}\n' \
         'UPDATE pg_class\nSET\n' \
@@ -64,11 +64,11 @@ def dumpTupleCount(cur):
         '(SELECT oid FROM pg_namespace WHERE nspname = \'{2}\');\n\n'
 
     cur.execute(stmt)
-    columns = map(lambda x: x[0], cur.description)
-    types = ['int', 'real']
+    columns = [x[0] for x in cur.description]
+    types = ['int', 'real', 'int']
     for vals in ResultIter(cur):
-        print setStmt.format(',\n'.join(map(lambda t: '\t%s = %s::%s' %
-                                            t, zip(columns[2:], vals[2:], types))), vals[0], vals[1])
+        print(setStmt.format(',\n'.join(['\t%s = %s::%s' %
+                                            t for t in zip(columns[2:], vals[2:], types)]), vals[0], vals[1]))
 
 
 def dumpStats(cur, inclHLL):
@@ -134,7 +134,7 @@ def dumpStats(cur, inclHLL):
 
             if val is None:
                 val = 'NULL'
-            elif isinstance(val, (str, unicode)) and val[0] == '{':
+            elif isinstance(val, str) and val[0] == '{':
                 val = val.replace("'", "''")
                 val = "E'" + val + "'"
 
@@ -147,7 +147,7 @@ def dumpStats(cur, inclHLL):
                 rowVals.append('\t{0}::{1}'.format(str_val, 'bytea[]'))
             else:
                 rowVals.append('\t{0}::{1}'.format(val, typ))
-        print pstring.format(vals[0], vals[2], ',\n'.join(rowVals))
+        print(pstring.format(vals[0], vals[2], ',\n'.join(rowVals)))
 
 
 def parseCmdLine():
@@ -207,11 +207,11 @@ def main():
         dumpGlobals(connectionInfo, envOpts)
         # Now be sure that when we load the rest we are doing it in the right
         # database
-        print '\\connect ' + db + '\n'
+        print('\\connect ' + db + '\n')
         sys.stdout.flush()
         dumpSchema(connectionInfo, envOpts)
     else:
-        print '\\connect ' + db + '\n'
+        print('\\connect ' + db + '\n')
         sys.stdout.flush()
 
     # Now we have to explicitly allow editing of these pg_class &
@@ -233,7 +233,7 @@ def main():
                                'which requires some data elements to be included in the output file.\n',
                                'Please review output file to ensure it is within corporate policy to transport the output file.\n'])
 
-    except pgdb.DatabaseError, err:  # catch *all* exceptions
+    except pgdb.DatabaseError as err:  # catch *all* exceptions
         sys.stderr.write('Error while dumping statistics:\n')
         sys.stderr.write(err.message)
         sys.exit(1)

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -122,7 +122,7 @@ def parse_cmd_line():
 
 def dump_query(connectionInfo, query_file):
     (host, port, user, db) = connectionInfo
-    print "Extracting metadata from query file %s ..." % query_file
+    print("Extracting metadata from query file %s ..." % query_file)
 
     with open(query_file, 'r') as query_f:
         sql_text = query_f.read()
@@ -134,12 +134,12 @@ def dump_query(connectionInfo, query_file):
 
     # disable .psqlrc to prevent unexpected timing and format output
     query_cmd = "psql %s --pset footer --no-psqlrc -Atq -h %s -p %s -U %s -f %s" % (db, host, port, user, toolkit_sql)
-    print query_cmd
+    print(query_cmd)
 
     p = subprocess.Popen(query_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ)
 
     if p.wait() is not 0:
-        errormsg = p.communicate()[1]
+        errormsg = p.communicate()[1].decode('ascii')
         sys.stderr.writelines('\nError when executing function gp_dump_query_oids.\n\n' + errormsg + '\n\n')
         sys.exit(1)
 
@@ -183,14 +183,14 @@ def pg_dump_object(mr_query, connectionInfo, envOpts):
     dmp_cmd = 'pg_dump -h %s -p %s -U %s -sxO %s' % connectionInfo
     dmp_cmd = "%s --relation-oids %s --function-oids %s -f %s" % \
         (dmp_cmd, mr_query.relids, mr_query.funcids, E(out_file))
-    print dmp_cmd
+    print(dmp_cmd)
     p = subprocess.Popen(dmp_cmd, shell=True, stderr=subprocess.PIPE, env=envOpts)
     if p.wait() is not 0:
-        sys.stderr.write('\nError while dumping schema.\n\n' + p.communicate()[1] + '\n\n')
+        sys.stderr.write('\nError while dumping schema.\n\n' + p.communicate()[1].decode('ascii') + '\n\n')
         sys.exit(1)
 
 def dump_tuple_count(cur, oid_str, f_out):
-    stmt = "SELECT pgc.relname, pgn.nspname, pgc.relpages, pgc.reltuples FROM pg_class pgc, pg_namespace pgn " \
+    stmt = "SELECT pgc.relname, pgn.nspname, pgc.relpages, pgc.reltuples, pgc.relallvisible FROM pg_class pgc, pg_namespace pgn " \
             "WHERE pgc.relnamespace = pgn.oid and pgc.oid in (%s) and pgn.nspname NOT LIKE 'pg_temp_%%'" % (oid_str)
 
     templateStmt = '-- Table: {1}\n' \
@@ -201,7 +201,7 @@ def dump_tuple_count(cur, oid_str, f_out):
 
     cur.execute(stmt)
     columns = [x[0] for x in cur.description]
-    types = ['int', 'real']
+    types = ['int', 'real', 'int']
     for vals in result_iter(cur):
         lines = []
         for col, val, typ in zip(columns[2:], vals[2:], types):
@@ -272,7 +272,7 @@ def dump_stats(cur, oid_str, f_out, inclHLL):
 
             if val is None:
                 val = 'NULL'
-            elif isinstance(val, (str, unicode)) and val[0] == '{':
+            elif isinstance(val, str) and val[0] == '{':
                 val = "E'%s'" % E(val)
             if i == 25 and hll == True:
                 if inclHLL == True:
@@ -338,7 +338,7 @@ def main():
             'options': pgoptions,
             }
 
-    print "Connecting to database: host=%s, port=%s, user=%s, db=%s ..." % connectionInfo
+    print("Connecting to database: host=%s, port=%s, user=%s, db=%s ..." % connectionInfo)
     conn = pgdb.connect(**connectionDict)
     cursor = conn.cursor()
 
@@ -360,7 +360,7 @@ def main():
     mr_query = parse_oids(cursor, json_str)
 
     # dump relations and functions
-    print "Invoking pg_dump to dump DDL ..."
+    print("Invoking pg_dump to dump DDL ...")
     pg_dump_object(mr_query, connectionInfo, envOpts)
 
     ### start writing out to stdout ###
@@ -381,14 +381,14 @@ def main():
     f_out.writelines('\\connect ' + db + '\n\n')
 
     # first create schema DDLs
-    print "Writing schema DDLs ..."
+    print("Writing schema DDLs ...")
     table_schemas = ["CREATE SCHEMA %s;\n" % E(schema) for schema in mr_query.schemas if schema != 'public']
     f_out.writelines(table_schemas)
 
     # write relation and function DDLs
-    print "Writing relation and function DDLs ..."
+    print("Writing relation and function DDLs ...")
     with open(PATH_PREFIX + PGDUMP_FILE, 'r') as f_pgdump:
-	f_out.writelines(f_pgdump)
+        f_out.writelines(f_pgdump)
 
     # explicitly allow editing of these pg_class & pg_statistic tables
     f_out.writelines(['\n-- ',
@@ -397,18 +397,18 @@ def main():
                            '\nset allow_system_table_mods=true;\n\n'])
 
     # dump table stats
-    print "Writing table statistics ..."
+    print("Writing table statistics ...")
     dump_tuple_count(cursor, mr_query.relids, f_out)
 
     # dump column stats
-    print "Writing column statistics ..."
+    print("Writing column statistics ...")
     dump_stats(cursor, mr_query.relids, f_out, inclHLL)
 
     cursor.close()
     conn.close()
 
     # attach query text
-    print "Attaching raw query text ..."
+    print("Attaching raw query text ...")
     f_out.writelines(['\n-- ',
                        '\n-- Query text',
                        '\n-- \n\n'])
@@ -420,11 +420,11 @@ def main():
     f_out.writelines('\n-- MiniRepro completed.\n')
     f_out.close()
 
-    print "--- MiniRepro completed! ---"
+    print("--- MiniRepro completed! ---")
 
     # upon success, leave a warning message about data collected
-    print 'WARNING: This tool collects statistics about your data, including most common values, which requires some data elements to be included in the output file.'
-    print 'Please review output file to ensure it is within corporate policy to transport the output file.'
+    print('WARNING: This tool collects statistics about your data, including most common values, which requires some data elements to be included in the output file.')
+    print('Please review output file to ensure it is within corporate policy to transport the output file.')
 
 if __name__ == "__main__":
         main()

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2085,9 +2085,12 @@ CTranslatorRelcacheToDXL::RetrieveRelStats(CMemoryPool *mp, IMDId *mdid)
 		relation_empty = true;
 	}
 
-	CDXLRelStats *dxl_rel_stats = GPOS_NEW(mp) CDXLRelStats(
-		mp, m_rel_stats_mdid, mdname, CDouble(num_rows), relation_empty);
+	ULONG relpages = rel->rd_rel->relpages;
+	ULONG relallvisible = rel->rd_rel->relallvisible;
 
+	CDXLRelStats *dxl_rel_stats = GPOS_NEW(mp)
+		CDXLRelStats(mp, m_rel_stats_mdid, mdname, CDouble(num_rows),
+					 relation_empty, relpages, relallvisible);
 
 	return dxl_rel_stats;
 }

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
@@ -313,7 +313,7 @@ SELECT * FROM btree_test WHERE a in (select 1);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="22">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.000126" Rows="1.000000" Width="4"/>
@@ -325,7 +325,7 @@ SELECT * FROM btree_test WHERE a in (select 1);
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000111" Rows="1.000000" Width="4"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
@@ -487,7 +487,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1818">
+    <dxl:Plan Id="0" SpaceSize="2048">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1299.001542" Rows="3.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
@@ -11022,7 +11022,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="66">
+    <dxl:Plan Id="0" SpaceSize="76">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="458.857269" Rows="3.941034" Width="127"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexNLJoin_Cast_NoMotion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexNLJoin_Cast_NoMotion.mdp
@@ -401,7 +401,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
         </dxl:LogicalJoin>
       </dxl:UnionAll>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="56">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1072.381940" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-NoDistKeyInIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-NoDistKeyInIndex.mdp
@@ -224,7 +224,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9999999999999999210968330832147026575540427693752222372866517696718412616639336002780474141705354144110364081118142324010404785714541315284281257752757291623642503417072967859774120474650369161140553335192009630674782085554695972153397552576515276800.0000" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000119" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="b">
@@ -235,7 +235,7 @@
         <dxl:SortingColumnList/>
         <dxl:IndexOnlyScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="9999999999999999210968330832147026575540427693752222372866517696718412616639336002780474141705354144110364081118142324010404785714541315284281257752757291623642503417072967859774120474650369161140553335192009630674782085554695972153397552576515276800.0000" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000101" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="b">

--- a/src/backend/gporca/data/dxl/minidump/IndexScanWithNestedCTEAndSetOp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScanWithNestedCTEAndSetOp.mdp
@@ -350,7 +350,7 @@ SELECT a FROM y WHERE (a IN (SELECT b FROM bar WHERE b = 2));
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="132">
+    <dxl:Plan Id="0" SpaceSize="209">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="868.000741" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/NestedNLJWithBlockingSpool.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NestedNLJWithBlockingSpool.mdp
@@ -538,10 +538,10 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="111">
+    <dxl:Plan Id="0" SpaceSize="60">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356691807.542455" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324038.343449" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="23" Alias="p_partkey">
@@ -550,9 +550,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356691807.542440" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324038.343434" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="23" Alias="p_partkey">
@@ -561,24 +561,11 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:JoinFilter>
-            <dxl:And>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.15.1.0">
-                <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.15.1.0">
-                <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="40" ColName="l_partkey" TypeMdid="0.20.1.0"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.416.1.0">
-                <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
-                <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:And>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
           </dxl:JoinFilter>
-          <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.342839" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.343126" Rows="3.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="l_partkey">
@@ -589,50 +576,54 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
-                <dxl:Ident ColId="40" ColName="l_partkey" TypeMdid="0.20.1.0"/>
-              </dxl:Comparison>
-            </dxl:JoinFilter>
-            <dxl:TableScan>
+            <dxl:SortingColumnList/>
+            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.342839" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="l_partkey">
                   <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.98421.1.0" TableName="lineitem">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="l_partkey" TypeMdid="0.20.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="3" Attno="4" ColName="l_linenumber" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:Materialize Eager="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000190" Rows="3.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
                 <dxl:ProjElem ColId="40" Alias="l_partkey">
                   <dxl:Ident ColId="40" ColName="l_partkey" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:JoinFilter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                  <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+                  <dxl:Ident ColId="40" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+                </dxl:Comparison>
+              </dxl:JoinFilter>
+              <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000182" Rows="3.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="l_partkey">
+                    <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.98421.1.0" TableName="lineitem">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="l_partkey" TypeMdid="0.20.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="3" Attno="4" ColName="l_linenumber" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:Materialize Eager="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000190" Rows="3.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="40" Alias="l_partkey">
@@ -640,10 +631,9 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
+                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000182" Rows="3.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="40" Alias="l_partkey">
@@ -651,27 +641,39 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.98421.1.0" TableName="lineitem">
-                    <dxl:Columns>
-                      <dxl:Column ColId="39" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="40" Attno="2" ColName="l_partkey" TypeMdid="0.20.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="42" Attno="4" ColName="l_linenumber" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="55" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="56" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="57" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="58" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="59" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="60" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="61" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:BroadcastMotion>
-            </dxl:Materialize>
-          </dxl:NestedLoopJoin>
-          <dxl:Materialize Eager="true">
+                  <dxl:SortingColumnList/>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="40" Alias="l_partkey">
+                        <dxl:Ident ColId="40" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.98421.1.0" TableName="lineitem">
+                      <dxl:Columns>
+                        <dxl:Column ColId="39" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="40" Attno="2" ColName="l_partkey" TypeMdid="0.20.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="42" Attno="4" ColName="l_linenumber" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="55" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="56" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="57" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="58" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="59" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="60" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="61" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:BroadcastMotion>
+              </dxl:Materialize>
+            </dxl:NestedLoopJoin>
+          </dxl:BroadcastMotion>
+          <dxl:IndexOnlyScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000333" Rows="3.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000292" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="23" Alias="p_partkey">
@@ -679,42 +681,34 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000329" Rows="3.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="23" Alias="p_partkey">
-                  <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000107" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="23" Alias="p_partkey">
-                    <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.98306.1.0" TableName="part">
-                  <dxl:Columns>
-                    <dxl:Column ColId="23" Attno="1" ColName="p_partkey" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="32" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="33" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="34" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="35" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="36" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="37" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="38" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:BroadcastMotion>
-          </dxl:Materialize>
+            <dxl:IndexCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.15.1.0">
+                <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+              </dxl:Comparison>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.15.1.0">
+                <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="40" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+              </dxl:Comparison>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.15.1.0">
+                <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+              </dxl:Comparison>
+            </dxl:IndexCondList>
+            <dxl:IndexDescriptor Mdid="0.98326.1.0" IndexName="part_pkey"/>
+            <dxl:TableDescriptor Mdid="0.98306.1.0" TableName="part">
+              <dxl:Columns>
+                <dxl:Column ColId="23" Attno="1" ColName="p_partkey" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="32" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="33" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="34" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="35" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="36" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="37" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="38" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:IndexOnlyScan>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/TimeTypeStatsNotComparable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TimeTypeStatsNotComparable.mdp
@@ -243,7 +243,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.005445" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
@@ -5,7 +5,7 @@
     <dxl:MDCast Mdid="3.23.1.0;26.1.0" Name="int" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.26.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
     <dxl:ArrayCoerceCast Mdid="3.1007.1.0;1022.1.0" Name="float8" CoercePathType="3" BinaryCoercible="false" SourceTypeId="0.1007.1.0" DestinationTypeId="0.1022.1.0" CastFuncId="0.316.1.0" IsExplicit="false" CoercionForm="2" Location="-1"/>
     <dxl:MDScalarComparison Mdid="4.23.1.0;20.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.23.1.0" RightType="0.20.1.0" OperatorMdid="0.416.1.0"/>
-    <dxl:RelationStatistics Mdid="2.1234.1.2" Name="T" Rows="1234.123400" EmptyRelation="false"/>
+    <dxl:RelationStatistics Mdid="2.1234.1.2" Name="T" Rows="1234.123400" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
     <dxl:ColumnStatistics Mdid="1.1234.1.2.1" Name="T.a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
       <dxl:StatsBucket Frequency="0.500000" DistinctValues="5.000000">
         <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>

--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
@@ -1117,8 +1117,9 @@ CMDAccessor::Pstats(CMemoryPool *mp, IMDId *rel_mdid, CColRefSet *pcrsHist,
 
 	CDouble rows = std::max(DOUBLE(1.0), pmdRelStats->Rows().Get());
 
-	return GPOS_NEW(mp) CStatistics(mp, col_histogram_mapping,
-									colid_width_mapping, rows, fEmptyTable);
+	return GPOS_NEW(mp) CStatistics(
+		mp, col_histogram_mapping, colid_width_mapping, rows, fEmptyTable,
+		pmdRelStats->RelPages(), pmdRelStats->RelAllVisible());
 }
 
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -1529,6 +1529,7 @@ CTranslatorExprToDXL::PdxlnIndexScanWithInlinedCondition(
 
 	COperator::EOperatorId op_id = pexprIndexScan->Pop()->Eopid();
 	GPOS_ASSERT(COperator::EopPhysicalIndexScan == op_id ||
+				COperator::EopPhysicalIndexOnlyScan == op_id ||
 				COperator::EopPhysicalDynamicIndexScan == op_id);
 
 	// TODO: Index only scans work on GiST and SP-GiST only for specific operators

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerStatsDerivedRelation.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerStatsDerivedRelation.h
@@ -41,6 +41,12 @@ private:
 	// flag to express that the statistics is on an empty input
 	BOOL m_empty;
 
+	// number of blocks in the relation (not always up to-to-date)
+	ULONG m_relpages;
+
+	// number of all-visible blocks in the relation (not always up-to-date)
+	ULONG m_relallvisible;
+
 	// relation stats
 	CDXLStatsDerivedRelation *m_dxl_stats_derived_relation;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -318,6 +318,8 @@ enum Edxltoken
 	EdxltokenTotalCost,
 	EdxltokenRows,
 	EdxltokenWidth,
+	EdxltokenRelPages,
+	EdxltokenRelAllVisible,
 	EdxltokenCTASOptions,
 	EdxltokenCTASOption,
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLRelStats.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLRelStats.h
@@ -61,11 +61,18 @@ private:
 	// DXL string for object
 	CWStringDynamic *m_dxl_str;
 
+	// number of blocks (not always up to-to-date)
+	ULONG m_relpages;
+
+	// number of all-visible blocks (not always up-to-date)
+	ULONG m_relallvisible;
+
 public:
 	CDXLRelStats(const CDXLRelStats &) = delete;
 
 	CDXLRelStats(CMemoryPool *mp, CMDIdRelStats *rel_stats_mdid,
-				 CMDName *mdname, CDouble rows, BOOL is_empty);
+				 CMDName *mdname, CDouble rows, BOOL is_empty, ULONG relpages,
+				 ULONG relallvisible);
 
 	~CDXLRelStats() override;
 
@@ -80,6 +87,20 @@ public:
 
 	// number of rows
 	CDouble Rows() const override;
+
+	// number of blocks (not always up to-to-date)
+	ULONG
+	RelPages() const override
+	{
+		return m_relpages;
+	}
+
+	// number of all-visible blocks (not always up-to-date)
+	ULONG
+	RelAllVisible() const override
+	{
+		return m_relallvisible;
+	}
 
 	// is statistics on an empty input
 	BOOL

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLStatsDerivedRelation.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLStatsDerivedRelation.h
@@ -44,6 +44,12 @@ private:
 	// flag to indicate if input relation is empty
 	BOOL m_empty;
 
+	// number of blocks in the relation (not always up to-to-date)
+	ULONG m_relpages;
+
+	// number of all-visible blocks in the relation (not always up-to-date)
+	ULONG m_relallvisible;
+
 	// array of derived column statistics
 	CDXLStatsDerivedColumnArray *m_dxl_stats_derived_col_array;
 
@@ -52,7 +58,7 @@ public:
 
 	// ctor
 	CDXLStatsDerivedRelation(
-		CDouble rows, BOOL is_empty,
+		CDouble rows, BOOL is_empty, ULONG relpages, ULONG relallvisible,
 		CDXLStatsDerivedColumnArray *dxl_stats_derived_col_array);
 
 	// dtor

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelStats.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelStats.h
@@ -45,6 +45,10 @@ public:
 	// number of rows
 	virtual CDouble Rows() const = 0;
 
+	virtual ULONG RelPages() const = 0;
+
+	virtual ULONG RelAllVisible() const = 0;
+
 	// is statistics on an empty input
 	virtual BOOL IsEmpty() const = 0;
 };

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
@@ -95,6 +95,12 @@ private:
 	// flag to indicate if input relation is empty
 	BOOL m_empty;
 
+	// number of blocks in the relation (not always up to-to-date)
+	ULONG m_relpages;
+
+	// number of all-visible blocks in the relation (not always up-to-date)
+	ULONG m_relallvisible;
+
 	// statistics could be computed using predicates with external parameters (outer
 	// references), this is the total number of external parameters' values
 	CDouble m_num_rebinds;
@@ -137,6 +143,11 @@ public:
 				UlongToDoubleMap *colid_width_mapping, CDouble rows,
 				BOOL is_empty, ULONG num_predicates = 0);
 
+	CStatistics(CMemoryPool *mp, UlongToHistogramMap *col_histogram_mapping,
+				UlongToDoubleMap *colid_width_mapping, CDouble rows,
+				BOOL is_empty, ULONG relpages, ULONG relallvisible);
+
+
 	// dtor
 	~CStatistics() override;
 
@@ -149,6 +160,18 @@ public:
 
 	// actual number of rows
 	CDouble Rows() const override;
+
+	ULONG
+	RelPages() const override
+	{
+		return m_relpages;
+	}
+
+	ULONG
+	RelAllVisible() const override
+	{
+		return m_relallvisible;
+	}
 
 	// number of rebinds
 	CDouble

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/IStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/IStatistics.h
@@ -104,6 +104,12 @@ public:
 	// how many rows
 	virtual CDouble Rows() const = 0;
 
+	// number of blocks in the relation (not always up to-to-date)
+	virtual ULONG RelPages() const = 0;
+
+	// number of all-visible blocks in the relation (not always up-to-date)
+	virtual ULONG RelAllVisible() const = 0;
+
 	// is statistics on an empty input
 	virtual BOOL IsEmpty() const = 0;
 

--- a/src/backend/gporca/libnaucrates/src/md/CDXLRelStats.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CDXLRelStats.cpp
@@ -30,12 +30,15 @@ using namespace gpmd;
 //
 //---------------------------------------------------------------------------
 CDXLRelStats::CDXLRelStats(CMemoryPool *mp, CMDIdRelStats *rel_stats_mdid,
-						   CMDName *mdname, CDouble rows, BOOL is_empty)
+						   CMDName *mdname, CDouble rows, BOOL is_empty,
+						   ULONG relpages, ULONG relallvisible)
 	: m_mp(mp),
 	  m_rel_stats_mdid(rel_stats_mdid),
 	  m_mdname(mdname),
 	  m_rows(rows),
-	  m_empty(is_empty)
+	  m_empty(is_empty),
+	  m_relpages(relpages),
+	  m_relallvisible(relallvisible)
 {
 	GPOS_ASSERT(rel_stats_mdid->IsValid());
 	m_dxl_str = CDXLUtils::SerializeMDObj(
@@ -134,6 +137,10 @@ CDXLRelStats::Serialize(CXMLSerializer *xml_serializer) const
 								 m_mdname->GetMDName());
 	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenRows),
 								 m_rows);
+	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenRelPages),
+								 m_relpages);
+	xml_serializer->AddAttribute(
+		CDXLTokens::GetDXLTokenStr(EdxltokenRelAllVisible), m_relallvisible);
 	xml_serializer->AddAttribute(
 		CDXLTokens::GetDXLTokenStr(EdxltokenEmptyRelation), m_empty);
 
@@ -166,6 +173,10 @@ CDXLRelStats::DebugPrint(IOstream &os) const
 
 	os << "Rows: " << Rows() << std::endl;
 
+	os << "RelPages: " << RelPages() << std::endl;
+
+	os << "RelAllVisible: " << RelAllVisible() << std::endl;
+
 	os << "Empty: " << IsEmpty() << std::endl;
 }
 
@@ -188,9 +199,9 @@ CDXLRelStats::CreateDXLDummyRelStats(CMemoryPool *mp, IMDId *mdid)
 	CAutoP<CMDName> mdname;
 	mdname = GPOS_NEW(mp) CMDName(mp, str.Value());
 	CAutoRef<CDXLRelStats> rel_stats_dxl;
-	rel_stats_dxl = GPOS_NEW(mp)
-		CDXLRelStats(mp, rel_stats_mdid, mdname.Value(),
-					 CStatistics::DefaultColumnWidth, false /* is_empty */);
+	rel_stats_dxl = GPOS_NEW(mp) CDXLRelStats(
+		mp, rel_stats_mdid, mdname.Value(), CStatistics::DefaultColumnWidth,
+		false /* is_empty */, 0 /* relpages */, 0 /* relallvisible */);
 	mdname.Reset();
 	return rel_stats_dxl.Reset();
 }

--- a/src/backend/gporca/libnaucrates/src/md/CDXLStatsDerivedRelation.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CDXLStatsDerivedRelation.cpp
@@ -26,10 +26,12 @@ using namespace gpmd;
 //
 //---------------------------------------------------------------------------
 CDXLStatsDerivedRelation::CDXLStatsDerivedRelation(
-	CDouble rows, BOOL is_empty,
+	CDouble rows, BOOL is_empty, ULONG relpages, ULONG relallvisible,
 	CDXLStatsDerivedColumnArray *dxl_stats_derived_col_array)
 	: m_rows(rows),
 	  m_empty(is_empty),
+	  m_relpages(relpages),
+	  m_relallvisible(relallvisible),
 	  m_dxl_stats_derived_col_array(dxl_stats_derived_col_array)
 {
 	GPOS_ASSERT(NULL != dxl_stats_derived_col_array);

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerRelStats.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerRelStats.cpp
@@ -98,8 +98,29 @@ CParseHandlerRelStats::StartElement(const XMLCh *const,	 // element_uri,
 			EdxltokenEmptyRelation, EdxltokenStatsDerivedRelation);
 	}
 
-	m_imd_obj = GPOS_NEW(m_mp) CDXLRelStats(m_mp, CMDIdRelStats::CastMdid(mdid),
-											mdname, rows, is_empty);
+	ULONG relpages = 0;
+	const XMLCh *xml_relpages =
+		attrs.getValue(CDXLTokens::XmlstrToken(EdxltokenRelPages));
+	if (NULL != xml_relpages)
+	{
+		relpages = CDXLOperatorFactory::ExtractConvertAttrValueToUlong(
+			m_parse_handler_mgr->GetDXLMemoryManager(), attrs,
+			EdxltokenRelPages, EdxltokenRelationStats);
+	}
+
+	ULONG relallvisible = 0;
+	const XMLCh *xml_relallvisible =
+		attrs.getValue(CDXLTokens::XmlstrToken(EdxltokenRelAllVisible));
+	if (NULL != xml_relallvisible)
+	{
+		relallvisible = CDXLOperatorFactory::ExtractConvertAttrValueToUlong(
+			m_parse_handler_mgr->GetDXLMemoryManager(), attrs,
+			EdxltokenRelAllVisible, EdxltokenRelationStats);
+	}
+
+	m_imd_obj =
+		GPOS_NEW(m_mp) CDXLRelStats(m_mp, CMDIdRelStats::CastMdid(mdid), mdname,
+									rows, is_empty, relpages, relallvisible);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerStatsDerivedRelation.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerStatsDerivedRelation.cpp
@@ -36,6 +36,8 @@ CParseHandlerStatsDerivedRelation::CParseHandlerStatsDerivedRelation(
 	: CParseHandlerBase(mp, parse_handler_mgr, parse_handler_root),
 	  m_rows(CStatistics::DefaultColumnWidth),
 	  m_empty(false),
+	  m_relpages(0),
+	  m_relallvisible(0),
 	  m_dxl_stats_derived_relation(NULL)
 {
 }
@@ -104,6 +106,26 @@ CParseHandlerStatsDerivedRelation::StartElement(
 				m_parse_handler_mgr->GetDXLMemoryManager(), xml_is_empty,
 				EdxltokenEmptyRelation, EdxltokenStatsDerivedRelation);
 		}
+
+		m_relpages = 0;
+		const XMLCh *xml_relpages =
+			attrs.getValue(CDXLTokens::XmlstrToken(EdxltokenRelPages));
+		if (NULL != xml_relpages)
+		{
+			m_relpages = CDXLOperatorFactory::ConvertAttrValueToUlong(
+				m_parse_handler_mgr->GetDXLMemoryManager(), xml_rows,
+				EdxltokenRelPages, EdxltokenStatsDerivedRelation);
+		}
+
+		m_relallvisible = 0;
+		const XMLCh *xml_relallvisible =
+			attrs.getValue(CDXLTokens::XmlstrToken(EdxltokenRelAllVisible));
+		if (NULL != xml_relallvisible)
+		{
+			m_relallvisible = CDXLOperatorFactory::ConvertAttrValueToUlong(
+				m_parse_handler_mgr->GetDXLMemoryManager(), xml_rows,
+				EdxltokenRelAllVisible, EdxltokenStatsDerivedRelation);
+		}
 	}
 }
 
@@ -151,7 +173,8 @@ CParseHandlerStatsDerivedRelation::EndElement(
 	}
 
 	m_dxl_stats_derived_relation = GPOS_NEW(m_mp)
-		CDXLStatsDerivedRelation(m_rows, m_empty, dxl_stats_derived_col_array);
+		CDXLStatsDerivedRelation(m_rows, m_empty, m_relpages, m_relallvisible,
+								 dxl_stats_derived_col_array);
 
 	// deactivate handler
 	m_parse_handler_mgr->DeactivateHandler();

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -370,6 +370,8 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenTotalCost, GPOS_WSZ_LIT("TotalCost")},
 		{EdxltokenRows, GPOS_WSZ_LIT("Rows")},
 		{EdxltokenWidth, GPOS_WSZ_LIT("Width")},
+		{EdxltokenRelPages, GPOS_WSZ_LIT("RelPages")},
+		{EdxltokenRelAllVisible, GPOS_WSZ_LIT("RelAllVisible")},
 		{EdxltokenTableName, GPOS_WSZ_LIT("TableName")},
 		{EdxltokenDerivedTableName, GPOS_WSZ_LIT("DerivedTableName")},
 		{EdxltokenExecuteAsUser, GPOS_WSZ_LIT("ExecuteAsUser")},

--- a/src/backend/gporca/scripts/tests/test_cal_bitmap_test.py
+++ b/src/backend/gporca/scripts/tests/test_cal_bitmap_test.py
@@ -1,0 +1,98 @@
+import unittest
+from unittest.mock import patch
+from unittest.mock import Mock
+from unittest.mock import MagicMock
+
+from itertools import count
+
+import cal_bitmap_test
+from cal_bitmap_test import connect
+from cal_bitmap_test import find_crossover
+from cal_bitmap_test import explain_index_scan
+from cal_bitmap_test import explain_join_scan
+
+class TestStringMethods(unittest.TestCase):
+
+    @patch('gppylib.db.dbconn.query')
+    def test_explain_index_scan(self, mock_query):
+        mock_query.return_value = Mock()
+        mock_query.return_value.fetchall.return_value = [
+            [" Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.04 rows=1 width=4)"],
+            ["   ->  Index Scan using cal_txtest_i_bitmap_10 on cal_txtest  (cost=0.00..8.02 rows=1 width=4)"],
+            ["         Index Cond: (bitmap10 > 42)"]
+        ]
+
+        (scan, cost) = explain_index_scan(Mock(), "mock sql query string")
+        self.assertEqual(scan, cal_bitmap_test.INDEX_SCAN)
+        self.assertEqual(cost, 8.02)
+
+    @patch('gppylib.db.dbconn.query')
+    def test_explain_index_only_scan(self, mock_query):
+        mock_query.return_value = Mock()
+        mock_query.return_value.fetchall.return_value = [
+            [" Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.04 rows=1 width=4)"],
+            ["   ->  Index Only Scan using cal_txtest_i_bitmap_10 on cal_txtest  (cost=0.00..8.02 rows=1 width=4)"],
+            ["         Index Cond: (bitmap10 > 42)"]
+        ]
+
+        (scan, cost) = explain_index_scan(Mock(), "mock sql query string")
+        self.assertEqual(scan, cal_bitmap_test.INDEX_ONLY_SCAN)
+        self.assertEqual(cost, 8.02)
+
+    @patch('gppylib.db.dbconn.query')
+    def test_explain_join_index_scan(self, mock_query):
+        mock_query.return_value = Mock()
+        mock_query.return_value.fetchall.return_value = [
+            [" Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..437.00 rows=1 width=4)"],
+            ["   ->  Nested Loop  (cost=0.00..437.00 rows=1 width=4)"],
+            ["         Join Filter: true"],
+            ["         ->  Seq Scan on cal_txtest  (cost=0.00..431.00 rows=1 width=4)"],
+            ["         ->  Index Scan using cal_txtest_a_idx on cal_txtest cal_txtest_1  (cost=0.00..6.00 rows=1 width=1)"],
+            ["               Index Cond: (a = cal_txtest.a)"]
+        ]
+
+        (scan, cost) = explain_join_scan(Mock(), "mock sql query string")
+        self.assertEqual(scan, cal_bitmap_test.INDEX_SCAN)
+        self.assertEqual(cost, 437.00)
+
+    @patch('gppylib.db.dbconn.query')
+    def test_explain_join_index_only_scan(self, mock_query):
+        mock_query.return_value = Mock()
+        mock_query.return_value.fetchall.return_value = [
+            [" Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..437.00 rows=1 width=4)"],
+            ["   ->  Nested Loop  (cost=0.00..437.00 rows=1 width=4)"],
+            ["         Join Filter: true"],
+            ["         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)"],
+            ["               ->  Seq Scan on cal_txtest  (cost=0.00..431.00 rows=1 width=4)"],
+            ["         ->  Index Only Scan using cal_txtest_a_idx on cal_txtest cal_txtest_1  (cost=0.00..6.00 rows=1 width=1)"],
+            ["               Index Cond: (a = cal_txtest.a)"]
+        ]
+
+        (scan, cost) = explain_join_scan(Mock(), "mock sql query string")
+        self.assertEqual(scan, cal_bitmap_test.INDEX_ONLY_SCAN)
+        self.assertEqual(cost, 437.00)
+
+    @patch('cal_bitmap_test.timed_execute_and_check_timeout')
+    @patch('cal_bitmap_test.execute_sql')
+    def test_x(self, mock_execute, mock_execute_and_check_timeout):
+        mock_conn = Mock()
+        mock_setup = Mock()
+        mock_parameterizeMethod = Mock()
+        mock_explain_method = Mock()
+        mock_explain_method.side_effect = [(cal_bitmap_test.INDEX_ONLY_SCAN, 1.1),
+                                           (cal_bitmap_test.INDEX_SCAN, 2.1),
+                                           (cal_bitmap_test.INDEX_ONLY_SCAN, 1.2),
+                                           (cal_bitmap_test.INDEX_SCAN, 2.2),
+                                           (cal_bitmap_test.INDEX_ONLY_SCAN, 1.3),
+                                           (cal_bitmap_test.INDEX_SCAN, 2.3)
+        ]
+        mock_reset_method = Mock()
+        plan_ids = [cal_bitmap_test.INDEX_ONLY_SCAN, cal_bitmap_test.INDEX_SCAN]
+        mock_force_methods = MagicMock()
+
+        explainDict, execDict, errMessages = find_crossover(mock_conn, 0, 2, mock_setup, mock_parameterizeMethod, mock_explain_method,
+                                                            mock_reset_method, plan_ids, mock_force_methods, 1)
+        self.assertEqual(explainDict, {0: ('indexonly_scan', 1.1, 1.2, 1.3), 1: ('index_scan', 2.1, 2.2, 2.3)})
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2178,7 +2178,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_indexonlyscan,
-		false,
+		true,
 		NULL, NULL, NULL
 	},
 

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -785,7 +785,7 @@ explain (costs off)
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Index Scan using tenk1_unique1 on tenk1
+               ->  Index Only Scan using tenk1_unique1 on tenk1
                      Index Cond: (unique1 < 42)
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)
@@ -803,7 +803,7 @@ explain (costs off)
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Index Scan using tenk1_unique1 on tenk1
+               ->  Index Only Scan using tenk1_unique1 on tenk1
                      Index Cond: (unique1 > 42)
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)
@@ -830,7 +830,7 @@ explain (costs off)
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Index Scan using tenk1_unique1 on tenk1
+               ->  Index Only Scan using tenk1_unique1 on tenk1
                      Index Cond: (unique1 > 42000)
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)
@@ -850,7 +850,7 @@ explain (costs off)
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Index Scan using tenk1_thous_tenthous on tenk1
+               ->  Index Only Scan using tenk1_thous_tenthous on tenk1
                      Index Cond: (thousand = 33)
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)
@@ -868,7 +868,7 @@ explain (costs off)
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Index Scan using tenk1_thous_tenthous on tenk1
+               ->  Index Only Scan using tenk1_thous_tenthous on tenk1
                      Index Cond: (thousand = 33)
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -1939,7 +1939,7 @@ ORDER BY thousand;
    Merge Key: thousand
    ->  Sort
          Sort Key: thousand
-         ->  Index Scan using tenk1_thous_tenthous on tenk1
+         ->  Index Only Scan using tenk1_thous_tenthous on tenk1
                Index Cond: (thousand < 2)
                Filter: (tenthous = ANY ('{1001,3000}'::integer[]))
  Optimizer: Pivotal Optimizer (GPORCA) version 3.80.0
@@ -1965,7 +1965,7 @@ ORDER BY thousand;
    Merge Key: thousand
    ->  Sort
          Sort Key: thousand
-         ->  Index Scan using tenk1_thous_tenthous on tenk1
+         ->  Index Only Scan using tenk1_thous_tenthous on tenk1
                Index Cond: (thousand < 2)
                Filter: (tenthous = ANY ('{1001,3000}'::integer[]))
  Optimizer: Pivotal Optimizer (GPORCA) version 3.80.0

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -390,16 +390,15 @@ explain (costs off)
          ->  Partial Aggregate
                ->  Nested Loop
                      Join Filter: true
-                     ->  Redistribute Motion 1:3  (slice2)
-                           Hash Key: (max(tenk2.unique1))
+                     ->  Broadcast Motion 1:3  (slice2)
                            ->  Finalize Aggregate
                                  ->  Gather Motion 3:1  (slice3; segments: 3)
                                        ->  Partial Aggregate
                                              ->  Seq Scan on tenk2
-                     ->  Index Scan using tenk1_unique1 on tenk1
+                     ->  Index Only Scan using tenk1_unique1 on tenk1
                            Index Cond: (unique1 = (max(tenk2.unique1)))
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(13 rows)
 
 select count(*) from tenk1
     where tenk1.unique1 = (Select max(tenk2.unique1) from tenk2);
@@ -441,7 +440,7 @@ explain (costs off)
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Index Scan using tenk1_thous_tenthous on tenk1
+               ->  Index Only Scan using tenk1_thous_tenthous on tenk1
                      Index Cond: (thousand > 95)
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
@@ -495,7 +494,7 @@ select * from
          ->  Materialize
                ->  Gather Motion 3:1  (slice1; segments: 3)
                      ->  Partial Aggregate
-                           ->  Index Scan using tenk1_thous_tenthous on tenk1
+                           ->  Index Only Scan using tenk1_thous_tenthous on tenk1
                                  Index Cond: (thousand > 99)
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
@@ -539,7 +538,7 @@ explain (costs off)
                      ->  Broadcast Motion 3:3  (slice2; segments: 3)
                            ->  Seq Scan on tenk2
                                  Filter: (thousand = 0)
-                     ->  Index Scan using tenk1_hundred on tenk1
+                     ->  Index Only Scan using tenk1_hundred on tenk1
                            Index Cond: (hundred > 1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
@@ -578,10 +577,11 @@ explain (analyze, timing off, summary off, costs off)
                            ->  Seq Scan on tenk2 (actual rows=5 loops=1)
                                  Filter: (thousand = 0)
                                  Rows Removed by Filter: 3363
-                     ->  Index Scan using tenk1_hundred on tenk1 (actual rows=3018 loops=11)
+                     ->  Index Only Scan using tenk1_hundred on tenk1 (actual rows=3018 loops=11)
                            Index Cond: (hundred > 1)
+                           Heap Fetches: 0
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(13 rows)
 
 alter table tenk2 reset (parallel_workers);
 reset work_mem;
@@ -627,18 +627,19 @@ set enable_hashjoin to off;
 set enable_nestloop to off;
 explain (costs off)
 	select  count(*) from tenk1, tenk2 where tenk1.unique1 = tenk2.unique1;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Hash Join
-                     Hash Cond: (tenk1.unique1 = tenk2.unique1)
-                     ->  Seq Scan on tenk1
-                     ->  Hash
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
                            ->  Seq Scan on tenk2
+                     ->  Index Only Scan using tenk1_unique1 on tenk1
+                           Index Cond: (unique1 = tenk2.unique1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(10 rows)
 
 select  count(*) from tenk1, tenk2 where tenk1.unique1 = tenk2.unique1;
  count 


### PR DESCRIPTION
Orca, like Planner uses `pg_class.relpages` and `pg_class.relallvisible` to
calculate the percentage of page fetches needed by an index-only-scan
proportional to the total number of pages in the relation. Both optimizers 
factor this percentage into the costing formula of index-scan to derive a 
formula for index-only-scan.

In DXL file these stats are added to RelationStatistics:
```
<dxl:RelationStatistics ... RelPages="XX" RelAllVisible="YY"/>
```