### PR TITLE
gpconfig always shows client_min_messages value as error

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -212,7 +212,7 @@ def do_list(skipvalidation):
 def get_gucs_from_database(gucname):
     try:
         dburl = dbconn.DbURL()
-        conn = dbconn.connect(dburl, False)
+        conn = dbconn.connect(dburl, False, True)
         query = ToolkitQuery(gucname).query
         cursor = dbconn.execSQL(conn, query)
         # we assume that all roles are primary due to the query.


### PR DESCRIPTION
gpconfig invokes dbconn.Connect with verbose=False due to which
client_min_messages is set to error for that connection and gpconfig -s
client_min_messages always shows error instead of the actual value.
So, instead pass verbose=True for connect with gpconfig. Ran gpconfig -s
for all the parameters and there is no case where it was printing any
warning with libpq.

backport of #11192 