### PR TITLE
Store lint/double mappable info in CDatumGenericGPDB

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/AddPredsInSubqueries.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddPredsInSubqueries.mdp
@@ -1,15 +1,116 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case:
+
+    drop table if exists foo, bar;
+    create table foo(a int, c char(100));
+    create table bar(a int, c char(100));
+    set optimizer_enumerate_plans = on;
+
+    explain
+    select *
+    from foo
+    where a in (select a1
+                from (select a a1 from foo order by a) fooo join
+                     (select a a2 from bar order by a) baro on a1 = a2 and a2=40);
+  ]]>
+  </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
-      <dxl:CTEConfig CTEInliningCutoff="0"/> 
-      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:TraceFlags Value="103027,102016,103001"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+      <dxl:RelationStatistics Mdid="2.114694.1.0" Name="foo" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.114694.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="2" Mdid="0.1042.1.0" TypeModifier="104" Nullable="true" ColWidth="100">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.114694.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.114697.1.0" Name="bar" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.114697.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="2" Mdid="0.1042.1.0" TypeModifier="104" Nullable="true" ColWidth="100">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -24,71 +125,9 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq">
-        <dxl:LeftType Mdid="0.23.1.0"/>
-        <dxl:RightType Mdid="0.23.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.65.1.0"/>
-        <dxl:Commutator Mdid="0.96.1.0"/>
-        <dxl:InverseOp Mdid="0.518.1.0"/>
-      </dxl:GPDBScalarOp>
-      <dxl:GPDBFunc Mdid="0.65.1.0" Name="int4eq" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
-        <dxl:ResultType Mdid="0.16.1.0"/>
-      </dxl:GPDBFunc>
-      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.410.1.0"/>
-        <dxl:InequalityOp Mdid="0.411.1.0"/>
-        <dxl:LessThanOp Mdid="0.412.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
-        <dxl:ComparisonOp Mdid="0.351.1.0"/>
-        <dxl:ArrayType Mdid="0.1016.1.0"/>
-        <dxl:MinAgg Mdid="0.2131.1.0"/>
-        <dxl:MaxAgg Mdid="0.2115.1.0"/>
-        <dxl:AvgAgg Mdid="0.2100.1.0"/>
-        <dxl:SumAgg Mdid="0.2107.1.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.607.1.0"/>
-        <dxl:InequalityOp Mdid="0.608.1.0"/>
-        <dxl:LessThanOp Mdid="0.609.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
-        <dxl:ComparisonOp Mdid="0.356.1.0"/>
-        <dxl:ArrayType Mdid="0.1028.1.0"/>
-        <dxl:MinAgg Mdid="0.2118.1.0"/>
-        <dxl:MaxAgg Mdid="0.2134.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1011.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq">
-        <dxl:LeftType Mdid="0.20.1.0"/>
-        <dxl:RightType Mdid="0.20.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.467.1.0"/>
-        <dxl:Commutator Mdid="0.410.1.0"/>
-        <dxl:InverseOp Mdid="0.411.1.0"/>
-      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.1042.1.0" Name="bpchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.427.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7106.1.0"/>
         <dxl:EqualityOp Mdid="0.1054.1.0"/>
         <dxl:InequalityOp Mdid="0.1057.1.0"/>
         <dxl:LessThanOp Mdid="0.1058.1.0"/>
@@ -103,47 +142,26 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true">
-        <dxl:ResultType Mdid="0.20.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
-      </dxl:GPDBAgg>
-      <dxl:ColumnStatistics Mdid="1.795208.1.1.8" Name="gp_segment_id" Width="4.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795208.1.1.1" Name="c" Width="8.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795208.1.1.0" Name="a" Width="8.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795185.1.1.8" Name="gp_segment_id" Width="4.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795185.1.1.1" Name="c" Width="8.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795185.1.1.0" Name="a" Width="8.000000"/>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
-        <dxl:EqualityOp Mdid="0.385.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
-        <dxl:LessThanOp Mdid="0.0.0.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
-        <dxl:ComparisonOp Mdid="0.0.0.0"/>
-        <dxl:ArrayType Mdid="0.1012.1.0"/>
-        <dxl:MinAgg Mdid="0.0.0.0"/>
-        <dxl:MaxAgg Mdid="0.0.0.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
-        <dxl:EqualityOp Mdid="0.387.1.0"/>
-        <dxl:InequalityOp Mdid="0.402.1.0"/>
-        <dxl:LessThanOp Mdid="0.2799.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
-        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
-        <dxl:ArrayType Mdid="0.1010.1.0"/>
-        <dxl:MinAgg Mdid="0.2798.1.0"/>
-        <dxl:MaxAgg Mdid="0.2797.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
         <dxl:EqualityOp Mdid="0.96.1.0"/>
         <dxl:InequalityOp Mdid="0.518.1.0"/>
         <dxl:LessThanOp Mdid="0.97.1.0"/>
@@ -158,106 +176,143 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT">
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.467.1.0"/>
+        <dxl:Commutator Mdid="0.410.1.0"/>
+        <dxl:InverseOp Mdid="0.411.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7028.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.20.1.0"/>
         <dxl:RightType Mdid="0.20.1.0"/>
         <dxl:ResultType Mdid="0.16.1.0"/>
         <dxl:OpFunc Mdid="0.470.1.0"/>
         <dxl:Commutator Mdid="0.412.1.0"/>
         <dxl:InverseOp Mdid="0.414.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7028.1.0"/>
+        </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true">
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:ColumnStatistics Mdid="1.795208.1.1.3" Name="xmin" Width="4.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795208.1.1.2" Name="ctid" Width="6.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795185.1.1.3" Name="xmin" Width="4.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795185.1.1.2" Name="ctid" Width="6.000000"/>
-      <dxl:RelationStatistics Mdid="2.795185.1.1" Name="foo" Rows="0.000000"/>
-      <dxl:Relation Mdid="0.795185.1.1" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c" Attno="2" Mdid="0.1042.1.0" Nullable="true" ColWidth="100">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.795208.1.1.5" Name="xmax" Width="4.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795208.1.1.4" Name="cmin" Width="4.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795185.1.1.5" Name="xmax" Width="4.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795185.1.1.4" Name="cmin" Width="4.000000"/>
-      <dxl:RelationStatistics Mdid="2.795208.1.1" Name="bar" Rows="0.000000"/>
-      <dxl:Relation Mdid="0.795208.1.1" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c" Attno="2" Mdid="0.1042.1.0" Nullable="true" ColWidth="100">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.795208.1.1.7" Name="tableoid" Width="4.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795208.1.1.6" Name="cmax" Width="4.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795185.1.1.7" Name="tableoid" Width="4.000000"/>
-      <dxl:ColumnStatistics Mdid="1.795185.1.1.6" Name="cmax" Width="4.000000"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.114697.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
         <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1042.1.0"/>
+        <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="104"/>
       </dxl:OutputColumns>
       <dxl:CTEList/>
       <dxl:LogicalSelect>
@@ -271,17 +326,17 @@
               <dxl:LimitCount/>
               <dxl:LimitOffset/>
               <dxl:LogicalGet>
-                <dxl:TableDescriptor Mdid="0.795185.1.1" TableName="foo">
+                <dxl:TableDescriptor Mdid="0.114694.1.0" TableName="foo">
                   <dxl:Columns>
-                    <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="11" Attno="2" ColName="c" TypeMdid="0.1042.1.0" ColWidth="100"/>
-                    <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="11" Attno="2" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="104" ColWidth="100"/>
+                    <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:LogicalGet>
@@ -293,17 +348,17 @@
               <dxl:LimitCount/>
               <dxl:LimitOffset/>
               <dxl:LogicalGet>
-                <dxl:TableDescriptor Mdid="0.795208.1.1" TableName="bar">
+                <dxl:TableDescriptor Mdid="0.114697.1.0" TableName="bar">
                   <dxl:Columns>
-                    <dxl:Column ColId="19" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="20" Attno="2" ColName="c" TypeMdid="0.1042.1.0" ColWidth="100"/>
-                    <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="19" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="20" Attno="2" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="104" ColWidth="100"/>
+                    <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:LogicalGet>
@@ -321,47 +376,47 @@
           </dxl:LogicalJoin>
         </dxl:SubqueryAny>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.795185.1.1" TableName="foo">
+          <dxl:TableDescriptor Mdid="0.114694.1.0" TableName="foo">
             <dxl:Columns>
-              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="2" Attno="2" ColName="c" TypeMdid="0.1042.1.0" ColWidth="100"/>
-              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="104" ColWidth="100"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="617">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Plan Id="0" SpaceSize="141">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5.548828" Rows="1.000000" Width="108"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001677" Rows="1.000000" Width="104"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="1" Alias="c">
-            <dxl:Ident ColId="1" ColName="c" TypeMdid="0.1042.1.0"/>
+            <dxl:Ident ColId="1" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="104"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="In">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="4.496094" Rows="1.000000" Width="108"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001289" Rows="1.000000" Width="104"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="1" Alias="c">
-              <dxl:Ident ColId="1" ColName="c" TypeMdid="0.1042.1.0"/>
+              <dxl:Ident ColId="1" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="104"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
@@ -374,34 +429,34 @@
           </dxl:HashCondList>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.105469" Rows="1.000000" Width="108"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="104"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="c">
-                <dxl:Ident ColId="1" ColName="c" TypeMdid="0.1042.1.0"/>
+                <dxl:Ident ColId="1" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="104"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.795185.1.1" TableName="foo">
+            <dxl:TableDescriptor Mdid="0.114694.1.0" TableName="foo">
               <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="1" Attno="2" ColName="c" TypeMdid="0.1042.1.0" ColWidth="100"/>
-                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="104" ColWidth="100"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3.140625" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000600" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -418,7 +473,7 @@
             </dxl:HashCondList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000114" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="a">
@@ -431,22 +486,22 @@
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="40"/>
                 </dxl:Comparison>
               </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.795185.1.1" TableName="foo">
+              <dxl:TableDescriptor Mdid="0.114694.1.0" TableName="foo">
                 <dxl:Columns>
-                  <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000114" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="18" Alias="a">
@@ -459,16 +514,16 @@
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="40"/>
                 </dxl:Comparison>
               </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.795208.1.1" TableName="bar">
+              <dxl:TableDescriptor Mdid="0.114697.1.0" TableName="bar">
                 <dxl:Columns>
-                  <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -1622,14 +1622,13 @@ CUtils::PexprScalarConstNull(CMemoryPool *mp, const IMDType *typ,
 	IDatum *datum = NULL;
 	IMDId *mdid = typ->MDId();
 	mdid->AddRef();
-	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
 
 	switch (typ->GetDatumType())
 	{
 		case IMDType::EtiInt2:
 		{
 			const IMDTypeInt2 *pmdtypeint2 =
-				md_accessor->PtMDType<IMDTypeInt2>();
+				dynamic_cast<const IMDTypeInt2 *>(typ);
 			datum = pmdtypeint2->CreateInt2Datum(mp, 0, true);
 		}
 		break;
@@ -1637,7 +1636,7 @@ CUtils::PexprScalarConstNull(CMemoryPool *mp, const IMDType *typ,
 		case IMDType::EtiInt4:
 		{
 			const IMDTypeInt4 *pmdtypeint4 =
-				md_accessor->PtMDType<IMDTypeInt4>();
+				dynamic_cast<const IMDTypeInt4 *>(typ);
 			datum = pmdtypeint4->CreateInt4Datum(mp, 0, true);
 		}
 		break;
@@ -1645,7 +1644,7 @@ CUtils::PexprScalarConstNull(CMemoryPool *mp, const IMDType *typ,
 		case IMDType::EtiInt8:
 		{
 			const IMDTypeInt8 *pmdtypeint8 =
-				md_accessor->PtMDType<IMDTypeInt8>();
+				dynamic_cast<const IMDTypeInt8 *>(typ);
 			datum = pmdtypeint8->CreateInt8Datum(mp, 0, true);
 		}
 		break;
@@ -1653,29 +1652,26 @@ CUtils::PexprScalarConstNull(CMemoryPool *mp, const IMDType *typ,
 		case IMDType::EtiBool:
 		{
 			const IMDTypeBool *pmdtypebool =
-				md_accessor->PtMDType<IMDTypeBool>();
+				dynamic_cast<const IMDTypeBool *>(typ);
 			datum = pmdtypebool->CreateBoolDatum(mp, false, true);
 		}
 		break;
 
 		case IMDType::EtiOid:
 		{
-			const IMDTypeOid *pmdtypeoid = md_accessor->PtMDType<IMDTypeOid>();
+			const IMDTypeOid *pmdtypeoid =
+				dynamic_cast<const IMDTypeOid *>(typ);
 			datum = pmdtypeoid->CreateOidDatum(mp, 0, true);
 		}
 		break;
 
 		case IMDType::EtiGeneric:
-			// sorry, no IMDType interface to generate a generic datum
-			datum =
-				GPOS_NEW(mp) CDatumGenericGPDB(mp, mdid, type_modifier,
-											   NULL,  // source value buffer
-											   0,  // source value buffer length
-											   true,  // is NULL
-											   0,	  // LINT mapping for stats
-											   0.0	// CDouble mapping for stats
-				);
-			break;
+		{
+			const IMDTypeGeneric *pmdtypegeneric =
+				dynamic_cast<const IMDTypeGeneric *>(typ);
+			datum = pmdtypegeneric->CreateGenericNullDatum(mp, type_modifier);
+		}
+		break;
 
 		default:
 			// shouldn't come here

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -1628,7 +1628,7 @@ CUtils::PexprScalarConstNull(CMemoryPool *mp, const IMDType *typ,
 		case IMDType::EtiInt2:
 		{
 			const IMDTypeInt2 *pmdtypeint2 =
-				dynamic_cast<const IMDTypeInt2 *>(typ);
+				static_cast<const IMDTypeInt2 *>(typ);
 			datum = pmdtypeint2->CreateInt2Datum(mp, 0, true);
 		}
 		break;
@@ -1636,7 +1636,7 @@ CUtils::PexprScalarConstNull(CMemoryPool *mp, const IMDType *typ,
 		case IMDType::EtiInt4:
 		{
 			const IMDTypeInt4 *pmdtypeint4 =
-				dynamic_cast<const IMDTypeInt4 *>(typ);
+				static_cast<const IMDTypeInt4 *>(typ);
 			datum = pmdtypeint4->CreateInt4Datum(mp, 0, true);
 		}
 		break;
@@ -1644,7 +1644,7 @@ CUtils::PexprScalarConstNull(CMemoryPool *mp, const IMDType *typ,
 		case IMDType::EtiInt8:
 		{
 			const IMDTypeInt8 *pmdtypeint8 =
-				dynamic_cast<const IMDTypeInt8 *>(typ);
+				static_cast<const IMDTypeInt8 *>(typ);
 			datum = pmdtypeint8->CreateInt8Datum(mp, 0, true);
 		}
 		break;
@@ -1652,15 +1652,14 @@ CUtils::PexprScalarConstNull(CMemoryPool *mp, const IMDType *typ,
 		case IMDType::EtiBool:
 		{
 			const IMDTypeBool *pmdtypebool =
-				dynamic_cast<const IMDTypeBool *>(typ);
+				static_cast<const IMDTypeBool *>(typ);
 			datum = pmdtypebool->CreateBoolDatum(mp, false, true);
 		}
 		break;
 
 		case IMDType::EtiOid:
 		{
-			const IMDTypeOid *pmdtypeoid =
-				dynamic_cast<const IMDTypeOid *>(typ);
+			const IMDTypeOid *pmdtypeoid = static_cast<const IMDTypeOid *>(typ);
 			datum = pmdtypeoid->CreateOidDatum(mp, 0, true);
 		}
 		break;
@@ -1668,7 +1667,7 @@ CUtils::PexprScalarConstNull(CMemoryPool *mp, const IMDType *typ,
 		case IMDType::EtiGeneric:
 		{
 			const IMDTypeGeneric *pmdtypegeneric =
-				dynamic_cast<const IMDTypeGeneric *>(typ);
+				static_cast<const IMDTypeGeneric *>(typ);
 			datum = pmdtypegeneric->CreateGenericNullDatum(mp, type_modifier);
 		}
 		break;

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -35,7 +35,6 @@
 #include "gpopt/operators/CExpressionPreprocessor.h"
 
 #include "naucrates/exception.h"
-#include "naucrates/base/CDatumGenericGPDB.h"
 #include "naucrates/base/IDatumBool.h"
 #include "naucrates/base/IDatumInt2.h"
 #include "naucrates/base/IDatumInt4.h"
@@ -46,6 +45,7 @@
 #include "naucrates/md/IMDScCmp.h"
 #include "naucrates/md/IMDType.h"
 #include "naucrates/md/IMDTypeBool.h"
+#include "naucrates/md/IMDTypeGeneric.h"
 #include "naucrates/md/IMDTypeInt2.h"
 #include "naucrates/md/IMDTypeInt4.h"
 #include "naucrates/md/IMDTypeInt8.h"

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalHashJoin.cpp
@@ -403,6 +403,7 @@ CPhysicalHashJoin::PdshashedMatching(
 		pdrgpexpr->Release();
 		if (NULL != pdshashed->PdshashedEquiv())
 		{
+			CRefCount::SafeRelease(opfamilies);
 			// try again using the equivalent hashed distribution
 			return PdshashedMatching(mp, pdshashed->PdshashedEquiv(),
 									 ulSourceChild);

--- a/src/backend/gporca/libnaucrates/include/naucrates/base/CDatumGenericGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/base/CDatumGenericGPDB.h
@@ -43,14 +43,13 @@ private:
 	// is null
 	BOOL m_is_null;
 
-	// datum is mappable to a LINT or double value
-	BOOL m_is_mappable_to_lint;
-	BOOL m_is_mappable_to_double;
-
 	// type information
 	IMDId *m_mdid;
 
 	INT m_type_modifier;
+
+	// cached type information (can be set from const methods)
+	mutable const IMDType *m_cached_type;
 
 	// long int value used for statistic computation
 	LINT m_stats_comp_val_int;
@@ -64,8 +63,7 @@ public:
 	// ctor
 	CDatumGenericGPDB(CMemoryPool *mp, IMDId *mdid, INT type_modifier,
 					  const void *src, ULONG size, BOOL is_null,
-					  LINT stats_comp_val_int, CDouble stats_comp_val_double,
-					  BOOL is_mappable_to_lint, BOOL is_mappable_to_double);
+					  LINT stats_comp_val_int, CDouble stats_comp_val_double);
 
 	// dtor
 	~CDatumGenericGPDB() override;
@@ -102,11 +100,7 @@ public:
 	// statistics related APIs
 
 	// can datum be mapped to a double
-	BOOL
-	IsDatumMappableToDouble() const override
-	{
-		return m_is_mappable_to_double;
-	}
+	BOOL IsDatumMappableToDouble() const override;
 
 	// map to double for stats computation
 	CDouble
@@ -118,11 +112,7 @@ public:
 	}
 
 	// can datum be mapped to LINT
-	BOOL
-	IsDatumMappableToLINT() const override
-	{
-		return m_is_mappable_to_lint;
-	}
+	BOOL IsDatumMappableToLINT() const override;
 
 	// map to LINT for statistics computation
 	LINT

--- a/src/backend/gporca/libnaucrates/include/naucrates/base/CDatumGenericGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/base/CDatumGenericGPDB.h
@@ -43,6 +43,10 @@ private:
 	// is null
 	BOOL m_is_null;
 
+	// datum is mappable to a LINT or double value
+	BOOL m_is_mappable_to_lint;
+	BOOL m_is_mappable_to_double;
+
 	// type information
 	IMDId *m_mdid;
 
@@ -60,7 +64,8 @@ public:
 	// ctor
 	CDatumGenericGPDB(CMemoryPool *mp, IMDId *mdid, INT type_modifier,
 					  const void *src, ULONG size, BOOL is_null,
-					  LINT stats_comp_val_int, CDouble stats_comp_val_double);
+					  LINT stats_comp_val_int, CDouble stats_comp_val_double,
+					  BOOL is_mappable_to_lint, BOOL is_mappable_to_double);
 
 	// dtor
 	~CDatumGenericGPDB() override;
@@ -97,7 +102,11 @@ public:
 	// statistics related APIs
 
 	// can datum be mapped to a double
-	BOOL IsDatumMappableToDouble() const override;
+	BOOL
+	IsDatumMappableToDouble() const override
+	{
+		return m_is_mappable_to_double;
+	}
 
 	// map to double for stats computation
 	CDouble
@@ -109,7 +118,11 @@ public:
 	}
 
 	// can datum be mapped to LINT
-	BOOL IsDatumMappableToLINT() const override;
+	BOOL
+	IsDatumMappableToLINT() const override
+	{
+		return m_is_mappable_to_lint;
+	}
 
 	// map to LINT for statistics computation
 	LINT

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
@@ -307,6 +307,10 @@ public:
 		CMemoryPool *mp, IMDId *mdid, INT type_modifier, BOOL is_null,
 		BYTE *byte_array, ULONG length, LINT lint_Value, CDouble double_Value);
 
+	// create a NULL constant for this type
+	IDatum *CreateGenericNullDatum(CMemoryPool *mp,
+								   INT type_modifier) const override;
+
 	// does a datum of this type need bytea to Lint mapping for statistics computation
 	static BOOL HasByte2IntMapping(const IMDType *mdtype);
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDTypeGeneric.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDTypeGeneric.h
@@ -49,6 +49,9 @@ public:
 	{
 		return IMDTypeGeneric::GetTypeInfo();
 	}
+
+	virtual IDatum *CreateGenericNullDatum(CMemoryPool *mp,
+										   INT type_modifier) const = 0;
 };
 }  // namespace gpmd
 

--- a/src/backend/gporca/libnaucrates/src/base/CDatumGenericGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/base/CDatumGenericGPDB.cpp
@@ -281,11 +281,11 @@ CDatumGenericGPDB::OsPrint(IOstream &os) const
 }
 
 //---------------------------------------------------------------------------
-//  @function:
-//      CDatumGenericGPDB::IsDatumMappableToDouble
+//	@function:
+//		CDatumGenericGPDB::IsDatumMappableToDouble
 //
-//  @doc:
-//      For statistics computation, can this datum be mapped to a CDouble
+//	@doc:
+//		For statistics computation, can this datum be mapped to a CDouble
 //
 //---------------------------------------------------------------------------
 BOOL
@@ -295,11 +295,11 @@ CDatumGenericGPDB::IsDatumMappableToDouble() const
 }
 
 //---------------------------------------------------------------------------
-//  @function:
-//      CDatumGenericGPDB::IsDatumMappableToLINT
+//	@function:
+//		CDatumGenericGPDB::IsDatumMappableToLINT
 //
-//  @doc:
-//      For statistics computation, can this datum be mapped to a LINT
+//	@doc:
+//		For statistics computation, can this datum be mapped to a LINT
 //
 //---------------------------------------------------------------------------
 BOOL

--- a/src/backend/gporca/libnaucrates/src/base/CDatumGenericGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/base/CDatumGenericGPDB.cpp
@@ -45,11 +45,15 @@ CDatumGenericGPDB::CDatumGenericGPDB(CMemoryPool *mp, IMDId *mdid,
 									 INT type_modifier, const void *src,
 									 ULONG size, BOOL is_null,
 									 LINT stats_comp_val_int,
-									 CDouble stats_comp_val_double)
+									 CDouble stats_comp_val_double,
+									 BOOL is_mappable_to_lint,
+									 BOOL is_mappable_to_double)
 	: m_mp(mp),
 	  m_size(size),
 	  m_bytearray_value(NULL),
 	  m_is_null(is_null),
+	  m_is_mappable_to_lint(is_mappable_to_lint),
+	  m_is_mappable_to_double(is_mappable_to_double),
 	  m_mdid(mdid),
 	  m_type_modifier(type_modifier),
 	  m_stats_comp_val_int(stats_comp_val_int),
@@ -257,7 +261,8 @@ CDatumGenericGPDB::MakeCopy(CMemoryPool *mp) const
 	// CDatumGenericGPDB makes a copy of the buffer
 	return GPOS_NEW(mp) CDatumGenericGPDB(
 		mp, m_mdid, m_type_modifier, m_bytearray_value, m_size, m_is_null,
-		m_stats_comp_val_int, m_stats_comp_val_double);
+		m_stats_comp_val_int, m_stats_comp_val_double, m_is_mappable_to_lint,
+		m_is_mappable_to_double);
 }
 
 
@@ -277,36 +282,6 @@ CDatumGenericGPDB::OsPrint(IOstream &os) const
 	GPOS_DELETE(str);
 
 	return os;
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CDatumGenericGPDB::IsDatumMappableToDouble
-//
-//	@doc:
-//		For statistics computation, can this datum be mapped to a CDouble
-//
-//---------------------------------------------------------------------------
-BOOL
-CDatumGenericGPDB::IsDatumMappableToDouble() const
-{
-	return CMDTypeGenericGPDB::HasByte2DoubleMapping(this->MDId());
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CDatumGenericGPDB::IsDatumMappableToLINT
-//
-//	@doc:
-//		For statistics computation, can this datum be mapped to a LINT
-//
-//---------------------------------------------------------------------------
-BOOL
-CDatumGenericGPDB::IsDatumMappableToLINT() const
-{
-	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
-	const IMDType *type = md_accessor->RetrieveType(MDId());
-	return CMDTypeGenericGPDB::HasByte2IntMapping(type);
 }
 
 //---------------------------------------------------------------------------
@@ -438,7 +413,8 @@ CDatumGenericGPDB::MakePaddedDatum(CMemoryPool *mp, ULONG col_len) const
 		this->MDId()->AddRef();
 		CDatumGenericGPDB *datum_new = GPOS_NEW(m_mp) CDatumGenericGPDB(
 			mp, this->MDId(), this->TypeModifier(), dest, adjusted_col_width,
-			this->IsNull(), this->GetLINTMapping(), 0 /* dValue */
+			this->IsNull(), this->GetLINTMapping(), 0 /* dValue */,
+			m_is_mappable_to_lint, false /*mappable to double*/
 		);
 
 		// clean up the input byte array as the constructor creates a copy

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
@@ -249,22 +249,18 @@ CMDTypeGenericGPDB::GetDatumForDXLConstVal(
 {
 	CDXLDatumGeneric *dxl_datum =
 		CDXLDatumGeneric::Cast(const_cast<CDXLDatum *>(dxl_op->GetDatumVal()));
-	BOOL is_mappable_to_lint = false;
-	BOOL is_mappable_to_double = false;
 	GPOS_ASSERT(NULL != dxl_op);
 
 	LINT lint_value = 0;
 	if (dxl_datum->IsDatumMappableToLINT())
 	{
 		lint_value = dxl_datum->GetLINTMapping();
-		is_mappable_to_lint = true;
 	}
 
 	CDouble double_value = 0;
 	if (dxl_datum->IsDatumMappableToDouble())
 	{
 		double_value = dxl_datum->GetDoubleMapping();
-		is_mappable_to_double = true;
 	}
 
 	m_mdid->AddRef();
@@ -288,21 +284,17 @@ CMDTypeGenericGPDB::GetDatumForDXLDatum(CMemoryPool *mp,
 	m_mdid->AddRef();
 	CDXLDatumGeneric *dxl_datum_generic =
 		CDXLDatumGeneric::Cast(const_cast<CDXLDatum *>(dxl_datum));
-	BOOL is_mappable_to_lint = false;
-	BOOL is_mappable_to_double = false;
 
 	LINT lint_value = 0;
 	if (dxl_datum_generic->IsDatumMappableToLINT())
 	{
 		lint_value = dxl_datum_generic->GetLINTMapping();
-		is_mappable_to_lint = true;
 	}
 
 	CDouble double_value = 0;
 	if (dxl_datum_generic->IsDatumMappableToDouble())
 	{
 		double_value = dxl_datum_generic->GetDoubleMapping();
-		is_mappable_to_double = true;
 	}
 
 	return GPOS_NEW(m_mp) CDatumGenericGPDB(
@@ -475,12 +467,12 @@ CMDTypeGenericGPDB::GetDXLDatumNull(CMemoryPool *mp) const
 }
 
 //---------------------------------------------------------------------------
-//  @function:
-//      CMDTypeGenericGPDB::HasByte2IntMapping
+//	@function:
+//		CMDTypeGenericGPDB::HasByte2IntMapping
 //
-//  @doc:
-//      Does the datum of this type need bytea -> Lint mapping for
-//      statistics computation
+//	@doc:
+//		Does the datum of this type need bytea -> Lint mapping for
+//		statistics computation
 //---------------------------------------------------------------------------
 BOOL
 CMDTypeGenericGPDB::HasByte2IntMapping(const IMDType *mdtype)

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
@@ -97,8 +97,7 @@ CMDTypeGenericGPDB::CMDTypeGenericGPDB(
 	m_mdid->AddRef();
 	m_datum_null = GPOS_NEW(m_mp) CDatumGenericGPDB(
 		m_mp, m_mdid, default_type_modifier, NULL /*pba*/, 0 /*length*/,
-		true /*constNull*/, 0 /*lValue */, 0 /*dValue */,
-		HasByte2IntMapping(this), HasByte2DoubleMapping(m_mdid));
+		true /*constNull*/, 0 /*lValue */, 0 /*dValue */);
 }
 
 //---------------------------------------------------------------------------
@@ -271,8 +270,7 @@ CMDTypeGenericGPDB::GetDatumForDXLConstVal(
 	m_mdid->AddRef();
 	return GPOS_NEW(m_mp) CDatumGenericGPDB(
 		m_mp, m_mdid, dxl_datum->TypeModifier(), dxl_datum->GetByteArray(),
-		dxl_datum->Length(), dxl_datum->IsNull(), lint_value, double_value,
-		is_mappable_to_lint, is_mappable_to_double);
+		dxl_datum->Length(), dxl_datum->IsNull(), lint_value, double_value);
 }
 
 //---------------------------------------------------------------------------
@@ -310,8 +308,7 @@ CMDTypeGenericGPDB::GetDatumForDXLDatum(CMemoryPool *mp,
 	return GPOS_NEW(m_mp) CDatumGenericGPDB(
 		mp, m_mdid, dxl_datum_generic->TypeModifier(),
 		dxl_datum_generic->GetByteArray(), dxl_datum_generic->Length(),
-		dxl_datum_generic->IsNull(), lint_value, double_value,
-		is_mappable_to_lint, is_mappable_to_double);
+		dxl_datum_generic->IsNull(), lint_value, double_value);
 }
 
 //---------------------------------------------------------------------------
@@ -502,9 +499,7 @@ CMDTypeGenericGPDB::CreateGenericNullDatum(CMemoryPool *mp,
 										  0,	 // source value buffer length
 										  true,	 // is NULL
 										  0,	 // LINT mapping for stats
-										  0.0,	 // CDouble mapping for stats
-										  HasByte2IntMapping(this),
-										  HasByte2DoubleMapping(MDId()));
+										  0.0);	 // CDouble mapping for stats
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/scripts/convert_minirepro_6_to_7.py
+++ b/src/backend/gporca/scripts/convert_minirepro_6_to_7.py
@@ -78,9 +78,6 @@ def convert_insert_statement(infile, outfile):
 		if line_number in range(11,16):
 			# read the 5 operator oids and translate them into collation oids
 			oid_match = re.search("([0-9]*)::oid", line)
-			print("Line %s" % line)
-			print(("oid match result:", oid_match))
-			print("Found oid, value is %s" % oid_match.group(1))
 			col_oid = int(oid_match.group(1))
 			coll = collation_map.get(col_oid)
 			if coll is None:

--- a/src/backend/gporca/scripts/convert_minirepro_6_to_7.py
+++ b/src/backend/gporca/scripts/convert_minirepro_6_to_7.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+
+_help = """
+Converts a minirepro taken with GPDB6 for use with GPDB 7
+"""
+
+
+# Description:
+#
+# Usage: ./convert_minirepro_6_to_7.py my_minirepro
+# creates my_minirepro_7X file
+#
+# GPDB7 added five new columns stacoll1 ... stacoll5 for the used collations.
+# This program will set the collation to 0::oid, except when staopn is the
+# operator for char (631), name (660), text (664), or bpchar (1058).
+# Other types use these operators as well, for example varchar uses the text
+# operator.
+# This script outputs a file suffixed with "_7X" in the same directory as the
+# original file.
+
+
+def process_minirepro(input_filepath, output_filepath):
+	with open(input_filepath, 'r') as infile, open(output_filepath, 'w+') as outfile:
+		line = infile.readline()
+		while line:
+			# this program does not handle 5X minirepros
+			if 'set allow_system_table_mods="DML";' in line:
+				raise Exception('Minirepro is in GPDB5 format, run convert_minirepro_5_to_6.py first')
+			outfile.write(line)
+			if 'INSERT INTO pg_statistic' in line:
+				convert_insert_statement(infile, outfile)
+			line = infile.readline()
+
+
+# This expects and converts an insert statement from the old,
+# GPDB6 format (below) to the new GPDB7 format:
+# INSERT INTO pg_statistic VALUES (
+# 	'schema.table'::regclass,
+# 	1::smallint,
+# 	False::boolean,
+# 	0.0::real,
+# 	24::integer,
+# 	-1.0::real,
+# 	2::smallint,
+# 	0::smallint,
+# 	0::smallint,
+# 	0::smallint,
+# 	0::smallint,
+# 	1058::oid,
+# 	0::oid,
+# 	0::oid,
+# 	0::oid,
+# 	0::oid,
+# 	NULL::real[],
+# 	NULL::real[],
+# 	NULL::real[],
+# 	NULL::real[],
+# 	NULL::real[],
+#	E'{1}::sometype[],
+#	E'{1}::sometype[],
+#	E'{1}::sometype[],
+#	E'{1}::sometype[],
+#	NULL::anyarray);
+
+# we add a list of 5 collation oids after the 5 operator oids
+# (starting with "1058::oid" in the example above)
+
+# use collation 100 (default) for text-related comparison operators
+collation_map = { 631: 100, 660: 100, 664: 100, 1058: 100 }
+
+def convert_insert_statement(infile, outfile):
+	coll_list = []
+	for line_number in range(0,22):
+		line = infile.readline()
+		if line_number in range(11,16):
+			# read the 5 operator oids and translate them into collation oids
+			oid_match = re.search("([0-9]*)::oid", line)
+			print("Line %s" % line)
+			print(("oid match result:", oid_match))
+			print("Found oid, value is %s" % oid_match.group(1))
+			col_oid = int(oid_match.group(1))
+			coll = collation_map.get(col_oid)
+			if coll is None:
+				coll = 0
+			coll_list.append(coll)
+		if line_number == 16:
+			# write the additional 5 collation oids to the output file
+			outfile.write("\t%d::oid,\n\t%d::oid,\n\t%d::oid,\n\t%d::oid,\n\t%d::oid,\n" % tuple(coll_list))
+		outfile.write(line)
+
+
+def parseargs():
+	parser = argparse.ArgumentParser(description=_help)
+
+	parser.add_argument("filepath", help="Path to minirepro file")
+
+	args = parser.parse_args()
+	return args
+
+
+def main():
+	args = parseargs()
+
+	input_filepath = args.filepath
+	output_filepath = input_filepath + "_7X"
+
+	process_minirepro(input_filepath, output_filepath)
+
+
+if __name__ == "__main__":
+	main()

--- a/src/backend/gporca/server/src/unittest/dxl/base/CDatumTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/base/CDatumTest.cpp
@@ -231,11 +231,10 @@ CDatumTest::CreateGenericDatum(CMemoryPool *mp, BOOL is_null)
 	CMDIdGPDB *pmdidChar = GPOS_NEW(mp) CMDIdGPDB(GPDB_CHAR);
 
 	const CHAR *val = "test";
-	return GPOS_NEW(mp) CDatumGenericGPDB(
-		mp, pmdidChar, default_type_modifier, val, 5 /*length*/, is_null,
-		0 /*value*/, 0 /*value*/, true /*mappable to lint*/,
-		false /*mappable to double*/
-	);
+	return GPOS_NEW(mp)
+		CDatumGenericGPDB(mp, pmdidChar, default_type_modifier, val,
+						  5 /*length*/, is_null, 0 /*value*/, 0 /*value*/
+		);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/server/src/unittest/dxl/base/CDatumTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/base/CDatumTest.cpp
@@ -231,10 +231,11 @@ CDatumTest::CreateGenericDatum(CMemoryPool *mp, BOOL is_null)
 	CMDIdGPDB *pmdidChar = GPOS_NEW(mp) CMDIdGPDB(GPDB_CHAR);
 
 	const CHAR *val = "test";
-	return GPOS_NEW(mp)
-		CDatumGenericGPDB(mp, pmdidChar, default_type_modifier, val,
-						  5 /*length*/, is_null, 0 /*value*/, 0 /*value*/
-		);
+	return GPOS_NEW(mp) CDatumGenericGPDB(
+		mp, pmdidChar, default_type_modifier, val, 5 /*length*/, is_null,
+		0 /*value*/, 0 /*value*/, true /*mappable to lint*/,
+		false /*mappable to double*/
+	);
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Methods CDatumGenericGPDB::IsDatumMappableToLINT() and
CDatumGenericGPDB::IsDatumMappableToDouble() were relatively
expensive and they can be called many times when we process
large, complicated queries. The calls mostly happen during
derivation of join stats, but also during generation of
partition predicates.

Adding two boolean flags that indicate whether a datum is
mappable to LINT or CDouble makes these methods much faster
and can speed up optimization significantly. In the example I
looked at, the improvement was 30% for 'exhaustive' and 55%
for 'exhaustive2'. (164 sec -> 114 sec and 87 sec --> 39 sec).
This was a UNION of two 15-way joins, containing several left
outer joins and subqueries on partitioned tables with many
text columns.

For most queries the gains will be much smaller. For TPC-DS
I saw gains of only about 1% for 'exhaustive'. This is because
TPC-DS doesn't use a lot of text columns, at least not in
predicates.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
