### PR TITLE
gpstart: improve testing of handling down hosts

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1828,6 +1828,19 @@ def impl(context, gppkg_name):
             raise Exception( '"%s" gppkg is not installed on host: %s. \nInstalled packages: %s' % (gppkg_name, hostname, cmd.get_stdout()))
 
 
+@given('the user runs command "{command}" on all hosts without validation')
+@when('the user runs command "{command}" on all hosts without validation')
+@then('the user runs command "{command}" on all hosts without validation')
+def impl(context, command):
+    hostlist = get_all_hostnames_as_list(context, 'template1')
+
+    for hostname in set(hostlist):
+        cmd = Command(name='running command:%s' % command,
+                      cmdStr=command,
+                      ctxt=REMOTE,
+                      remoteHost=hostname)
+        cmd.run(validateAfter=False)
+
 @given('"{gppkg_name}" gppkg files do not exist on any hosts')
 @when('"{gppkg_name}" gppkg files do not exist on any hosts')
 @then('"{gppkg_name}" gppkg files do not exist on any hosts')


### PR DESCRIPTION
We add a down mirror case.  This was tricky as Greenplum only detects
a down mirror after a timeout period.  We also needed to make sure this
test works on a multihost cluster.

We also refactored the tests.  This improves the testing of the merged https://github.com/greenplum-db/gpdb/pull/11002.

Co-authored-by: David Krieger <dkrieger@vmware.com>