### PR TITLE
Fix resqueue's CPU priority invalid in segments

### DIFF
--- a/src/backend/utils/mmgr/portalmem.c
+++ b/src/backend/utils/mmgr/portalmem.c
@@ -223,11 +223,16 @@ CreatePortal(const char *name, bool allowDup, bool dupSilent)
 	portal->visible = true;
 	portal->creation_time = GetCurrentStatementStartTimestamp();
 
-	/* set portal id and queue id if have enabled resource scheduling */
-	if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled())
+	if (IsResQueueEnabled())
 	{
-		portal->portalId = ResCreatePortalId(name);
-		portal->queueId = GetResQueueId();
+		/* Only QD needs to set portal id if have enabled resource scheduling */
+		if (Gp_role == GP_ROLE_DISPATCH)
+		{
+			portal->portalId = ResCreatePortalId(name);
+			portal->queueId = GetResQueueId();
+		}
+		else if (Gp_role == GP_ROLE_EXECUTE)
+			portal->queueId = GetResQueueId();
 	}
 	portal->is_extended_query = false; /* default value */
 

--- a/src/test/regress/expected/resource_queue.out
+++ b/src/test/regress/expected/resource_queue.out
@@ -182,6 +182,32 @@ ERROR:  Invalid parameter value "0" for resource type "MEMORY_LIMIT". Value must
 create resource queue test_rq with (active_statements=2);
 drop resource queue test_rq;
 create resource queue test_rq with (active_statements=2, memory_limit='1024MB');
+--
+-- CPU priority feature
+--
+create resource queue test_rq_cpu with (active_statements=2, priority='HIGH');
+create user test_rp_user with login;
+alter role test_rp_user resource queue test_rq_cpu;
+SET ROLE test_rp_user;
+-- query priority and weight on master
+select rqppriority, rqpweight from gp_toolkit.gp_resq_priority_backend where rqpsession in (select sess_id from pg_stat_activity where pid  = pg_backend_pid());
+ rqppriority | rqpweight 
+-------------+-----------
+ HIGH        |      1000
+(1 row)
+
+-- query priority and weight on segments
+select rqppriority, rqpweight from gp_dist_random('gp_toolkit.gp_resq_priority_backend') where rqpsession in (select sess_id from pg_stat_activity where pid  = pg_backend_pid());
+ rqppriority | rqpweight 
+-------------+-----------
+ HIGH        |      1000
+ HIGH        |      1000
+ HIGH        |      1000
+(3 rows)
+
+RESET ROLE;
+drop user test_rp_user;
+drop resource queue test_rq_cpu;
 -- Alters
 alter resource queue test_rq with (memory_limit='1024mb');
 ERROR:  Invalid parameter value "1024mb" for resource type "MEMORY_LIMIT". Value must be in kB, MB or GB.

--- a/src/test/regress/sql/resource_queue.sql
+++ b/src/test/regress/sql/resource_queue.sql
@@ -96,6 +96,21 @@ create resource queue test_rq with (active_statements=2);
 drop resource queue test_rq;
 create resource queue test_rq with (active_statements=2, memory_limit='1024MB');
 
+--
+-- CPU priority feature
+--
+create resource queue test_rq_cpu with (active_statements=2, priority='HIGH');
+create user test_rp_user with login;
+alter role test_rp_user resource queue test_rq_cpu;
+SET ROLE test_rp_user;
+-- query priority and weight on master
+select rqppriority, rqpweight from gp_toolkit.gp_resq_priority_backend where rqpsession in (select sess_id from pg_stat_activity where pid  = pg_backend_pid());
+-- query priority and weight on segments
+select rqppriority, rqpweight from gp_dist_random('gp_toolkit.gp_resq_priority_backend') where rqpsession in (select sess_id from pg_stat_activity where pid  = pg_backend_pid());
+RESET ROLE;
+drop user test_rp_user;
+drop resource queue test_rq_cpu;
+
 -- Alters
 
 alter resource queue test_rq with (memory_limit='1024mb');


### PR DESCRIPTION
When creating a portal, we should assign the portal->queueId with
GetResQueueId() not only for master, but also for segments. Or,
resqueue's CPU priority will have no effect.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
