### PR TITLE
Dropping column in distribution policy may cause crash

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -8696,7 +8696,7 @@ ATExecDropColumn(List **wqueue, Relation rel, const char *colName,
 				GpPolicyReplace(RelationGetRelid(rel), policy);
 				rel->rd_cdbpolicy = policy;
 				if (Gp_role != GP_ROLE_EXECUTE)
-				    ereport(NOTICE,
+				    ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							 errmsg("dropping a column that is part of the distribution policy forces a NULL distribution policy")));
 			}


### PR DESCRIPTION
create table exchange_part(a int, b int) partition by range(b) (start (0) end(10) every(5));
create table exchange1(a int, c int, b int)distributed by(a,c);

dropping column c in distribution policy may cause NULL distribution policy. After that excute alter table xx with table xx may cause postgres crash.

alter table exchange1 drop column c;
alter table exchange_part exchange partition for (1) with table exchange1;

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
create table exchange_part(a int, b int) partition by range(b) (start (0) end(10) every(5));
create table exchange1(a int, c int, b int)distributed by(a,c);

alter table exchange1 drop column c;
alter table exchange_part exchange partition for (1) with table exchange1;
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
