### PR TITLE
Fix flaky test expand matview

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -431,7 +431,6 @@ Feature: expand the cluster by adding more segments
         And database "gptest" exists
         And the user runs psql with "-c 'CREATE TABLE public.test_matview_base AS SELECT i FROM generate_series(1,10000) i'" against database "gptest"
         And the user runs psql with "-c 'CREATE MATERIALIZED VIEW public.test_matview as select * from public.test_matview_base'" against database "gptest"
-        And distribution information from table "public.test_matview" with data in "gptest" is saved
         And there are no gpexpand_inputfiles
         And the cluster is setup for an expansion on hosts "localhost"
         When the user runs gpexpand interview to add 3 new segment and 0 new host "ignored.host"
@@ -440,4 +439,4 @@ Feature: expand the cluster by adding more segments
         Then verify that the cluster has 3 new segments
         When the user runs gpexpand to redistribute
         Then the numsegments of table "public.test_matview" is 4
-        And distribution information from table "public.test_matview" with data in "gptest" is verified against saved data
+        And distribution information from table "public.test_matview" and "public.test_matview_base" in "gptest" are the same

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2633,9 +2633,16 @@ def impl(context, table, dbname):
         raise Exception("Unexpected variance for redistributed data in table %s. Relative standard error %f exceeded tolerance factor of %f." %
                 (table, relative_std_error, tolerance))
 
+@then('distribution information from table "{table1}" and "{table2}" in "{dbname}" are the same')
+def impl(context, table1, table2, dbname):
+    distribution_row_count_tbl1 = _get_row_count_per_segment(table1, dbname)
+    distribution_row_count_tbl2 = _get_row_count_per_segment(table2, dbname)
+    if distribution_row_count_tbl1 != distribution_row_count_tbl2:
+        raise Exception("%s and %s have different distribution. Row count of %s is %s and row count of %s is %s" % (table1, table2, table1, distribution_row_count_tbl1, table2, distribution_row_count_tbl2)) 
+
 def _get_row_count_per_segment(table, dbname):
     with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
-        query = "SELECT gp_segment_id,COUNT(i) FROM %s GROUP BY gp_segment_id;" % table
+        query = "SELECT gp_segment_id,COUNT(i) FROM %s GROUP BY gp_segment_id ORDER BY gp_segment_id;" % table
         cursor = dbconn.query(conn, query)
         rows = cursor.fetchall()
     conn.close()


### PR DESCRIPTION
Compare the variance of row count can be flaky, fix it by comparing the
distribution of matview and base table.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
