### PR TITLE
[6X backport] Make greenplum-path.sh compatible with more shells

### DIFF
--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -3,7 +3,24 @@
 SET_PYTHONHOME="${1:-no}"
 
 cat <<"EOF"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+if test -n "$ZSH_VERSION"; then
+    # zsh
+    SCRIPT_PATH="${(%):-%x}"
+elif test -n "$BASH_VERSION"; then
+    # bash
+    SCRIPT_PATH="${BASH_SOURCE[0]}"
+else
+    # Unknown shell, hope below works.
+    # Tested with dash
+    result=$(lsof -p $$ -Fn | tail --lines=1 | xargs --max-args=2 | cut --delimiter=' ' --fields=2)
+    SCRIPT_PATH=${result#n}
+fi
+
+if test -z "$SCRIPT_PATH"; then
+    echo "The shell cannot be identified. \$GPHOME may not be set correctly." >&2
+fi
+SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" >/dev/null 2>&1 && pwd)"
+
 if [ ! -L "${SCRIPT_DIR}" ]; then
 	GPDB_DIR=$(basename "${SCRIPT_DIR}")
 else

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -3,10 +3,10 @@
 SET_PYTHONHOME="${1:-no}"
 
 cat <<"EOF"
-if test -n "$ZSH_VERSION"; then
+if test -n "${ZSH_VERSION:-}"; then
     # zsh
     SCRIPT_PATH="${(%):-%x}"
-elif test -n "$BASH_VERSION"; then
+elif test -n "${BASH_VERSION:-}"; then
     # bash
     SCRIPT_PATH="${BASH_SOURCE[0]}"
 else


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/11043 and https://github.com/greenplum-db/gpdb/pull/11085, which allow greenplum_path.sh to work on zsh due to the changes in cb632ef109b526ee82f09247d1c73e57d41f1b6d. These two commits also need to be backported to 5X.