### PR TITLE
Fix memory leak in GpPolicyFetch() called in RelationBuildDesc()

### DIFF
--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -1267,7 +1267,6 @@ RelationBuildDesc(Oid targetRelId, bool insertIt)
 		 * so they cannot be freed during RelationDestroyRelation(),
 		 * that is, these allocations will never be freed.
 		 */
-		Assert(CurrentMemoryContext != CacheMemoryContext);
 		GpPolicy *policy = GpPolicyFetch(targetRelId);
 		MemoryContext oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
 		relation->rd_cdbpolicy = GpPolicyCopy(policy);

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -1261,8 +1261,16 @@ RelationBuildDesc(Oid targetRelId, bool insertIt)
 		relation->rd_rel->relkind == RELKIND_FOREIGN_TABLE ||
 		relation->rd_rel->relkind == RELKIND_MATVIEW)
 	{
+		/*
+		 * There are many memory allocations in GpPolicyFetch(), especially 
+		 * when targetRelId is a foreign table. These allocations are not bound to RelationData, 
+		 * so they cannot be freed during RelationDestroyRelation(),
+		 * that is, these allocations will never be freed.
+		 */
+		Assert(CurrentMemoryContext != CacheMemoryContext);
+		GpPolicy *policy = GpPolicyFetch(targetRelId);
 		MemoryContext oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
-		relation->rd_cdbpolicy = GpPolicyFetch(targetRelId);
+		relation->rd_cdbpolicy = GpPolicyCopy(policy);
 		MemoryContextSwitchTo(oldcontext);
 	}
 


### PR DESCRIPTION
when the table is an external table.

Fix #11244

