### PR TITLE
Reinstate GPOS_OOM_CHECK in CMemoryPoolTracker::NewImpl

### DIFF
--- a/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp
@@ -80,12 +80,6 @@ CMemoryPoolTracker::NewImpl(const ULONG bytes, const CHAR *file,
 
 	void *ptr = clib::Malloc(alloc_size);
 
-	// check if allocation failed
-	if (NULL == ptr)
-	{
-		return NULL;
-	}
-
 	GPOS_OOM_CHECK(ptr);
 
 	// successful allocation: update header information and any memory pool data


### PR DESCRIPTION
Issue is that when Malloc returns NULL due to OOM, we no longer raise
through GPOS_OOM_CHECK, which was the previous behavior (commit
644d3131826). The fallout of this is that callers of NewImpl() can
SIGSEGV, for example in NewArrayImpl().

Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>

This needs backport to 6X and 5X