### PR TITLE
[5x_stable]Notice reject messages of external tables executed on master

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -319,6 +319,23 @@ external_endscan(FileScanDesc scan)
 {
 	char	   *relname = pstrdup(RelationGetRelationName(scan->fs_rd));
 
+	/*
+	 * report Sreh results if external web table execute on master with reject limit.
+	 * if external web table execute on segment, these messages are printed
+	 * in cdbdisp_sumRejectedRows()
+	*/
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		CopyState cstate = scan->fs_pstate;
+		if (cstate && cstate->cdbsreh)
+		{
+			CdbSreh	 *cdbsreh = cstate->cdbsreh;
+			uint64	total_rejected_from_qd = cdbsreh->rejectcount;
+			if (total_rejected_from_qd > 0)
+				ReportSrehResults(cdbsreh, total_rejected_from_qd);
+		}
+	}
+
 	if (scan->fs_pstate != NULL)
 	{
 		/*

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -1690,3 +1690,37 @@ LOCATION (
 FORMAT 'CUSTOM' (formatter='gpformatter');
 
 SELECT * FROM tbl_ext_gpformatter;
+
+-- Test notice reject message when execute on master
+
+CREATE EXTERNAL WEB TABLE web_exec_on_master_with_err_limit (c1 int) EXECUTE 'for i in `seq 1 2`; do echo 1 3;done; echo 22' ON MASTER FORMAT 'TEXT' SEGMENT REJECT LIMIT 3;
+
+SELECT * FROM web_exec_on_master_with_err_limit;
+
+DROP EXTERNAL TABLE web_exec_on_master_with_err_limit;
+
+-- Test notice reject message when execute on master with multiple commands
+
+CREATE EXTERNAL WEB TABLE web_exec_on_master_with_multiple_commands (c1 int) EXECUTE 'for i in `seq 1 `; do echo 2 1;
+done; echo 2 ; echo 1 2; echo 2;  echo 3 4' ON MASTER FORMAT 'TEXT' SEGMENT REJECT LIMIT 6;
+
+SELECT * FROM  web_exec_on_master_with_multiple_commands;
+
+DROP EXTERNAL TABLE web_exec_on_master_with_multiple_commands;
+
+-- Test notice reject message when execute on segments with multiple commands
+
+CREATE EXTERNAL WEB TABLE web_exec_on_segments_with_multiple_commands (c1 int) EXECUTE 'for i in `seq 1 `; do echo 2 1;
+done; echo 2 ; echo 1 2; echo 2;  echo 3 4' FORMAT 'TEXT' SEGMENT REJECT LIMIT 6;
+
+SELECT * FROM  web_exec_on_segments_with_multiple_commands;
+
+DROP EXTERNAL TABLE web_exec_on_segments_with_multiple_commands;
+
+-- Test reject number reached when execute on master
+
+CREATE EXTERNAL WEB TABLE web_exec_on_master_with_err_limit_reached (c1 int) EXECUTE 'for i in `seq 1 3`; do echo 1 3;done; echo 22' ON MASTER FORMAT 'TEXT' SEGMENT REJECT LIMIT 3;
+
+SELECT * FROM web_exec_on_master_with_err_limit_reached;
+
+DROP EXTERNAL TABLE web_exec_on_master_with_err_limit_reached;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -625,6 +625,7 @@ EXECUTE E'cat @abs_srcdir@/data/exttab.data' ON MASTER
 FORMAT 'TEXT' (DELIMITER '|')
 SEGMENT REJECT LIMIT 20;
 SELECT * FROM exttab_basic_error_1;
+NOTICE:  Found 10 data formatting errors (10 or more input rows). Rejected related input data.
  i 
 ---
 (0 rows)
@@ -3025,3 +3026,47 @@ CONTEXT:  External table tbl_ext_gpformatter
  1
 (2 rows)
 
+-- Test notice reject message when execute on master
+CREATE EXTERNAL WEB TABLE web_exec_on_master_with_err_limit (c1 int) EXECUTE 'for i in `seq 1 2`; do echo 1 3;done; echo 22' ON MASTER FORMAT 'TEXT' SEGMENT REJECT LIMIT 3;
+SELECT * FROM web_exec_on_master_with_err_limit;
+NOTICE:  Found 2 data formatting errors (2 or more input rows). Rejected related input data.
+ c1 
+----
+ 22
+(1 row)
+
+DROP EXTERNAL TABLE web_exec_on_master_with_err_limit;
+-- Test notice reject message when execute on master with multiple commands
+CREATE EXTERNAL WEB TABLE web_exec_on_master_with_multiple_commands (c1 int) EXECUTE 'for i in `seq 1 `; do echo 2 1;
+done; echo 2 ; echo 1 2; echo 2;  echo 3 4' ON MASTER FORMAT 'TEXT' SEGMENT REJECT LIMIT 6;
+SELECT * FROM  web_exec_on_master_with_multiple_commands;
+NOTICE:  Found 3 data formatting errors (3 or more input rows). Rejected related input data.
+ c1 
+----
+  2
+  2
+(2 rows)
+
+DROP EXTERNAL TABLE web_exec_on_master_with_multiple_commands;
+-- Test notice reject message when execute on segments with multiple commands
+CREATE EXTERNAL WEB TABLE web_exec_on_segments_with_multiple_commands (c1 int) EXECUTE 'for i in `seq 1 `; do echo 2 1;
+done; echo 2 ; echo 1 2; echo 2;  echo 3 4' FORMAT 'TEXT' SEGMENT REJECT LIMIT 6;
+SELECT * FROM  web_exec_on_segments_with_multiple_commands;
+NOTICE:  Found 9 data formatting errors (9 or more input rows). Rejected related input data.
+ c1 
+----
+  2
+  2
+  2
+  2
+  2
+  2
+(6 rows)
+
+DROP EXTERNAL TABLE web_exec_on_segments_with_multiple_commands;
+-- Test reject number reached when execute on master
+CREATE EXTERNAL WEB TABLE web_exec_on_master_with_err_limit_reached (c1 int) EXECUTE 'for i in `seq 1 3`; do echo 1 3;done; echo 22' ON MASTER FORMAT 'TEXT' SEGMENT REJECT LIMIT 3;
+SELECT * FROM web_exec_on_master_with_err_limit_reached;
+ERROR:  Segment reject limit reached. Aborting operation. Last error was: invalid input syntax for integer: "1 3", column c1
+CONTEXT:  External table web_exec_on_master_with_err_limit_reached, line 3 of execute:for i in `seq 1 3`; do echo 1 3;done; echo 22, column c1
+DROP EXTERNAL TABLE web_exec_on_master_with_err_limit_reached;


### PR DESCRIPTION
With reject limit, if reject limit is not reached,
there should be some messages that how many rows
are rejected as `execute on segments` does.

Co-authored-by Mingli Zhang <zmingli@vmware.com>
Co-authored-by Adam Lee <adlee@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
