### PR TITLE
gpstart: improve handling of down segment hosts

### DIFF
--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -122,12 +122,19 @@ class GpStart:
             if self.masteronly:
                 return 0
 
+            num_workers = min(len(self.gparray.get_hostlist()), self.parallel)
+            # We check for unreachable segment hosts first thing, because if a host is down but its segments
+            # are marked up, later checks can return invalid or misleading results and the cluster may not
+            # start in a good state.
+            unreachable_hosts = self.get_unreachable_segment_hosts(num_workers)
+            if unreachable_hosts:
+                self.mark_segments_down_for_unreachable_hosts(unreachable_hosts)
+
             if self.skip_heap_checksum_validation:
                 self.master_checksum_value = None
                 logger.warning("Because of --skip-heap-checksum-validation, the GUC for data_checksums "
                                    "will not be checked between master and segments")
             else:
-                num_workers = min(len(self.gparray.get_hostlist()), self.parallel)
                 self.master_checksum_value = HeapChecksum(gparray=self.gparray, num_workers=num_workers,
                                                           logger=logger).get_master_value()
 
@@ -324,6 +331,46 @@ class GpStart:
         cmd.run(validateAfter=True)
         logger.info("Master Stopped...")
         raise ExceptionNoStackTraceNeeded("Standby activated, this node no more can act as master.")
+
+    def get_unreachable_segment_hosts(self, num_workers):
+        hostlist = set(self.gparray.get_hostlist(includeMaster=False))
+
+        pool = base.WorkerPool(numWorkers=num_workers)
+        try:
+            for host in hostlist:
+                cmd = Command(name='check %s is up' % host, cmdStr="ssh %s 'echo %s'" % (host, host))
+                pool.addCommand(cmd)
+            pool.join()
+        finally:
+            pool.haltWork()
+            pool.joinWorkers()
+
+        # There's no good way to map a CommandResult back to its originating Command so instead
+        # of looping through and finding the hosts that errored out, we remove any hosts that
+        # succeeded from the hostlist and any remaining hosts will be ones that were unreachable.
+        for item in pool.getCompletedItems():
+            result = item.get_results()
+            if result.rc == 0:
+                host = result.stdout.strip()
+                hostlist.remove(host)
+
+        if len(hostlist) > 0:
+            logger.warning("One or more hosts are not reachable via SSH.  Any segments on those hosts will be marked down")
+            for host in sorted(hostlist):
+                logger.warning("Host %s is unreachable" % host)
+            return hostlist
+        return None
+
+    def mark_segments_down_for_unreachable_hosts(self, unreachable_hosts):
+        # We only mark the segment down in gparray for use by later checks, as
+        # setting the actual segment down in gp_segment_configuration leads to
+        # an inconsistent state and may prevent the database from starting.
+        for segment in self.gparray.segments:
+            for seg in [segment.primaryDB] + segment.mirrorDBs:
+                host = seg.getSegmentHostName()
+                if host in unreachable_hosts:
+                    logger.warning("Marking segment %d down because %s is unreachable" % (seg.dbid, host))
+                    seg.setSegmentStatus(STATUS_DOWN)
 
     ######
     def _recovery_startup(self):

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -3,7 +3,9 @@ import signal
 import subprocess
 
 from behave import given, when, then
-from  test.behave_utils import utils
+from test.behave_utils import utils
+from test.behave_utils.utils import wait_for_unblocked_transactions
+from gppylib.db import dbconn
 
 @given('the temporary filespace is moved')
 def impl(context):
@@ -31,36 +33,25 @@ def _run_sql(sql, opts=None):
         "-c", sql,
     ], env=env)
 
-@when('the standby host goes down')
-def impl(context):
-    """
-    Fakes a host failure by updating the standby segment entry to point at an
-    invalid hostname and address.
-    """
-    opts = {
-        'gp_session_role': 'utility',
-        'allow_system_table_mods': 'dml',
-    }
+def change_hostname(content, preferred_role, hostname):
+    with dbconn.connect(dbconn.DbURL(dbname="template1"), allowSystemTableMods='dml') as conn:
+        dbconn.execSQL(conn, "UPDATE gp_segment_configuration SET hostname = '{0}', address = '{0}' WHERE content = {1} AND preferred_role = '{2}'".format(hostname, content, preferred_role))
+        conn.commit()
 
-    subprocess.check_call(['gpstart', '-am'])
-    _run_sql("""
-        UPDATE gp_segment_configuration
-           SET hostname = 'standby.invalid',
-                address = 'standby.invalid'
-         WHERE content = -1 AND role = 'm'
-    """, opts=opts)
-    subprocess.check_call(['gpstop', '-am'])
+@when('the standby host is made unreachable')
+def impl(context):
+    change_hostname(-1, 'm', 'invalid_host')
 
     def cleanup(context):
         """
         Reverses the above SQL by starting up in master-only utility mode. Since
         the standby host is incorrect, a regular gpstart call won't work.
         """
-
         utils.stop_database_if_started(context)
 
         subprocess.check_call(['gpstart', '-am'])
         _run_sql("""
+            SET allow_system_table_mods='dml';
             UPDATE gp_segment_configuration
                SET hostname = master.hostname,
                     address = master.address
@@ -70,7 +61,7 @@ def impl(context):
                       WHERE content = -1 and role = 'p'
                    ) master
              WHERE content = -1 AND role = 'm'
-        """, opts=opts)
+        """, {'gp_session_role': 'utility'})
         subprocess.check_call(['gpstop', '-am'])
 
     context.cleanup_standby_host_failure = cleanup
@@ -83,14 +74,14 @@ def _handle_sigpipe():
     """
     signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
-@when('gpstart is run with prompts accepted')
-def impl(context):
+@when('"{cmd}" is run with prompts accepted')
+def impl(context, cmd):
     """
-    Runs `yes | gpstart`.
+    Runs `yes | cmd`.
     """
 
     p = subprocess.Popen(
-        [ "bash", "-c", "yes | gpstart" ],
+        ["bash", "-c", "yes | %s" % cmd],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         preexec_fn=_handle_sigpipe,
@@ -98,3 +89,69 @@ def impl(context):
 
     context.stdout_message, context.stderr_message = p.communicate()
     context.ret_code = p.returncode
+
+@given('the host for the {seg_type} on content {content} is made unreachable')
+def impl(context, seg_type, content):
+    if seg_type == "primary":
+        preferred_role = 'p'
+    elif seg_type == "mirror":
+        preferred_role = 'm'
+    else:
+        raise Exception("Invalid segment type %s (options are primary and mirror)" % seg_type)
+
+    with dbconn.connect(dbconn.DbURL(dbname="template1")) as conn:
+        dbid, hostname = dbconn.execSQLForSingletonRow(conn, "SELECT dbid, hostname FROM gp_segment_configuration WHERE content = %s AND preferred_role = '%s'" % (content, preferred_role))
+    if not hasattr(context, 'old_hostnames'):
+        context.old_hostnames = {}
+    context.old_hostnames[(content, preferred_role)] = hostname
+    change_hostname(content, preferred_role, 'invalid_host')
+
+    if not hasattr(context, 'down_segment_dbids'):
+        context.down_segment_dbids = []
+    context.down_segment_dbids.append(dbid)
+
+    wait_for_unblocked_transactions(context)
+
+@then('gpstart should print unreachable host messages for the down segments')
+def impl(context):
+    if not hasattr(context, 'down_segment_dbids'):
+        raise Exception("Cannot check messages for down segments: no dbids are saved")
+    for dbid in sorted(context.down_segment_dbids):
+        context.execute_steps(u'Then gpstart should print "Marking segment %s down because invalid_host is unreachable" to stdout' % dbid)
+
+def must_have_expected_status(content, preferred_role, expected_status):
+    with dbconn.connect(dbconn.DbURL(dbname="template1")) as conn:
+        status = dbconn.execSQLForSingleton(conn, "SELECT status FROM gp_segment_configuration WHERE content = %s AND preferred_role = '%s'" % (content, preferred_role))
+    if status != expected_status:
+        raise Exception("Expected status for role %s to be %s, but it is %s" % (preferred_role, expected_status, status))
+
+@then('the status of the {seg_type} on content {content} should be "{expected_status}"')
+def impl(context, seg_type, content, expected_status):
+    if seg_type == "primary":
+        preferred_role = 'p'
+    elif seg_type == "mirror":
+        preferred_role = 'm'
+    else:
+        raise Exception("Invalid segment type %s (options are primary and mirror)" % seg_type)
+
+    wait_for_unblocked_transactions(context)
+
+    must_have_expected_status(content, preferred_role, expected_status)
+
+@then('the cluster is returned to a good state')
+def impl(context):
+    if not hasattr(context, 'old_hostnames'):
+        raise Exception("Cannot reset segment hostnames: no hostnames are saved")
+    for key, hostname in context.old_hostnames.items():
+        change_hostname(key[0], key[1], hostname)
+
+    context.execute_steps(u"""
+    When the user runs "gprecoverseg -a"
+    Then gprecoverseg should return a return code of 0
+    And all the segments are running
+    And the segments are synchronized
+    When the user runs "gprecoverseg -a -r"
+    Then gprecoverseg should return a return code of 0
+    And all the segments are running
+    And the segments are synchronized
+    """)

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4250,6 +4250,8 @@ def impl(context):
 	if len(statrep) != 1:
 		raise Exception("pg_stat_replication did not have standby master")
 
+	context.standby_dbid = segconfig[0][0]
+
 @when('user can "{can_ssh}" ssh locally on standby')
 @then('user can "{can_ssh}" ssh locally on standby')
 def impl(context, can_ssh):
@@ -5465,6 +5467,19 @@ def impl(context, gppkg_name):
         if not gppkg_name in cmd.get_stdout():
             raise Exception( '"%s" gppkg is not installed on host: %s. \nInstalled packages: %s' % (gppkg_name, hostname, cmd.get_stdout()))
 
+
+@given('the user runs command "{command}" on all hosts without validation')
+@when('the user runs command "{command}" on all hosts without validation')
+@then('the user runs command "{command}" on all hosts without validation')
+def impl(context, command):
+    hostlist = get_all_hostnames_as_list(context, 'template1')
+
+    for hostname in set(hostlist):
+        cmd = Command(name='running command:%s' % command,
+                      cmdStr=command,
+                      ctxt=REMOTE,
+                      remoteHost=hostname)
+        cmd.run(validateAfter=False)
 
 @given('"{gppkg_name}" gppkg files do not exist on any hosts')
 @when('"{gppkg_name}" gppkg files do not exist on any hosts')


### PR DESCRIPTION
Currently, if a host is unreachable when gpstart is run, it will not report this
and will instead fail with an error that is both inaccurate and unhelpful to the
user, such as claiming that checksums are invalid for segments on a given host
when it simply can't reach that host to verify the checksums.

This commit adds a check to verify that all hosts are reachable before beginning
the startup process and, if one or more hosts are not reachable, marks segments
on those hosts down (in gparray, not in the cluster) so gpstart won't try to run
any checks against unreachable hosts and so that the cluster can still be started
in this state so long as there are otherwise enough valid segments to start it.

This commit is a backport of commit 0c7c2b609b from 6X_STABLE, with some minor
modifications to the Behave tests because testing behavior with a down mirror is
much more flaky than in 6X.

Co-authored-by: David Krieger <dkrieger@vmware.com>