### PR TITLE
[6X Backport] Add Orca costing of index only scan

### DIFF
--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -59,7 +59,7 @@ def dumpGlobals(connectionInfo, envOpts):
 
 
 def dumpTupleCount(cur):
-    stmt = "SELECT pgc.relname, pgn.nspname, pgc.relpages, pgc.reltuples FROM pg_class pgc, pg_namespace pgn WHERE pgc.relnamespace = pgn.oid and pgn.nspname NOT IN " + \
+    stmt = "SELECT pgc.relname, pgn.nspname, pgc.relpages, pgc.reltuples, pgc.relallvisible FROM pg_class pgc, pg_namespace pgn WHERE pgc.relnamespace = pgn.oid and pgn.nspname NOT IN " + \
         sysnslist
     setStmt = '-- Table: {1}\n' \
         'UPDATE pg_class\nSET\n' \
@@ -69,7 +69,7 @@ def dumpTupleCount(cur):
 
     cur.execute(stmt)
     columns = map(lambda x: x[0], cur.description)
-    types = ['int', 'real']
+    types = ['int', 'real', 'int']
     for vals in ResultIter(cur):
         print setStmt.format(',\n'.join(map(lambda t: '\t%s = %s::%s' %
                                             t, zip(columns[2:], vals[2:], types))), vals[0], vals[1])

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -190,7 +190,7 @@ def pg_dump_object(mr_query, connectionInfo, envOpts):
         sys.exit(1)
 
 def dump_tuple_count(cur, oid_str, f_out):
-    stmt = "SELECT pgc.relname, pgn.nspname, pgc.relpages, pgc.reltuples FROM pg_class pgc, pg_namespace pgn " \
+    stmt = "SELECT pgc.relname, pgn.nspname, pgc.relpages, pgc.reltuples, pgc.relallvisible FROM pg_class pgc, pg_namespace pgn " \
             "WHERE pgc.relnamespace = pgn.oid and pgc.oid in (%s) and pgn.nspname NOT LIKE 'pg_temp_%%'" % (oid_str)
 
     templateStmt = '-- Table: {1}\n' \
@@ -201,7 +201,7 @@ def dump_tuple_count(cur, oid_str, f_out):
 
     cur.execute(stmt)
     columns = [x[0] for x in cur.description]
-    types = ['int', 'real']
+    types = ['int', 'real', 'int']
     for vals in result_iter(cur):
         lines = []
         for col, val, typ in zip(columns[2:], vals[2:], types):

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2165,6 +2165,8 @@ CTranslatorRelcacheToDXL::RetrieveRelStats(CMemoryPool *mp, IMDId *mdid)
 
 	double num_rows = 0.0;
 	CMDName *mdname = NULL;
+	ULONG relpages = 0;
+	ULONG relallvisible = 0;
 
 	GPOS_TRY
 	{
@@ -2177,6 +2179,9 @@ CTranslatorRelcacheToDXL::RetrieveRelStats(CMemoryPool *mp, IMDId *mdid)
 		GPOS_DELETE(relname_str);
 
 		num_rows = gpdb::CdbEstimatePartitionedNumTuples(rel);
+
+		relpages = rel->rd_rel->relpages;
+		relallvisible = rel->rd_rel->relallvisible;
 
 		m_rel_stats_mdid->AddRef();
 		gpdb::CloseRelation(rel);
@@ -2198,9 +2203,9 @@ CTranslatorRelcacheToDXL::RetrieveRelStats(CMemoryPool *mp, IMDId *mdid)
 		relation_empty = true;
 	}
 
-	CDXLRelStats *dxl_rel_stats = GPOS_NEW(mp) CDXLRelStats(
-		mp, m_rel_stats_mdid, mdname, CDouble(num_rows), relation_empty);
-
+	CDXLRelStats *dxl_rel_stats = GPOS_NEW(mp)
+		CDXLRelStats(mp, m_rel_stats_mdid, mdname, CDouble(num_rows),
+					 relation_empty, relpages, relallvisible);
 
 	return dxl_rel_stats;
 }

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
@@ -313,7 +313,7 @@ SELECT * FROM btree_test WHERE a in (select 1);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="22">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.000126" Rows="1.000000" Width="4"/>
@@ -325,7 +325,7 @@ SELECT * FROM btree_test WHERE a in (select 1);
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="6.000111" Rows="1.000000" Width="4"/>
           </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
@@ -487,7 +487,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1818">
+    <dxl:Plan Id="0" SpaceSize="2048">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1299.001542" Rows="3.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
@@ -11022,7 +11022,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="66">
+    <dxl:Plan Id="0" SpaceSize="76">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="458.857269" Rows="3.941034" Width="127"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexNLJoin_Cast_NoMotion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexNLJoin_Cast_NoMotion.mdp
@@ -401,7 +401,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
         </dxl:LogicalJoin>
       </dxl:UnionAll>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="56">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1072.381940" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-NoDistKeyInIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-NoDistKeyInIndex.mdp
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Index only scan on table with index on non-distribution column
+
+      CREATE TABLE table_with_index_not_covering_distribution_column(a int, b int) DISTRIBUTED BY (a);
+      CREATE INDEX ON table_with_index_not_covering_distribution_column(b);
+
+      INSERT INTO table_with_index_not_covering_distribution_column VALUES (10, 20);
+
+      SET enable_seqscan=off;
+      SET enable_bitmapscan=off;
+      SET optimizer_enable_tablescan=off;
+      SET optimizer_enable_indexscan=off;
+      SET optimizer_enable_indexonlyscan=on;
+      EXPLAIN VERBOSE SELECT b FROM table_with_index_not_covering_distribution_column WHERE b > 5;
+
+      Expect a plan with an index only scan
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102004,102005,102074,102120,102146,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.73750.1.0" Name="table_with_index_not_covering_distribution_column" Rows="1.000000" EmptyRelation="false"/>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.73750.1.0" Name="table_with_index_not_covering_distribution_column" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="0.73764.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Index Mdid="0.73764.1.0" Name="table_with_index_not_covering_distribution_column_b_idx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:ColumnStatistics Mdid="1.73750.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.73750.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.73750.1.0" TableName="table_with_index_not_covering_distribution_column">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="9999999999999999210968330832147026575540427693752222372866517696718412616639336002780474141705354144110364081118142324010404785714541315284281257752757291623642503417072967859774120474650369161140553335192009630674782085554695972153397552576515276800.0000" Rows="1.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:IndexOnlyScan IndexScanDirection="Forward">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="9999999999999999210968330832147026575540427693752222372866517696718412616639336002780474141705354144110364081118142324010404785714541315284281257752757291623642503417072967859774120474650369161140553335192009630674782085554695972153397552576515276800.0000" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:IndexCondList>
+            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+            </dxl:Comparison>
+          </dxl:IndexCondList>
+          <dxl:IndexDescriptor Mdid="0.73764.1.0" IndexName="table_with_index_not_covering_distribution_column_b_idx"/>
+          <dxl:TableDescriptor Mdid="0.73750.1.0" TableName="table_with_index_not_covering_distribution_column">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:IndexOnlyScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-NoDistKeyInIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-NoDistKeyInIndex.mdp
@@ -224,7 +224,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9999999999999999210968330832147026575540427693752222372866517696718412616639336002780474141705354144110364081118142324010404785714541315284281257752757291623642503417072967859774120474650369161140553335192009630674782085554695972153397552576515276800.0000" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000119" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="b">
@@ -235,7 +235,7 @@
         <dxl:SortingColumnList/>
         <dxl:IndexOnlyScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="9999999999999999210968330832147026575540427693752222372866517696718412616639336002780474141705354144110364081118142324010404785714541315284281257752757291623642503417072967859774120474650369161140553335192009630674782085554695972153397552576515276800.0000" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000101" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="b">

--- a/src/backend/gporca/data/dxl/minidump/IndexScanWithNestedCTEAndSetOp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScanWithNestedCTEAndSetOp.mdp
@@ -350,7 +350,7 @@ SELECT a FROM y WHERE (a IN (SELECT b FROM bar WHERE b = 2));
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="132">
+    <dxl:Plan Id="0" SpaceSize="209">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="868.000741" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/NestedNLJWithBlockingSpool.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NestedNLJWithBlockingSpool.mdp
@@ -538,10 +538,10 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="111">
+    <dxl:Plan Id="0" SpaceSize="60">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356691807.542455" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324038.343449" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="23" Alias="p_partkey">
@@ -550,9 +550,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356691807.542440" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324038.343434" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="23" Alias="p_partkey">
@@ -561,24 +561,11 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:JoinFilter>
-            <dxl:And>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.15.1.0">
-                <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.15.1.0">
-                <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="40" ColName="l_partkey" TypeMdid="0.20.1.0"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.416.1.0">
-                <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
-                <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:And>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
           </dxl:JoinFilter>
-          <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.342839" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.343126" Rows="3.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="l_partkey">
@@ -589,50 +576,54 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
-                <dxl:Ident ColId="40" ColName="l_partkey" TypeMdid="0.20.1.0"/>
-              </dxl:Comparison>
-            </dxl:JoinFilter>
-            <dxl:TableScan>
+            <dxl:SortingColumnList/>
+            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.342839" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="l_partkey">
                   <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.98421.1.0" TableName="lineitem">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="l_partkey" TypeMdid="0.20.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="3" Attno="4" ColName="l_linenumber" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:Materialize Eager="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000190" Rows="3.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
                 <dxl:ProjElem ColId="40" Alias="l_partkey">
                   <dxl:Ident ColId="40" ColName="l_partkey" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:JoinFilter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                  <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+                  <dxl:Ident ColId="40" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+                </dxl:Comparison>
+              </dxl:JoinFilter>
+              <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000182" Rows="3.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="l_partkey">
+                    <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.98421.1.0" TableName="lineitem">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="l_partkey" TypeMdid="0.20.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="3" Attno="4" ColName="l_linenumber" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:Materialize Eager="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000190" Rows="3.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="40" Alias="l_partkey">
@@ -640,10 +631,9 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
+                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000182" Rows="3.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="40" Alias="l_partkey">
@@ -651,27 +641,39 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.98421.1.0" TableName="lineitem">
-                    <dxl:Columns>
-                      <dxl:Column ColId="39" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="40" Attno="2" ColName="l_partkey" TypeMdid="0.20.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="42" Attno="4" ColName="l_linenumber" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="55" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="56" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="57" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="58" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="59" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="60" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="61" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:BroadcastMotion>
-            </dxl:Materialize>
-          </dxl:NestedLoopJoin>
-          <dxl:Materialize Eager="true">
+                  <dxl:SortingColumnList/>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="40" Alias="l_partkey">
+                        <dxl:Ident ColId="40" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.98421.1.0" TableName="lineitem">
+                      <dxl:Columns>
+                        <dxl:Column ColId="39" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="40" Attno="2" ColName="l_partkey" TypeMdid="0.20.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="42" Attno="4" ColName="l_linenumber" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="55" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="56" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="57" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="58" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="59" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="60" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="61" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:BroadcastMotion>
+              </dxl:Materialize>
+            </dxl:NestedLoopJoin>
+          </dxl:BroadcastMotion>
+          <dxl:IndexOnlyScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000333" Rows="3.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000292" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="23" Alias="p_partkey">
@@ -679,42 +681,34 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000329" Rows="3.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="23" Alias="p_partkey">
-                  <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000107" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="23" Alias="p_partkey">
-                    <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.98306.1.0" TableName="part">
-                  <dxl:Columns>
-                    <dxl:Column ColId="23" Attno="1" ColName="p_partkey" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="32" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="33" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="34" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="35" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="36" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="37" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="38" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:BroadcastMotion>
-          </dxl:Materialize>
+            <dxl:IndexCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.15.1.0">
+                <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+              </dxl:Comparison>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.15.1.0">
+                <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="40" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+              </dxl:Comparison>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.15.1.0">
+                <dxl:Ident ColId="23" ColName="p_partkey" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.20.1.0"/>
+              </dxl:Comparison>
+            </dxl:IndexCondList>
+            <dxl:IndexDescriptor Mdid="0.98326.1.0" IndexName="part_pkey"/>
+            <dxl:TableDescriptor Mdid="0.98306.1.0" TableName="part">
+              <dxl:Columns>
+                <dxl:Column ColId="23" Attno="1" ColName="p_partkey" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="32" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="33" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="34" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="35" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="36" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="37" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="38" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:IndexOnlyScan>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/TimeTypeStatsNotComparable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TimeTypeStatsNotComparable.mdp
@@ -243,7 +243,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.005445" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
@@ -5,7 +5,7 @@
     <dxl:MDCast Mdid="3.23.1.0;26.1.0" Name="int" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.26.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
     <dxl:ArrayCoerceCast Mdid="3.1007.1.0;1022.1.0" Name="float8" CoercePathType="3" BinaryCoercible="false" SourceTypeId="0.1007.1.0" DestinationTypeId="0.1022.1.0" CastFuncId="0.316.1.0" IsExplicit="false" CoercionForm="2" Location="-1"/>
     <dxl:MDScalarComparison Mdid="4.23.1.0;20.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.23.1.0" RightType="0.20.1.0" OperatorMdid="0.416.1.0"/>
-    <dxl:RelationStatistics Mdid="2.1234.1.2" Name="T" Rows="1234.123400" EmptyRelation="false"/>
+    <dxl:RelationStatistics Mdid="2.1234.1.2" Name="T" Rows="1234.123400" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
     <dxl:ColumnStatistics Mdid="1.1234.1.2.1" Name="T.a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
       <dxl:StatsBucket Frequency="0.500000" DistinctValues="5.000000">
         <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
@@ -1586,20 +1586,60 @@ CCostModelGPDB::CostIndexScan(CMemoryPool *,  // mp
 
 
 CCost
-CCostModelGPDB::CostIndexOnlyScan(CMemoryPool *,		   // mp
-								  CExpressionHandle &,	   //exprhdl
-								  const CCostModelGPDB *,  // pcmgpdb
-								  const SCostingInfo *pci  //pci
+CCostModelGPDB::CostIndexOnlyScan(CMemoryPool *,				  // mp
+								  CExpressionHandle &exprhdl,	  //exprhdl
+								  const CCostModelGPDB *pcmgpdb,  // pcmgpdb
+								  const SCostingInfo *pci		  //pci
 )
 {
-	// FIXME: Gather relation's visibility map statistics and use that info to
-	// create a cost model. When a block is visible then the scan can rely
-	// solely on the values stored in the index and does not have to open the
-	// corresponding heap page of the relation. If the blocks are not visible
-	// then there is no benefit over an index scan and you pay overhead of
-	// looking at visibility map.
-	pci->NumRebinds();
-	return CCost(std::numeric_limits<double>::max());
+	GPOS_ASSERT(NULL != pcmgpdb);
+	GPOS_ASSERT(NULL != pci);
+
+	COperator *pop = exprhdl.Pop();
+	GPOS_ASSERT(COperator::EopPhysicalIndexOnlyScan == pop->Eopid());
+
+	const CDouble dTableWidth =
+		CPhysicalScan::PopConvert(pop)->PstatsBaseTable()->Width();
+
+	const CDouble dIndexFilterCostUnit =
+		pcmgpdb->GetCostModelParams()
+			->PcpLookup(CCostModelParamsGPDB::EcpIndexFilterCostUnit)
+			->Get();
+	const CDouble dIndexScanTupCostUnit =
+		pcmgpdb->GetCostModelParams()
+			->PcpLookup(CCostModelParamsGPDB::EcpIndexScanTupCostUnit)
+			->Get();
+	const CDouble dIndexScanTupRandomFactor =
+		pcmgpdb->GetCostModelParams()
+			->PcpLookup(CCostModelParamsGPDB::EcpIndexScanTupRandomFactor)
+			->Get();
+	GPOS_ASSERT(0 < dIndexFilterCostUnit);
+	GPOS_ASSERT(0 < dIndexScanTupCostUnit);
+	GPOS_ASSERT(0 < dIndexScanTupRandomFactor);
+
+	CDouble dRowsIndex = pci->Rows();
+
+	ULONG ulIndexKeys =
+		CPhysicalIndexOnlyScan::PopConvert(pop)->Pindexdesc()->Keys();
+	IStatistics *stats =
+		CPhysicalIndexOnlyScan::PopConvert(pop)->PstatsBaseTable();
+
+	// Calculating cost of index-only-scan is identical to index-scan with the
+	// addition of dPartialVisFrac which indicates the percentage of pages not
+	// currently marked as all-visible. Planner has similar logic inside
+	// `cost_index()` to calculate pages fetched from index-only-scan.
+
+	CDouble dCostPerIndexRow = ulIndexKeys * dIndexFilterCostUnit +
+							   dTableWidth * dIndexScanTupCostUnit;
+	CDouble dPartialVisFrac(1);
+	if (stats->RelPages() != 0)
+	{
+		dPartialVisFrac =
+			1 - (CDouble(stats->RelAllVisible()) / CDouble(stats->RelPages()));
+	}
+	return CCost(pci->NumRebinds() *
+				 (dRowsIndex * dCostPerIndexRow +
+				  dIndexScanTupRandomFactor * dPartialVisFrac));
 }
 
 CCost

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDBLegacy.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDBLegacy.cpp
@@ -30,6 +30,7 @@ const CCostModelGPDBLegacy::SCostMapping CCostModelGPDBLegacy::m_rgcm[] = {
 
 	{COperator::EopPhysicalIndexScan, CostIndexScan},
 	{COperator::EopPhysicalDynamicIndexScan, CostIndexScan},
+	{COperator::EopPhysicalIndexOnlyScan, CostIndexScan},
 	{COperator::EopPhysicalBitmapTableScan, CostBitmapTableScan},
 	{COperator::EopPhysicalDynamicBitmapTableScan, CostBitmapTableScan},
 
@@ -952,6 +953,7 @@ CCostModelGPDBLegacy::CostIndexScan(CMemoryPool *,	// mp
 
 	COperator::EOperatorId op_id = exprhdl.Pop()->Eopid();
 	GPOS_ASSERT(COperator::EopPhysicalIndexScan == op_id ||
+				COperator::EopPhysicalIndexOnlyScan == op_id ||
 				COperator::EopPhysicalDynamicIndexScan == op_id);
 
 	CDouble dRandomIOBandwidth =
@@ -964,6 +966,7 @@ CCostModelGPDBLegacy::CostIndexScan(CMemoryPool *,	// mp
 	{
 		case COperator::EopPhysicalDynamicIndexScan:
 		case COperator::EopPhysicalIndexScan:
+		case COperator::EopPhysicalIndexOnlyScan:
 			return CCost(pci->NumRebinds() * (pci->Rows() * pci->Width()) /
 						 dRandomIOBandwidth);
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
@@ -204,10 +204,12 @@ public:
 	}
 
 	EUsedStatus
-	GetUsage(BOOL check_system_col = false) const
+	GetUsage(BOOL check_system_col = false,
+			 BOOL check_distribution_col = false) const
 	{
 		if (GPOS_FTRACE(EopttraceTranslateUnusedColrefs) ||
-			(!check_system_col && IsSystemCol()))
+			(!check_system_col && IsSystemCol()) ||
+			(!check_distribution_col && IsDistCol()))
 		{
 			return EUsed;
 		}

--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
@@ -1119,8 +1119,9 @@ CMDAccessor::Pstats(CMemoryPool *mp, IMDId *rel_mdid, CColRefSet *pcrsHist,
 
 	CDouble rows = std::max(DOUBLE(1.0), pmdRelStats->Rows().Get());
 
-	return GPOS_NEW(mp) CStatistics(mp, col_histogram_mapping,
-									colid_width_mapping, rows, fEmptyTable);
+	return GPOS_NEW(mp) CStatistics(
+		mp, col_histogram_mapping, colid_width_mapping, rows, fEmptyTable,
+		pmdRelStats->RelPages(), pmdRelStats->RelAllVisible());
 }
 
 

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -1392,10 +1392,6 @@ CLogical::PcrsDist(CMemoryPool *mp, const CTableDescriptor *ptabdesc,
 		CColumnDescriptor *pcoldesc = (*pdrgpcoldescDist)[ul2];
 		const INT attno = pcoldesc->AttrNum();
 		CColRef *pcrMapped = phmicr->Find(&attno);
-		// The distribution columns are not explicity referenced in the query but we
-		// still need to mark distribution columns as used since they are required
-		// to add motions
-		pcrMapped->MarkAsUsed();
 		GPOS_ASSERT(NULL != pcrMapped);
 		pcrsDist->Include(pcrMapped);
 	}

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -1529,6 +1529,7 @@ CTranslatorExprToDXL::PdxlnIndexScanWithInlinedCondition(
 
 	COperator::EOperatorId op_id = pexprIndexScan->Pop()->Eopid();
 	GPOS_ASSERT(COperator::EopPhysicalIndexScan == op_id ||
+				COperator::EopPhysicalIndexOnlyScan == op_id ||
 				COperator::EopPhysicalDynamicIndexScan == op_id);
 
 	// TODO: Index only scans work on GiST and SP-GiST only for specific operators

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerStatsDerivedRelation.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerStatsDerivedRelation.h
@@ -41,6 +41,12 @@ private:
 	// flag to express that the statistics is on an empty input
 	BOOL m_empty;
 
+	// number of blocks in the relation (not always up to-to-date)
+	ULONG m_relpages;
+
+	// number of all-visible blocks in the relation (not always up-to-date)
+	ULONG m_relallvisible;
+
 	// relation stats
 	CDXLStatsDerivedRelation *m_dxl_stats_derived_relation;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -318,6 +318,8 @@ enum Edxltoken
 	EdxltokenTotalCost,
 	EdxltokenRows,
 	EdxltokenWidth,
+	EdxltokenRelPages,
+	EdxltokenRelAllVisible,
 	EdxltokenCTASOptions,
 	EdxltokenCTASOption,
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLRelStats.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLRelStats.h
@@ -64,9 +64,16 @@ private:
 	// private copy ctor
 	CDXLRelStats(const CDXLRelStats &);
 
+	// number of blocks (not always up to-to-date)
+	ULONG m_relpages;
+
+	// number of all-visible blocks (not always up-to-date)
+	ULONG m_relallvisible;
+
 public:
 	CDXLRelStats(CMemoryPool *mp, CMDIdRelStats *rel_stats_mdid,
-				 CMDName *mdname, CDouble rows, BOOL is_empty);
+				 CMDName *mdname, CDouble rows, BOOL is_empty, ULONG relpages,
+				 ULONG relallvisible);
 
 	virtual ~CDXLRelStats();
 
@@ -81,6 +88,20 @@ public:
 
 	// number of rows
 	virtual CDouble Rows() const;
+
+	// number of blocks (not always up to-to-date)
+	virtual ULONG
+	RelPages() const
+	{
+		return m_relpages;
+	}
+
+	// number of all-visible blocks (not always up-to-date)
+	virtual ULONG
+	RelAllVisible() const
+	{
+		return m_relallvisible;
+	}
 
 	// is statistics on an empty input
 	virtual BOOL

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelStats.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelStats.h
@@ -45,6 +45,10 @@ public:
 	// number of rows
 	virtual CDouble Rows() const = 0;
 
+	virtual ULONG RelPages() const = 0;
+
+	virtual ULONG RelAllVisible() const = 0;
+
 	// is statistics on an empty input
 	virtual BOOL IsEmpty() const = 0;
 };

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
@@ -101,6 +101,12 @@ private:
 
 	// flag to indicate if input relation is empty
 	BOOL m_empty;
+	//
+	// number of blocks in the relation (not always up to-to-date)
+	ULONG m_relpages;
+
+	// number of all-visible blocks in the relation (not always up-to-date)
+	ULONG m_relallvisible;
 
 	// statistics could be computed using predicates with external parameters (outer references),
 	// this is the total number of external parameters' values
@@ -139,6 +145,11 @@ public:
 				UlongToDoubleMap *colid_width_mapping, CDouble rows,
 				BOOL is_empty, ULONG num_predicates = 0);
 
+	CStatistics(CMemoryPool *mp, UlongToHistogramMap *col_histogram_mapping,
+				UlongToDoubleMap *colid_width_mapping, CDouble rows,
+				BOOL is_empty, ULONG relpages, ULONG relallvisible);
+
+
 	// dtor
 	virtual ~CStatistics();
 
@@ -151,6 +162,18 @@ public:
 
 	// actual number of rows
 	virtual CDouble Rows() const;
+
+	virtual ULONG
+	RelPages() const
+	{
+		return m_relpages;
+	}
+
+	virtual ULONG
+	RelAllVisible() const
+	{
+		return m_relallvisible;
+	}
 
 	// number of rebinds
 	virtual CDouble

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/IStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/IStatistics.h
@@ -110,6 +110,12 @@ public:
 	// how many rows
 	virtual CDouble Rows() const = 0;
 
+	// number of blocks in the relation (not always up to-to-date)
+	virtual ULONG RelPages() const = 0;
+
+	// number of all-visible blocks in the relation (not always up-to-date)
+	virtual ULONG RelAllVisible() const = 0;
+
 	// is statistics on an empty input
 	virtual BOOL IsEmpty() const = 0;
 

--- a/src/backend/gporca/libnaucrates/src/md/CDXLRelStats.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CDXLRelStats.cpp
@@ -30,12 +30,15 @@ using namespace gpmd;
 //
 //---------------------------------------------------------------------------
 CDXLRelStats::CDXLRelStats(CMemoryPool *mp, CMDIdRelStats *rel_stats_mdid,
-						   CMDName *mdname, CDouble rows, BOOL is_empty)
+						   CMDName *mdname, CDouble rows, BOOL is_empty,
+						   ULONG relpages, ULONG relallvisible)
 	: m_mp(mp),
 	  m_rel_stats_mdid(rel_stats_mdid),
 	  m_mdname(mdname),
 	  m_rows(rows),
-	  m_empty(is_empty)
+	  m_empty(is_empty),
+	  m_relpages(relpages),
+	  m_relallvisible(relallvisible)
 {
 	GPOS_ASSERT(rel_stats_mdid->IsValid());
 	m_dxl_str = CDXLUtils::SerializeMDObj(
@@ -134,6 +137,10 @@ CDXLRelStats::Serialize(CXMLSerializer *xml_serializer) const
 								 m_mdname->GetMDName());
 	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenRows),
 								 m_rows);
+	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenRelPages),
+								 m_relpages);
+	xml_serializer->AddAttribute(
+		CDXLTokens::GetDXLTokenStr(EdxltokenRelAllVisible), m_relallvisible);
 	xml_serializer->AddAttribute(
 		CDXLTokens::GetDXLTokenStr(EdxltokenEmptyRelation), m_empty);
 
@@ -166,6 +173,10 @@ CDXLRelStats::DebugPrint(IOstream &os) const
 
 	os << "Rows: " << Rows() << std::endl;
 
+	os << "RelPages: " << RelPages() << std::endl;
+
+	os << "RelAllVisible: " << RelAllVisible() << std::endl;
+
 	os << "Empty: " << IsEmpty() << std::endl;
 }
 
@@ -188,9 +199,9 @@ CDXLRelStats::CreateDXLDummyRelStats(CMemoryPool *mp, IMDId *mdid)
 	CAutoP<CMDName> mdname;
 	mdname = GPOS_NEW(mp) CMDName(mp, str.Value());
 	CAutoRef<CDXLRelStats> rel_stats_dxl;
-	rel_stats_dxl = GPOS_NEW(mp)
-		CDXLRelStats(mp, rel_stats_mdid, mdname.Value(),
-					 CStatistics::DefaultColumnWidth, false /* is_empty */);
+	rel_stats_dxl = GPOS_NEW(mp) CDXLRelStats(
+		mp, rel_stats_mdid, mdname.Value(), CStatistics::DefaultColumnWidth,
+		false /* is_empty */, 0 /* relpages */, 0 /* relallvisible */);
 	mdname.Reset();
 	return rel_stats_dxl.Reset();
 }

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerRelStats.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerRelStats.cpp
@@ -98,8 +98,29 @@ CParseHandlerRelStats::StartElement(const XMLCh *const,	 // element_uri,
 			EdxltokenEmptyRelation, EdxltokenStatsDerivedRelation);
 	}
 
-	m_imd_obj = GPOS_NEW(m_mp) CDXLRelStats(m_mp, CMDIdRelStats::CastMdid(mdid),
-											mdname, rows, is_empty);
+	ULONG relpages = 0;
+	const XMLCh *xml_relpages =
+		attrs.getValue(CDXLTokens::XmlstrToken(EdxltokenRelPages));
+	if (NULL != xml_relpages)
+	{
+		relpages = CDXLOperatorFactory::ExtractConvertAttrValueToUlong(
+			m_parse_handler_mgr->GetDXLMemoryManager(), attrs,
+			EdxltokenRelPages, EdxltokenRelationStats);
+	}
+
+	ULONG relallvisible = 0;
+	const XMLCh *xml_relallvisible =
+		attrs.getValue(CDXLTokens::XmlstrToken(EdxltokenRelAllVisible));
+	if (NULL != xml_relallvisible)
+	{
+		relallvisible = CDXLOperatorFactory::ExtractConvertAttrValueToUlong(
+			m_parse_handler_mgr->GetDXLMemoryManager(), attrs,
+			EdxltokenRelAllVisible, EdxltokenRelationStats);
+	}
+
+	m_imd_obj =
+		GPOS_NEW(m_mp) CDXLRelStats(m_mp, CMDIdRelStats::CastMdid(mdid), mdname,
+									rows, is_empty, relpages, relallvisible);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerStatsDerivedRelation.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerStatsDerivedRelation.cpp
@@ -36,6 +36,8 @@ CParseHandlerStatsDerivedRelation::CParseHandlerStatsDerivedRelation(
 	: CParseHandlerBase(mp, parse_handler_mgr, parse_handler_root),
 	  m_rows(CStatistics::DefaultColumnWidth),
 	  m_empty(false),
+	  m_relpages(0),
+	  m_relallvisible(0),
 	  m_dxl_stats_derived_relation(NULL)
 {
 }
@@ -103,6 +105,26 @@ CParseHandlerStatsDerivedRelation::StartElement(
 			m_empty = CDXLOperatorFactory::ConvertAttrValueToBool(
 				m_parse_handler_mgr->GetDXLMemoryManager(), xml_is_empty,
 				EdxltokenEmptyRelation, EdxltokenStatsDerivedRelation);
+		}
+
+		m_relpages = 0;
+		const XMLCh *xml_relpages =
+			attrs.getValue(CDXLTokens::XmlstrToken(EdxltokenRelPages));
+		if (NULL != xml_relpages)
+		{
+			m_relpages = CDXLOperatorFactory::ConvertAttrValueToUlong(
+				m_parse_handler_mgr->GetDXLMemoryManager(), xml_rows,
+				EdxltokenRelPages, EdxltokenStatsDerivedRelation);
+		}
+
+		m_relallvisible = 0;
+		const XMLCh *xml_relallvisible =
+			attrs.getValue(CDXLTokens::XmlstrToken(EdxltokenRelAllVisible));
+		if (NULL != xml_relallvisible)
+		{
+			m_relallvisible = CDXLOperatorFactory::ConvertAttrValueToUlong(
+				m_parse_handler_mgr->GetDXLMemoryManager(), xml_rows,
+				EdxltokenRelAllVisible, EdxltokenStatsDerivedRelation);
 		}
 	}
 }

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatistics.cpp
@@ -67,9 +67,38 @@ CStatistics::CStatistics(CMemoryPool *mp,
 	  m_rows(rows),
 	  m_stats_estimation_risk(no_card_est_risk_default_val),
 	  m_empty(is_empty),
+	  m_relpages(0),
+	  m_relallvisible(0),
 	  m_num_rebinds(
 		  1.0),	 // by default, a stats object is rebound to parameters only once
 	  m_num_predicates(num_predicates),
+	  m_src_upper_bound_NDVs(NULL)
+{
+	GPOS_ASSERT(NULL != m_colid_histogram_mapping);
+	GPOS_ASSERT(NULL != m_colid_width_mapping);
+	GPOS_ASSERT(CDouble(0.0) <= m_rows);
+
+	// hash map for source id -> max source cardinality mapping
+	m_src_upper_bound_NDVs = GPOS_NEW(mp) CUpperBoundNDVPtrArray(mp);
+
+	m_stats_conf =
+		COptCtxt::PoctxtFromTLS()->GetOptimizerConfig()->GetStatsConf();
+}
+
+CStatistics::CStatistics(CMemoryPool *mp,
+						 UlongToHistogramMap *col_histogram_mapping,
+						 UlongToDoubleMap *colid_width_mapping, CDouble rows,
+						 BOOL is_empty, ULONG relpages, ULONG relallvisible)
+	: m_colid_histogram_mapping(col_histogram_mapping),
+	  m_colid_width_mapping(colid_width_mapping),
+	  m_rows(rows),
+	  m_stats_estimation_risk(no_card_est_risk_default_val),
+	  m_empty(is_empty),
+	  m_relpages(relpages),
+	  m_relallvisible(relallvisible),
+	  m_num_rebinds(
+		  1.0),	 // by default, a stats object is rebound to parameters only once
+	  m_num_predicates(0),
 	  m_src_upper_bound_NDVs(NULL)
 {
 	GPOS_ASSERT(NULL != m_colid_histogram_mapping);

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -370,6 +370,8 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenTotalCost, GPOS_WSZ_LIT("TotalCost")},
 		{EdxltokenRows, GPOS_WSZ_LIT("Rows")},
 		{EdxltokenWidth, GPOS_WSZ_LIT("Width")},
+		{EdxltokenRelPages, GPOS_WSZ_LIT("RelPages")},
+		{EdxltokenRelAllVisible, GPOS_WSZ_LIT("RelAllVisible")},
 		{EdxltokenTableName, GPOS_WSZ_LIT("TableName")},
 		{EdxltokenDerivedTableName, GPOS_WSZ_LIT("DerivedTableName")},
 		{EdxltokenExecuteAsUser, GPOS_WSZ_LIT("ExecuteAsUser")},

--- a/src/backend/gporca/scripts/cal_bitmap_test.py
+++ b/src/backend/gporca/scripts/cal_bitmap_test.py
@@ -45,6 +45,7 @@ The results can be copied and pasted into a spreadsheet for further processing.
 TABLE_NAME_PATTERN = r"cal_txtest"
 NDV_TABLE_NAME_PATTERN = r"cal_ndvtest"
 BFV_TABLE_NAME_PATTERN = r"cal_bfvtest"
+WIDE_TABLE_NAME_PATTERN = r"cal_widetest"
 
 TABLE_SCAN = "table_scan"
 TABLE_SCAN_PATTERN = r"Seq Scan"
@@ -53,6 +54,10 @@ TABLE_SCAN_PATTERN_V5 = r"Table Scan"
 INDEX_SCAN = "index_scan"
 INDEX_SCAN_PATTERN = r">  Index Scan"
 INDEX_SCAN_PATTERN_V5 = r">  Index Scan"
+
+INDEX_ONLY_SCAN = "indexonly_scan"
+INDEX_ONLY_SCAN_PATTERN = r">  Index Only Scan"
+INDEX_ONLY_SCAN_PATTERN_V5 = r">  Index Only Scan"
 
 BITMAP_SCAN = "bitmap_scan"
 BITMAP_SCAN_PATTERN = r"Bitmap Heap Scan"
@@ -92,7 +97,7 @@ glob_appendonly = False
 # -----------------------------------------------------------------------------
 
 _drop_tables = """
-DROP TABLE IF EXISTS cal_txtest, cal_temp_ids, cal_dim, cal_bfvtest, cal_bfv_dim, cal_ndvtest;
+DROP TABLE IF EXISTS cal_txtest, cal_temp_ids, cal_dim, cal_bfvtest, cal_bfv_dim, cal_ndvtest, cal_widetest;
 """
 
 # create the table. Parameters:
@@ -281,9 +286,11 @@ def parseargs():
     parser = argparse.ArgumentParser(description=_help, version='1.0')
 
     parser.add_argument("tests", metavar="TEST", choices=[[], "all", "none", "bitmap_scan_tests", "btree_ao_scan_tests",
-                                                          "bitmap_ndv_scan_tests", "index_join_tests", "bfv_join_tests"],
+                                                          "bitmap_ndv_scan_tests", "index_join_tests", "bfv_join_tests",
+                                                          "index_only_scan_tests"],
                         nargs="*",
-                        help="Run these tests (all, none, bitmap_scan_tests, btree_ao_scan_tests, bitmap_ndv_scan_tests, index_join_tests, bfv_join_tests), default is none")
+                        help="Run these tests (all, none, bitmap_scan_tests, btree_ao_scan_tests, bitmap_ndv_scan_tests, "
+                              "index_join_tests, bfv_join_tests, index_only_scan_tests), default is none")
     parser.add_argument("--create", action="store_true",
                         help="Create the tables to use in the test")
     parser.add_argument("--execute", type=int, default="0",
@@ -452,22 +459,28 @@ def explain_index_scan(conn, sqlStr):
         rows = exp_curs.fetchall()
         table_scan_pattern = TABLE_SCAN_PATTERN
         index_scan_pattern = INDEX_SCAN_PATTERN
+        index_only_scan_pattern = INDEX_ONLY_SCAN_PATTERN
         bitmap_scan_pattern = BITMAP_SCAN_PATTERN
         fallback_pattern = FALLBACK_PATTERN
         if (glob_gpdb_major_version) <= 5:
             table_scan_pattern = TABLE_SCAN_PATTERN_V5
             index_scan_pattern = INDEX_SCAN_PATTERN_V5
+            index_only_scan_pattern = INDEX_ONLY_SCAN_PATTERN_V5
             bitmap_scan_pattern = BITMAP_SCAN_PATTERN_V5
             fallback_pattern = FALLBACK_PATTERN_V5
 
         for row in rows:
             log_output(row[0])
-            if re.search(TABLE_NAME_PATTERN, row[0]) or re.search(NDV_TABLE_NAME_PATTERN, row[0]):
+            if (re.search(TABLE_NAME_PATTERN, row[0]) or re.search(NDV_TABLE_NAME_PATTERN, row[0]) or
+                re.search(WIDE_TABLE_NAME_PATTERN, row[0])):
                 if re.search(bitmap_scan_pattern, row[0]):
                     scan_type = BITMAP_SCAN
                     cost = cost_from_explain_line(row[0])
                 elif re.search(index_scan_pattern, row[0]):
                     scan_type = INDEX_SCAN
+                    cost = cost_from_explain_line(row[0])
+                elif re.search(index_only_scan_pattern, row[0]):
+                    scan_type = INDEX_ONLY_SCAN
                     cost = cost_from_explain_line(row[0])
                 elif re.search(table_scan_pattern, row[0]):
                     scan_type = TABLE_SCAN
@@ -498,13 +511,14 @@ def explain_join_scan(conn, sqlStr):
         nl_join_pattern = NL_JOIN_PATTERN
         table_scan_pattern = TABLE_SCAN_PATTERN
         index_scan_pattern = INDEX_SCAN_PATTERN
+        index_only_scan_pattern = INDEX_ONLY_SCAN_PATTERN
         bitmap_scan_pattern = BITMAP_SCAN_PATTERN
         fallback_pattern = FALLBACK_PATTERN
         if (glob_gpdb_major_version) <= 5:
             hash_join_pattern = HASH_JOIN_PATTERN_V5
             nl_join_pattern = NL_JOIN_PATTERN_V5
             table_scan_pattern = TABLE_SCAN_PATTERN_V5
-            index_scan_pattern = INDEX_SCAN_PATTERN_V5
+            index_only_scan_pattern = INDEX_ONLY_SCAN_PATTERN_V5
             bitmap_scan_pattern = BITMAP_SCAN_PATTERN_V5
             fallback_pattern = FALLBACK_PATTERN_V5
 
@@ -515,12 +529,15 @@ def explain_join_scan(conn, sqlStr):
                 cost = cost_from_explain_line(row[0])
             elif re.search(hash_join_pattern, row[0]):
                 cost = cost_from_explain_line(row[0])
+
             # mark the scan type used underneath the join
             if re.search(TABLE_NAME_PATTERN, row[0]) or re.search(BFV_TABLE_NAME_PATTERN, row[0]):
                 if re.search(bitmap_scan_pattern, row[0]):
                     scan_type = BITMAP_SCAN
                 elif re.search(index_scan_pattern, row[0]):
                     scan_type = INDEX_SCAN
+                elif re.search(index_only_scan_pattern, row[0]):
+                    scan_type = INDEX_ONLY_SCAN
                 elif re.search(table_scan_pattern, row[0]):
                     scan_type = TABLE_SCAN
                 elif re.search(fallback_pattern, row[0]):
@@ -577,13 +594,7 @@ def find_crossover(conn, lowParamValue, highParamLimit, setup, parameterizeMetho
     execDict = {}
     errMessages = []
     timedOutDict = {}
-    expPrevPlan = ""
-    expPrevParamValue = lowParamValue
-    expCrossoverOccurred = False
     expCrossoverLow = lowParamValue - 1
-    expCrossoverHigh = highParamLimit
-    expCrossoverLowPlan = ""
-    expCrossoverHighPlan = ""
     reset_method(conn)
 
     # determine the increment
@@ -606,16 +617,6 @@ def find_crossover(conn, lowParamValue, highParamLimit, setup, parameterizeMetho
         (plan, cost) = explain_method(conn, sqlString)
         explainDict[paramValue] = (plan, cost)
         log_output("For param value %d the optimizer chose %s with a cost of %f" % (paramValue, plan, cost))
-
-        # look for the crossover from one plan to another
-        if not expCrossoverOccurred and paramValue > lowParamValue and plan != expPrevPlan:
-            expCrossoverOccurred = True
-            expCrossoverLow = expPrevParamValue
-            expCrossoverLowPlan = expPrevPlan
-            expCrossoverHigh = paramValue
-            expCrossoverHighPlan = plan
-        expPrevPlan = plan
-        expPrevParamValue = paramValue
 
         # execute the query, if requested
         if execute_n_times > 0:
@@ -825,7 +826,7 @@ def timed_execute_and_check_timeout(conn, sqlString, execute_n_times, paramValue
 #   created by this program or add more tables to be created.
 # - Define methods that parameterize these test queries, given an integer
 #   parameter value in a range that you can define later.
-# - Use the predefined types of plans (TABLE_SCAN, INDEX_SCAN) or add your
+# - Use the predefined types of plans (TABLE_SCAN, INDEX_SCAN, INDEX_ONLY_SCAN) or add your
 #   own plan types above. Note that you will also need to change or implement
 #   an explain method that takes a query, explains it, and returns the plan
 #   type and the estimated cost.
@@ -848,6 +849,9 @@ SELECT enable_xform('CXformImplementBitmapTableGet');
 """,
                             """
 SELECT enable_xform('CXformGet2TableScan');
+""",
+                            """
+SELECT enable_xform('CXformIndexGet2IndexScan');
 """ ]
 
 _force_sequential_scan = ["""
@@ -857,6 +861,10 @@ SELECT disable_xform('CXformImplementBitmapTableGet');
 _force_index_scan = ["""
 SELECT disable_xform('CXformGet2TableScan');
 """]
+
+_force_index_only_scan = ["SELECT disable_xform('CXformGet2TableScan');",
+                          "SELECT disable_xform('CXformIndexGet2IndexScan');"]
+
 
 _reset_index_join_forces = ["""
 SELECT enable_xform('CXformPushGbBelowJoin');
@@ -1001,6 +1009,7 @@ WHERE val <= 1000000;
 # Parameterize methods for the test queries above
 # -----------------------------------------------------------------------------
 
+
 # bitmap index scan with 0...100 % of values, for parameter values 0...10, in 10 % increments
 def parameterize_bitmap_index_10_narrow(paramValue):
     return _bitmap_select_10_pct % ("", paramValue)
@@ -1130,6 +1139,14 @@ def force_bitmap_scan(conn):
     execute_sql_arr(conn, _force_index_scan)
 
 
+def force_index_scan(conn):
+    execute_sql_arr(conn, _force_index_scan)
+
+
+def force_index_only_scan(conn):
+    execute_sql_arr(conn, _force_index_only_scan)
+
+
 def reset_index_join(conn):
     execute_sql_arr(conn, _reset_index_join_forces)
 
@@ -1166,11 +1183,50 @@ def run_one_bitmap_join_test(conn, testTitle, paramValueLow, paramValueHigh, set
                                                    execute_n_times)
     print_results(testTitle, explainDict, execDict, errors, plan_ids, execute_n_times)
 
+def run_one_index_scan_test(conn, testTitle, paramValueLow, paramValueHigh, setup, parameterizeMethod,
+                             execute_n_times):
+    log_output("Running index scan test " + testTitle)
+    plan_ids = [INDEX_SCAN, INDEX_ONLY_SCAN]
+    force_methods = [force_index_scan, force_index_only_scan]
+    explainDict, execDict, errors = find_crossover(conn, paramValueLow, paramValueHigh, setup, parameterizeMethod,
+                                                   explain_index_scan, reset_index_test, plan_ids, force_methods,
+                                                   execute_n_times)
+    print_results(testTitle, explainDict, execDict, errors, plan_ids, execute_n_times)
+
 
 # Main driver for the tests
 # -----------------------------------------------------------------------------
 
+def run_index_only_scan_tests(conn, execute_n_times):
+    def setup_wide_table(paramValue):
+        execute_sql_arr(conn, [
+            "DROP TABLE IF EXISTS cal_widetest;",
+            "CREATE TABLE cal_widetest(a int, {})".format(','.join('col' + str(i) + " text" for i in range(1, max(2, paramValue)))),
+            "CREATE INDEX cal_widetest_index ON cal_widetest(a);",
+            "TRUNCATE cal_widetest;",
+            "INSERT INTO cal_widetest SELECT i%50, {} FROM generate_series(1,100000)i;".format(','.join("repeat('a', 1024)" for i in range(1, max(2, paramValue)))),
+            "VACUUM ANALYZE cal_widetest;"
+        ])
+        return "select 1;"
+
+    def parameterized_method(paramValue):
+        return """
+            SELECT count(a)
+            FROM cal_widetest
+            WHERE a<25;
+            """
+
+    run_one_index_scan_test(conn,
+                            "Index Scan Test; Wide table; Narrow index",
+                            1,
+                            6,
+                            setup_wide_table,
+                            parameterized_method,
+                            execute_n_times)
+
+
 def run_bitmap_index_scan_tests(conn, execute_n_times):
+
     run_one_bitmap_scan_test(conn,
                              "Bitmap Scan Test; NDV=10; selectivity_pct=10*parameter_value; count(*)",
                              0,
@@ -1509,6 +1565,8 @@ def main():
                 run_btree_ao_index_scan_tests(conn, args.execute)
             run_index_join_tests(conn, args.execute)
             # skip the long-running bitmap_ndv_scan_tests and bfv_join_tests
+        elif test_unit == "index_only_scan_tests":
+            run_index_only_scan_tests(conn, args.execute)
         elif test_unit == "bitmap_scan_tests":
             run_bitmap_index_scan_tests(conn, args.execute)
         elif test_unit == "bitmap_ndv_scan_tests":

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -331,7 +331,10 @@ Distinct-LegacyOpfamily;
 
 CSubquery2Test:
 Subq2PartialDecorrelate Subq2CorrSQInLOJOn Subq2NotInWhereLOJ Subq2OuterRef2InJoin Subq2OuterRefMultiLevelInOn
-Index-Join-With-Subquery-In-Pred
+Index-Join-With-Subquery-In-Pred;
+
+CIndexOnlyScanTest:
+IndexOnlyScan-NoDistKeyInIndex
 ")
 
 set(mdp_dir "../data/dxl/minidump/")

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2426,7 +2426,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_indexonlyscan,
-		false,
+		true,
 		NULL, NULL, NULL
 	},
 

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -653,7 +653,7 @@ explain (costs off)
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
-               ->  Index Scan using tenk1_unique1 on tenk1
+               ->  Index Only Scan using tenk1_unique1 on tenk1
                      Index Cond: (unique1 < 42)
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)
@@ -671,7 +671,7 @@ explain (costs off)
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
-               ->  Index Scan using tenk1_unique1 on tenk1
+               ->  Index Only Scan using tenk1_unique1 on tenk1
                      Index Cond: (unique1 > 42)
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)
@@ -691,7 +691,7 @@ explain (costs off)
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
-               ->  Index Scan using tenk1_unique1 on tenk1
+               ->  Index Only Scan using tenk1_unique1 on tenk1
                      Index Cond: (unique1 > 42000)
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)
@@ -711,7 +711,7 @@ explain (costs off)
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
-               ->  Index Scan using tenk1_thous_tenthous on tenk1
+               ->  Index Only Scan using tenk1_thous_tenthous on tenk1
                      Index Cond: (thousand = 33)
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)
@@ -729,7 +729,7 @@ explain (costs off)
  Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Aggregate
-               ->  Index Scan using tenk1_thous_tenthous on tenk1
+               ->  Index Only Scan using tenk1_thous_tenthous on tenk1
                      Index Cond: (thousand = 33)
  Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
 (6 rows)

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -3099,7 +3099,7 @@ ORDER BY thousand;
    Merge Key: thousand
    ->  Sort
          Sort Key: thousand
-         ->  Index Scan using tenk1_thous_tenthous on tenk1
+         ->  Index Only Scan using tenk1_thous_tenthous on tenk1
                Index Cond: (thousand < 2)
                Filter: (tenthous = ANY ('{1001,3000}'::integer[]))
  Optimizer: Pivotal Optimizer (GPORCA) version 3.80.0
@@ -3130,7 +3130,7 @@ ORDER BY thousand;
    Merge Key: thousand
    ->  Sort
          Sort Key: thousand
-         ->  Index Scan using tenk1_thous_tenthous on tenk1
+         ->  Index Only Scan using tenk1_thous_tenthous on tenk1
                Index Cond: (thousand < 2)
                Filter: (tenthous = ANY ('{1001,3000}'::integer[]))
  Optimizer: Pivotal Optimizer (GPORCA) version 3.80.0

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -2233,7 +2233,7 @@ where b.f1 = t.thousand and a.f1 = b.f1 and (a.f1+b.f1+999) = t.tenthous;
                                  ->  Gather Motion 3:1  (slice1; segments: 3)
                                        ->  Aggregate
                                              ->  Seq Scan on int4_tbl
-               ->  Index Scan using tenk1_thous_tenthous on tenk1
+               ->  Index Only Scan using tenk1_thous_tenthous on tenk1
                      Index Cond: (thousand = (((pg_catalog.sum((sum(int4_tbl.f1)))) + 1)))
          ->  Hash
                ->  Broadcast Motion 1:3  (slice4)


### PR DESCRIPTION
 Cherry-pick https://github.com/greenplum-db/gpdb/pull/11129 and https://github.com/greenplum-db/gpdb/pull/11106 from master.

Conflicts/diffs encountered during backport:
1) Python 3 diffs in minidump/gpsd; no python 3 diffs where backported.
2) In `RetrieveRelStats()` exception handling conflict from e754018a8a23724be7339048087bb878a8fc01e7
3) C++98 in 6X branch has no `override` keyword

Manually ran 3 utils (minidump, gpsd, and cal_bitmap_test) to make sure they produced expected output.

Pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-6X-orca-index-only-scan-costing