### PR TITLE
Remove gpdb specific dtx recovery code for utility mode.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6155,7 +6155,6 @@ XLogProcessCheckpointRecord(XLogReaderState *rec)
 	if (ckptExtended.dtxCheckpoint)
 	{
 		/* Handle the DTX information. */
-		UtilityModeFindOrCreateDtmRedoFile();
 		redoDtxCheckPoint(ckptExtended.dtxCheckpoint);
 		/*
 		 * Avoid closing the file here as possibly the file was already open
@@ -7080,8 +7079,6 @@ StartupXLOG(void)
 		/* Check that the GUCs used to generate the WAL allow recovery */
 		CheckRequiredParameterValues();
 
-		UtilityModeFindOrCreateDtmRedoFile();
-		
 		/*
 		 * We're in recovery, so unlogged relations may be trashed and must be
 		 * reset.  This should be done BEFORE allowing Hot Standby
@@ -7866,8 +7863,6 @@ StartupXLOG(void)
 		}
 		else
 			CreateCheckPoint(CHECKPOINT_END_OF_RECOVERY | CHECKPOINT_IMMEDIATE);
-
-		UtilityModeCloseDtmRedoFile();
 
 		/*
 		 * And finally, execute the recovery_end_command, if any.

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1032,10 +1032,10 @@ tmShmemInit(void)
 	 * We can assign MaxBackends (MaxConnections should be fine also but let's
 	 * be conservative) to max_tm_gxacts on master/standby to tolerate various
 	 * configuration combinations of max_prepared_transactions and
-	 * max_connections. For segments or utility mode, max_tm_gxacts is useless
-	 * so let's set it as zero to save memory.
+	 * max_connections. max_tm_gxacts is used on the coordinator only, and the
+	 * coordinator might be accessed in dispatch mode or utility mode.
 	 */
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (IS_QUERY_DISPATCHER())
 		max_tm_gxacts = MaxBackends;
 	else
 		max_tm_gxacts = 0;

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -327,8 +327,6 @@ extern void finishDistributedTransactionContext (char *debugCaller, bool aborted
 extern void performDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 									  const char *gid,
 									  DtxContextInfo *contextInfo);
-extern void UtilityModeFindOrCreateDtmRedoFile(void);
-extern void UtilityModeCloseDtmRedoFile(void);
 
 extern bool currentDtxDispatchProtocolCommand(DtxProtocolCommand dtxProtocolCommand, bool raiseError);
 extern bool doDispatchSubtransactionInternalCmd(DtxProtocolCommand cmdType);


### PR DESCRIPTION
Those functionality is handled in checkpoint during recovery in utility
mode also.  The code is not needed anymore.
