### PR TITLE
Implement two-stage sampling for AO/AOC analyze

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -288,7 +288,7 @@ close_ds_write(DatumStreamWrite **ds, int nvp)
  * GPDB_12_MERGE_FIXME: Find a better name to match what this function is
  * actually doing
  */
-static void
+void
 aocs_initscan(AOCSScanDesc scan)
 {
 	MemoryContext	oldCtx;
@@ -322,13 +322,15 @@ aocs_initscan(AOCSScanDesc scan)
 
 	scan->cur_seg = -1;
 	scan->cur_seg_row = 0;
+	scan->total_row = 0;
+	scan->rows_to_scan = 0;
 
 	ItemPointerSet(&scan->cdb_fake_ctid, 0, 0);
 
 	pgstat_count_heap_scan(scan->rs_base.rs_rd);
 }
 
-static int
+int
 open_next_scan_seg(AOCSScanDesc scan)
 {
 	while (++scan->cur_seg < scan->total_seg)
@@ -426,7 +428,7 @@ open_next_scan_seg(AOCSScanDesc scan)
 	return -1;
 }
 
-static void
+void
 close_cur_scan_seg(AOCSScanDesc scan)
 {
 	if (scan->cur_seg < 0)
@@ -539,6 +541,9 @@ aocs_beginscan_internal(Relation relation,
 	scan->seginfo = seginfo;
 	scan->total_seg = total_seg;
 	scan->columnScanInfo.scanCtx = CurrentMemoryContext;
+
+	/* block size for analyze scan */
+	scan->analyze_block_size = gp_appendonly_analyze_block_size;
 
 	/* relationTupleDesc will be inited by the slot when needed */
 	scan->columnScanInfo.relationTupleDesc = NULL;
@@ -811,6 +816,7 @@ ReadNext:
 			}
 		}
 
+		scan->total_row++;
 		scan->cur_seg_row++;
 		if (rowNum == INT64CONST(-1))
 		{

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -140,6 +140,9 @@ static void AppendOnlyExecutorReadBlock_Init(
 static void AppendOnlyExecutorReadBlock_Finish(
 								   AppendOnlyExecutorReadBlock *executorReadBlock);
 
+static void AppendOnlyExecutorReadBlock_NewSegmentCounts(
+										AppendOnlyExecutorReadBlock *executorReadBlock);
+
 static void AppendOnlyExecutorReadBlock_ResetCounts(
 										AppendOnlyExecutorReadBlock *executorReadBlock);
 
@@ -174,7 +177,7 @@ initscan(AppendOnlyScanDesc scan, ScanKey key)
 /*
  * Open the next file segment to scan and allocate all resources needed for it.
  */
-static bool
+bool
 SetNextFileSegForRead(AppendOnlyScanDesc scan)
 {
 	Relation	reln = scan->aos_rd;
@@ -342,6 +345,8 @@ SetNextFileSegForRead(AppendOnlyScanDesc scan)
 												 &scan->executorReadBlock,
 												  /* blockFirstRowNum */ 1);
 
+	AppendOnlyExecutorReadBlock_NewSegmentCounts(&scan->executorReadBlock);
+
 	/* ready to go! */
 	scan->aos_need_new_segfile = false;
 
@@ -505,7 +510,7 @@ SetCurrentFileSegForWrite(AppendOnlyInsertDesc aoInsertDesc)
 /*
  * Finished scanning this file segment. Close it.
  */
-static void
+void
 CloseScannedFileSeg(AppendOnlyScanDesc scan)
 {
 	AppendOnlyStorageRead_CloseFile(&scan->storageRead);
@@ -554,7 +559,7 @@ CloseWritableFileSeg(AppendOnlyInsertDesc aoInsertDesc)
 
 /* ------------------------------------------------------------------------------ */
 
-static void
+void
 AppendOnlyExecutorReadBlock_GetContents(AppendOnlyExecutorReadBlock *executorReadBlock)
 {
 	VarBlockCheckError varBlockCheckError;
@@ -745,7 +750,7 @@ AppendOnlyExecutorReadBlock_GetContents(AppendOnlyExecutorReadBlock *executorRea
 	}
 }
 
-static bool
+bool
 AppendOnlyExecutorReadBlock_GetBlockInfo(AppendOnlyStorageRead *storageRead,
 										 AppendOnlyExecutorReadBlock *executorReadBlock)
 {
@@ -797,7 +802,7 @@ AppendOnlyExecutionReadBlock_SetPositionInfo(AppendOnlyExecutorReadBlock *execut
 	executorReadBlock->blockFirstRowNum = blockFirstRowNum;
 }
 
-static void
+void
 AppendOnlyExecutionReadBlock_FinishedScanBlock(AppendOnlyExecutorReadBlock *executorReadBlock)
 {
 	executorReadBlock->blockFirstRowNum += executorReadBlock->rowCount;
@@ -852,9 +857,17 @@ AppendOnlyExecutorReadBlock_Finish(AppendOnlyExecutorReadBlock *executorReadBloc
 }
 
 static void
+AppendOnlyExecutorReadBlock_NewSegmentCounts(AppendOnlyExecutorReadBlock *executorReadBlock)
+{
+	executorReadBlock->segmentRowsScanned = 0;
+}
+
+static void
 AppendOnlyExecutorReadBlock_ResetCounts(AppendOnlyExecutorReadBlock *executorReadBlock)
 {
-	executorReadBlock->totalRowsScannned = 0;
+	executorReadBlock->totalRowsScanned = 0;
+	executorReadBlock->rows_to_scan = 0;
+	AppendOnlyExecutorReadBlock_NewSegmentCounts(executorReadBlock);
 }
 
 /*
@@ -1124,7 +1137,9 @@ AppendOnlyExecutorReadBlock_ScanNextTuple(AppendOnlyExecutorReadBlock *executorR
 
 				executorReadBlock->currentItemCount++;
 
-				executorReadBlock->totalRowsScannned++;
+				executorReadBlock->segmentRowsScanned++;
+
+				executorReadBlock->totalRowsScanned++;
 
 				if (itemLen > 0)
 				{
@@ -1177,7 +1192,9 @@ AppendOnlyExecutorReadBlock_ScanNextTuple(AppendOnlyExecutorReadBlock *executorR
 				executorReadBlock->singleRow = NULL;
 				executorReadBlock->singleRowLen = 0;
 
-				executorReadBlock->totalRowsScannned++;
+				executorReadBlock->segmentRowsScanned++;
+
+				executorReadBlock->totalRowsScanned++;
 
 				if (AppendOnlyExecutorReadBlock_ProcessTuple(
 															 executorReadBlock,
@@ -1286,7 +1303,7 @@ AppendOnlyExecutorReadBlock_FetchTuple(AppendOnlyExecutorReadBlock *executorRead
 /*
  * You can think of this scan routine as get next "executor" AO block.
  */
-static bool
+bool
 getNextBlock(AppendOnlyScanDesc scan)
 {
 	if (scan->aos_need_new_segfile)
@@ -1644,6 +1661,9 @@ appendonly_beginrangescan_internal(Relation relation,
 	scan->snapshot = snapshot;
 	scan->aos_nkeys = nkeys;
 	scan->aoScanInitContext = CurrentMemoryContext;
+
+	/* block size for analyze scan */
+	scan->analyze_block_size = gp_appendonly_analyze_block_size;
 
 	initStringInfo(&titleBuf);
 	appendStringInfo(&titleBuf, "Scan of Append-Only Row-Oriented relation '%s'",

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1114,6 +1114,28 @@ appendonly_analyze_find_segment(AppendOnlyScanDesc scan, int64 targetrow)
 	return true;
 }
 
+/*
+ * AO table on a physical level is a collection of segments,
+ * each constructed from a variable sized blocks. This approach is
+ * not suitable for algorithm S from Knuth used by acquire_sample_rows().
+ * To overcome this limitation we treat AO table as a collection of
+ * segment files with a global sequence of rows among them.
+ *
+ * For example:
+ * - segno 1 with 100 rows - global positions 0-99
+ * - segno 2 with 200 rows - global positions 100-299
+ *
+ * This global sequence of rows is divided on some arbitrary number of
+ * "logical" analyze blocks fitting BlockNumber (uint32). These blocks
+ * are not interconnected with variable sized physical blocks of segment
+ * files - it is simply a range of global row positions. So block sampling
+ * by algorithm S from Knuth gives us the starting global position of a
+ * target block (the size of the block is fixed and known). We get a benefit
+ * of this schema when the number of blocks is more that 300 * statistics
+ * target. So if we are lucky enough there would be several physical variable
+ * sized blocks between logical blocks and we can just read their headers
+ * without data decompression.
+ */
 static bool
 appendonly_scan_analyze_next_block(TableScanDesc scan, BlockNumber blockno,
 							   BufferAccessStrategy bstrategy)

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1388,32 +1388,7 @@ acquire_sample_rows(Relation onerel, int elevel,
 											  totalrows, totaldeadrows);
 	}
 
-	/*
-	 * GPDB: Analyze does make a lot of assumptions regarding the file layout of a
-	 * relation. These assumptions are heap specific and do not hold for AO/AOCO
-	 * relations. In the case of AO/AOCO, what is actually needed and used instead
-	 * of number of blocks, is number of tuples.
-	 *
-	 * GPDB_12_MERGE_FIXME: BlockNumber is uint32 and Number of tuples is uint64.
-	 * That means that after row number UINT_MAX we will never analyze the table.
-	 */
-	if (RelationIsAppendOptimized(onerel))
-	{
-		BlockNumber pages;
-		double		tuples;
-		double		allvisfrac;
-		int32		attr_widths;
-
-		table_relation_estimate_size(onerel,	&attr_widths, &pages,
-									&tuples, &allvisfrac);
-
-		if (tuples > UINT_MAX)
-			tuples = UINT_MAX;
-
-		totalblocks = (BlockNumber)tuples;
-	}
-	else
-		totalblocks = RelationGetNumberOfBlocks(onerel);
+	totalblocks = RelationGetNumberOfBlocks(onerel);
 
 	/* Need a cutoff xmin for HeapTupleSatisfiesVacuum */
 	OldestXmin = GetOldestXmin(onerel, PROCARRAY_FLAGS_VACUUM);

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -1083,7 +1083,7 @@ datumstreamwrite_lob(DatumStreamWrite * acc,
 	return varLen;
 }
 
-static bool
+bool
 datumstreamread_block_info(DatumStreamRead * acc)
 {
 	bool		readOK = false;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -137,6 +137,7 @@ bool        Test_print_prefetch_joinqual = false;
 bool		Test_copy_qd_qe_split = false;
 bool		gp_permit_relation_node_change = false;
 int			gp_max_local_distributed_cache = 1024;
+int			gp_appendonly_analyze_block_size = 0;
 bool		gp_appendonly_verify_block_checksums = true;
 bool		gp_appendonly_verify_write_block = false;
 bool		gp_appendonly_compaction = true;
@@ -2961,6 +2962,17 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&gp_max_plan_size,
 		0, 0, MAX_KILOBYTES,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"gp_appendonly_analyze_block_size", PGC_USERSET, APPENDONLY_TABLES,
+			gettext_noop("AO/AOC relation logical block size we try to use during analyze."
+						 "We can use a larger block size if the resulting block number is too big."),
+			NULL
+		},
+		&gp_appendonly_analyze_block_size,
+		100, 1, APPENDONLY_ANALYZE_BLOCK_SIZE > INT_MAX ? INT_MAX : (int) APPENDONLY_ANALYZE_BLOCK_SIZE,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -108,14 +108,14 @@ typedef struct AOCSScanDescData
 
 	/* synthetic system attributes */
 	ItemPointerData cdb_fake_ctid;
-	int64 total_row;
-	int64 cur_seg_row;
+	int64 total_row;	/* row count behind current position among all scanned segments */
+	int64 cur_seg_row;	/* row count behind current position in a current segment */
 
 	/*
 	 * Only used by `analyze`
 	 */
-	int64		nextTupleId;
-	int64		targetTupleId;
+	int64		analyze_block_size;
+	int64		rows_to_scan;	/* row count left to scan during analyze */
 
 	/*
 	 * Part of the struct to be used only inside aocsam.c
@@ -297,8 +297,11 @@ extern AOCSScanDesc aocs_beginrangescan(Relation relation, Snapshot snapshot,
 
 extern void aocs_rescan(AOCSScanDesc scan);
 extern void aocs_endscan(AOCSScanDesc scan);
+extern void aocs_initscan(AOCSScanDesc scan);
 
 extern bool aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot);
+extern int open_next_scan_seg(AOCSScanDesc scan);
+extern void close_cur_scan_seg(AOCSScanDesc scan);
 extern AOCSInsertDesc aocs_insert_init(Relation rel, int segno);
 extern void aocs_insert_values(AOCSInsertDesc idesc, Datum *d, bool *null, AOTupleId *aoTupleId);
 static inline void aocs_insert(AOCSInsertDesc idesc, TupleTableSlot *slot)

--- a/src/include/utils/datumstream.h
+++ b/src/include/utils/datumstream.h
@@ -315,6 +315,7 @@ extern void datumstreamread_rewind_block(DatumStreamRead * datumStream);
 extern bool datumstreamread_find_block(DatumStreamRead * datumStream,
 						   DatumStreamFetchDesc datumStreamFetchDesc,
 						   int64 rowNum);
+extern bool datumstreamread_block_info(DatumStreamRead * acc);
 extern void *datumstreamread_get_upgrade_space(DatumStreamRead *datumStream,
 											   size_t len);
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -293,6 +293,7 @@ extern bool Debug_bitmap_print_insert;
 extern bool enable_checksum_on_tables;
 extern int  gp_max_local_distributed_cache;
 extern bool gp_local_distributed_cache_stats;
+extern int	gp_appendonly_analyze_block_size;
 extern bool gp_appendonly_verify_block_checksums;
 extern bool gp_appendonly_verify_write_block;
 extern bool gp_appendonly_compaction;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -150,6 +150,7 @@
 		"gp_adjust_selectivity_for_outerjoins",
 		"gp_allow_non_uniform_partitioning_ddl",
 		"gp_allow_rename_relation_without_lock",
+		"gp_appendonly_analyze_block_size",
 		"gp_appendonly_compaction",
 		"gp_appendonly_compaction_threshold",
 		"gp_appendonly_verify_block_checksums",


### PR DESCRIPTION
To calculate statistics at first we have to retrieve in reservoir some representative sample from relation. PostgreSQL uses two stage sampling to avoid sequential scan of the whole relation:

* at first it samples blocks with algorithm S from Knuth
* for each block it samples tuples with algorithm Z from Vitter

To make it work every AM has to know how to estimate block number for any relation. These blocks should be of the fix size to make algorithm S from Knuth work correctly. Previously, AO/AOC relations didn't use two stage sampling and sequentially scanned the whole relation. The main reason for it was the fact that segment files are constructed from variable sized blocks (that are not suitable for algorithm S from Knuth).

Current implementation treats AO/AOC relations as a collection of segment files with a global sequence of rows among them:

* segno 1 with 100 rows - its rows are treated as global positions 0-99
* segno 2 with 200 rows - its rows are treated as global positions 100-299

This global sequence of rows is divided on some arbitrary number of "logical" analyze blocks fitting BlockNumber (uint32). These blocks are not interconnected with variable sized physical blocks of segment files - it is simply a range of global row positions. So block sampling by algorithm S from Knuth gives us the starting global position of a target block (the size of the block is fixed and known). We get a benefit of this schema when the number of blocks is more that 300 * statistics target.
So if we are lucky enough there would be several physical variable sized blocks between logical blocks and we can just read their headers without decompressing data. This is the main idea of speeding up AO/AOC analyze. After that we simply iterate among all rows in a logical analyze block and fill reservoir with samples.

To divide AO/AOC table into logical blocks we introduce a new GUC `gp_appendonly_analyze_block_size` controlling the default analyze block size. We divide AO/AOC table with logical blocks of this size. If the result number of blocks doesn't fit BlockNumber we replace it with the maximum possible number of blocks (`2^33-1`).

Current implementation is suboptimal in AOC projections at the beginning of analyze scan: AM API doesn't allow us to project only required columns for analyze scan and we have to scan all of them. It would be nice to improve AM cause a simple scan is initialised with such projection, but analyze scan is not.

I would also like to explain why we use fix sized logical blocks sampling with algorithm S from Knuth instead of weighted random sampling (WRS) algorithms (A-Chao or Efraimidis and Spirakis). At first I tried them but was confused with AOC sampling. Every column has its own variable sized blocks with different sizes and I didn't know what column to choose for WRS. The only thing in common among all columns segment files was the row count, so that was the reason to chose sampling based on fix sized logical blocks in a global sequence of rows in a table.