### PR TITLE
Fix catalog definition of gp_terminate_mpp_backends()

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302010201
+#define CATALOG_VERSION_NO	302012031
 
 #endif

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -5988,7 +5988,7 @@
   proargtypes => 'int4', prosrc => 'pg_terminate_backend' },
 { oid => '6999', descr => 'terminate all mpp backends on the segment',
   proname => 'gp_terminate_mpp_backends', provolatile => 'v', proparallel => 'r',
-  prorettype => 'void', proargtypes => 'int4', prosrc => 'gp_terminate_mpp_backends' },
+  prorettype => 'void', proargtypes => '', prosrc => 'gp_terminate_mpp_backends' },
 { oid => '2172', descr => 'prepare for taking an online backup',
   proname => 'pg_start_backup', provolatile => 'v', proparallel => 'r',
   prorettype => 'pg_lsn', proargtypes => 'text bool bool',

--- a/src/test/isolation2/expected/gp_terminate_mpp_backends.out
+++ b/src/test/isolation2/expected/gp_terminate_mpp_backends.out
@@ -1,0 +1,15 @@
+-- test gp_terminate_mpp_backends
+1:create table gp_terminate_mpp_backends_t (a int);
+CREATE
+
+select gp_terminate_mpp_backends() from gp_dist_random('gp_id');
+ gp_terminate_mpp_backends 
+---------------------------
+                           
+                           
+                           
+(3 rows)
+
+-- expect following to fail as writer gang was killed
+1:select count(*) from gp_terminate_mpp_backends_t;
+ERROR:  terminating connection due to administrator command  (seg0 slice1 10.138.0.26:7002 pid=26162)

--- a/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
@@ -114,13 +114,16 @@ ERROR:  terminating connection due to administrator command  (seg0 slice1 192.16
 create table standby_config as (select hostname, datadir, port, role from gp_segment_configuration where content = -1) distributed by (hostname);
 CREATE 2
 
-create or replace function reinitialize_standby() returns text as $$ import subprocess rv = plpy.execute("select hostname, datadir, port from standby_config order by role", 2) standby = rv[0] # role = 'm' master = rv[1] # role = 'p' try: cmd = 'rm -rf %s.dtm_recovery && cp -R %s %s.dtm_recovery' % (standby['datadir'], standby['datadir'], standby['datadir']) remove_output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT) cmd = 'gpinitstandby -ar -P %d' % master['port'] remove_output += subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT) cmd = 'export PGPORT=%d; gpinitstandby -a -s %s -S %s -P %d' % (master['port'], standby['hostname'], standby['datadir'], standby['port']) init_output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT) except subprocess.CalledProcessError as e: plpy.info(e.output) raise 
+create or replace function reinitialize_standby() returns text as $$ import subprocess rv = plpy.execute("select hostname, datadir, port from standby_config order by role", 2) standby = rv[0] # role = 'm' master = rv[1] # role = 'p' try: cmd = 'rm -rf %s.dtm_recovery && cp -R %s %s.dtm_recovery' % (standby['datadir'], standby['datadir'], standby['datadir']) remove_output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode('ascii') cmd = 'gpinitstandby -ar -P %d' % master['port'] remove_output += subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode('ascii') cmd = 'export PGPORT=%d; gpinitstandby -a -s %s -S %s -P %d' % (master['port'], standby['hostname'], standby['datadir'], standby['port']) init_output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode('ascii') except subprocess.CalledProcessError as e: plpy.info(e.output) raise 
+if "ERROR" not in remove_output and "FATAL" not in remove_output and \ "ERROR" not in init_output and "FATAL" not in init_output: return "standby initialized" 
 return remove_output + "\n" + init_output $$ language plpython3u;
 CREATE
 
--- start_ignore
 select reinitialize_standby();
--- end_ignore
+ reinitialize_standby 
+----------------------
+ standby initialized  
+(1 row)
 
 -- Sync state between master and standby must be restored at the end.
 select wait_until_standby_in_state('streaming');

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -58,6 +58,7 @@ test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa
 
 # below test(s) inject faults so each of them need to be in a separate group
 test: pg_terminate_backend
+test: gp_terminate_mpp_backends
 
 # this case contains fault injection, must be put in a separate test group
 test: terminate_in_gang_creation

--- a/src/test/isolation2/sql/gp_terminate_mpp_backends.sql
+++ b/src/test/isolation2/sql/gp_terminate_mpp_backends.sql
@@ -1,0 +1,7 @@
+-- test gp_terminate_mpp_backends
+1:create table gp_terminate_mpp_backends_t (a int);
+
+select gp_terminate_mpp_backends() from gp_dist_random('gp_id');
+
+-- expect following to fail as writer gang was killed
+1:select count(*) from gp_terminate_mpp_backends_t;


### PR DESCRIPTION
This led to "No function matches the given name and argument types.".
Possible mismerge when rebasing master into iteration_REL_12 branch
during postgres 12 merge.

This function was originally introduced by GPDB commit b04175666ae and
merged into iteration_REL_12 in commit 19cfbeb5f0.

Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>
