### PR TITLE
fix gpfdist header not work in gpdb4

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -111,7 +111,7 @@ PGUSER = os.environ.get("PGUSER")
 if PGUSER is None:
     PGUSER = USER
 PGHOST = os.environ.get("PGHOST")
-if PGHOST is None:
+if PGHOST is None or PGHOST=="":
     PGHOST = HOST
 
 d = mkpath('config')
@@ -119,8 +119,8 @@ if not os.path.exists(d):
     os.mkdir(d)
 
 def write_config_file(config='config/config_file',file='data/external_file_01.txt',input_port='8081',columns=None, format='text', log_errors=None, error_limit=None, delimiter='|', 
-    encoding=None, escape=None, null_as=None, fill_missing_fields=None, quote=None, table='texttable', mode='insert', update_columns=['n2'],update_condition=None, match_columns=['n1','s1','s2'], staging_table=None,
-    mapping=None, externalSchema=None, preload=True, truncate=False, reuse_tables=True, fast_match=None,sql=False, before=None, after=None
+    encoding=None, escape=None, null_as=None, fill_missing_fields=None, quote=None, header=None, table='texttable', mode='insert', update_columns=['n2'],update_condition=None, 
+    match_columns=['n1','s1','s2'], staging_table=None, mapping=None, externalSchema=None, preload=True, truncate=False, reuse_tables=True, fast_match=None,sql=False, before=None, after=None
     , error_table=None):
     '''
 
@@ -182,6 +182,8 @@ def write_config_file(config='config/config_file',file='data/external_file_01.tx
         gpload_input.append({'FILL_MISSING_FIELDS':fill_missing_fields})
     if quote:
         gpload_input.append({'QUOTE':quote})
+    if header:
+        gpload_input.append({'HEADER': header})
     
     conf['GPLOAD']['INPUT'] = gpload_input
 
@@ -909,3 +911,12 @@ def test_43_gpload_column_without_data_type():
     columns = [{'"Field1"': ''},{'"Field#2"': ''}]
     write_config_file(mode='insert',reuse_tables=True,fast_match=False, file='data_file.txt',table='testSpecialChar',columns=columns, delimiter=";")
     doTest(43)
+
+def test_44_gpload_header_compat_with_4():
+    "44 gpload header attribute and make it usable in gpdb4"
+    file = mkpath('setup.sql')
+    prepare_test_file(44)
+    runfile(file)
+    copy_data('external_file_01.txt','data_file.txt')
+    write_config_file(format='text',file='data_file.txt',table='texttable',delimiter='|', header=True)
+    doTest(44)

--- a/gpMgmt/bin/gpload_test/gpload2/query44.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query44.ans
@@ -1,0 +1,22 @@
+NOTICE:  HEADER means that each one of the data files has a header row
+NOTICE:  HEADER means that each one of the data files has a header row
+2020-11-12 15:43:40|INFO|gpload session started 2020-11-12 15:43:40
+2020-11-12 15:43:40|INFO|setting schema 'public' for table 'texttable'
+2020-11-12 15:43:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2020-11-12 15:43:40|INFO|did not find an external table to reuse. creating ext_gpload_reusable_c7e75476_24ba_11eb_8532_00505698707d
+2020-11-12 15:43:40|INFO|running time: 0.15 seconds
+2020-11-12 15:43:40|INFO|rows Inserted          = 15
+2020-11-12 15:43:40|INFO|rows Updated           = 0
+2020-11-12 15:43:40|INFO|data formatting errors = 0
+2020-11-12 15:43:40|INFO|gpload succeeded
+NOTICE:  HEADER means that each one of the data files has a header row
+NOTICE:  HEADER means that each one of the data files has a header row
+2020-11-12 15:43:40|INFO|gpload session started 2020-11-12 15:43:40
+2020-11-12 15:43:40|INFO|setting schema 'public' for table 'texttable'
+2020-11-12 15:43:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2020-11-12 15:43:40|INFO|did not find an external table to reuse. creating ext_gpload_reusable_c825d732_24ba_11eb_b3a6_00505698707d
+2020-11-12 15:43:40|INFO|running time: 0.12 seconds
+2020-11-12 15:43:40|INFO|rows Inserted          = 15
+2020-11-12 15:43:40|INFO|rows Updated           = 0
+2020-11-12 15:43:40|INFO|data formatting errors = 0
+2020-11-12 15:43:40|INFO|gpload succeeded


### PR DESCRIPTION
fix gpfdist in master header attribute not compatible in gpdb4

We cannot test if this gpfdist(for gp7) can work fine in gpdb4 in pipeline. But I have test this patch and can avoid header not recognizing issue in gp4 in my docker.

make gpfdist header attribute compat with gpdb4
add gpload test case 44 to test header

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
