### PR TITLE
[6X only] PartitionSelector is not projection capable

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6911,6 +6911,7 @@ is_projection_capable_plan(Plan *plan)
 		case T_RecursiveUnion:
 		case T_Motion:
 		case T_ShareInputScan:
+		case T_PartitionSelector:
 			return false;
 		default:
 			break;

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -3333,4 +3333,137 @@ select get_selected_parts('explain analyze select * from bar where j is distinct
  [0, 0]
 (1 row)
 
+-- Validate that a planner bug found in production is fixed.  The bug
+-- caused a SIGSEGV during execution due to incorrect manipulation of
+-- target list when adding a junk attribute for a sort key when
+-- generating a Merge Join plan with Parition Selector.
+--
+-- Prerequisites to trigger the bug include dynamic partition
+-- elimination node (Partition Selector) in the plan, one or more junk
+-- attributes in sort key and presense of a Motion node between the
+-- Partition Selector and Append nodes.
+create table part_left (id int, pkey timestamp, d int)
+distributed by (pkey)
+partition by range (pkey)
+(start ('2020-12-01 00:00:00'::timestamp)
+ end   ('2020-12-04 23:59:59'::timestamp)
+ every ('1 day'::interval));
+NOTICE:  CREATE TABLE will create partition "part_left_1_prt_1" for table "part_left"
+NOTICE:  CREATE TABLE will create partition "part_left_1_prt_2" for table "part_left"
+NOTICE:  CREATE TABLE will create partition "part_left_1_prt_3" for table "part_left"
+NOTICE:  CREATE TABLE will create partition "part_left_1_prt_4" for table "part_left"
+insert into part_left values (1, '2020-12-01 00:00:00'::timestamp, 1);
+insert into part_left values (1, '2020-12-02 13:00:00'::timestamp, 2);
+insert into part_left values (1, '2020-12-03 14:00:00'::timestamp, 3);
+create table part_right (id int, pkey timestamp, d int)
+distributed by (id)
+partition by range (pkey)
+(start ('2020-12-01 00:00:00'::timestamp)
+ end   ('2020-12-31 23:59:59'::timestamp)
+ every ('1 day'::interval));
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_1" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_2" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_3" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_4" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_5" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_6" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_7" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_8" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_9" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_10" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_11" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_12" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_13" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_14" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_15" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_16" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_17" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_18" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_19" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_20" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_21" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_22" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_23" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_24" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_25" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_26" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_27" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_28" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_29" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_30" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_31" for table "part_right"
+insert into part_right values (1, '2020-12-01 12:00:00'::timestamp, 1);
+insert into part_right values (1, '2020-12-10 13:00:00'::timestamp, 2);
+insert into part_right values (1, '2020-12-20 14:00:00'::timestamp, 3);
+analyze part_left;
+analyze part_right;
+-- Enforce merge join because the plan should have a Sort node.
+set enable_hashjoin=off;
+set enable_mergejoin=on;
+-- The date_trunc() function causes a junk attribute to be generated
+-- when computing the sort key for the merge join.  The target list of
+-- Sort node is appended with one target entry corresponding to the
+-- junk attribute.  Presence of a Result node as a child of the Sort
+-- node indicates that the generated plan is correct.  The Result node
+-- has its own target list, separate from its child node's target
+-- list.  Without a Result node, the target list of Partition Selector
+-- node ends up being modified and Partition Node shares the target
+-- list with its child, which happens to be Motion node in this case.
+-- Motion node does not share targe list with its children.  However,
+-- if Motion node's target list does not match its child, there will
+-- be trouble during execution because the expected number of
+-- attributes received is more than the number of attributes actually
+-- sent by the motion sender (aka SIGSEGV).
+explain (costs off) select r.id, l.pkey from part_left l inner join part_right r
+on (date_trunc('day', r.pkey) = l.pkey
+    and r.pkey between '2020-12-01 00:00:00'::timestamp and
+                        '2020-12-03 00:00:59'::timestamp
+                        );
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Merge Join
+         Merge Cond: (l.pkey = (date_trunc('day'::text, r.pkey)))
+         ->  Sort
+               Sort Key: l.pkey
+               ->  Append
+                     ->  Result
+                           One-Time Filter: PartSelected
+                           ->  Seq Scan on part_left_1_prt_1 l
+                     ->  Result
+                           One-Time Filter: PartSelected
+                           ->  Seq Scan on part_left_1_prt_2 l_1
+                     ->  Result
+                           One-Time Filter: PartSelected
+                           ->  Seq Scan on part_left_1_prt_3 l_2
+                     ->  Result
+                           One-Time Filter: PartSelected
+                           ->  Seq Scan on part_left_1_prt_4 l_3
+         ->  Sort
+               Sort Key: (date_trunc('day'::text, r.pkey))
+               ->  Result
+                     ->  Partition Selector for part_left (dynamic scan id: 1)
+                           Filter: date_trunc('day'::text, r.pkey)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: date_trunc('day'::text, r.pkey)
+                                 ->  Append
+                                       ->  Seq Scan on part_right_1_prt_1 r
+                                             Filter: ((pkey >= 'Tue Dec 01 00:00:00 2020'::timestamp without time zone) AND (pkey <= 'Thu Dec 03 00:00:59 2020'::timestamp without time zone))
+                                       ->  Seq Scan on part_right_1_prt_2 r_1
+                                             Filter: ((pkey >= 'Tue Dec 01 00:00:00 2020'::timestamp without time zone) AND (pkey <= 'Thu Dec 03 00:00:59 2020'::timestamp without time zone))
+                                       ->  Seq Scan on part_right_1_prt_3 r_2
+                                             Filter: ((pkey >= 'Tue Dec 01 00:00:00 2020'::timestamp without time zone) AND (pkey <= 'Thu Dec 03 00:00:59 2020'::timestamp without time zone))
+ Optimizer: Postgres query optimizer
+(33 rows)
+
+select r.id, l.pkey from part_left l inner join part_right r
+on (date_trunc('day', r.pkey) = l.pkey
+    and r.pkey between '2020-12-01 00:00:00'::timestamp and
+                        '2020-12-03 00:00:59'::timestamp
+                        );
+ id |           pkey           
+----+--------------------------
+  1 | Tue Dec 01 00:00:00 2020
+(1 row)
+
 RESET ALL;

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -2936,4 +2936,120 @@ select get_selected_parts('explain analyze select * from bar where j is distinct
  [8, 8]
 (1 row)
 
+-- Validate that a planner bug found in production is fixed.  The bug
+-- caused a SIGSEGV during execution due to incorrect manipulation of
+-- target list when adding a junk attribute for a sort key when
+-- generating a Merge Join plan with Parition Selector.
+--
+-- Prerequisites to trigger the bug include dynamic partition
+-- elimination node (Partition Selector) in the plan, one or more junk
+-- attributes in sort key and presense of a Motion node between the
+-- Partition Selector and Append nodes.
+create table part_left (id int, pkey timestamp, d int)
+distributed by (pkey)
+partition by range (pkey)
+(start ('2020-12-01 00:00:00'::timestamp)
+ end   ('2020-12-04 23:59:59'::timestamp)
+ every ('1 day'::interval));
+NOTICE:  CREATE TABLE will create partition "part_left_1_prt_1" for table "part_left"
+NOTICE:  CREATE TABLE will create partition "part_left_1_prt_2" for table "part_left"
+NOTICE:  CREATE TABLE will create partition "part_left_1_prt_3" for table "part_left"
+NOTICE:  CREATE TABLE will create partition "part_left_1_prt_4" for table "part_left"
+insert into part_left values (1, '2020-12-01 00:00:00'::timestamp, 1);
+insert into part_left values (1, '2020-12-02 13:00:00'::timestamp, 2);
+insert into part_left values (1, '2020-12-03 14:00:00'::timestamp, 3);
+create table part_right (id int, pkey timestamp, d int)
+distributed by (id)
+partition by range (pkey)
+(start ('2020-12-01 00:00:00'::timestamp)
+ end   ('2020-12-31 23:59:59'::timestamp)
+ every ('1 day'::interval));
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_1" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_2" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_3" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_4" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_5" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_6" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_7" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_8" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_9" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_10" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_11" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_12" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_13" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_14" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_15" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_16" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_17" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_18" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_19" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_20" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_21" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_22" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_23" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_24" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_25" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_26" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_27" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_28" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_29" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_30" for table "part_right"
+NOTICE:  CREATE TABLE will create partition "part_right_1_prt_31" for table "part_right"
+insert into part_right values (1, '2020-12-01 12:00:00'::timestamp, 1);
+insert into part_right values (1, '2020-12-10 13:00:00'::timestamp, 2);
+insert into part_right values (1, '2020-12-20 14:00:00'::timestamp, 3);
+analyze part_left;
+analyze part_right;
+-- Enforce merge join because the plan should have a Sort node.
+set enable_hashjoin=off;
+set enable_mergejoin=on;
+-- The date_trunc() function causes a junk attribute to be generated
+-- when computing the sort key for the merge join.  The target list of
+-- Sort node is appended with one target entry corresponding to the
+-- junk attribute.  Presence of a Result node as a child of the Sort
+-- node indicates that the generated plan is correct.  The Result node
+-- has its own target list, separate from its child node's target
+-- list.  Without a Result node, the target list of Partition Selector
+-- node ends up being modified and Partition Node shares the target
+-- list with its child, which happens to be Motion node in this case.
+-- Motion node does not share targe list with its children.  However,
+-- if Motion node's target list does not match its child, there will
+-- be trouble during execution because the expected number of
+-- attributes received is more than the number of attributes actually
+-- sent by the motion sender (aka SIGSEGV).
+explain (costs off) select r.id, l.pkey from part_left l inner join part_right r
+on (date_trunc('day', r.pkey) = l.pkey
+    and r.pkey between '2020-12-01 00:00:00'::timestamp and
+                        '2020-12-03 00:00:59'::timestamp
+                        );
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Hash Join
+         Hash Cond: (date_trunc('day'::text, part_right.pkey) = part_left.pkey)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: date_trunc('day'::text, part_right.pkey)
+               ->  Sequence
+                     ->  Partition Selector for part_right (dynamic scan id: 2)
+                           Partitions selected: 3 (out of 31)
+                     ->  Dynamic Seq Scan on part_right (dynamic scan id: 2)
+                           Filter: ((pkey >= 'Tue Dec 01 00:00:00 2020'::timestamp without time zone) AND (pkey <= 'Thu Dec 03 00:00:59 2020'::timestamp without time zone))
+         ->  Hash
+               ->  Sequence
+                     ->  Partition Selector for part_left (dynamic scan id: 1)
+                           Partitions selected: 4 (out of 4)
+                     ->  Dynamic Seq Scan on part_left (dynamic scan id: 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
+select r.id, l.pkey from part_left l inner join part_right r
+on (date_trunc('day', r.pkey) = l.pkey
+    and r.pkey between '2020-12-01 00:00:00'::timestamp and
+                        '2020-12-03 00:00:59'::timestamp
+                        );
+ id |           pkey           
+----+--------------------------
+  1 | Tue Dec 01 00:00:00 2020
+(1 row)
+
 RESET ALL;


### PR DESCRIPTION
This is how it is on master branch.  Without this patch, it is possible to generate a plan such as the following:

```
   ->  Merge Join
         Merge Cond: ((t_left.a = (func(t_right.a))) AND ((t_left.b)::text = (t_right.b)))
         ->  Sort  t_left
         ->  Sort  t_right
               Sort Key: (func(t_right.a)), t_right.b
               ->  Partition Selector for t_left
                     Filter: (func(t_right.a))
                     ->  Broadcast Motion
                           ->  Append
                                 ->  Seq Scan on t_right
```

The problem with such a plan is the Sort node needs to generate a new junk attribute representing func(t_rigth.a) by appending an entry to the target list of its child - Partition Selector.  However, the Append node's target list does not contain this junk attribute.  This results in the motion sender sending a tuple with two columns but the receiver thinking that it received a tuple with three columns because the target list of the receiver side of motion is shared with that of
the Partition Selector.

With the proposed patch, `prepare_sort_from_pathkeys()` creates a new Result node with its own target list when generating the sort keys. Any junk attributes added do not propagate to the Result node's children.

A similar plan was generated at a production deployment, causing SIGSEGV when the Sort node tried to interpret the tuple returned by the Partition Selector.  I am trying to find a simpler reproduction of the crash but haven't succeeded.  Therefore, the patch does not have a test case yet.
