### PR TITLE
Coverity: Wrong sizeof argument

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -307,7 +307,7 @@ aocs_initscan(AOCSScanDesc scan)
 	{
 		scan->columnScanInfo.num_proj_atts = natts;
 		scan->columnScanInfo.proj_atts = (AttrNumber *)
-										 palloc0(natts * sizeof(AttrNumber *));
+										 palloc0(natts * sizeof(AttrNumber));
 
 		for (AttrNumber attno = 0; attno < natts; attno++)
 			scan->columnScanInfo.proj_atts[attno] = attno;
@@ -556,7 +556,8 @@ aocs_beginscan_internal(Relation relation,
 	if (proj)
 	{
 		natts = RelationGetNumberOfAttributes(relation);
-		scan->columnScanInfo.proj_atts = palloc0(natts * sizeof(AttrNumber *));
+		scan->columnScanInfo.proj_atts = (AttrNumber *)
+										 palloc0(natts * sizeof(AttrNumber));
 		scan->columnScanInfo.num_proj_atts = 0;
 
 		for (AttrNumber i = 0; i < natts; i++)


### PR DESCRIPTION
should replace sizeof(AttrNumber*) with sizeof(AttrNumber).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
