### PR TITLE
Remove locks in pg_get_expr()

### DIFF
--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -11490,8 +11490,3 @@
 
 { oid => 5066, descr => 'itemwise add two integer arrays',
    proname => 'array_add', prorettype => '_int4', proargtypes => '_int4 _int4', prosrc => 'array_int4_add' },
-
-{ oid => '7021',
-  descr => 'deparse an encoded expression',
-  proname => 'pg_get_expr', provolatile => 's', prorettype => 'text',
-  proargtypes => 'pg_node_tree oid bool bool', prosrc => 'pg_get_expr_ext_lock' },


### PR DESCRIPTION
Locks were introduced by #7478 to prevent flaky tests using pg_partitions. But this view currently does not exist, so it's safe
to return to REL_12_STABLE implementation of pg_get_expr().

cc @d 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
