### PR TITLE
fix gpfdist for gpdb5 header not compatible in gpdb4

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -91,14 +91,14 @@ PGUSER = os.environ.get("PGUSER")
 if PGUSER is None:
     PGUSER = USER
 PGHOST = os.environ.get("PGHOST")
-if PGHOST is None:
+if PGHOST is None or PGHOST=="":
     PGHOST = HOST
 
 d = mkpath('config')
 if not os.path.exists(d):
     os.mkdir(d)
 
-def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',portNum='8081',database='reuse_gptest',host='localhost',formatOpts='text',file='data/external_file_01.txt',table='texttable',format='text',delimiter="'|'",escape='',quote='',truncate='False',log_errors=None, error_limit='0',error_table=None,externalSchema=None,staging_table=None,fast_match='false', encoding=None, preload=True):
+def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',portNum='8081',database='reuse_gptest',host='localhost',formatOpts='text',file='data/external_file_01.txt',table='texttable',format='text',delimiter="'|'",escape='',quote='',header=None,truncate='False',log_errors=None, error_limit='0',error_table=None,externalSchema=None,staging_table=None,fast_match='false', encoding=None, preload=True):
 
     f = open(mkpath('config/config_file'),'w')
     f.write("VERSION: 1.0.0.1")
@@ -147,6 +147,8 @@ def write_config_file(mode='insert', reuse_flag='',columns_flag='0',mapping='0',
         f.write("\n    - ESCAPE: "+escape)
     if quote:
         f.write("\n    - QUOTE: "+quote)
+    if header:
+        f.write("\n    - HEADER: "+header)
     f.write("\n   OUTPUT:")
     f.write("\n    - TABLE: "+table)
     if mode:
@@ -432,7 +434,7 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
 
     def test_00_gpload_formatOpts_setup(self):
         "0  gpload setup"
-        for num in range(1,39):
+        for num in range(1,40):
            f = open(mkpath('query%d.sql' % num),'w')
            f.write("\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n"+"\! gpload -f "+mkpath('config/config_file')+ " -d reuse_gptest\n")
            f.close()
@@ -739,6 +741,14 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         copy_data('external_file_04.txt','data_file.txt')
         write_config_file(mode='insert',reuse_flag='true',fast_match='false',file='data_file.txt',error_table="err_table",error_limit='1000',preload=False)
         self.doTest(38)
+
+    def test_39_gpload_header_compat_with_4(self):
+        "39 gpload header attribute and make it usable in gpdb4"
+        file = mkpath('setup.sql')
+        runfile(file)
+        copy_data('external_file_01.txt','data_file.txt')
+        write_config_file(formatOpts='text',file='data_file.txt',table='texttable',delimiter="'|'", header='true')
+        self.doTest(39)
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(GPLoad_FormatOpts_TestCase)

--- a/gpMgmt/bin/gpload_test/gpload2/query39.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query39.ans
@@ -1,0 +1,16 @@
+2020-11-16 09:29:32|INFO|gpload session started 2020-11-16 09:29:32
+2020-11-16 09:29:32|INFO|setting schema 'public' for table 'texttable'
+2020-11-16 09:29:32|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2020-11-16 09:29:32|INFO|running time: 0.18 seconds
+2020-11-16 09:29:32|INFO|rows Inserted          = 15
+2020-11-16 09:29:32|INFO|rows Updated           = 0
+2020-11-16 09:29:32|INFO|data formatting errors = 0
+2020-11-16 09:29:32|INFO|gpload succeeded
+2020-11-16 09:29:32|INFO|gpload session started 2020-11-16 09:29:32
+2020-11-16 09:29:32|INFO|setting schema 'public' for table 'texttable'
+2020-11-16 09:29:32|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2020-11-16 09:29:32|INFO|running time: 0.16 seconds
+2020-11-16 09:29:32|INFO|rows Inserted          = 15
+2020-11-16 09:29:32|INFO|rows Updated           = 0
+2020-11-16 09:29:32|INFO|data formatting errors = 0
+2020-11-16 09:29:32|INFO|gpload succeeded

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -1554,11 +1554,27 @@ static int session_attach(request_t* r)
 			int quote = 0;
 			int escape = 0;
 			int eol_type = 0;
-			sscanf(r->csvopt, "m%dx%dq%dn%dh%d", &fstream_options.is_csv, &escape,
+			/* csvopt is different in gp4 and later version */
+			/* for gp4, csv opt is like "mxqnh"; for later version of gpdb, csv opt is like "mxqhn" */
+			/* we check the number of successful match here to make sure eol_type and header is right */
+			if ( strcmp(r->csvopt, "") != 0 ){    //writable external table doesn't have csvopt
+				int n = sscanf(r->csvopt, "m%dx%dq%dn%dh%d", &fstream_options.is_csv, &escape,
 					&quote, &eol_type, &fstream_options.header);
-			fstream_options.quote = quote;
-			fstream_options.escape = escape;
-			fstream_options.eol_type = eol_type;
+				if (n!=5){
+					n = sscanf(r->csvopt, "m%dx%dq%dh%dn%d", &fstream_options.is_csv, &escape,
+						&quote, &fstream_options.header, &eol_type);
+				}
+				if (n==5){
+					fstream_options.quote = quote;
+					fstream_options.escape = escape;
+					fstream_options.eol_type = eol_type;
+				}
+				else{
+					http_error(r, FDIST_BAD_REQUEST, "bad request, csvopt doesn't meet the format");
+					request_end(r, 1, 0);
+					return -1;
+				}
+			}
 		}
 
 		/* set fstream for read (GET) or write (PUT) */


### PR DESCRIPTION
fix gpfdist for gpdb5 header not compatible in gpdb4

We cannot test if this gpfdist(for gp5) can work fine in gpdb4 in pipeline. But I have test this patch and can avoid header not recognizing issue in gp4 in my docker.

1. make gpfdist header attribute compat with gpdb4
2. add gpload test case 39 to test header attribute

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
