### PR TITLE
[6X Backport]Get pg_database tuple from disk in vac_update_datfrozenxid.

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1861,6 +1861,35 @@ vac_update_relstats(Relation relation,
 	heap_close(rd, RowExclusiveLock);
 }
 
+/*
+ * fetch_database_tuple - Fetch a copy of database tuple from pg_database.
+ *
+ * This using disk heap table instead of system cache.
+ * relation: opened pg_database relation in vac_update_datfrozenxid().
+ */
+static HeapTuple
+fetch_database_tuple(Relation relation, Oid dbOid)
+{
+	ScanKeyData skey[1];
+	SysScanDesc sscan;
+	HeapTuple	tuple = NULL;
+
+	ScanKeyInit(&skey[0],
+				ObjectIdAttributeNumber,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(dbOid));
+
+	sscan = systable_beginscan(relation, DatabaseOidIndexId, true,
+							   NULL, 1, skey);
+
+	tuple = systable_getnext(sscan);
+	if (HeapTupleIsValid(tuple))
+		tuple = heap_copytuple(tuple);
+
+	systable_endscan(sscan);
+
+	return tuple;
+}
 
 /*
  *	vac_update_datfrozenxid() -- update pg_database.datfrozenxid for our DB
@@ -1883,8 +1912,8 @@ vac_update_relstats(Relation relation,
 void
 vac_update_datfrozenxid(void)
 {
-	HeapTuple	tuple;
-	Form_pg_database dbform;
+	HeapTuple	cached_tuple;
+	Form_pg_database	cached_dbform;
 	Relation	relation;
 	SysScanDesc scan;
 	HeapTuple	classTup;
@@ -1999,45 +2028,53 @@ vac_update_datfrozenxid(void)
 	/* Now fetch the pg_database tuple we need to update. */
 	relation = heap_open(DatabaseRelationId, RowExclusiveLock);
 
-	/* Fetch a copy of the tuple to scribble on */
-	tuple = SearchSysCacheCopy1(DATABASEOID, ObjectIdGetDatum(MyDatabaseId));
-	if (!HeapTupleIsValid(tuple))
-		elog(ERROR, "could not find tuple for database %u", MyDatabaseId);
-	dbform = (Form_pg_database) GETSTRUCT(tuple);
+	cached_tuple = SearchSysCache1(DATABASEOID, ObjectIdGetDatum(MyDatabaseId));
+	cached_dbform = (Form_pg_database) GETSTRUCT(cached_tuple);
 
 	/*
 	 * As in vac_update_relstats(), we ordinarily don't want to let
 	 * datfrozenxid go backward; but if it's "in the future" then it must be
 	 * corrupt and it seems best to overwrite it.
 	 */
-	if (dbform->datfrozenxid != newFrozenXid &&
-		(TransactionIdPrecedes(dbform->datfrozenxid, newFrozenXid) ||
-		 TransactionIdPrecedes(lastSaneFrozenXid, dbform->datfrozenxid)))
-	{
-		dbform->datfrozenxid = newFrozenXid;
+	if (cached_dbform->datfrozenxid != newFrozenXid &&
+		(TransactionIdPrecedes(cached_dbform->datfrozenxid, newFrozenXid) ||
+		 TransactionIdPrecedes(lastSaneFrozenXid, cached_dbform->datfrozenxid)))
 		dirty = true;
-	}
 	else
-		newFrozenXid = dbform->datfrozenxid;
+		newFrozenXid = cached_dbform->datfrozenxid;
 
 	/* Ditto for datminmxid */
-	if (dbform->datminmxid != newMinMulti &&
-		(MultiXactIdPrecedes(dbform->datminmxid, newMinMulti) ||
-		 MultiXactIdPrecedes(lastSaneMinMulti, dbform->datminmxid)))
-	{
-		dbform->datminmxid = newMinMulti;
+	if (cached_dbform->datminmxid != newMinMulti &&
+		(MultiXactIdPrecedes(cached_dbform->datminmxid, newMinMulti) ||
+		 MultiXactIdPrecedes(lastSaneMinMulti, cached_dbform->datminmxid)))
 		dirty = true;
-	}
 	else
-		newMinMulti = dbform->datminmxid;
+		newMinMulti = cached_dbform->datminmxid;
 
 	if (dirty)
 	{
+		HeapTuple			tuple;
+		Form_pg_database	tmp_dbform;
+		/*
+		 * Fetch a copy of the tuple to scribble on from pg_database disk
+		 * heap table instead of system cache
+		 * "SearchSysCacheCopy1(DATABASEOID, ObjectIdGetDatum(MyDatabaseId))".
+		 * Since the cache already flatten toast tuple, so the
+		 * heap_inplace_update will fail with "wrong tuple length".
+		 */
+		tuple = fetch_database_tuple(relation, MyDatabaseId);
+		if (!HeapTupleIsValid(tuple))
+			elog(ERROR, "could not find tuple for database %u", MyDatabaseId);
+		tmp_dbform = (Form_pg_database) GETSTRUCT(tuple);
+		tmp_dbform->datfrozenxid = newFrozenXid;
+		tmp_dbform->datminmxid = newMinMulti;
+
 		heap_inplace_update(relation, tuple);
+		heap_freetuple(tuple);
 		SIMPLE_FAULT_INJECTOR("vacuum_update_dat_frozen_xid");
 	}
 
-	heap_freetuple(tuple);
+	ReleaseSysCache(cached_tuple);
 	heap_close(relation, RowExclusiveLock);
 
 	/*

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -358,3 +358,59 @@ DROP TABLE vac_acl_heap;
 DROP TABLE vac_acl_ao;
 DROP TABLE vac_acl_aocs;
 DROP ROLE non_super_user_vacuum;
+-- Vacuum freeze for database with toast attribute in pg_database tuple cause
+-- heap_inplace_update raise error "wrong tuple length". This is because system
+-- cache flatten toast tuple.
+DROP DATABASE IF EXISTS vacuum_freeze_test;
+CREATE DATABASE vacuum_freeze_test;
+-- start_ignore
+create or replace function toast_pg_database_datacl() returns text as $body$
+declare
+	mycounter int;
+begin
+	for mycounter in select i from generate_series(1, 2800) i loop
+		execute 'create role aaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' || mycounter;
+		execute 'grant ALL on database vacuum_freeze_test to aaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' || mycounter;
+	end loop;
+	return 'ok';
+end;
+$body$ language plpgsql volatile strict;
+
+create or replace function clean_roles() returns text as $body$
+declare
+	mycounter int;
+begin
+	for mycounter in select i from generate_series(1, 2800) i loop
+		execute 'drop role aaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' || mycounter;
+	end loop;
+	return 'ok';
+end;
+$body$ language plpgsql volatile strict;
+
+select toast_pg_database_datacl();
+-- end_ignore
+\c vacuum_freeze_test
+create temp table before_vacuum as select datname, pg_column_size(datacl) > 8192 as datacl_size, age(datfrozenxid) from pg_database where datname='vacuum_freeze_test';
+select datname, datacl_size from before_vacuum;
+      datname       | datacl_size 
+--------------------+-------------
+ vacuum_freeze_test | t
+(1 row)
+
+vacuum freeze;
+select datname, pg_column_size(datacl) > 8192 as datacl_size, age(datfrozenxid) != (select age from before_vacuum) as age_changed from pg_database where datname='vacuum_freeze_test';
+      datname       | datacl_size | age_changed 
+--------------------+-------------+-------------
+ vacuum_freeze_test | t           | t
+(1 row)
+
+\c regression
+DROP DATABASE vacuum_freeze_test;
+-- start_ignore
+select clean_roles();
+drop function toast_pg_database_datacl();
+drop function clean_roles();
+-- end_ignore
+-- free pg_global space, otherwise it fails db_size_functions
+VACUUM FULL pg_authid;
+VACUUM FULL pg_database;

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -232,3 +232,51 @@ DROP TABLE vac_acl_heap;
 DROP TABLE vac_acl_ao;
 DROP TABLE vac_acl_aocs;
 DROP ROLE non_super_user_vacuum;
+
+
+-- Vacuum freeze for database with toast attribute in pg_database tuple cause
+-- heap_inplace_update raise error "wrong tuple length". This is because system
+-- cache flatten toast tuple.
+DROP DATABASE IF EXISTS vacuum_freeze_test;
+CREATE DATABASE vacuum_freeze_test;
+-- start_ignore
+create or replace function toast_pg_database_datacl() returns text as $body$
+declare
+	mycounter int;
+begin
+	for mycounter in select i from generate_series(1, 2800) i loop
+		execute 'create role aaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' || mycounter;
+		execute 'grant ALL on database vacuum_freeze_test to aaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' || mycounter;
+	end loop;
+	return 'ok';
+end;
+$body$ language plpgsql volatile strict;
+
+create or replace function clean_roles() returns text as $body$
+declare
+	mycounter int;
+begin
+	for mycounter in select i from generate_series(1, 2800) i loop
+		execute 'drop role aaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' || mycounter;
+	end loop;
+	return 'ok';
+end;
+$body$ language plpgsql volatile strict;
+
+select toast_pg_database_datacl();
+-- end_ignore
+\c vacuum_freeze_test
+create temp table before_vacuum as select datname, pg_column_size(datacl) > 8192 as datacl_size, age(datfrozenxid) from pg_database where datname='vacuum_freeze_test';
+select datname, datacl_size from before_vacuum;
+vacuum freeze;
+select datname, pg_column_size(datacl) > 8192 as datacl_size, age(datfrozenxid) != (select age from before_vacuum) as age_changed from pg_database where datname='vacuum_freeze_test';
+\c regression
+DROP DATABASE vacuum_freeze_test;
+-- start_ignore
+select clean_roles();
+drop function toast_pg_database_datacl();
+drop function clean_roles();
+-- end_ignore
+-- free pg_global space, otherwise it fails db_size_functions
+VACUUM FULL pg_authid;
+VACUUM FULL pg_database;


### PR DESCRIPTION
In vac_update_datfrozenxid.(), the pg_database tuple for current
database should be fetched from disk heap table instead of system cache.
Since the cache already flatten toast tuple, so if the tuple in
pg_database contains toast attribute, heap_inplace_update() will fail
with "wrong tuple length".

Postgres upstream also has this issue. But since the issue is hot,
let's fix in GPDB first.

(cherry picked from commit 373e676de819fc0cdadfb59d35d9279abe3d11d9)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
