### PR TITLE
Some DB size functions should not execute on entry db.

### DIFF
--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -52,6 +52,16 @@
 
 static int64 calculate_total_relation_size(Relation rel);
 
+/**
+ * Some functions are peculiar in that they do their own dispatching.
+ * They do not work on entry db since we do not support dispatching
+ * from entry-db currently.
+ */
+#define ERROR_ON_ENTRY_DB()	\
+	if (Gp_role == GP_ROLE_EXECUTE && IS_QUERY_DISPATCHER())	\
+		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),	\
+						errmsg("This query is not currently supported by GPDB.")))
+
 /*
  * Helper function to dispatch a size-returning command.
  *
@@ -203,6 +213,8 @@ pg_database_size_oid(PG_FUNCTION_ARGS)
 	Oid			dbOid = PG_GETARG_OID(0);
 	int64		size;
 
+	ERROR_ON_ENTRY_DB();
+
 	size = calculate_database_size(dbOid);
 
 	if (Gp_role == GP_ROLE_DISPATCH)
@@ -226,6 +238,8 @@ pg_database_size_name(PG_FUNCTION_ARGS)
 	Name		dbName = PG_GETARG_NAME(0);
 	Oid			dbOid = get_database_oid(NameStr(*dbName), false);
 	int64		size;
+
+	ERROR_ON_ENTRY_DB();
 
 	size = calculate_database_size(dbOid);
 
@@ -326,6 +340,8 @@ pg_tablespace_size_oid(PG_FUNCTION_ARGS)
 	Oid			tblspcOid = PG_GETARG_OID(0);
 	int64		size;
 
+	ERROR_ON_ENTRY_DB();
+
 	size = calculate_tablespace_size(tblspcOid);
 
 	if (Gp_role == GP_ROLE_DISPATCH)
@@ -349,6 +365,8 @@ pg_tablespace_size_name(PG_FUNCTION_ARGS)
 	Name		tblspcName = PG_GETARG_NAME(0);
 	Oid			tblspcOid = get_tablespace_oid(NameStr(*tblspcName), false);
 	int64		size;
+
+	ERROR_ON_ENTRY_DB();
 
 	size = calculate_tablespace_size(tblspcOid);
 
@@ -437,13 +455,7 @@ pg_relation_size(PG_FUNCTION_ARGS)
 	Relation	rel;
 	int64		size = 0;
 
-	/**
-	 * This function is peculiar in that it does its own dispatching.
-	 * It does not work on entry db since we do not support dispatching
-	 * from entry-db currently.
-	 */
-	if (Gp_role == GP_ROLE_EXECUTE && IS_QUERY_DISPATCHER())
-		elog(ERROR, "This query is not currently supported by GPDB.");
+	ERROR_ON_ENTRY_DB();
 
 	rel = try_relation_open(relOid, AccessShareLock, false);
 
@@ -646,6 +658,8 @@ pg_table_size(PG_FUNCTION_ARGS)
 	Relation	rel;
 	int64		size;
 
+	ERROR_ON_ENTRY_DB();
+
 	rel = try_relation_open(relOid, AccessShareLock, false);
 
 	if (rel == NULL)
@@ -673,6 +687,8 @@ pg_indexes_size(PG_FUNCTION_ARGS)
 	Oid			relOid = PG_GETARG_OID(0);
 	Relation	rel;
 	int64		size;
+
+	ERROR_ON_ENTRY_DB();
 
 	rel = try_relation_open(relOid, AccessShareLock, false);
 
@@ -724,6 +740,8 @@ pg_total_relation_size(PG_FUNCTION_ARGS)
 	Oid			relOid = PG_GETARG_OID(0);
 	Relation	rel;
 	int64		size;
+
+	ERROR_ON_ENTRY_DB();
 
 	/*
 	 * While we scan pg_class with an MVCC snapshot,

--- a/src/test/regress/expected/db_size_functions.out
+++ b/src/test/regress/expected/db_size_functions.out
@@ -108,6 +108,11 @@ select pg_total_relation_size('pg_tables');
                       0
 (1 row)
 
+-- Test that run pg_relation_size, pg_total_relation_size on entryDB is not supported.
+create temp table t1 as select pg_relation_size('pg_tables') from pg_class limit 1;
+ERROR:  This query is not currently supported by GPDB.
+create temp table t1 as select pg_total_relation_size('pg_tables') from pg_class limit 1;
+ERROR:  This query is not currently supported by GPDB.
 --
 -- Tests on the table and index size variants.
 --

--- a/src/test/regress/sql/db_size_functions.sql
+++ b/src/test/regress/sql/db_size_functions.sql
@@ -38,6 +38,9 @@ select pg_table_size('pg_tables');
 select pg_indexes_size('pg_tables');
 select pg_total_relation_size('pg_tables');
 
+-- Test that run pg_relation_size, pg_total_relation_size on entryDB is not supported.
+create temp table t1 as select pg_relation_size('pg_tables') from pg_class limit 1;
+create temp table t1 as select pg_total_relation_size('pg_tables') from pg_class limit 1;
 
 --
 -- Tests on the table and index size variants.


### PR DESCRIPTION
Error out if this kind of functions execute on entry db, so
user will not confuse with the generated wrong results.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
