### PR TITLE
Fix: gpcheckperf did not close the SSH connections completely

### DIFF
--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -73,7 +73,7 @@ GV = Global()
 
 
 def killall(procname):
-    return 'F=%s && (pkill $F || pkill -f $F || killall -9 $F) > /dev/null 2>&1 || true' % procname
+    return '(pkill %s || killall -9 %s) > /dev/null 2>&1 || true' % (procname[0:15], procname)
 
 
 def strcmd(cmd):


### PR DESCRIPTION
man pkill:

> The process name used for matching is limited to the 15 characters
> present in the output of /proc/pid/stat. Use the -f option to match
> against the complete command line.

When executing command, e.g. `gpcheckperf -f hostfiles -r N -d /tmp`,
the following subcommand will be executed:

```
/path/to/greenplum/bin/gpssh -f hostfiles 'F=gpnetbenchServer &&
  (pkill $F || pkill -f $F || killall -9 $F) > /dev/null 2>&1 || true'
```

The length of `gpnetbenchServer` is 16, so `pkill gpnetbenchServer` will fail.
`pkill -f gpnetbenchServer` can succeed but it can also kill gpssh(its command
line contains gpnetbenchServer) if hostfiles contains this host. It can cause
some ssh connections from gpssh disconnected:

```
$ ps -ef | grep ssh
gpadmin   672077       1  0 17:30 ?        00:00:00 /bin/ssh -o BatchMode=yes -o StrictHostKeyChecking=no -q -l gpadmin sdw1
gpadmin   672078       1  0 17:30 ?        00:00:00 /bin/ssh -o BatchMode=yes -o StrictHostKeyChecking=no -q -l gpadmin sdw2
......
```

Fix it by using procname[0:15] for `pkill`, and removing `pkill -f`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
