### PR TITLE
Replace copy-paste with a function call

### DIFF
--- a/src/backend/cdb/cdblegacyhash.c
+++ b/src/backend/cdb/cdblegacyhash.c
@@ -408,7 +408,7 @@ cdblegacyhash_char(PG_FUNCTION_ARGS)
 	PG_RETURN_UINT32(hashFn(&char_buf, 1));
 }
 
-/* also for VARCHAR */
+/* also for BPCHAR and VARCHAR */
 Datum
 cdblegacyhash_text(PG_FUNCTION_ARGS)
 {
@@ -434,23 +434,7 @@ cdblegacyhash_text(PG_FUNCTION_ARGS)
 Datum
 cdblegacyhash_bpchar(PG_FUNCTION_ARGS)
 {
-	BpChar	   *bpchar_buf = PG_GETARG_BPCHAR_PP(0);
-	int			len;
-	void	   *buf;		/* pointer to the data */
-	uint32		hash;
-
-	buf = (void *) VARDATA_ANY(bpchar_buf);
-	len = VARSIZE_ANY_EXHDR(bpchar_buf);
-	/* adjust length to not include trailing blanks */
-	if (len > 1)
-		len = ignoreblanks((char *) buf, len);
-
-	hash = hashFn(buf, len);
-
-	/* Avoid leaking memory for toasted inputs */
-	PG_FREE_IF_COPY(bpchar_buf, 0);
-
-	PG_RETURN_UINT32(hash);
+	return cdblegacyhash_text(fcinfo);
 }
 
 Datum


### PR DESCRIPTION
Following up on 3df1dcbc56cc65a0, we don't have to duplicate the legacy
hash function for text, simply calling it suffices.

No catver bump.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
