### PR TITLE
[Backport6X] Avoid bgwriter sending statistics to stat collector when mirror is no…

### DIFF
--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -39,6 +39,7 @@
 #include "access/transam.h"
 #include "access/twophase_rmgr.h"
 #include "access/xact.h"
+#include "access/xlog.h"
 #include "catalog/pg_database.h"
 #include "catalog/pg_proc.h"
 #include "executor/instrument.h"
@@ -3262,6 +3263,15 @@ pgstat_send_bgwriter(void)
 {
 	/* We assume this initializes to zeroes */
 	static const PgStat_MsgBgWriter all_zeroes;
+
+	/*
+	 * Non hot standby mirror should not send bgwriter statistics to the
+	 * stat collector, since stat collector is not started when mirror
+	 * is not in hot standby mode. Sending statistics would cause the
+	 * Recv-Q buffer to be filled up.
+	 */
+	if (!EnableHotStandby && IsRoleMirror())
+		return;
 
 	/*
 	 * This function can be called even if nothing at all has happened. In


### PR DESCRIPTION
…t in hot standby mode

Stat collector is not started when mirror is not in hot standby mode.
Sending statistics would cause the kernel Recv-Q buffer to be filled up.

Reviewed-by: Ashwin Agrawal <aashwin@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
