### PR TITLE
ic-proxy: fix address classifying

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -416,13 +416,18 @@ ic_proxy_server_drop_legacy_peers(uv_loop_t *loop)
 	 * close the current listener.
 	 */
 	if (!myaddr)
+	{
+		ic_proxy_log(LOG, "ic-proxy-server: my addr is NULL, dropping my peer listener");
 		ic_proxy_server_peer_listener_reinit(loop);
+	}
 
 	foreach(cell, ic_proxy_removed_addrs)
 	{
 		ICProxyAddr *addr = lfirst(cell);
 		ICProxyPeer *peer;
 
+		ic_proxy_log(LOG, "ic-proxy-server: handling removed peer addr: %s:%s, seg%d,dbid%d",
+					 addr->hostname, addr->service, addr->content, addr->dbid);
 		/*
 		 * Also take the chance to check the peer listener.
 		 *
@@ -430,7 +435,10 @@ ic_proxy_server_drop_legacy_peers(uv_loop_t *loop)
 		 * been changed or removed, no need to compare the sockaddrs again.
 		 */
 		if (myaddr && myaddr->dbid == addr->dbid)
+		{
+			ic_proxy_log(LOG, "ic-proxy-server: my addr is deleted, dropping my peer listener");
 			ic_proxy_server_peer_listener_reinit(loop);
+		}
 
 		/*
 		 * Refer to ic_proxy_server_ensure_peers() on why we need below checks.

--- a/src/backend/cdb/motion/ic_proxy_peer.c
+++ b/src/backend/cdb/motion/ic_proxy_peer.c
@@ -173,6 +173,8 @@ ic_proxy_peer_unregister(ICProxyPeer *peer)
 		 */
 		ICProxyPeer *placeholder = ic_proxy_peers[peer->dbid];
 
+		ic_proxy_log(LOG, "%s: transfer my pending reqs to a placeholder", peer->name);
+
 		placeholder->reqs = list_concat(placeholder->reqs, peer->reqs);
 		peer->reqs = NIL;
 


### PR DESCRIPTION
The ic-proxy addresses specified with the GUC
gp_interconnect_proxy_addresses must be classified as removed, added,
updated, and unchanged.  This is done by comparing the old address list
and the new list.  However an bug was that only the dns-resolved
addresses were used as the old ones, so if the address reloading logic
is re-triggered before all the addresses are resolved, then the
unresolved addresses will be marked as removed unexpectedly.

Fixed by combining both the dns resolved and unresolved addresses as the
old ones.

This PR is used to fix the pipeline failure.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
