### PR TITLE
[6X Backport]Some functions do dispatch so they should not execute on entry db.

### DIFF
--- a/src/test/regress/expected/db_size_functions.out
+++ b/src/test/regress/expected/db_size_functions.out
@@ -108,6 +108,11 @@ select pg_total_relation_size('pg_tables');
                       0
 (1 row)
 
+-- Test that run pg_relation_size, pg_total_relation_size on entryDB is not supported.
+create temp table t1 as select pg_relation_size('pg_tables') from pg_class limit 1;
+ERROR:  This query is not currently supported by GPDB.
+create temp table t1 as select pg_total_relation_size('pg_tables') from pg_class limit 1;
+ERROR:  This query is not currently supported by GPDB.
 --
 -- Tests on the table and index size variants.
 --

--- a/src/test/regress/sql/db_size_functions.sql
+++ b/src/test/regress/sql/db_size_functions.sql
@@ -38,6 +38,9 @@ select pg_table_size('pg_tables');
 select pg_indexes_size('pg_tables');
 select pg_total_relation_size('pg_tables');
 
+-- Test that run pg_relation_size, pg_total_relation_size on entryDB is not supported.
+create temp table t1 as select pg_relation_size('pg_tables') from pg_class limit 1;
+create temp table t1 as select pg_total_relation_size('pg_tables') from pg_class limit 1;
 
 --
 -- Tests on the table and index size variants.


### PR DESCRIPTION
Error out if this kind of functions runs on entry DB, so
user will not confuse with the generated wrong results.

(cherry picked from commit ca90fb093c0e4c9f968427a4512f8e33882df5ec)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
