### PR TITLE
Do not copy extParam/allParam when creating plan nodes

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6320,8 +6320,6 @@ make_subqueryscan(List *qptlist,
 	plan->qual = qpqual;
 	plan->lefttree = NULL;
 	plan->righttree = NULL;
-	plan->extParam = bms_copy(subplan->extParam);
-	plan->allParam = bms_copy(subplan->allParam);
 
 	/*
 	 * Note that, in most scan nodes, scanrelid refers to an entry in the rtable of the
@@ -7283,9 +7281,6 @@ make_motion(PlannerInfo *root, Plan *lefttree,
 
 	node->sendSorted = (numSortCols > 0);
 
-	plan->extParam = bms_copy(lefttree->extParam);
-	plan->allParam = bms_copy(lefttree->allParam);
-
 	return node;
 }
 
@@ -7387,14 +7382,6 @@ make_agg(List *tlist, List *qual,
 	plan->lefttree = lefttree;
 	plan->righttree = NULL;
 
-	/* GPDB_12_MERGE_FIXME: We had these in GPDB since forever, but now
-	 * the caller can pass lefttree == NULL. I assume this isn't really
-	 * needed and can be removed? */
-#if 0
-	plan->extParam = bms_copy(lefttree->extParam);
-	plan->allParam = bms_copy(lefttree->allParam);
-#endif
-
 	return node;
 }
 
@@ -7412,9 +7399,6 @@ make_tup_split(List *tlist, List *dqa_expr_lst, int numGroupCols,
 	plan->targetlist = tlist;
 	plan->lefttree = lefttree;
 	plan->righttree = NULL;
-
-	plan->extParam = bms_copy(lefttree->extParam);
-	plan->allParam = bms_copy(lefttree->allParam);
 
 	return node;
 }

--- a/src/backend/optimizer/plan/planshare.c
+++ b/src/backend/optimizer/plan/planshare.c
@@ -50,9 +50,6 @@ make_shareinputscan(PlannerInfo *root, Plan *inputplan)
 	sisc->scan.plan.plan_rows = inputplan->plan_rows;
 	sisc->scan.plan.plan_width = inputplan->plan_width;
 
-	sisc->scan.plan.extParam = bms_copy(inputplan->extParam);
-	sisc->scan.plan.allParam = bms_copy(inputplan->allParam);
-
 	return sisc;
 }
 


### PR DESCRIPTION
The extParam and allParam sets for every Plan node are recursively computed in
SS_finalize_plan(). We do not need to copy them from children when creating
plan nodes.

This removes the GPDB_12_MERGE_FIXME in make_agg().

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
