### PR TITLE
Fix multiple definition linker error in unit tests

### DIFF
--- a/src/backend/tcop/test/postgres_test.c
+++ b/src/backend/tcop/test/postgres_test.c
@@ -32,7 +32,6 @@ _errfinish_impl()
 		will_return_with_sideeffect(errstart, false, &_errfinish_impl, NULL); \
     } \
 
-const char *progname = "postgres";
 
 /* List with multiple elements, return FALSE. */
 static void


### PR DESCRIPTION
In the same spirit as ee7eb0e8ec77d1b6, this removes the extra
definition in postgres_test.c.

This is uncovered by building with GCC 10, where -fno-common is the new
default [1][2] (vis a vis -fcommon). I could also reproduce this by
turning on "-fno-common" in older releases of GCC and Clang.

Backpatch to 6X_STABLE.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
