### PR TITLE
Revert "Provide workaround to reclaim space on truncate cmd in sub-tr…

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -111,7 +111,6 @@ bool        gp_guc_need_restore = false;
 
 char	   *Debug_dtm_action_sql_command_tag;
 
-bool		dev_opt_unsafe_truncate_in_subtransaction = false;
 bool		Debug_print_full_dtm = false;
 bool		Debug_print_snapshot_dtm = false;
 bool		Debug_disable_distributed_snapshot = false;
@@ -1048,21 +1047,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL
 		},
 		&gp_debug_resqueue_priority,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"dev_opt_unsafe_truncate_in_subtransaction", PGC_USERSET, DEVELOPER_OPTIONS,
-		 gettext_noop("Pick unsafe truncate instead of safe truncate inside sub-transaction."),
-		 gettext_noop("Usage of this GUC is strongly discouraged and only "
-					  "should be used after understanding the impact of using "
-					  "the same. Setting the GUC comes with cost of losing "
-					  "table data on truncate command despite sub-transaction "
-					  "rollback for table created within transaction."),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE
-		},
-		&dev_opt_unsafe_truncate_in_subtransaction,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -270,7 +270,6 @@ extern bool Debug_print_parse;
 extern bool Debug_print_rewritten;
 extern bool Debug_pretty_print;
 
-extern bool dev_opt_unsafe_truncate_in_subtransaction;
 extern bool	Debug_print_full_dtm;
 extern bool	Debug_print_snapshot_dtm;
 extern bool Debug_disable_distributed_snapshot;

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -5,7 +5,6 @@
 		"DateStyle",
 		"default_table_access_method",
 		"default_tablespace",
-		"dev_opt_unsafe_truncate_in_subtransaction",
 		"dml_ignore_target_partition_check",
 		"execute_pruned_plan",
 		"explain_memory_verbosity",

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -299,43 +299,6 @@ NOTICE:  command without clusterwide effect
 HINT:  Consider alternatives as DEALLOCATE ALL, or DISCARD TEMP if a clusterwide effect is desired.
 CREATE TEMP TABLE reset_test ( data text ) ON COMMIT PRESERVE ROWS;
 ERROR:  relation "reset_test" already exists  (seg0 127.0.1.1:7002 pid=26153)
--- test for guc dev_opt_unsafe_truncate_in_subtransaction
--- start_ignore
-CREATE LANGUAGE plpython3u;
--- end_ignore
-CREATE OR REPLACE FUNCTION run_all_in_one() RETURNS VOID AS
-$$
-     plpy.execute('CREATE TABLE unsafe_truncate(a int, b int) DISTRIBUTED BY (a)')
-     plpy.execute('INSERT INTO unsafe_truncate SELECT * FROM generate_series(1, 10)')
-     for i in range(1,4):
-         plpy.execute('UPDATE unsafe_truncate SET b = b + 1')
-         plpy.execute('CREATE TABLE foobar AS SELECT * FROM unsafe_truncate DISTRIBUTED BY (a)')
-
-         before_truncate = plpy.execute('SELECT relfilenode FROM gp_dist_random(\'pg_class\') WHERE relname=\'unsafe_truncate\' ORDER BY gp_segment_id')
-         plpy.execute('truncate unsafe_truncate')
-         after_truncate = plpy.execute('SELECT relfilenode FROM gp_dist_random(\'pg_class\') WHERE relname=\'unsafe_truncate\' ORDER BY gp_segment_id')
-
-         plpy.execute('DROP TABLE unsafe_truncate')
-         plpy.execute('ALTER TABLE foobar RENAME TO unsafe_truncate')
-
-         if before_truncate[0]['relfilenode'] == after_truncate[0]['relfilenode']:
-             plpy.info('iteration:%d unsafe truncate performed' % (i))
-         else:
-             plpy.info('iteration:%d safe truncate performed' % (i))
-
-         plpy.execute('SET dev_opt_unsafe_truncate_in_subtransaction TO ON')
-     plpy.execute('DROP TABLE unsafe_truncate')
-     plpy.execute('RESET dev_opt_unsafe_truncate_in_subtransaction')
-$$ language plpython3u;
-select run_all_in_one();
-INFO:  iteration:1 safe truncate performed
-INFO:  iteration:2 unsafe truncate performed
-INFO:  iteration:3 unsafe truncate performed
- run_all_in_one 
-----------------
- 
-(1 row)
-
 CREATE TABLE guc_gp_t1(i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -189,37 +189,6 @@ SELECT * FROM reset_test;
 DISCARD ALL;
 CREATE TEMP TABLE reset_test ( data text ) ON COMMIT PRESERVE ROWS;
 
--- test for guc dev_opt_unsafe_truncate_in_subtransaction
--- start_ignore
-CREATE LANGUAGE plpython3u;
--- end_ignore
-CREATE OR REPLACE FUNCTION run_all_in_one() RETURNS VOID AS
-$$
-     plpy.execute('CREATE TABLE unsafe_truncate(a int, b int) DISTRIBUTED BY (a)')
-     plpy.execute('INSERT INTO unsafe_truncate SELECT * FROM generate_series(1, 10)')
-     for i in range(1,4):
-         plpy.execute('UPDATE unsafe_truncate SET b = b + 1')
-         plpy.execute('CREATE TABLE foobar AS SELECT * FROM unsafe_truncate DISTRIBUTED BY (a)')
-
-         before_truncate = plpy.execute('SELECT relfilenode FROM gp_dist_random(\'pg_class\') WHERE relname=\'unsafe_truncate\' ORDER BY gp_segment_id')
-         plpy.execute('truncate unsafe_truncate')
-         after_truncate = plpy.execute('SELECT relfilenode FROM gp_dist_random(\'pg_class\') WHERE relname=\'unsafe_truncate\' ORDER BY gp_segment_id')
-
-         plpy.execute('DROP TABLE unsafe_truncate')
-         plpy.execute('ALTER TABLE foobar RENAME TO unsafe_truncate')
-
-         if before_truncate[0]['relfilenode'] == after_truncate[0]['relfilenode']:
-             plpy.info('iteration:%d unsafe truncate performed' % (i))
-         else:
-             plpy.info('iteration:%d safe truncate performed' % (i))
-
-         plpy.execute('SET dev_opt_unsafe_truncate_in_subtransaction TO ON')
-     plpy.execute('DROP TABLE unsafe_truncate')
-     plpy.execute('RESET dev_opt_unsafe_truncate_in_subtransaction')
-$$ language plpython3u;
-
-select run_all_in_one();
-
 CREATE TABLE guc_gp_t1(i int);
 INSERT INTO guc_gp_t1 VALUES(1),(2);
 


### PR DESCRIPTION
…ansaction"

This reverts commit 6c16abcad31337233aa34f39107d63079374c3bf.

After we merged to PostgreSQL 12, plpython has the plpy.commit(), this
workaround is not needed then.