### PR TITLE
[ORCA] Modernize: Use default member initializers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: |
   modernize-use-equals-default,
   modernize-use-equals-delete,
   modernize-use-nullptr,
+  modernize-use-default-member-init,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'gpdbcost|gpopt|gpos|naucrates'

--- a/src/backend/gpopt/utils/CMemoryPoolPalloc.cpp
+++ b/src/backend/gpopt/utils/CMemoryPoolPalloc.cpp
@@ -25,7 +25,7 @@ extern "C" {
 using namespace gpos;
 
 // ctor
-CMemoryPoolPalloc::CMemoryPoolPalloc() : m_cxt(nullptr)
+CMemoryPoolPalloc::CMemoryPoolPalloc()
 {
 	m_cxt = gpdb::GPDBAllocSetContextCreate();
 }

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -93,18 +93,7 @@ const CSystemId default_sysid(IMDId::EmdidGPDB, GPOS_WSZ_STR_LENGTH("GPDB"));
 //		Ctor
 //
 //---------------------------------------------------------------------------
-SOptContext::SOptContext()
-	: m_query_dxl(nullptr),
-	  m_query(nullptr),
-	  m_plan_dxl(nullptr),
-	  m_plan_stmt(nullptr),
-	  m_should_generate_plan_stmt(false),
-	  m_should_serialize_plan_dxl(false),
-	  m_is_unexpected_failure(false),
-	  m_should_error_out(false),
-	  m_error_msg(nullptr)
-{
-}
+SOptContext::SOptContext() = default;
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColumnFactory.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColumnFactory.h
@@ -45,13 +45,13 @@ class CColumnFactory
 {
 private:
 	// MTS memory pool
-	CMemoryPool *m_mp;
+	CMemoryPool *m_mp{nullptr};
 
 	// mapping between column id of computed column and a set of used column references
-	ColRefToColRefSetMap *m_phmcrcrs;
+	ColRefToColRefSetMap *m_phmcrcrs{nullptr};
 
 	// id counter
-	ULONG m_aul;
+	ULONG m_aul{0};
 
 	// hash table
 	CSyncHashtable<CColRef, ULONG> m_sht;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecNonSingleton.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecNonSingleton.h
@@ -34,7 +34,7 @@ class CDistributionSpecNonSingleton : public CDistributionSpec
 {
 private:
 	// should Replicated distribution satisfy current distribution
-	BOOL m_fAllowReplicated;
+	BOOL m_fAllowReplicated{true};
 
 public:
 	CDistributionSpecNonSingleton(const CDistributionSpecNonSingleton &) =

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecRandom.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecRandom.h
@@ -32,14 +32,14 @@ class CDistributionSpecRandom : public CDistributionSpec
 {
 protected:
 	// is the random distribution sensitive to duplicates
-	BOOL m_is_duplicate_sensitive;
+	BOOL m_is_duplicate_sensitive{false};
 
 	// does Singleton spec satisfy current distribution?
 	// by default, Singleton satisfies hashed/random since all tuples with the same hash value
 	// are moved to the same host/segment,
 	// this flag adds the ability to mark a distribution request as non-satisfiable by Singleton
 	// in case we need to enforce across segments distribution
-	BOOL m_fSatisfiedBySingleton;
+	BOOL m_fSatisfiedBySingleton{true};
 
 	// private copy ctor
 	CDistributionSpecRandom(const CDistributionSpecRandom &);

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropPlan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropPlan.h
@@ -45,16 +45,16 @@ class CDrvdPropPlan : public CDrvdProp
 {
 private:
 	// derived sort order
-	COrderSpec *m_pos;
+	COrderSpec *m_pos{nullptr};
 
 	// derived distribution
-	CDistributionSpec *m_pds;
+	CDistributionSpec *m_pds{nullptr};
 
 	// derived rewindability
-	CRewindabilitySpec *m_prs;
+	CRewindabilitySpec *m_prs{nullptr};
 
 	// derived cte map
-	CCTEMap *m_pcm;
+	CCTEMap *m_pcm{nullptr};
 
 	// copy CTE producer plan properties from given context to current object
 	void CopyCTEProducerPlanProps(CMemoryPool *mp, CDrvdPropCtxt *pdpctxt,

--- a/src/backend/gporca/libgpopt/include/gpopt/base/COptimizationContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/COptimizationContext.h
@@ -64,37 +64,37 @@ public:
 
 private:
 	// memory pool
-	CMemoryPool *m_mp;
+	CMemoryPool *m_mp{nullptr};
 
 	// private copy ctor
 	COptimizationContext(const COptimizationContext &);
 
 	// unique id within owner group, used for debugging
-	ULONG m_id;
+	ULONG m_id{GPOPT_INVALID_OPTCTXT_ID};
 
 	// back pointer to owner group, used for debugging
-	CGroup *m_pgroup;
+	CGroup *m_pgroup{nullptr};
 
 	// required plan properties
-	CReqdPropPlan *m_prpp;
+	CReqdPropPlan *m_prpp{nullptr};
 
 	// required relational properties -- used for stats computation during costing
-	CReqdPropRelational *m_prprel;
+	CReqdPropRelational *m_prprel{nullptr};
 
 	// stats of previously optimized expressions
-	IStatisticsArray *m_pdrgpstatCtxt;
+	IStatisticsArray *m_pdrgpstatCtxt{nullptr};
 
 	// index of search stage where context is generated
-	ULONG m_ulSearchStageIndex;
+	ULONG m_ulSearchStageIndex{0};
 
 	// best cost context under the optimization context
-	CCostContext *m_pccBest;
+	CCostContext *m_pccBest{nullptr};
 
 	// optimization context state
-	EState m_estate;
+	EState m_estate{estUnoptimized};
 
 	// is there a multi-stage Agg plan satisfying required properties
-	BOOL m_fHasMultiStageAggPlan;
+	BOOL m_fHasMultiStageAggPlan{false};
 
 	// context's optimization job queue
 	CJobQueue m_jqOptimization;
@@ -103,19 +103,7 @@ private:
 	BOOL FMatchSortColumns(const COptimizationContext *poc) const;
 
 	// private dummy ctor; used for creating invalid context
-	COptimizationContext()
-		: m_mp(nullptr),
-		  m_id(GPOPT_INVALID_OPTCTXT_ID),
-		  m_pgroup(nullptr),
-		  m_prpp(nullptr),
-		  m_prprel(nullptr),
-		  m_pdrgpstatCtxt(nullptr),
-		  m_ulSearchStageIndex(0),
-		  m_pccBest(nullptr),
-		  m_estate(estUnoptimized),
-		  m_fHasMultiStageAggPlan(false)
-	{
-	}
+	COptimizationContext() = default;
 
 	// check if Agg node should be optimized for the given context
 	static BOOL FOptimizeAgg(CMemoryPool *mp, CGroupExpression *pgexprParent,
@@ -149,15 +137,11 @@ public:
 			*stats_ctxt,  // stats of previously optimized expressions
 		ULONG ulSearchStageIndex)
 		: m_mp(mp),
-		  m_id(GPOPT_INVALID_OPTCTXT_ID),
 		  m_pgroup(pgroup),
 		  m_prpp(prpp),
 		  m_prprel(prprel),
 		  m_pdrgpstatCtxt(stats_ctxt),
-		  m_ulSearchStageIndex(ulSearchStageIndex),
-		  m_pccBest(nullptr),
-		  m_estate(estUnoptimized),
-		  m_fHasMultiStageAggPlan(false)
+		  m_ulSearchStageIndex(ulSearchStageIndex)
 	{
 		GPOS_ASSERT(nullptr != pgroup);
 		GPOS_ASSERT(nullptr != prpp);

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CReqdPropPlan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CReqdPropPlan.h
@@ -46,32 +46,25 @@ class CReqdPropPlan : public CReqdProp
 {
 private:
 	// required columns
-	CColRefSet *m_pcrs;
+	CColRefSet *m_pcrs{nullptr};
 
 	// required sort order
-	CEnfdOrder *m_peo;
+	CEnfdOrder *m_peo{nullptr};
 
 	// required distribution
-	CEnfdDistribution *m_ped;
+	CEnfdDistribution *m_ped{nullptr};
 
 	// required rewindability
-	CEnfdRewindability *m_per;
+	CEnfdRewindability *m_per{nullptr};
 
 	// required ctes
-	CCTEReq *m_pcter;
+	CCTEReq *m_pcter{nullptr};
 
 public:
 	CReqdPropPlan(const CReqdPropPlan &) = delete;
 
 	// default ctor
-	CReqdPropPlan()
-		: m_pcrs(nullptr),
-		  m_peo(nullptr),
-		  m_ped(nullptr),
-		  m_per(nullptr),
-		  m_pcter(nullptr)
-	{
-	}
+	CReqdPropPlan() = default;
 
 	// ctor
 	CReqdPropPlan(CColRefSet *pcrs, CEnfdOrder *peo, CEnfdDistribution *ped,

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CReqdPropRelational.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CReqdPropRelational.h
@@ -37,10 +37,10 @@ class CReqdPropRelational : public CReqdProp
 {
 private:
 	// required stat columns
-	CColRefSet *m_pcrsStat;
+	CColRefSet *m_pcrsStat{nullptr};
 
 	// predicate on partition key
-	CExpression *m_pexprPartPred;
+	CExpression *m_pexprPartPred{nullptr};
 
 public:
 	CReqdPropRelational(const CReqdPropRelational &) = delete;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CStateMachine.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CStateMachine.h
@@ -64,7 +64,7 @@ private:
 	TEnumState m_tenumstate;
 
 	// flag indicating if the state machine is initialized
-	BOOL m_fInit;
+	BOOL m_fInit{false};
 
 	// array of transitions
 	TEnumEvent m_rgrgtenumeventTransitions[tenumstateSentinel]
@@ -85,7 +85,7 @@ private:
 	const WCHAR *m_rgwszEvents[tenumeventSentinel];
 
 	// current index into history
-	ULONG m_ulHistory;
+	ULONG m_ulHistory{0};
 
 	// state history
 	TEnumState m_tenumstateHistory[GPOPT_FSM_HISTORY];
@@ -263,12 +263,7 @@ public:
 	// ctor
 	CStateMachine<TEnumState, tenumstateSentinel, TEnumEvent,
 				  tenumeventSentinel>()
-		: m_tenumstate(TesInitial()),
-		  m_fInit(false)
-#ifdef GPOS_DEBUG
-		  ,
-		  m_ulHistory(0)
-#endif	// GPOS_DEBUG
+		: m_tenumstate(TesInitial())
 	{
 		GPOS_ASSERT(0 < tenumstateSentinel && 0 < tenumeventSentinel &&
 					(ULONG) tenumeventSentinel + 1 >=

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CWindowFrame.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CWindowFrame.h
@@ -74,25 +74,25 @@ public:
 
 private:
 	// specification method
-	const EFrameSpec m_efs;
+	const EFrameSpec m_efs{EfsRange};
 
 	// type of leading edge
-	const EFrameBoundary m_efbLeading;
+	const EFrameBoundary m_efbLeading{EfbUnboundedPreceding};
 
 	// type of trailing edge
-	const EFrameBoundary m_efbTrailing;
+	const EFrameBoundary m_efbTrailing{EfbCurrentRow};
 
 	// scalar value of leading edge, memory owned by this class
-	CExpression *m_pexprLeading;
+	CExpression *m_pexprLeading{nullptr};
 
 	// scalar value of trailing edge, memory owned by this class
-	CExpression *m_pexprTrailing;
+	CExpression *m_pexprTrailing{nullptr};
 
 	// exclusion strategy
-	const EFrameExclusionStrategy m_efes;
+	const EFrameExclusionStrategy m_efes{EfesNone};
 
 	// columns used by frame edges
-	CColRefSet *m_pcrsUsed;
+	CColRefSet *m_pcrsUsed{nullptr};
 
 	// singelton empty frame -- used with any unspecified window function frame
 	static const CWindowFrame m_wfEmpty;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalAssert.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalAssert.h
@@ -35,9 +35,8 @@
 
 #include "gpos/base.h"
 
-#include "naucrates/dxl/errorcodes.h"
-
 #include "gpopt/operators/CPhysical.h"
+#include "naucrates/dxl/errorcodes.h"
 
 namespace gpopt
 {

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CGroupExpression.h
@@ -94,42 +94,42 @@ private:
 
 
 	// expression id
-	ULONG m_id;
+	ULONG m_id{GPOPT_INVALID_GEXPR_ID};
 
 	// duplicate group expression
 	CGroupExpression *m_pgexprDuplicate;
 
 	// operator class
-	COperator *m_pop;
+	COperator *m_pop{nullptr};
 
 	// array of child groups
-	CGroupArray *m_pdrgpgroup;
+	CGroupArray *m_pdrgpgroup{nullptr};
 
 	// sorted array of children groups for faster comparison
 	// of order-insensitive operators
-	CGroupArray *m_pdrgpgroupSorted;
+	CGroupArray *m_pdrgpgroupSorted{nullptr};
 
 	// back pointer to group
-	CGroup *m_pgroup;
+	CGroup *m_pgroup{nullptr};
 
 	// id of xform that generated group expression
-	CXform::EXformId m_exfidOrigin;
+	CXform::EXformId m_exfidOrigin{CXform::ExfInvalid};
 
 	// group expression that generated current group expression via xform
-	CGroupExpression *m_pgexprOrigin;
+	CGroupExpression *m_pgexprOrigin{nullptr};
 
 	// flag to indicate if group expression was created as a node at some
 	// intermediate level when origin expression was inserted to memo
-	BOOL m_fIntermediate;
+	BOOL m_fIntermediate{false};
 
 	// state of group expression
-	EState m_estate;
+	EState m_estate{estUnexplored};
 
 	// optimization level
-	EOptimizationLevel m_eol;
+	EOptimizationLevel m_eol{EolLow};
 
 	// map of partial plans to their cost lower bound
-	PartialPlanToCostMap *m_ppartialplancostmap;
+	PartialPlanToCostMap *m_ppartialplancostmap{nullptr};
 
 	// circular dependency state
 	ECircularDependency m_ecirculardependency;
@@ -175,20 +175,7 @@ private:
 	IOstream &OsPrintCostContexts(IOstream &os, const CHAR *szPrefix) const;
 
 	//private dummy ctor; used for creating invalid gexpr
-	CGroupExpression()
-		: m_id(GPOPT_INVALID_GEXPR_ID),
-		  m_pop(nullptr),
-		  m_pdrgpgroup(nullptr),
-		  m_pdrgpgroupSorted(nullptr),
-		  m_pgroup(nullptr),
-		  m_exfidOrigin(CXform::ExfInvalid),
-		  m_pgexprOrigin(nullptr),
-		  m_fIntermediate(false),
-		  m_estate(estUnexplored),
-		  m_eol(EolLow),
-		  m_ppartialplancostmap(nullptr)
-	{
-	}
+	CGroupExpression() = default;
 
 
 public:

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJob.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJob.h
@@ -116,26 +116,26 @@ private:
 #endif	// GPOS_DEBUG
 
 	// parent job
-	CJob *m_pjParent;
+	CJob *m_pjParent{nullptr};
 
 	// assigned job queue
-	CJobQueue *m_pjq;
+	CJobQueue *m_pjq{nullptr};
 
 	// reference counter
-	ULONG_PTR m_ulpRefs;
+	ULONG_PTR m_ulpRefs{0};
 
 	// job id - set by job factory
-	ULONG m_id;
+	ULONG m_id{0};
 
 	// job type
 	EJobType m_ejt;
 
 	// flag indicating if job is initialized
-	BOOL m_fInit;
+	BOOL m_fInit{false};
 
 #ifdef GPOS_DEBUG
 	// job state
-	EJobState m_ejs;
+	EJobState m_ejs{EjsInit};
 #endif	// GPOS_DEBUG
 
 	//-------------------------------------------------------------------
@@ -227,18 +227,7 @@ protected:
 	}
 
 	// ctor
-	CJob()
-		: m_pjParent(nullptr),
-		  m_pjq(nullptr),
-		  m_ulpRefs(0),
-		  m_id(0),
-		  m_fInit(false)
-#ifdef GPOS_DEBUG
-		  ,
-		  m_ejs(EjsInit)
-#endif	// GPOS_DEBUG
-	{
-	}
+	CJob() = default;
 
 	// dtor
 	virtual ~CJob()

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroup.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroup.h
@@ -36,15 +36,13 @@ class CJobGroup : public CJob
 private:
 protected:
 	// target group
-	CGroup *m_pgroup;
+	CGroup *m_pgroup{nullptr};
 
 	// last scheduled group expression
 	CGroupExpression *m_pgexprLastScheduled;
 
 	// ctor
-	CJobGroup() : m_pgroup(nullptr)
-	{
-	}
+	CJobGroup() = default;
 
 	// dtor
 	~CJobGroup() override = default;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobGroupExpression.h
@@ -44,12 +44,10 @@ private:
 
 protected:
 	// target group expression
-	CGroupExpression *m_pgexpr;
+	CGroupExpression *m_pgexpr{nullptr};
 
 	// ctor
-	CJobGroupExpression() : m_pgexpr(nullptr)
-	{
-	}
+	CJobGroupExpression() = default;
 
 	// dtor
 	~CJobGroupExpression() override = default;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobQueue.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobQueue.h
@@ -33,10 +33,10 @@ class CJobQueue
 {
 private:
 	// main job
-	CJob *m_pj;
+	CJob *m_pj{nullptr};
 
 	// flag indicating if main job has completed
-	BOOL m_fCompleted;
+	BOOL m_fCompleted{false};
 
 	// list of jobs waiting for main job to complete
 	CList<CJob> m_listjQueued;
@@ -51,7 +51,7 @@ public:
 	};
 
 	// ctor
-	CJobQueue() : m_pj(nullptr), m_fCompleted(false)
+	CJobQueue()
 	{
 		m_listjQueued.Init(GPOS_OFFSET(CJob, m_linkQueue));
 	}

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CJobTest.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CJobTest.h
@@ -44,16 +44,16 @@ public:
 
 private:
 	// test type
-	ETestType m_ett;
+	ETestType m_ett{EttSpawn};
 
 	// number of job spawning rounds
-	ULONG m_ulRounds;
+	ULONG m_ulRounds{gpos::ulong_max};
 
 	// spawning fanout
-	ULONG m_ulFanout;
+	ULONG m_ulFanout{gpos::ulong_max};
 
 	// CPU-burning iterations per job
-	ULONG m_ulIters;
+	ULONG m_ulIters{gpos::ulong_max};
 
 	// iteration counter
 	static ULONG_PTR m_ulpCnt;

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CSchedulerContext.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CSchedulerContext.h
@@ -36,22 +36,22 @@ class CSchedulerContext
 {
 private:
 	// memory pool used by all workers
-	CMemoryPool *m_pmpGlobal;
+	CMemoryPool *m_pmpGlobal{nullptr};
 
 	// memory pool used by only by current worker (scratch space)
-	CMemoryPool *m_pmpLocal;
+	CMemoryPool *m_pmpLocal{nullptr};
 
 	// job factory
 	CJobFactory *m_pjf;
 
 	// scheduler
-	CScheduler *m_psched;
+	CScheduler *m_psched{nullptr};
 
 	// optimization engine
 	CEngine *m_peng;
 
 	// flag indicating if context has been initialized
-	BOOL m_fInit;
+	BOOL m_fInit{false};
 
 	BOOL
 	FInit() const

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -176,13 +176,10 @@ private:
 	// this identifies a group and one expression belonging to that group
 	struct SGroupAndExpression
 	{
-		SGroupInfo *m_group_info;
-		ULONG m_expr_index;
+		SGroupInfo *m_group_info{nullptr};
+		ULONG m_expr_index{gpos::ulong_max};
 
-		SGroupAndExpression()
-			: m_group_info(nullptr), m_expr_index(gpos::ulong_max)
-		{
-		}
+		SGroupAndExpression() = default;
 		SGroupAndExpression(SGroupInfo *g, ULONG ix)
 			: m_group_info(g), m_expr_index(ix)
 		{

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CSubqueryHandler.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CSubqueryHandler.h
@@ -51,49 +51,37 @@ private:
 	struct SSubqueryDesc
 	{
 		// subquery can return more than one row
-		BOOL m_returns_set;
+		BOOL m_returns_set{false};
 
 		// subquery has volatile functions
-		BOOL m_fHasVolatileFunctions;
+		BOOL m_fHasVolatileFunctions{false};
 
 		// subquery has outer references
-		BOOL m_fHasOuterRefs;
+		BOOL m_fHasOuterRefs{false};
 
 		// the returned column is an outer reference
-		BOOL m_fReturnedPcrIsOuterRef;
+		BOOL m_fReturnedPcrIsOuterRef{false};
 
 		// subquery has skip level correlations -- when inner expression refers to columns defined above the immediate outer expression
-		BOOL m_fHasSkipLevelCorrelations;
+		BOOL m_fHasSkipLevelCorrelations{false};
 
 		// subquery has a single count(*)/count(Any) agg
-		BOOL m_fHasCountAgg;
+		BOOL m_fHasCountAgg{false};
 
 		// column defining count(*)/count(Any) agg, if any
-		CColRef *m_pcrCountAgg;
+		CColRef *m_pcrCountAgg{nullptr};
 
 		//  does subquery project a count expression
-		BOOL m_fProjectCount;
+		BOOL m_fProjectCount{false};
 
 		// subquery is used in a value context
-		BOOL m_fValueSubquery;
+		BOOL m_fValueSubquery{false};
 
 		// subquery requires correlated execution
-		BOOL m_fCorrelatedExecution;
+		BOOL m_fCorrelatedExecution{false};
 
 		// ctor
-		SSubqueryDesc()
-			: m_returns_set(false),
-			  m_fHasVolatileFunctions(false),
-			  m_fHasOuterRefs(false),
-			  m_fReturnedPcrIsOuterRef(false),
-			  m_fHasSkipLevelCorrelations(false),
-			  m_fHasCountAgg(false),
-			  m_pcrCountAgg(nullptr),
-			  m_fProjectCount(false),
-			  m_fValueSubquery(false),
-			  m_fCorrelatedExecution(false)
-		{
-		}
+		SSubqueryDesc() = default;
 
 		// set correlated execution flag
 		void SetCorrelatedExecution();

--- a/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
@@ -36,7 +36,7 @@ using namespace gpmd;
 //		ctor
 //
 //---------------------------------------------------------------------------
-CColumnFactory::CColumnFactory() : m_mp(nullptr), m_phmcrcrs(nullptr), m_aul(0)
+CColumnFactory::CColumnFactory()
 {
 	CAutoMemoryPool amp;
 	m_mp = amp.Pmp();

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecNonSingleton.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecNonSingleton.cpp
@@ -29,10 +29,7 @@ using namespace gpopt;
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CDistributionSpecNonSingleton::CDistributionSpecNonSingleton()
-	: m_fAllowReplicated(true)
-{
-}
+CDistributionSpecNonSingleton::CDistributionSpecNonSingleton() = default;
 
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecRandom.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecRandom.cpp
@@ -32,7 +32,6 @@ using namespace gpopt;
 //
 //---------------------------------------------------------------------------
 CDistributionSpecRandom::CDistributionSpecRandom()
-	: m_is_duplicate_sensitive(false), m_fSatisfiedBySingleton(true)
 {
 	if (COptCtxt::PoctxtFromTLS()->FDMLQuery())
 	{

--- a/src/backend/gporca/libgpopt/src/base/CDrvdPropPlan.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDrvdPropPlan.cpp
@@ -33,9 +33,8 @@ using namespace gpopt;
 //
 //---------------------------------------------------------------------------
 CDrvdPropPlan::CDrvdPropPlan()
-	: m_pos(nullptr), m_pds(nullptr), m_prs(nullptr), m_pcm(nullptr)
-{
-}
+
+	= default;
 
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/base/CReqdPropRelational.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CReqdPropRelational.cpp
@@ -32,9 +32,8 @@ using namespace gpopt;
 //
 //---------------------------------------------------------------------------
 CReqdPropRelational::CReqdPropRelational()
-	: m_pcrsStat(nullptr), m_pexprPartPred(nullptr)
-{
-}
+
+	= default;
 
 //---------------------------------------------------------------------------
 //	@function:
@@ -44,8 +43,7 @@ CReqdPropRelational::CReqdPropRelational()
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CReqdPropRelational::CReqdPropRelational(CColRefSet *pcrs)
-	: m_pcrsStat(pcrs), m_pexprPartPred(nullptr)
+CReqdPropRelational::CReqdPropRelational(CColRefSet *pcrs) : m_pcrsStat(pcrs)
 {
 	GPOS_ASSERT(nullptr != pcrs);
 }

--- a/src/backend/gporca/libgpopt/src/base/CWindowFrame.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CWindowFrame.cpp
@@ -60,8 +60,7 @@ CWindowFrame::CWindowFrame(CMemoryPool *mp, EFrameSpec efs,
 	  m_efbTrailing(efbTrailing),
 	  m_pexprLeading(pexprLeading),
 	  m_pexprTrailing(pexprTrailing),
-	  m_efes(efes),
-	  m_pcrsUsed(nullptr)
+	  m_efes(efes)
 {
 	GPOS_ASSERT_IMP(EfbBoundedPreceding == m_efbLeading ||
 						EfbBoundedFollowing == m_efbLeading,
@@ -93,15 +92,10 @@ CWindowFrame::CWindowFrame(CMemoryPool *mp, EFrameSpec efs,
 //
 //---------------------------------------------------------------------------
 CWindowFrame::CWindowFrame()
-	: m_efs(EfsRange),
-	  m_efbLeading(EfbUnboundedPreceding),
-	  m_efbTrailing(EfbCurrentRow),
-	  m_pexprLeading(nullptr),
-	  m_pexprTrailing(nullptr),
-	  m_efes(EfesNone),
-	  m_pcrsUsed(nullptr)
-{
-}
+
+
+
+	= default;
 
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
@@ -32,7 +32,7 @@ using namespace gpopt;
 #define GPOPT_COSTCTXT_HT_BUCKETS 100
 
 // invalid group expression
-const CGroupExpression CGroupExpression::m_gexprInvalid;
+const CGroupExpression CGroupExpression::m_gexprInvalid{};
 
 
 //---------------------------------------------------------------------------
@@ -48,18 +48,14 @@ CGroupExpression::CGroupExpression(CMemoryPool *mp, COperator *pop,
 								   CXform::EXformId exfid,
 								   CGroupExpression *pgexprOrigin,
 								   BOOL fIntermediate)
-	: m_id(GPOPT_INVALID_GEXPR_ID),
-	  m_pgexprDuplicate(nullptr),
+	: m_pgexprDuplicate(nullptr),
 	  m_pop(pop),
 	  m_pdrgpgroup(pdrgpgroup),
-	  m_pdrgpgroupSorted(nullptr),
-	  m_pgroup(nullptr),
+
 	  m_exfidOrigin(exfid),
 	  m_pgexprOrigin(pgexprOrigin),
 	  m_fIntermediate(fIntermediate),
-	  m_estate(estUnexplored),
-	  m_eol(EolLow),
-	  m_ppartialplancostmap(nullptr),
+
 	  m_ecirculardependency(ecdDefault)
 {
 	GPOS_ASSERT(nullptr != pop);

--- a/src/backend/gporca/libgpopt/src/search/CJobTest.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CJobTest.cpp
@@ -34,14 +34,7 @@ ULONG_PTR CJobTest::m_ulpCnt;
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CJobTest::CJobTest()
-	: CJob(),
-	  m_ett(EttSpawn),
-	  m_ulRounds(gpos::ulong_max),
-	  m_ulFanout(gpos::ulong_max),
-	  m_ulIters(gpos::ulong_max)
-{
-}
+CJobTest::CJobTest() = default;
 
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/search/CSchedulerContext.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CSchedulerContext.cpp
@@ -31,12 +31,8 @@ using namespace gpopt;
 //
 //---------------------------------------------------------------------------
 CSchedulerContext::CSchedulerContext()
-	: m_pmpGlobal(nullptr),
-	  m_pmpLocal(nullptr),
-	  m_psched(nullptr),
-	  m_fInit(false)
-{
-}
+
+	= default;
 
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpos/include/gpos/common/CLink.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CLink.h
@@ -20,13 +20,11 @@ public:
 	SLink(const SLink &) = delete;
 
 	// link forward/backward
-	void *m_next;
-	void *m_prev;
+	void *m_next{nullptr};
+	void *m_prev{nullptr};
 
 	// ctor
-	SLink() : m_next(nullptr), m_prev(nullptr)
-	{
-	}
+	SLink() = default;
 };
 
 }  // namespace gpos

--- a/src/backend/gporca/libgpos/include/gpos/common/CList.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CList.h
@@ -47,10 +47,10 @@ class CList
 
 private:
 	// offest of link element
-	ULONG m_offset;
+	ULONG m_offset{gpos::ulong_max};
 
 	// size
-	ULONG m_size;
+	ULONG m_size{0};
 
 	// head element
 	T *m_head;
@@ -75,8 +75,7 @@ public:
 	CList(const CList &) = delete;
 
 	// ctor
-	CList()
-		: m_offset(gpos::ulong_max), m_size(0), m_head(nullptr), m_tail(nullptr)
+	CList() : m_head(nullptr), m_tail(nullptr)
 	{
 	}
 

--- a/src/backend/gporca/libgpos/include/gpos/common/CRandom.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CRandom.h
@@ -27,7 +27,7 @@ class CRandom
 {
 private:
 	// seed
-	ULONG m_seed;
+	ULONG m_seed;  // NOLINT(modernize-use-default-member-init)
 
 public:
 	CRandom(const CRandom &) = delete;

--- a/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h
@@ -39,7 +39,7 @@ class CRefCount : public CHeapObject
 {
 private:
 	// reference counter -- first in class to be in sync with Check()
-	ULONG_PTR m_refs;
+	ULONG_PTR m_refs{1};
 
 #ifdef GPOS_DEBUG
 	// sanity check to detect deleted memory
@@ -55,9 +55,7 @@ public:
 	CRefCount(const CRefCount &) = delete;
 
 	// ctor
-	CRefCount() : m_refs(1)
-	{
-	}
+	CRefCount() = default;
 
 	// FIXME: should mark this noexcept in non-assert builds
 	// dtor

--- a/src/backend/gporca/libgpos/include/gpos/common/CStackDescriptor.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CStackDescriptor.h
@@ -31,7 +31,7 @@ class CStackDescriptor
 {
 private:
 	// stack depth
-	ULONG m_depth;
+	ULONG m_depth{0};
 
 	// array with frame return addresses
 	void *m_array_of_addresses[GPOS_STACK_TRACE_DEPTH];
@@ -51,7 +51,7 @@ private:
 
 public:
 	// ctor
-	CStackDescriptor() : m_depth(0)
+	CStackDescriptor()
 	{
 		Reset();
 	}

--- a/src/backend/gporca/libgpos/include/gpos/common/CSyncHashtable.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CSyncHashtable.h
@@ -85,13 +85,13 @@ private:
 	SBucket *m_buckets;
 
 	// number of ht buckets
-	ULONG m_nbuckets;
+	ULONG m_nbuckets{0};
 
 	// number of ht entries
-	ULONG_PTR m_size;
+	ULONG_PTR m_size{0};
 
 	// offset of key
-	ULONG m_key_offset;
+	ULONG m_key_offset{gpos::ulong_max};
 
 	// invalid key - needed for iteration
 	const K *m_invalid_key;
@@ -146,9 +146,7 @@ public:
 	// ctor
 	CSyncHashtable<T, K>()
 		: m_buckets(nullptr),
-		  m_nbuckets(0),
-		  m_size(0),
-		  m_key_offset(gpos::ulong_max),
+
 		  m_invalid_key(nullptr)
 	{
 	}

--- a/src/backend/gporca/libgpos/include/gpos/error/CErrorContext.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CErrorContext.h
@@ -39,16 +39,16 @@ private:
 	CException m_exception;
 
 	// exception severity
-	ULONG m_severity;
+	ULONG m_severity{CException::ExsevError};
 
 	// flag to indicate if handled yet
-	BOOL m_pending;
+	BOOL m_pending{false};
 
 	// flag to indicate if handled yet
-	BOOL m_rethrown;
+	BOOL m_rethrown{false};
 
 	// flag to indicate that we are currently serializing this.
-	BOOL m_serializing;
+	BOOL m_serializing{false};
 
 	// error message buffer
 	WCHAR m_error_msg[GPOS_ERROR_MESSAGE_BUFFER_SIZE];

--- a/src/backend/gporca/libgpos/include/gpos/error/CMiniDumper.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CMiniDumper.h
@@ -29,14 +29,14 @@ class CMiniDumper : CStackObject
 {
 private:
 	// flag indicating if handler is initialized
-	BOOL m_initialized;
+	BOOL m_initialized{false};
 
 	// flag indicating if handler is finalized
-	BOOL m_finalized;
+	BOOL m_finalized{false};
 
 protected:
 	// stream to serialize objects to
-	COstream *m_oos;
+	COstream *m_oos{nullptr};
 
 public:
 	CMiniDumper(const CMiniDumper &) = delete;

--- a/src/backend/gporca/libgpos/include/gpos/io/CFileReader.h
+++ b/src/backend/gporca/libgpos/include/gpos/io/CFileReader.h
@@ -31,10 +31,10 @@ class CFileReader : public CFileDescriptor
 {
 private:
 	// file size
-	ULLONG m_file_size;
+	ULLONG m_file_size{0};
 
 	// read size
-	ULLONG m_file_read_size;
+	ULLONG m_file_read_size{0};
 
 public:
 	CFileReader(const CFileReader &) = delete;

--- a/src/backend/gporca/libgpos/include/gpos/io/CFileWriter.h
+++ b/src/backend/gporca/libgpos/include/gpos/io/CFileWriter.h
@@ -29,7 +29,7 @@ class CFileWriter : public CFileDescriptor
 {
 private:
 	// file size
-	ULLONG m_file_size;
+	ULLONG m_file_size{0};
 
 public:
 	CFileWriter(const CFileWriter &) = delete;

--- a/src/backend/gporca/libgpos/include/gpos/io/COstream.h
+++ b/src/backend/gporca/libgpos/include/gpos/io/COstream.h
@@ -76,7 +76,7 @@ private:
 	CWStringStatic m_static_string_buffer;
 
 	// current mode
-	EStreamManipulator m_stream_manipulator;
+	EStreamManipulator m_stream_manipulator{EsmDec};
 
 	// append formatted string
 	IOstream &AppendFormat(const WCHAR *format, ...);

--- a/src/backend/gporca/libgpos/include/gpos/io/IOstream.h
+++ b/src/backend/gporca/libgpos/include/gpos/io/IOstream.h
@@ -31,11 +31,9 @@ class IOstream
 {
 protected:
 	// ctor
-	IOstream() : m_fullPrecision(false)
-	{
-	}
+	IOstream() = default;
 
-	BOOL m_fullPrecision;
+	BOOL m_fullPrecision{false};
 
 public:
 	enum EStreamManipulator

--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolStatistics.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolStatistics.h
@@ -26,31 +26,23 @@ namespace gpos
 class CMemoryPoolStatistics
 {
 private:
-	ULLONG m_num_successful_allocations;
+	ULLONG m_num_successful_allocations{0};
 
-	ULLONG m_num_failed_allocations;
+	ULLONG m_num_failed_allocations{0};
 
-	ULLONG m_num_free;
+	ULLONG m_num_free{0};
 
-	ULLONG m_num_live_obj;
+	ULLONG m_num_live_obj{0};
 
-	ULLONG m_live_obj_user_size;
+	ULLONG m_live_obj_user_size{0};
 
-	ULLONG m_live_obj_total_size;
+	ULLONG m_live_obj_total_size{0};
 
 public:
 	CMemoryPoolStatistics(CMemoryPoolStatistics &) = delete;
 
 	// ctor
-	CMemoryPoolStatistics()
-		: m_num_successful_allocations(0),
-		  m_num_failed_allocations(0),
-		  m_num_free(0),
-		  m_num_live_obj(0),
-		  m_live_obj_user_size(0),
-		  m_live_obj_total_size(0)
-	{
-	}
+	CMemoryPoolStatistics() = default;
 
 	// dtor
 	virtual ~CMemoryPoolStatistics() = default;

--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolTracker.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolTracker.h
@@ -67,7 +67,7 @@ private:
 	CMemoryPoolStatistics m_memory_pool_statistics;
 
 	// allocation sequence number
-	ULONG m_alloc_sequence;
+	ULONG m_alloc_sequence{0};
 
 	// list of allocated (live) objects
 	CList<SAllocHeader> m_allocations_list;

--- a/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CRefCountTest.h
+++ b/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CRefCountTest.h
@@ -39,14 +39,11 @@ private:
 	{
 	private:
 		// is calling object's destructor allowed?
-		BOOL m_fDeletable;
+		BOOL m_fDeletable{false};
 
 	public:
 		// ctor
-		CDeletableTest()
-			: m_fDeletable(false)  // by default, object is not deletable
-		{
-		}
+		CDeletableTest() = default;
 
 		// return true if calling object's destructor is allowed
 		BOOL

--- a/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CSyncListTest.h
+++ b/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CSyncListTest.h
@@ -34,28 +34,26 @@ private:
 	struct SElem
 	{
 		// object id
-		ULONG m_id;
+		ULONG m_id{0};
 
 		// generic link for list
 		SLink m_link;
 
 		// ctor
-		SElem() : m_id(0)
-		{
-		}
+		SElem() = default;
 	};
 
 	// collection of parameters for parallel tasks
 	struct SArg
 	{
 		// pointer to list
-		CSyncList<SElem> *m_plist;
+		CSyncList<SElem> *m_plist{nullptr};
 
 		// pool of elements to insert
-		CSyncPool<SElem> *m_psp;
+		CSyncPool<SElem> *m_psp{nullptr};
 
 		// number of tasks
-		ULONG m_ulCount;
+		ULONG m_ulCount{0};
 
 		// ctor
 		SArg(CSyncList<SElem> *pstack, CSyncPool<SElem> *psp, ULONG count)
@@ -64,9 +62,7 @@ private:
 		}
 
 		// ctor
-		SArg() : m_plist(nullptr), m_psp(nullptr), m_ulCount(0)
-		{
-		}
+		SArg() = default;
 	};
 
 public:

--- a/src/backend/gporca/libgpos/src/error/CErrorContext.cpp
+++ b/src/backend/gporca/libgpos/src/error/CErrorContext.cpp
@@ -34,10 +34,7 @@ GPOS_CPL_ASSERT(GPOS_ERROR_MESSAGE_BUFFER_SIZE <= GPOS_LOG_ENTRY_BUFFER_SIZE);
 //---------------------------------------------------------------------------
 CErrorContext::CErrorContext(CMiniDumper *mini_dumper_handle)
 	: m_exception(CException::m_invalid_exception),
-	  m_severity(CException::ExsevError),
-	  m_pending(false),
-	  m_rethrown(false),
-	  m_serializing(false),
+
 	  m_static_buffer(m_error_msg, GPOS_ARRAY_SIZE(m_error_msg)),
 	  m_mini_dumper_handle(mini_dumper_handle)
 {

--- a/src/backend/gporca/libgpos/src/error/CMiniDumper.cpp
+++ b/src/backend/gporca/libgpos/src/error/CMiniDumper.cpp
@@ -27,10 +27,7 @@ using namespace gpos;
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CMiniDumper::CMiniDumper()
-	: m_initialized(false), m_finalized(false), m_oos(nullptr)
-{
-}
+CMiniDumper::CMiniDumper() = default;
 
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpos/src/io/CFileReader.cpp
+++ b/src/backend/gporca/libgpos/src/io/CFileReader.cpp
@@ -26,8 +26,7 @@ using namespace gpos;
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CFileReader::CFileReader()
-	: CFileDescriptor(), m_file_size(0), m_file_read_size(0)
+CFileReader::CFileReader() : CFileDescriptor()
 {
 }
 

--- a/src/backend/gporca/libgpos/src/io/CFileWriter.cpp
+++ b/src/backend/gporca/libgpos/src/io/CFileWriter.cpp
@@ -28,7 +28,7 @@ using namespace gpos;
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CFileWriter::CFileWriter() : CFileDescriptor(), m_file_size(0)
+CFileWriter::CFileWriter() : CFileDescriptor()
 {
 }
 

--- a/src/backend/gporca/libgpos/src/io/COstream.cpp
+++ b/src/backend/gporca/libgpos/src/io/COstream.cpp
@@ -25,8 +25,8 @@ using namespace gpos;
 //
 //---------------------------------------------------------------------------
 COstream::COstream()
-	: m_static_string_buffer(m_string_format_buffer, GPOS_OSTREAM_CONVBUF_SIZE),
-	  m_stream_manipulator(EsmDec)
+	: m_static_string_buffer(m_string_format_buffer, GPOS_OSTREAM_CONVBUF_SIZE)
+
 {
 }
 

--- a/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp
@@ -35,7 +35,7 @@ using namespace gpos;
 
 
 // ctor
-CMemoryPoolTracker::CMemoryPoolTracker() : CMemoryPool(), m_alloc_sequence(0)
+CMemoryPoolTracker::CMemoryPoolTracker() : CMemoryPool()
 {
 	m_allocations_list.Init(GPOS_OFFSET(SAllocHeader, m_link));
 }

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLProperties.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLProperties.h
@@ -39,7 +39,7 @@ class CDXLProperties : public CRefCount
 {
 private:
 	// derived statistics
-	CDXLStatsDerivedRelation *m_dxl_stats_derived_relation;
+	CDXLStatsDerivedRelation *m_dxl_stats_derived_relation{nullptr};
 
 protected:
 	// serialize statistics in DXL format

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLWindowKey.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLWindowKey.h
@@ -32,10 +32,10 @@ class CDXLWindowKey : public CRefCount
 {
 private:
 	// window frame associated with the window key
-	CDXLWindowFrame *m_window_frame_dxl;
+	CDXLWindowFrame *m_window_frame_dxl{nullptr};
 
 	// sorting columns
-	CDXLNode *m_sort_col_list_dxlnode;
+	CDXLNode *m_sort_col_list_dxlnode{nullptr};
 
 public:
 	CDXLWindowKey(const CDXLWindowKey &) = delete;

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -754,13 +754,11 @@ private:
 	// element for mapping Edxltoken to CWStringConst
 	struct SStrMapElem
 	{
-		Edxltoken m_edxlt;
-		CWStringConst *m_pstr;
+		Edxltoken m_edxlt{EdxltokenSentinel};
+		CWStringConst *m_pstr{nullptr};
 
 		// ctor
-		SStrMapElem() : m_edxlt(EdxltokenSentinel), m_pstr(nullptr)
-		{
-		}
+		SStrMapElem() = default;
 
 		// ctor
 		SStrMapElem(Edxltoken edxlt, CWStringConst *str)
@@ -780,13 +778,11 @@ private:
 	// element for mapping Edxltoken to XML string
 	struct SXMLStrMapElem
 	{
-		Edxltoken m_edxlt;
-		XMLCh *m_xmlsz;
+		Edxltoken m_edxlt{EdxltokenSentinel};
+		XMLCh *m_xmlsz{nullptr};
 
 		// ctor
-		SXMLStrMapElem() : m_edxlt(EdxltokenSentinel), m_xmlsz(nullptr)
-		{
-		}
+		SXMLStrMapElem() = default;
 
 		// ctor
 		SXMLStrMapElem(Edxltoken edxlt, XMLCh *xml_val)

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDId.h
@@ -54,7 +54,7 @@ private:
 	// number of deletion locks -- each MDAccessor adds a new deletion lock if it uses
 	// an MDId object in its internal hash-table, the deletion lock is released when
 	// MDAccessor is destroyed
-	ULONG_PTR m_deletion_locks;
+	ULONG_PTR m_deletion_locks{0};
 
 public:
 	//------------------------------------------------------------------
@@ -76,9 +76,7 @@ public:
 	};
 
 	// ctor
-	IMDId() : m_deletion_locks(0)
-	{
-	}
+	IMDId() = default;
 
 	// dtor
 	~IMDId() override = default;

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLProperties.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLProperties.cpp
@@ -23,9 +23,7 @@ using namespace gpdxl;
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CDXLProperties::CDXLProperties() : m_dxl_stats_derived_relation(nullptr)
-{
-}
+CDXLProperties::CDXLProperties() = default;
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLWindowKey.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLWindowKey.cpp
@@ -27,9 +27,8 @@ using namespace gpdxl;
 //
 //---------------------------------------------------------------------------
 CDXLWindowKey::CDXLWindowKey()
-	: m_window_frame_dxl(nullptr), m_sort_col_list_dxlnode(nullptr)
-{
-}
+
+	= default;
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/include/gpopt/utils/CMemoryPoolPalloc.h
+++ b/src/include/gpopt/utils/CMemoryPoolPalloc.h
@@ -23,7 +23,7 @@ namespace gpos
 class CMemoryPoolPalloc : public CMemoryPool
 {
 private:
-	MemoryContext m_cxt;
+	MemoryContext m_cxt{nullptr};
 
 	// When destroying arrays, we need to call the destructor of each element
 	// To do this, we need the size of the allocation, which we then divide by the

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -68,32 +68,32 @@ struct SOptContext
 	};
 
 	// query object serialized to DXL
-	CHAR *m_query_dxl;
+	CHAR *m_query_dxl{nullptr};
 
 	// query object
-	Query *m_query;
+	Query *m_query{nullptr};
 
 	// plan object serialized to DXL
-	CHAR *m_plan_dxl;
+	CHAR *m_plan_dxl{nullptr};
 
 	// plan object
-	PlannedStmt *m_plan_stmt;
+	PlannedStmt *m_plan_stmt{nullptr};
 
 	// is generating a plan object required ?
-	BOOL m_should_generate_plan_stmt;
+	BOOL m_should_generate_plan_stmt{false};
 
 	// is serializing a plan to DXL required ?
-	BOOL m_should_serialize_plan_dxl;
+	BOOL m_should_serialize_plan_dxl{false};
 
 	// did the optimizer fail unexpectedly?
-	BOOL m_is_unexpected_failure;
+	BOOL m_is_unexpected_failure{false};
 
 	// should the error be propagated to user, instead of falling back to the
 	// Postres planner?
-	BOOL m_should_error_out;
+	BOOL m_should_error_out{false};
 
 	// buffer for optimizer error messages
-	CHAR *m_error_msg;
+	CHAR *m_error_msg{nullptr};
 
 	// ctor
 	SOptContext();


### PR DESCRIPTION
In principle, every field that is initialized with a hard-coded value
instead of a constructor parameter can be changed to use a default
member initializer. In practice, I've used clang-tidy's
"modernize-use-default-member-init" check [1], which applies to fields
initialized in default constructors (but also strip the changed fields
from other constructors if applicable). A lot of manual fix-up is needed
because the tooling is extremely finicky when dealing with commas and
macros in constructor member initializer lists.

A nice benefit of this change is it opens up new possibilities to apply
"= default" for constructors, and that's also done in this patch.

[1] https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-default-member-init.html

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
