### PR TITLE
6X: Level down the lock of creating indexes on AO tables if blkdir exists

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -62,6 +62,7 @@
 
 #include "catalog/pg_inherits_fn.h"
 #include "catalog/oid_dispatch.h"
+#include "catalog/pg_appendonly_fn.h"
 #include "cdb/cdbcat.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbdispatchresult.h"
@@ -469,10 +470,30 @@ DefineIndex(Oid relationId,
 	 * relation.  To avoid lock upgrade hazards, that lock should be at least
 	 * as strong as the one we take here.
 	 */
+	lockmode = stmt->concurrent ? ShareUpdateExclusiveLock : ShareLock;
+
+	/*
+	 * Appendoptimized tables need block directory relation for index
+	 * access. Creating and maintaining block directory is expensive,
+	 * because it needs to be kept up to date whenever new data is inserted
+	 * in the table. We delay the block directory creation until it is
+	 * really needed - the first index creation. Once created, all indexes
+	 * share the same block directory. We need stronger lock
+	 * (ShareRowExclusiveLock) that blocks index creation from another
+	 * transaction (not to be confused with create index concurrently) as
+	 * well as concurrent insert for appendoptimized tables, if the block
+	 * directory needs to be created. If the block directory already exists,
+	 * we can use the same lock as heap tables.
+	 */
 	if (RangeVarIsAppendOptimizedTable(stmt->relation))
-		lockmode = ShareRowExclusiveLock;
-	else
-		lockmode = stmt->concurrent ? ShareUpdateExclusiveLock : ShareLock;
+	{
+		Oid blkdirrelid = InvalidOid;
+		GetAppendOnlyEntryAuxOids(relationId, NULL, NULL, &blkdirrelid, NULL, NULL, NULL);
+
+		if (!OidIsValid(blkdirrelid))
+			lockmode = ShareRowExclusiveLock; /* Relation is AO, and has no block directory */
+	}
+
 	rel = heap_open(relationId, lockmode);
 
 	relationId = RelationGetRelid(rel);

--- a/src/test/isolation2/expected/reindex/createidx_while_reindex_ao_gist.out
+++ b/src/test/isolation2/expected/reindex/createidx_while_reindex_ao_gist.out
@@ -46,11 +46,10 @@ DELETE 254
 BEGIN
 1: REINDEX index idx_gist_reindex_ao;
 REINDEX
-2&: create index idx_gist_reindex_ao2 on reindex_ao_gist USING Gist(target);  <waiting ...>
+2: create index idx_gist_reindex_ao2 on reindex_ao_gist USING Gist(target);
+CREATE
 1: COMMIT;
 COMMIT
-2<:  <... completed>
-CREATE
 2: COMMIT;
 COMMIT
 3: SELECT COUNT(*) FROM reindex_ao_gist WHERE id = 1500;

--- a/src/test/isolation2/expected/reindex/createidx_while_reindex_ao_partition.out
+++ b/src/test/isolation2/expected/reindex/createidx_while_reindex_ao_partition.out
@@ -45,11 +45,10 @@ DELETE 254
 BEGIN
 1: REINDEX index idx_gist_reindex_ao;
 REINDEX
-2&: create index idx_gist_reindex_ao2 on reindex_ao_gist USING Gist(target);  <waiting ...>
+2: create index idx_gist_reindex_ao2 on reindex_ao_gist USING Gist(target);
+CREATE
 1: COMMIT;
 COMMIT
-2<:  <... completed>
-CREATE
 2: COMMIT;
 COMMIT
 3: SELECT COUNT(*) FROM reindex_ao_gist WHERE id = 1500;

--- a/src/test/isolation2/expected/reindex/createidx_while_reindex_aoco_gist.out
+++ b/src/test/isolation2/expected/reindex/createidx_while_reindex_aoco_gist.out
@@ -27,11 +27,10 @@ DELETE 254
 BEGIN
 1: REINDEX index idx_gist_reindex_aoco;
 REINDEX
-2&: create index idx_gist_reindex_aoco2 on reindex_aoco_gist USING Gist(target);  <waiting ...>
+2: create index idx_gist_reindex_aoco2 on reindex_aoco_gist USING Gist(target);
+CREATE
 1: COMMIT;
 COMMIT
-2<:  <... completed>
-CREATE
 2: COMMIT;
 COMMIT
 3: SELECT COUNT(*) FROM reindex_aoco_gist WHERE id = 1500;

--- a/src/test/isolation2/expected/reindex/createidx_while_reindex_idx_ao_bitmap.out
+++ b/src/test/isolation2/expected/reindex/createidx_while_reindex_idx_ao_bitmap.out
@@ -26,11 +26,10 @@ BEGIN
 BEGIN
 1: REINDEX index idx_reindex_crtab_ao_bitmap;
 REINDEX
-2&: create index idx_reindex_crtab_ao_bitmap2 on reindex_crtab_ao_bitmap USING bitmap(a);  <waiting ...>
+2: create index idx_reindex_crtab_ao_bitmap2 on reindex_crtab_ao_bitmap USING bitmap(a);
+CREATE
 1: COMMIT;
 COMMIT
-2<:  <... completed>
-CREATE
 2: COMMIT;
 COMMIT
 3: SELECT 1 AS oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE relname = 'idx_reindex_crtab_ao_bitmap' GROUP BY oid having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);

--- a/src/test/isolation2/expected/reindex/createidx_while_reindex_idx_ao_btree.out
+++ b/src/test/isolation2/expected/reindex/createidx_while_reindex_idx_ao_btree.out
@@ -26,11 +26,10 @@ BEGIN
 BEGIN
 1: REINDEX index idx_reindex_crtab_ao_btree;
 REINDEX
-2&: create index idx_reindex_crtab_ao_btree2 on reindex_crtab_ao_btree(a);  <waiting ...>
+2: create index idx_reindex_crtab_ao_btree2 on reindex_crtab_ao_btree(a);
+CREATE
 1: COMMIT;
 COMMIT
-2<:  <... completed>
-CREATE
 2: COMMIT;
 COMMIT
 3: SELECT 1 AS oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE relname = 'idx_reindex_crtab_ao_btree' GROUP BY oid having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);

--- a/src/test/isolation2/expected/reindex/createidx_while_reindex_idx_aoco_bitmap.out
+++ b/src/test/isolation2/expected/reindex/createidx_while_reindex_idx_aoco_bitmap.out
@@ -26,11 +26,10 @@ BEGIN
 BEGIN
 1: REINDEX index idx_reindex_crtab_aoco_bitmap;
 REINDEX
-2&: create index idx_reindex_crtab_aoco_bitmap2 on reindex_crtab_aoco_bitmap USING bitmap(a);  <waiting ...>
+2: create index idx_reindex_crtab_aoco_bitmap2 on reindex_crtab_aoco_bitmap USING bitmap(a);
+CREATE
 1: COMMIT;
 COMMIT
-2<:  <... completed>
-CREATE
 2: COMMIT;
 COMMIT
 3: SELECT 1 AS oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE relname = 'idx_reindex_crtab_aoco_bitmap' GROUP BY oid having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);

--- a/src/test/isolation2/expected/reindex/createidx_while_reindex_idx_aoco_btree.out
+++ b/src/test/isolation2/expected/reindex/createidx_while_reindex_idx_aoco_btree.out
@@ -26,11 +26,10 @@ BEGIN
 BEGIN
 1: REINDEX index idx_reindex_crtab_aoco_btree;
 REINDEX
-2&: create index idx_reindex_crtab_aoco_btree2 on reindex_crtab_aoco_btree(a);  <waiting ...>
+2: create index idx_reindex_crtab_aoco_btree2 on reindex_crtab_aoco_btree(a);
+CREATE
 1: COMMIT;
 COMMIT
-2<:  <... completed>
-CREATE
 2: COMMIT;
 COMMIT
 3: SELECT 1 AS oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE relname = 'idx_reindex_crtab_aoco_btree' GROUP BY oid having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);

--- a/src/test/isolation2/sql/reindex/createidx_while_reindex_ao_gist.sql
+++ b/src/test/isolation2/sql/reindex/createidx_while_reindex_ao_gist.sql
@@ -41,9 +41,8 @@ SELECT 1 AS table_oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE r
 DELETE FROM reindex_ao_gist  WHERE id < 128;
 1: BEGIN;
 1: REINDEX index idx_gist_reindex_ao;
-2&: create index idx_gist_reindex_ao2 on reindex_ao_gist USING Gist(target);
+2: create index idx_gist_reindex_ao2 on reindex_ao_gist USING Gist(target);
 1: COMMIT;
-2<:
 2: COMMIT;
 3: SELECT COUNT(*) FROM reindex_ao_gist WHERE id = 1500;
 3: insert into reindex_ao_gist (id, owner, description, property, poli, target) values(1500, 'gpadmin', 'Reindex Concurrency test', '((1500, 1500), (1560, 1580))', '( (111, 112), (114, 115), (110, 110) )', '( (96, 86), 96)' );

--- a/src/test/isolation2/sql/reindex/createidx_while_reindex_ao_partition.sql
+++ b/src/test/isolation2/sql/reindex/createidx_while_reindex_ao_partition.sql
@@ -40,9 +40,8 @@ SELECT 1 AS default_partition_oid_same_on_all_segs from gp_dist_random('pg_class
 DELETE FROM reindex_ao_gist  WHERE id < 128;
 1: BEGIN;
 1: REINDEX index idx_gist_reindex_ao;
-2&: create index idx_gist_reindex_ao2 on reindex_ao_gist USING Gist(target);
+2: create index idx_gist_reindex_ao2 on reindex_ao_gist USING Gist(target);
 1: COMMIT;
-2<:
 2: COMMIT;
 3: SELECT COUNT(*) FROM reindex_ao_gist WHERE id = 1500;
 3: insert into reindex_ao_gist (id, owner, description, property, poli, target) values(1500, 'gpadmin', 'Reindex Concurrency test', '((1500, 1500), (1560, 1580))', '( (111, 112), (114, 115), (110, 110) )', '( (96, 86), 96)' );

--- a/src/test/isolation2/sql/reindex/createidx_while_reindex_aoco_gist.sql
+++ b/src/test/isolation2/sql/reindex/createidx_while_reindex_aoco_gist.sql
@@ -34,9 +34,8 @@ SELECT 1 AS oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE relname
 DELETE FROM reindex_aoco_gist  WHERE id < 128;
 1: BEGIN;
 1: REINDEX index idx_gist_reindex_aoco;
-2&: create index idx_gist_reindex_aoco2 on reindex_aoco_gist USING Gist(target);
+2: create index idx_gist_reindex_aoco2 on reindex_aoco_gist USING Gist(target);
 1: COMMIT;
-2<:
 2: COMMIT;
 3: SELECT COUNT(*) FROM reindex_aoco_gist WHERE id = 1500;
 3: select count(*) from reindex_aoco_gist;

--- a/src/test/isolation2/sql/reindex/createidx_while_reindex_idx_ao_bitmap.sql
+++ b/src/test/isolation2/sql/reindex/createidx_while_reindex_idx_ao_bitmap.sql
@@ -13,9 +13,8 @@ DELETE FROM reindex_crtab_ao_bitmap WHERE a < 128;
 1: BEGIN;
 2: BEGIN;
 1: REINDEX index idx_reindex_crtab_ao_bitmap;
-2&: create index idx_reindex_crtab_ao_bitmap2 on reindex_crtab_ao_bitmap USING bitmap(a);
+2: create index idx_reindex_crtab_ao_bitmap2 on reindex_crtab_ao_bitmap USING bitmap(a);
 1: COMMIT;
-2<:
 2: COMMIT;
 3: SELECT 1 AS oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE relname = 'idx_reindex_crtab_ao_bitmap' GROUP BY oid having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);
 3: SELECT 1 AS oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE relname = 'idx_reindex_crtab_ao_bitmap2' GROUP BY oid having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);

--- a/src/test/isolation2/sql/reindex/createidx_while_reindex_idx_ao_btree.sql
+++ b/src/test/isolation2/sql/reindex/createidx_while_reindex_idx_ao_btree.sql
@@ -13,9 +13,8 @@ DELETE FROM reindex_crtab_ao_btree WHERE a < 128;
 1: BEGIN;
 2: BEGIN;
 1: REINDEX index idx_reindex_crtab_ao_btree;
-2&: create index idx_reindex_crtab_ao_btree2 on reindex_crtab_ao_btree(a);
+2: create index idx_reindex_crtab_ao_btree2 on reindex_crtab_ao_btree(a);
 1: COMMIT;
-2<:
 2: COMMIT;
 3: SELECT 1 AS oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE relname = 'idx_reindex_crtab_ao_btree' GROUP BY oid having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);
 3: SELECT 1 AS oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE relname = 'idx_reindex_crtab_ao_btree2' GROUP BY oid having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);

--- a/src/test/isolation2/sql/reindex/createidx_while_reindex_idx_aoco_bitmap.sql
+++ b/src/test/isolation2/sql/reindex/createidx_while_reindex_idx_aoco_bitmap.sql
@@ -13,9 +13,8 @@ DELETE FROM reindex_crtab_aoco_bitmap WHERE a < 128;
 1: BEGIN;
 2: BEGIN;
 1: REINDEX index idx_reindex_crtab_aoco_bitmap;
-2&: create index idx_reindex_crtab_aoco_bitmap2 on reindex_crtab_aoco_bitmap USING bitmap(a);
+2: create index idx_reindex_crtab_aoco_bitmap2 on reindex_crtab_aoco_bitmap USING bitmap(a);
 1: COMMIT;
-2<:
 2: COMMIT;
 3: SELECT 1 AS oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE relname = 'idx_reindex_crtab_aoco_bitmap' GROUP BY oid having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);
 3: SELECT 1 AS oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE relname = 'idx_reindex_crtab_aoco_bitmap2' GROUP BY oid having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);

--- a/src/test/isolation2/sql/reindex/createidx_while_reindex_idx_aoco_btree.sql
+++ b/src/test/isolation2/sql/reindex/createidx_while_reindex_idx_aoco_btree.sql
@@ -13,9 +13,8 @@ DELETE FROM reindex_crtab_aoco_btree WHERE a < 128;
 1: BEGIN;
 2: BEGIN;
 1: REINDEX index idx_reindex_crtab_aoco_btree;
-2&: create index idx_reindex_crtab_aoco_btree2 on reindex_crtab_aoco_btree(a);
+2: create index idx_reindex_crtab_aoco_btree2 on reindex_crtab_aoco_btree(a);
 1: COMMIT;
-2<:
 2: COMMIT;
 3: SELECT 1 AS oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE relname = 'idx_reindex_crtab_aoco_btree' GROUP BY oid having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);
 3: SELECT 1 AS oid_same_on_all_segs from gp_dist_random('pg_class')   WHERE relname = 'idx_reindex_crtab_aoco_btree2' GROUP BY oid having count(*) = (SELECT count(*) FROM gp_segment_configuration WHERE role='p' AND content > -1);


### PR DESCRIPTION
Appendoptimized tables need block directory relation for index access. Creating
and maintaining block directory is expensive. We delay the block directory
creation until it is really needed - the first index creation. Once created,
all indexes share the same block directory. We need a stronger lock
(ShareRowExclusiveLock) if the block directory needs to be created. If the
block directory already exists, we can use the same lock as heap tables.

(backported from commit 514bcfe990773f4854d9994da936abd25b371b28)