### PR TITLE
Fix computing of final agg GROUPING value for not distributed queries

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1268,9 +1268,15 @@ agg_retrieve_direct(AggState *aggstate)
 
 	uint64      input_grouping = node->inputGrouping;
 	bool        input_has_grouping = node->inputHasGrouping;
-	bool        is_final_rollup_agg =
-		(node->lastAgg ||
-		 (input_has_grouping && node->numNullCols == 0));
+
+	/*
+	 * The final Agg node brings back all rollup results from different
+	 * segments. This node is very similar to the non-rollup Agg node, except
+	 * that we need a way to know this to properly set GROUPING value during
+	 * execution.
+	 */
+	bool        is_final_agg_over_rollup =
+		(input_has_grouping && node->numNullCols == 0);
 	bool        is_middle_rollup_agg =
 		(input_has_grouping && node->numNullCols > 0);
 
@@ -1603,27 +1609,25 @@ agg_retrieve_direct(AggState *aggstate)
 		}
 
 		/*
+		 * Set GROUP_ID and GROUPING values
 		 * We obtain GROUP_ID from the input tuples when this is
-		 * the middle Agg or final Agg in a ROLLUP.
+		 * the middle Agg in a ROLLUP or final Agg over it.
 		 */
-		if ((is_final_rollup_agg ||
-			(passthru_ready && is_middle_rollup_agg)) &&
-			input_has_grouping)
+		if (is_final_agg_over_rollup ||
+			(passthru_ready && is_middle_rollup_agg))
+		{
 			econtext->group_id =
 				get_grouping_groupid(econtext->ecxt_outertuple,
 									 node->grpColIdx[node->numCols-node->numNullCols-1]);
-		else
-			econtext->group_id = node->rollupGSTimes;
-
-		/* Set GROUPING value */
-		if ((is_final_rollup_agg ||
-			 (passthru_ready && is_middle_rollup_agg)) &&
-			input_has_grouping)
 			econtext->grouping =
 				get_grouping_groupid(econtext->ecxt_outertuple,
 									 node->grpColIdx[node->numCols-node->numNullCols-2]);
+		}
 		else
+		{
+			econtext->group_id = node->rollupGSTimes;
 			econtext->grouping = node->grouping;
+		}
 
 		/*
 		 * When some grouping columns do not appear in this Agg node,
@@ -1716,9 +1720,15 @@ agg_retrieve_hash_table(AggState *aggstate)
 	int			aggno;
 	Agg		   *node = (Agg *) aggstate->ss.ps.plan;
 	bool        input_has_grouping = node->inputHasGrouping;
-	bool        is_final_rollup_agg =
-		(node->lastAgg ||
-		 (input_has_grouping && node->numNullCols == 0));
+
+	/*
+	 * The final Agg node brings back all rollup results from different
+	 * segments. This node is very similar to the non-rollup Agg node, except
+	 * that we need a way to know this to properly set GROUPING value during
+	 * execution.
+	 */
+	bool        is_final_agg_over_rollup =
+		(input_has_grouping && node->numNullCols == 0);
 
 	/*
 	 * get state info from node
@@ -1785,7 +1795,7 @@ agg_retrieve_hash_table(AggState *aggstate)
 		 */
 		econtext->ecxt_outertuple = firstSlot;
 
-		if (is_final_rollup_agg && input_has_grouping)
+		if (is_final_agg_over_rollup)
 		{
 			econtext->group_id =
 				get_grouping_groupid(econtext->ecxt_outertuple,

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1073,11 +1073,6 @@ typedef struct Agg
 	 * The GROUPING value of input tuples for Agg(a,b,c) is 0, and the values
 	 * for Agg(a,b), Agg(a), Agg() are 0, 1, 3, respectively.
 	 *
-	 * We also use the value "-1" to indicate an Agg node is the final
-	 * one that brings back all rollup results from different segments. This final
-	 * Agg node is very similar to the non-rollup Agg node, except that we need
-	 * a way to know this to properly set GROUPING value during execution.
-	 *
 	 * For a non-rollup Agg node, this value is 0.
 	 */
 	uint64 inputGrouping;

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6074,7 +6074,7 @@ select x,y,count(*), grouping(x), grouping(y),grouping(x,y) from generate_series
 ---+---+-------+----------+----------+----------
  1 | 1 |     1 |        0 |        0 |        0
    | 1 |     1 |        1 |        0 |        2
-   |   |     1 |        1 |        0 |        2
+   |   |     1 |        1 |        1 |        3
  1 |   |     1 |        0 |        1 |        1
 (4 rows)
 
@@ -6083,7 +6083,7 @@ select x,y,count(*), grouping(x,y) from generate_series(1,1) x, generate_series(
 ---+---+-------+----------
  1 | 1 |     1 |        0
    | 1 |     1 |        2
-   |   |     1 |        2
+   |   |     1 |        3
  1 |   |     1 |        1
 (4 rows)
 
@@ -6096,7 +6096,7 @@ select x,y,count(*), grouping(x,y) from generate_series(1,2) x, generate_series(
  1 | 2 |     1 |        0
  2 | 2 |     1 |        0
    | 2 |     2 |        2
-   |   |     4 |        2
+   |   |     4 |        3
  1 |   |     2 |        1
  2 |   |     2 |        1
 (9 rows)


### PR DESCRIPTION
# Problem description

Computing of distributed ROLLUP aggregates is based on injection of special final aggregate node over RedistributedMotion one that performs final aggregation over already locally evaluated ROLLUP aggregates. This final Agg node have to pass the GROUPING and GROUP_ID values pulled from incoming tuples. This mechanics works well for distributed case but current implementation tries to apply this logic to single node executed queries assigning the role of final Agg node to the last most generalized ROLLUP aggregate. As result this thing incorrectly evaluates the final GROUPING and GROUP_ID values discarding the corresponding correct ones assigned to the Agg node in the `grouping` and `rollupGSTimes` fields.

## Example to reproduce

```sql
# Plan of single node query
explain (costs off) SELECT
  *
, COUNT(*)
, GROUPING(col1, col2)::BIT(2)::TEXT
FROM (
  VALUES
    (1, 1)
  , (1, 2)
  , (2, 1)
  ) AS t (col1, col2)
GROUP BY
  GROUPING SETS (
    (col1, col2)
  , (col1)
  );
                                     QUERY PLAN                                      
-------------------------------------------------------------------------------------
 GroupAggregate
   Group Key: "rollup".col1, "rollup"."grouping", "rollup"."group_id", "rollup".col2
   ->  Subquery Scan on "rollup"
         ->  GroupAggregate
               Group Key: "*VALUES*".column1, "*VALUES*".column2
               ->  Sort
                     Sort Key: "*VALUES*".column1, "*VALUES*".column2
                     ->  Values Scan on "*VALUES*"

# Result of its execution
# result values around asterisks are faulty
SELECT                     
  *
, COUNT(*)
, GROUPING(col1, col2)::BIT(2)::TEXT
FROM (
  VALUES
    (1, 1)
  , (1, 2)
  , (2, 1)
  ) AS t (col1, col2)
GROUP BY
  GROUPING SETS (
    (col1, col2)
  , (col1)
  );
 col1 |  col2  | count | grouping 
------+--------+-------+----------
    1 |      1 |     1 | 00
    1 |      2 |     1 | 00
    1 | (null) |     2 | *00*
    2 |      1 |     1 | 00
    2 | (null) |     1 | *00*
(5 rows)

# Distributed query case
create table test(col1 int, col2 int);
insert into test values (1, 1), (1, 2), (2, 1);

# HashAggregate node under Gather Motion is that final Agg node over Redistribute Motion
explain (costs off) SELECT
  *
, COUNT(*)
, GROUPING(col1, col2)::BIT(2)::TEXT
FROM test 
GROUP BY
  GROUPING SETS (
    (col1, col2)
  , (col2)
  );
                                                 QUERY PLAN                                                  
-------------------------------------------------------------------------------------------------------------
 Gather Motion 1:1  (slice2; segments: 1)
   ->  HashAggregate
         Group Key: "rollup".col2, "rollup".col1, "rollup"."grouping", "rollup"."group_id"
         ->  Subquery Scan on "rollup"
               ->  Redistribute Motion 1:1  (slice1; segments: 1)
                     Hash Key: rollup_1.col2, rollup_1.col1, (Grouping), group_id()
                     ->  GroupAggregate
                           Group Key: rollup_1.col2, rollup_1."grouping", rollup_1."group_id", rollup_1.col1
                           ->  Subquery Scan on rollup_1
                                 ->  GroupAggregate
                                       Group Key: test.col2, test.col1
                                       ->  Sort
                                             Sort Key: test.col2, test.col1
                                             ->  Seq Scan on test

# Appropriate grouping values are correct
SELECT                    
  *
, COUNT(*)
, GROUPING(col1, col2)::BIT(2)::TEXT
FROM test
GROUP BY
  GROUPING SETS (
    (col1, col2)
  , (col2)
  );
  col1  | col2 | count | grouping 
--------+------+-------+----------
 (null) |    2 |     1 | *10*
      1 |    1 |     1 | 00
      2 |    1 |     1 | 00
 (null) |    1 |     2 | *10*
      1 |    2 |     1 | 00
```

## Fix description

The current patch tries to differentiate the kind of final Agg node in multistage aggregation pipeline: the one on top of `Redistributed Motion` node from the rollup-aware one in locally executed query. In particular, it removes the `lastAgg` field of Agg node from the definition of final distributed aggregate that is later used in algorithm of GROUPING and GROUP_ID computing because of:
- this flag identifies this kind of node with the second one - the main reason of invalid result
- the condition `inputHasGrouping && numNullCols == 0` is enough to determine this kind of node.

The patch also removes comment note for `inputGrouping` field of Agg struct about a special value (-1) for final distributed Agg nodes because IMO it have become obsolete.

## Affected versions

6X and 5X

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
