### PR TITLE
Make faultinjector configurable, take2

### DIFF
--- a/configure
+++ b/configure
@@ -3414,7 +3414,9 @@ if test "${enable_debug_extensions+set}" = set; then :
   enableval=$enable_debug_extensions;
   case $enableval in
     yes)
-      :
+
+$as_echo "#define FAULT_INJECTOR 1" >>confdefs.h
+
       ;;
     no)
       :
@@ -3426,7 +3428,7 @@ if test "${enable_debug_extensions+set}" = set; then :
 
 else
   enable_debug_extensions=yes
-
+$as_echo "#define FAULT_INJECTOR 1" >>confdefs.h
 fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -229,8 +229,10 @@ AC_SUBST(enable_pxf)
 #
 # include debug extensions in gpcontrib
 #
-PGAC_ARG_BOOL(enable, debug-extensions, yes,
-              [exclude debug extensions in gpcontrib])
+PGAC_ARG_BOOL (enable, debug-extensions, yes,
+              [exclude debug extensions in gpcontrib],
+              [AC_DEFINE([FAULT_INJECTOR], 1,
+                         [Define to 1 to build with fault injector. (--enable-faultinjector)])])
 AC_SUBST(enable_debug_extensions)
 
 #

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -494,6 +494,24 @@ prove_installcheck = @echo "TAP tests not enabled"
 prove_check = $(prove_installcheck)
 endif
 
+ifeq ($(enable_debug_extensions),yes)
+define faultinjector_prep
+$(top_builddir)/src/test/regress/scan_flaky_fault_injectors.sh &&
+endef
+FAULTINJECTOR_OPTS := --load-extension=gp_inject_fault
+else
+define faultinjector_prep
+# TODO: A similar grep command is used in
+# scan_flaky_fault_injectors.sh script.  Find a way to avoid the
+# duplication.
+grep -sERIli '(select|perform)\s.*gp_inject_fault' sql input specs \
+	| sed 's,^[^/]*/\(.*\)\.[^.]*$$,\1,' \
+	| sort -u \
+	> tests_using_faultinjector.txt &&
+endef
+FAULTINJECTOR_OPTS := --exclude-file=tests_using_faultinjector.txt
+endif
+
 # Installation.
 
 install_bin = @install_bin@
@@ -682,41 +700,47 @@ TEMP_CONF += --temp-config=$(TEMP_CONFIG)
 endif
 
 pg_regress_locale_flags = $(if $(ENCODING),--encoding=$(ENCODING)) $(NOLOCALE)
-pg_regress_clean_files = results/ regression.diffs regression.out tmp_check/ tmp_check_iso/ log/ output_iso/
+pg_regress_clean_files = results/ regression.diffs regression.out tmp_check/ tmp_check_iso/ log/ output_iso/ tests_using_faultinjector.txt
 
 pg_regress_check = \
+    $(faultinjector_prep) \
     $(with_temp_install) \
     $(top_builddir)/src/test/regress/pg_regress \
     --temp-instance=./tmp_check \
     --inputdir=$(srcdir) \
     --bindir= \
     $(TEMP_CONF) \
-    $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS)
+    $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS) $(FAULTINJECTOR_OPTS)
 pg_regress_installcheck = \
+    $(faultinjector_prep) \
     $(top_builddir)/src/test/regress/pg_regress \
     --inputdir=$(srcdir) \
     --bindir='$(bindir)' \
-    $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS)
+    $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS) $(FAULTINJECTOR_OPTS)
 
 pg_isolation_regress_check = \
+    $(faultinjector_prep) \
     $(with_temp_install) \
     $(top_builddir)/src/test/isolation/pg_isolation_regress \
     --temp-instance=./tmp_check_iso \
     --inputdir=$(srcdir) --outputdir=output_iso \
     --bindir= \
     $(TEMP_CONF) \
-    $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS)
+    $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS) $(FAULTINJECTOR_OPTS)
 pg_isolation_regress_installcheck = \
+    $(faultinjector_prep) \
     $(top_builddir)/src/test/isolation/pg_isolation_regress \
     --inputdir=$(srcdir) --outputdir=output_iso \
     --bindir='$(bindir)' \
-    $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS)
+    $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS) $(FAULTINJECTOR_OPTS)
 
 pg_isolation2_regress_installcheck = \
+    $(faultinjector_prep) \
     $(top_builddir)/src/test/isolation2/pg_isolation2_regress \
     --inputdir=$(srcdir) \
-    --bindir= \
-    $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS)
+    --bindir='$(bindir)' \
+    $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS) $(FAULTINJECTOR_OPTS)
+
 ##########################################################################
 #
 # Customization

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -712,6 +712,11 @@ pg_isolation_regress_installcheck = \
     --bindir='$(bindir)' \
     $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS)
 
+pg_isolation2_regress_installcheck = \
+    $(top_builddir)/src/test/isolation2/pg_isolation2_regress \
+    --inputdir=$(srcdir) \
+    --bindir= \
+    $(pg_regress_locale_flags) $(EXTRA_REGRESS_OPTS)
 ##########################################################################
 #
 # Customization

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -61,6 +61,9 @@
    (--enable-thread-safety) */
 #undef ENABLE_THREAD_SAFETY
 
+/* Define to 1 to build with fault injector. (--enable-debug-extensions) */
+#undef FAULT_INJECTOR
+
 /* Define to nothing if C supports flexible array members, and to 1 if it does
    not. That way, with a declaration like `struct s { int n; double
    d[FLEXIBLE_ARRAY_MEMBER]; };', the struct hack can be used with pre-C99

--- a/src/include/pg_config_manual.h
+++ b/src/include/pg_config_manual.h
@@ -316,11 +316,6 @@
 /* #define WAL_DEBUG */
 
 /*
- * Enable injecting faults.
- */
-#define FAULT_INJECTOR 1
-
-/*
  * Enable tracing of resource consumption during sort operations;
  * see also the trace_sort GUC var.  For 8.1 this is enabled by default.
  */

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -9,7 +9,7 @@
 #ifndef FAULTINJECTOR_H
 #define FAULTINJECTOR_H
 
-#include "pg_config_manual.h"
+#include "pg_config.h"
 
 #define FAULTINJECTOR_MAX_SLOTS	16
 

--- a/src/test/fsync/Makefile
+++ b/src/test/fsync/Makefile
@@ -2,7 +2,6 @@ MODULES=fsync_helper
 PG_CONFIG=pg_config
 
 REGRESS = setup bgwriter_checkpoint
-REGRESS_OPTS = --load-extension=gp_inject_fault
 
 subdir = src/test/fsync
 top_builddir = ../../..

--- a/src/test/heap_checksum/Makefile
+++ b/src/test/heap_checksum/Makefile
@@ -2,7 +2,7 @@ MODULES=heap_checksum_helper
 PG_CONFIG=pg_config
 
 REGRESS = setup heap_checksum_corruption
-REGRESS_OPTS = --init-file=../regress/init_file --load-extension=gp_inject_fault
+REGRESS_OPTS = --init-file=../regress/init_file
 
 subdir = src/test/heap_checksum
 top_builddir = ../../..

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -61,7 +61,7 @@ clean distclean:
 install: all gpdiff.pl gpstringsubs.pl
 
 installcheck: install
-	./pg_isolation2_regress $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --bindir='$(bindir)' --inputdir=$(srcdir) --load-extension=gp_inject_fault --schedule=$(srcdir)/isolation2_schedule
+	$(pg_isolation2_regress_installcheck) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --schedule=$(srcdir)/isolation2_schedule
 
 installcheck-resgroup: install
-	./pg_isolation2_regress $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_resgroup --bindir='$(bindir)' --inputdir=$(srcdir) --dbname=isolation2resgrouptest --load-extension=gp_inject_fault --schedule=$(srcdir)/isolation2_resgroup_schedule
+	$(pg_isolation2_regress_installcheck) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_resgroup --dbname=isolation2resgrouptest --schedule=$(srcdir)/isolation2_resgroup_schedule

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -17,7 +17,7 @@ endif
 override CPPFLAGS := -I$(srcdir) -I$(libpq_srcdir) -I$(srcdir)/../regress $(CPPFLAGS)
 override LDLIBS := $(libpq_pgport) $(LDLIBS)
 
-all: pg_isolation2_regress$(X) all-lib data extended_protocol_test scan_flaky_fault_injectors
+all: pg_isolation2_regress$(X) all-lib data extended_protocol_test
 
 extended_protocol_test: extended_protocol_test.c
 	$(CC) $(CPPFLAGS) -I$(top_builddir)/src/interfaces/libpq -L$(GPHOME)/lib -L$(top_builddir)/src/interfaces/libpq  -o $@ $< -lpq
@@ -43,10 +43,6 @@ explain.pm:
 
 data:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/data
-
-.PHONY: scan_flaky_fault_injectors
-scan_flaky_fault_injectors:
-	$(top_builddir)/src/test/regress/scan_flaky_fault_injectors.sh
 
 pg_isolation2_regress$(X): isolation2_main.o pg_regress.o submake-libpq submake-libpgport
 	$(CC) $(CFLAGS) $(filter %.o,$^) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -40,7 +40,7 @@ EXTRADEFS = '-DHOST_TUPLE="$(host_tuple)"' \
 
 # Build regression test driver
 
-all: pg_regress$(X) scan_flaky_fault_injectors
+all: pg_regress$(X)
 
 pg_regress$(X): pg_regress.o pg_regress_main.o $(WIN32RES) | submake-libpgport
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@
@@ -50,10 +50,6 @@ pg_regress.o: pg_regress.c $(top_builddir)/src/port/pg_config_paths.h
 pg_regress.o: override CPPFLAGS += -I$(top_builddir)/src/port $(EXTRADEFS)
 regress_gp.o: override CPPFLAGS += -I$(libpq_srcdir)
 regress_gp.o: override LDFLAGS += -L$(top_builddir)/src/interfaces/libpq
-
-.PHONY: scan_flaky_fault_injectors
-scan_flaky_fault_injectors:
-	$(top_builddir)/src/test/regress/scan_flaky_fault_injectors.sh
 
 twophase_pqexecparams: twophase_pqexecparams.c
 	$(CC) $(CPPFLAGS) -I$(top_builddir)/src/interfaces/libpq -L$(GPHOME)/lib -L$(top_builddir)/src/interfaces/libpq  -o $@ $< -lpq
@@ -72,7 +68,7 @@ install: all installdirs
 	$(INSTALL_PROGRAM) explain.pl '$(DESTDIR)$(pgxsdir)/$(subdir)/explain.pl'
 	$(INSTALL_PROGRAM) explain.pm '$(DESTDIR)$(pgxsdir)/$(subdir)/explain.pm'
 	$(INSTALL_PROGRAM) GPTest.pm '$(DESTDIR)$(pgxsdir)/$(subdir)/GPTest.pm'
-
+	$(INSTALL_PROGRAM) scan_flaky_fault_injectors.sh '$(DESTDIR)$(pgxsdir)/$(subdir)/scan_flaky_fault_injectors.sh'
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(pgxsdir)/$(subdir)'
 
@@ -180,7 +176,7 @@ query_info_hook_test:
 ## Run tests
 ##
 
-REGRESS_OPTS = --dlpath=. --max-concurrent-tests=20 --init-file=$(srcdir)/init_file $(EXTRA_REGRESS_OPTS) --load-extension=gp_inject_fault
+REGRESS_OPTS = --dlpath=. --max-concurrent-tests=20 --init-file=$(srcdir)/init_file $(EXTRA_REGRESS_OPTS)
 
 check: all tablespace-setup
 	$(pg_regress_check) $(REGRESS_OPTS) --schedule=$(srcdir)/parallel_schedule $(MAXCONNOPT) $(EXTRA_TESTS)

--- a/src/test/regress/expected/alter_extension.out
+++ b/src/test/regress/expected/alter_extension.out
@@ -1,10 +1,13 @@
-CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- Creating extension to test alter extension
+-- Assume: pageinspect is shipped by default
+CREATE EXTENSION pageinspect;
 CREATE AGGREGATE example_agg(int4) (
     SFUNC = int4larger,
     STYPE = int4
 );
-ALTER EXTENSION gp_inject_fault ADD AGGREGATE example_agg(int4);
-ALTER EXTENSION gp_inject_fault DROP AGGREGATE example_agg(int4);
+ALTER EXTENSION pageinspect ADD AGGREGATE example_agg(int4);
+ALTER EXTENSION pageinspect DROP AGGREGATE example_agg(int4);
+DROP EXTENSION pageinspect;
 -- Test creating an extension that already exists. Nothing too exciting about
 -- it, but let's keep up the test coverage.
 CREATE EXTENSION gp_inject_fault;

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -1,26 +1,23 @@
 --
 -- Test \dx and \dx+, to display extensions.
 --
--- We just use gp_inject_fault as an example of an extension here. We don't
--- inject any faults.
-\dx gp_inject*
-                           List of installed extensions
-      Name       | Version | Schema |                 Description                  
------------------+---------+--------+----------------------------------------------
- gp_inject_fault | 1.0     | public | simulate various faults for testing purposes
+-- We just use plpgsql as an example of an extension here.
+\dx plpgsql
+                 List of installed extensions
+  Name   | Version |   Schema   |         Description          
+---------+---------+------------+------------------------------
+ plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
 (1 row)
 
-\dx+ gp_inject*
-                       Objects in extension "gp_inject_fault"
-                                 Object description                                 
-------------------------------------------------------------------------------------
- function force_mirrors_to_catch_up()
- function gp_inject_fault(text,text,integer)
- function gp_inject_fault(text,text,text,text,text,integer,integer,integer,integer)
- function gp_inject_fault_infinite(text,text,integer)
- function gp_wait_until_triggered_fault(text,integer,integer)
- function insert_noop_xlog_record()
-(6 rows)
+\dx+ plpgsql
+      Objects in extension "plpgsql"
+            Object description             
+-------------------------------------------
+ function plpgsql_call_handler()
+ function plpgsql_inline_handler(internal)
+ function plpgsql_validator(oid)
+ language plpgsql
+(4 rows)
 
 --
 -- Test extended \du flags

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -42,9 +42,10 @@ test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp li
 test: gpcopy
 
 test: orca_static_pruning
-test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format olap_plans misc_jiras
+test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format olap_plans misc_jiras
 # below test(s) inject faults so each of them need to be in a separate group
 test: guc_gp
+test: toast
 
 # namespace_gp test will show diff if concurrent tests use temporary tables.
 # So run it separately.

--- a/src/test/regress/scan_flaky_fault_injectors.sh
+++ b/src/test/regress/scan_flaky_fault_injectors.sh
@@ -12,14 +12,14 @@ parallel_tests=$(mktemp parallel_tests.XXX)
 retcode=0
 
 # list the tests that inject faults
-grep -ERIli '(select|perform)\s+gp_inject_fault' sql input \
+grep -sERIli '(select|perform)\s.*gp_inject_fault' sql input specs \
 | sed 's,^[^/]*/\(.*\)\.[^.]*$,\1,' \
 | sort -u \
 > $fault_injection_tests
 
 echo "scanning for flaky fault-injection tests..."
 
-for schedule in *_schedule; do
+for schedule in $(ls *schedule 2>&1 | grep -v 'No such file'); do
 	# list the tests that are in parallel testing groups
 	grep -E '^test:(\s+\S+){2,}' $schedule \
 	| cut -d' ' -f2- \

--- a/src/test/regress/sql/alter_extension.sql
+++ b/src/test/regress/sql/alter_extension.sql
@@ -1,12 +1,16 @@
-CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- Creating extension to test alter extension
+-- Assume: pageinspect is shipped by default
+CREATE EXTENSION pageinspect;
 
 CREATE AGGREGATE example_agg(int4) (
     SFUNC = int4larger,
     STYPE = int4
 );
 
-ALTER EXTENSION gp_inject_fault ADD AGGREGATE example_agg(int4);
-ALTER EXTENSION gp_inject_fault DROP AGGREGATE example_agg(int4);
+ALTER EXTENSION pageinspect ADD AGGREGATE example_agg(int4);
+ALTER EXTENSION pageinspect DROP AGGREGATE example_agg(int4);
+
+DROP EXTENSION pageinspect;
 
 -- Test creating an extension that already exists. Nothing too exciting about
 -- it, but let's keep up the test coverage.

--- a/src/test/regress/sql/psql_gp_commands.sql
+++ b/src/test/regress/sql/psql_gp_commands.sql
@@ -1,12 +1,9 @@
 --
 -- Test \dx and \dx+, to display extensions.
 --
--- We just use gp_inject_fault as an example of an extension here. We don't
--- inject any faults.
-
-\dx gp_inject*
-\dx+ gp_inject*
-
+-- We just use plpgsql as an example of an extension here.
+\dx plpgsql
+\dx+ plpgsql
 
 --
 -- Test extended \du flags

--- a/src/test/walrep/Makefile
+++ b/src/test/walrep/Makefile
@@ -8,7 +8,6 @@ include $(top_builddir)/src/Makefile.global
 
 REGRESS = setup
 REGRESS += replication_views_mirrored missing_xlog walreceiver generate_ao_xlog generate_aoco_xlog
-REGRESS_OPTS = --load-extension=gp_inject_fault
 
 NO_PGXS = 1
 include $(top_srcdir)/src/makefiles/pgxs.mk


### PR DESCRIPTION
This PR picks relevant parts of previous work by Wu Hao from PR #9029 and attempts to propose a slightly different developer workflow.  The objective remains the same - the code that uses faultinjector extension `gpcontrib/gp_inject_fault` and the extension itself should be stripped from release binaries.  The extension is only needed to run tests in the CI, it should not be deployed in production.

Another objective is to minimize impact on developer workflow - typically, developers run tests with faultinjector enabled.  The PR has no impact on developer workflow when faultinjector is enabled.  A new command line option `--exclude-file` to `pg_regress` is added.  The option should be used to specify tests that use faults and hence should be excluded from running a schedule (and also from the list of tests specified on command line) when faultinjector is disabled (`--enable-faultinjector` configure option is not specified).  As far as I can tell, faultinjector should only be disabled in release pipeline, developers should always have it enabled.
