### PR TITLE
Unlink other segfiles than 0 when truncate an AO table

### DIFF
--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -237,7 +237,7 @@ mdunlink_ao(RelFileNodeBackend rnode, ForkNumber forkNumber, bool isRedo)
 					(errcode_for_file_access(),
 					 errmsg("could not remove file \"%s\": %m", path)));
 	}
-	/* This storage manager is not concerend with forks other than MAIN_FORK */
+	/* This storage manager is not concerned with forks other than MAIN_FORK */
 	else if (forkNumber == MAIN_FORKNUM)
 	{
 		int pathSize = strlen(path);
@@ -536,12 +536,13 @@ ao_truncate_one_rel(Relation rel)
 	 *
 	 * Segfile 0 first, ao_foreach_extent_file() doesn't invoke the
 	 * callback for it.
-	 *
-	 * GPDB_12_MERGE_FIXME: shouldn't we unlink, not truncate, the
-	 * other segfiles?
 	 */
 	truncate_ao_perFile(0, &truncateFiles);
-	ao_foreach_extent_file(truncate_ao_perFile, &truncateFiles);
+	/*
+	 * Other segfiles than segfile 0 could be unlinked here, they are not
+	 * necessary for a clean truncated AO table.
+	 */
+	ao_foreach_extent_file(mdunlink_ao_perFile, &truncateFiles);
 
 	pfree(segPath);
 	pfree(basepath);


### PR DESCRIPTION
These other segfiles are only for ao_row and ao_column tables to avoid
merge conflicts, which could be unliked when truncate.
