### PR TITLE
Don't do port validation if passed explicity by configuration file

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
+++ b/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
@@ -511,7 +511,8 @@ class GpAddMirrorsProgram:
         # check that heap_checksums is consistent across cluster, fail immediately if not
         self.validate_heap_checksums(gpArray)
 
-        self.checkMirrorOffset(gpArray)
+        if self.__options.mirrorConfigFile is None:
+            self.checkMirrorOffset(gpArray)
         
         # check that we actually have mirrors
         if gpArray.hasMirrors:

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -83,7 +83,7 @@ Feature: gpconfig integration tests
 #       | integer with time unit with spaces     | statement_timeout            | int w/unit | 2min       | "'7 min'" | '7 min'    | 7min       | "'7 min'"         | '7 min'                | "'7 min'"    | '7 min'           | 7min              |
 # 'Integer with time unit with spaces' fails because the live server parses '7 min' as 7min, and our comparison logic does not handle this correctly.
         | utf-8 works                            | search_path                  | string     | boo        | Ομήρου    | 'Ομήρου'   | Ομήρου     | Ομήρου            | 'Ομήρου'               | Ομήρου       | 'Ομήρου'          | Ομήρου            |
-        | client min messages works              | client_min_messages          | string     | log        | notice    | notice     | notice     | notice            | 'notice'               | notice       | notice            | notice            |
+        | client min messages works              | client_min_messages          | string     | log        | notice    | notice     | notice     | notice            | notice                 | notice       | notice            | notice            |
 
     @skip_fixme_ubuntu18.04
     Examples:


### PR DESCRIPTION
If the configuration to add mirrors is passed by -i parameters, don't
perform mirror offset calculation as the entries in the files are
manually edited based on the preference of the customer.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
