### PR TITLE
Fix potential assertion failure when resgroup inc/sub memusage

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1463,7 +1463,6 @@ groupDecMemUsage(ResGroupData *group, ResGroupSlotData *slot, int32 chunks)
 		/* Sub chunks from memSharedUsage in group */
 		int32 oldSharedUsage = pg_atomic_fetch_sub_u32((pg_atomic_uint32 *) &group->memSharedUsage,
 										deltaSharedMemUsage);
-		Assert(oldSharedUsage >= deltaSharedMemUsage);
 
 		/* record the total global share usage of current group */
 		int32 grpTotalGlobalUsage = Max(0, oldSharedUsage - group->memSharedGranted);


### PR DESCRIPTION
groupIncMemUsage/groupDecMemUsage are not protected by locks, it
may occur concurrency problem, e.g.

```
Assume:

  slot->memQuota = 500
  slot->memUsage = 500
  group->memSharedGranted = 100
  group->memSharedUsage = 0

Now:

A groupIncMemUsage chunks=2:
  atomic add slot->memUsage = 500+2 = 502
  atomic fetch slotMemUsage = 502

B groupDecMemUsage chunks=2:
  atomic fetch slotMemUsage = 502
  atomic sub slot->memUsage = 502-2 = 500

  slotMemUsage 502 > memQuota 500, so:
    deltaSharedMemUsage = Min(502-500, 2) = 2
    atomic fetch oldSharedUsage = 0
    atomic sub group->memSharedUsage = 0-2 = -2
    Assert(0 >= 2); // FAILED if --enable-cassert

A groupIncMemUsage chunks=2: -- continue
  slotMemUsage 502 > memQuota 500, so:
    deltaSharedMemUsage = Min(2, 2) = 2
    atomic fetch oldSharedUsage = -2
    atomic add group->memSharedUsage = -2+2 = 0

After that:
  slot->memUsage = 500
  group->memSharedUsage = 0

Its final results are always correct.
```

Fix it by removing Assert(oldSharedUsage >= deltaSharedMemUsage), it
should be safe for group->memSharedUsage to have a short-lived
negative value.

NOTE: another pair of groupIncSlotMemUsage/groupDecSlotMemUsage
  are protected by exclusive ResGroupLock, no need to change
  its implementation.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
