### PR TITLE
Include <signal.h> to fix compiler error on MacOS

### DIFF
--- a/src/backend/storage/file/execute_pipe.c
+++ b/src/backend/storage/file/execute_pipe.c
@@ -22,6 +22,7 @@
 
 #include <unistd.h>
 #include <sys/wait.h>
+#include <signal.h>
 
 #include "postgres.h"
 #include "storage/execute_pipe.h"


### PR DESCRIPTION
```
execute_pipe.c:197:6: error: implicit declaration of function 'kill' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        if (kill(pid, 0) == 0) /* process exists */
            ^
1 error generated.
```

This actually showed up in Travis CI on PR #11121 (https://travis-ci.org/github/greenplum-db/gpdb/builds/742342058) before it got merged into master.

Co-authored-by: Jesse Zhang