### PR TITLE
docs - for the dtx_phase2_retry_count guc

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -1578,12 +1578,15 @@
   <topic id="dtx_phase2_retry_count">
     <title>dtx_phase2_retry_count</title>
     <body>
-      <p>The maximum number of retries during two phase commit, after which the
-        Greenplum Database master generates a PANIC.</p>
+      <p>The maximum number of retries attempted by Greenplum Database during the
+        second phase of a two phase commit. When one or more segments cannot
+        successfully complete the commit phase, the master retries the commit a
+        maximum of <codeph>dtx_phase2_retry_count</codeph> times. If the commit
+        continues to fail on the last retry attempt, the master generates a PANIC.</p>
       <p>When the network is unstable, the master may be unable to connect to one
         or more segments; increasing the number of two phase commit retries may
-        aid Greenplum recovery when the master encounters transient network
-        issues.</p>
+        improve high availability of Greenplum when the master encounters
+        transient network issues.</p>
       <table id="dtx_phase2_retry_count_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -99,6 +99,9 @@
               <xref href="#default_transaction_read_only"/>
             </li>
             <li>
+              <xref href="#dtx_phase2_retry_count"/>
+            </li>
+            <li>
               <xref href="#dynamic_library_path"/>
             </li>
             <li>
@@ -1566,6 +1569,38 @@
               <entry colname="col1">Boolean</entry>
               <entry colname="col2">off</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="dtx_phase2_retry_count">
+    <title>dtx_phase2_retry_count</title>
+    <body>
+      <p>The maximum number of retries during two phase commit, after which the
+        Greenplum Database master generates a PANIC.</p>
+      <p>When the network is unstable, the master may be unable to connect to one
+        or more segments; increasing the number of two phase commit retries may
+        aid Greenplum recovery when the master encounters transient network
+        issues.</p>
+      <table id="dtx_phase2_retry_count_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">0 - <codeph>INT_MAX</codeph></entry>
+              <entry colname="col2">10</entry>
+              <entry colname="col3">master<p>system</p><p>restart</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1488,6 +1488,12 @@
                   >gp_max_local_distributed_cache</xref>
               </p>
             </stentry>
+            <stentry>
+              <p>
+                <xref href="guc-list.xml#dtx_phase2_retry_count" type="section"
+                  >dtx_phase2_retry_count</xref>
+              </p>
+            </stentry>
           </strow>
         </simpletable>
       </body>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -57,6 +57,7 @@
             <topicref href="guc-list.xml#default_transaction_deferrable"/>
             <topicref href="guc-list.xml#default_transaction_isolation"/>
             <topicref href="guc-list.xml#default_transaction_read_only"/>
+            <topicref href="guc-list.xml#dtx_phase2_retry_count"/>
             <topicref href="guc-list.xml#dynamic_library_path"/>
             <topicref href="guc-list.xml#effective_cache_size"/>
             <topicref href="guc-list.xml#enable_bitmapscan"/>


### PR DESCRIPTION
update the guc reference to include info about the dtx_phase2_retry count guc.

question:  guc_gp.c identifies the min/max as 0/INT_MAX.  per this comment and statement in src/test/isolation2/expected/crash_recovery_dtm.out:

```
-- Set to maximum number of 2PC retries to avoid any failures. Alter
-- system is required to set the GUC and can't be set on session level
-- as session reset happens for every abort retry.
11: alter system set dtx_phase2_retry_count to 1500;
```

does this mean that the max is actually 1500?
