### PR TITLE
Fix memory leak in ao_truncate_replay

### DIFF
--- a/src/backend/cdb/cdbappendonlyxlog.c
+++ b/src/backend/cdb/cdbappendonlyxlog.c
@@ -140,6 +140,8 @@ ao_truncate_replay(XLogReaderState *record)
 		snprintf(path, MAXPGPATH, "%s/%u", dbPath, xlrec->target.node.relNode);
 	else
 		snprintf(path, MAXPGPATH, "%s/%u.%u", dbPath, xlrec->target.node.relNode, xlrec->target.segment_filenum);
+	pfree(dbPath);
+	dbPath = NULL;
 
 	file = PathNameOpenFile(path, O_RDWR | PG_BINARY);
 	if (file < 0)


### PR DESCRIPTION
The value returned by GetDatabasePath is palloc'd, and
CurrentMemoryContext is TopMemoryContext when we enter
ao_truncate_replay(), so we should do a pfree.

Fix #11202
