### PR TITLE
Coverity: Copy paste error in vacuum param check

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -2741,7 +2741,7 @@ vacuum_params_to_options_list(VacuumParams *params)
 	else if (params->index_cleanup == VACOPT_TERNARY_ENABLED)
 		options = lappend(options, makeDefElem("index_cleanup", (Node *) makeInteger(1), -1));
 	else
-		elog(ERROR, "unexpected VACUUM 'index_cleanup' option '%d'", (int) params->truncate);
+		elog(ERROR, "unexpected VACUUM 'index_cleanup' option '%d'", (int) params->index_cleanup);
 
 	/* GPDB_12_MERGE_FIXME: Should we do something about 'is_wraparound',
 	 * multixact_freeze ages and other options? */


### PR DESCRIPTION
Index cleanup error message should include params->index_cleanup

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
