### PR TITLE
Coverity: Remove logically dead code

### DIFF
--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -2486,16 +2486,6 @@ keep_going:						/* We will come back to here until there is
 						goto keep_going;
 					}
 
-					if (addr_cur == NULL)
-					{
-						/*
-						 * Ooops, no more addresses.  An appropriate error
-						 * message is already set up, so just set the right
-						 * status.
-						 */
-						goto error_return;
-					}
-
 					/* Remember current address for possible error msg */
 					memcpy(&conn->raddr.addr, addr_cur->ai_addr,
 						   addr_cur->ai_addrlen);


### PR DESCRIPTION
Reported by coverity check.

addr_cur is already checked above and will `goto keep_going;` when addr_cur is NULL

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
