### PR TITLE
gpconfig always shows client_min_messages value as error

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -225,7 +225,7 @@ def get_gucs_from_database(gucname):
         # we always want to unset search path except when getting the
         # 'search_path' GUC itself
         unsetSearchPath = gucname != 'search_path'
-        conn = dbconn.connect(dburl, False, unsetSearchPath=unsetSearchPath)
+        conn = dbconn.connect(dburl, False, True, unsetSearchPath=unsetSearchPath)
         query = ToolkitQuery(gucname).query
         cursor = dbconn.execSQL(conn, query)
         # we assume that all roles are primary due to the query.

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -83,6 +83,7 @@ Feature: gpconfig integration tests
         | utf-8 works                            | search_path                  | string     | boo        | Ομήρου    | 'Ομήρου'   | Ομήρου     | Ομήρου            | 'Ομήρου'               | Ομήρου       | 'Ομήρου'          | Ομήρου            |
 #       | integer with time unit with spaces     | statement_timeout            | int w/unit | 2min       | "'7 min'" | '7 min'    | 7min       | "'7 min'"         | '7 min'                | "'7 min'"    | '7 min'           | 7min              |
 # 'Integer with time unit with spaces' fails because the live server parses '7 min' as 7min, and our comparison logic does not handle this correctly.
+        | client min messages works              | client_min_messages          | string     | log        | notice    | notice     | notice     | notice            | notice                 | notice       | notice            | notice            |
 
     @concourse_cluster
     @demo_cluster


### PR DESCRIPTION
gpconfig invokes dbconn.Connect with verbose=False due to which
client_min_messages is set to error for that connection and gpconfig -s
client_min_messages always shows error instead of the actual value.
So, instead pass verbose=True for connect with gpconfig. Ran gpconfig -s
for all the parameters and there is no case where it was printing any
warning with libpq.

Backport of #11191 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
