### PR TITLE
Resolve bitmap index pages GPDB_12_MERGE_FIXMEs.

### DIFF
--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -45,7 +45,7 @@ select count(*) from bm_test where i in(1, 3);
 (1 row)
 
 drop index bm_test_idx;
-create index bm_test_multi_idx on bm_test using bitmap(i, t);
+create index bm_test_coll_idx on bm_test using bitmap(i, t COLLATE "C");
 select * from bm_test where i=5 and t='5';
  i | t 
 ---+---

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -45,7 +45,7 @@ select count(*) from bm_test where i in(1, 3);
 (1 row)
 
 drop index bm_test_idx;
-create index bm_test_multi_idx on bm_test using bitmap(i, t);
+create index bm_test_coll_idx on bm_test using bitmap(i, t COLLATE "C");
 select * from bm_test where i=5 and t='5';
  i | t 
 ---+---

--- a/src/test/regress/sql/bitmap_index.sql
+++ b/src/test/regress/sql/bitmap_index.sql
@@ -17,7 +17,7 @@ select * from bm_test where i > 10;
 reindex index bm_test_idx;
 select count(*) from bm_test where i in(1, 3);
 drop index bm_test_idx;
-create index bm_test_multi_idx on bm_test using bitmap(i, t);
+create index bm_test_coll_idx on bm_test using bitmap(i, t COLLATE "C");
 select * from bm_test where i=5 and t='5';
 select * from bm_test where i=5 or t='6';
 


### PR DESCRIPTION
Pass the index attribute collation for build_hash_key and
build_match_key from the index relation.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
