### PR TITLE
Avoid moving the same query to resource group concurrently

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -4772,7 +4772,7 @@ moveQueryCheck(int sessionId, Oid groupId)
 		!TimestampDifferenceExceeds(slot->moveTimestamp, GetCurrentTimestamp(), 5000))
 	{
 		LWLockRelease(ResGroupLock);
-		elog(ERROR, "The query cannot be moved because it was been moving to a new group by another session");
+		elog(ERROR, "the query cannot be moved to a new resource group because a move initiated by another session is currently in progress.");
 	}
 
 	slot->moveTimestamp = GetCurrentTimestamp();

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -223,6 +223,7 @@ extern Oid SessionGetResGroupId(SessionState *session);
 extern int32 SessionGetResGroupGlobalShareMemUsage(SessionState *session);
 extern void HandleMoveResourceGroup(void);
 extern void ResGroupMoveQuery(int sessionId, Oid groupId, const char *groupName);
+extern struct ResGroupSlotData * ResGroupGetSlotBySessionId(int sessionId);
 extern int32 ResGroupGetSessionMemUsage(int sessionId);
 extern int32 ResGroupGetGroupAvailableMem(Oid groupId);
 extern Oid ResGroupGetGroupIdBySessionId(int sessionId);

--- a/src/test/isolation2/input/resgroup/resgroup_move_query.source
+++ b/src/test/isolation2/input/resgroup/resgroup_move_query.source
@@ -143,6 +143,22 @@ SELECT is_session_in_group(pid, 'rg_move_query_mem_small') FROM pg_stat_activity
 1q:
 2q:
 
+-- test8: should wait at least 5 seconds to move the same query
+1: SET ROLE role_move_query_mem_small;
+1: BEGIN;
+1: SELECT hold_memory_by_percent_on_qe(1,0.1);
+2: SELECT pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND rsgname='rg_move_query_mem_small';
+2: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND state = 'idle in transaction';
+-- should fail
+3: SELECT pg_resgroup_move_query(pid, 'admin_group') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND rsgname='rg_move_query';
+3: select pg_sleep(5);
+-- should success
+3: SELECT pg_resgroup_move_query(pid, 'admin_group') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND rsgname='rg_move_query';
+2: SELECT is_session_in_group(pid, 'admin_group') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND state = 'idle in transaction';
+1q:
+2q:
+3q:
+
 DROP ROLE role_move_query;
 DROP RESOURCE GROUP rg_move_query;
 DROP ROLE role_move_query_mem_small;

--- a/src/test/isolation2/output/resgroup/resgroup_move_query.source
+++ b/src/test/isolation2/output/resgroup/resgroup_move_query.source
@@ -221,6 +221,49 @@ BEGIN
 1q: ... <quitting>
 2q: ... <quitting>
 
+-- test8: should wait at least 5 seconds to move the same query
+1: SET ROLE role_move_query_mem_small;
+SET
+1: BEGIN;
+BEGIN
+1: SELECT hold_memory_by_percent_on_qe(1,0.1);
+ hold_memory_by_percent_on_qe 
+------------------------------
+ 0                            
+(1 row)
+2: SELECT pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND rsgname='rg_move_query_mem_small';
+ pg_resgroup_move_query 
+------------------------
+ t                      
+(1 row)
+2: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND state = 'idle in transaction';
+ is_session_in_group 
+---------------------
+ t                   
+(1 row)
+-- should fail
+3: SELECT pg_resgroup_move_query(pid, 'admin_group') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND rsgname='rg_move_query';
+ERROR:  The query cannot be moved because it was been moving to a new group by another session (resgroup.c:4775)
+3: select pg_sleep(5);
+ pg_sleep 
+----------
+          
+(1 row)
+-- should success
+3: SELECT pg_resgroup_move_query(pid, 'admin_group') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND rsgname='rg_move_query';
+ pg_resgroup_move_query 
+------------------------
+ t                      
+(1 row)
+2: SELECT is_session_in_group(pid, 'admin_group') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND state = 'idle in transaction';
+ is_session_in_group 
+---------------------
+ t                   
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+
 DROP ROLE role_move_query;
 DROP
 DROP RESOURCE GROUP rg_move_query;

--- a/src/test/isolation2/output/resgroup/resgroup_move_query.source
+++ b/src/test/isolation2/output/resgroup/resgroup_move_query.source
@@ -243,7 +243,7 @@ BEGIN
 (1 row)
 -- should fail
 3: SELECT pg_resgroup_move_query(pid, 'admin_group') FROM pg_stat_activity WHERE query LIKE '%hold_memory_by_percent_on_qe%' AND rsgname='rg_move_query';
-ERROR:  The query cannot be moved because it was been moving to a new group by another session (resgroup.c:4775)
+ERROR:  the query cannot be moved to a new resource group because a move initiated by another session is currently in progress. (resgroup.c:4775)
 3: select pg_sleep(5);
  pg_sleep 
 ----------


### PR DESCRIPTION
We move a query to a resource group by sending signal to every backend process
of the query and it would be difficult to check the completion. Instead, we
disallow move the same query in a certain time interval to prevent concurrent
move operation.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
