### PR TITLE
Coverity: Unchecked return value

### DIFF
--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -1159,7 +1159,10 @@ BufFileResume(BufFile *buffile)
 	Assert(buffile->buffer.data == NULL);
 	buffile->buffer.data = palloc(BLCKSZ);
 
-	BufFileSeek(buffile, 0, 0, SEEK_SET);
+	if (BufFileSeek(buffile, 0, 0, SEEK_SET) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not seek to the first block of temporary file: %m")));
 }
 
 /*


### PR DESCRIPTION
should check the return value of BufFileSeek

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
