### PR TITLE
Remove guc gp_keep_all_xlog

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9281,7 +9281,7 @@ CreateCheckPoint(int flags)
 	 * Update the average distance between checkpoints if the prior checkpoint
 	 * exists.
 	 */
-	if (gp_keep_all_xlog == false && PriorRedoPtr != InvalidXLogRecPtr)
+	if (PriorRedoPtr != InvalidXLogRecPtr)
 		UpdateCheckPointDistanceEstimate(RedoRecPtr - PriorRedoPtr);
 
 	/*
@@ -9610,7 +9610,7 @@ CreateRestartPoint(int flags)
 	 * Update the average distance between checkpoints/restartpoints if the
 	 * prior checkpoint exists.
 	 */
-	if (!gp_keep_all_xlog && PriorRedoPtr != InvalidXLogRecPtr)
+	if (PriorRedoPtr != InvalidXLogRecPtr)
 		UpdateCheckPointDistanceEstimate(RedoRecPtr - PriorRedoPtr);
 
 	/*

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -172,8 +172,6 @@ bool		debug_basebackup = false;
 
 int rep_lag_avoidance_threshold = 0;
 
-bool		gp_keep_all_xlog = false;
-
 #define DEBUG_DTM_ACTION_PRIMARY_DEFAULT true
 bool		Debug_dtm_action_primary = DEBUG_DTM_ACTION_PRIMARY_DEFAULT;
 
@@ -1587,17 +1585,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY
 		},
 		&pljava_debug,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"gp_keep_all_xlog", PGC_SUSET, DEVELOPER_OPTIONS,
-			gettext_noop("Do not remove old xlog files."),
-			NULL,
-			GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&gp_keep_all_xlog,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -119,7 +119,6 @@ extern int	XLogArchiveTimeout;
 extern int	wal_retrieve_retry_interval;
 extern char *XLogArchiveCommand;
 extern bool EnableHotStandby;
-extern bool gp_keep_all_xlog;
 
 extern bool fullPageWrites;
 extern bool wal_log_hints;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -207,7 +207,6 @@
 		"gp_instrument_shmem_size",
 		"gp_interconnect_cache_future_packets",
 		"gp_is_writer",
-		"gp_keep_all_xlog",
 		"gp_local_distributed_cache_stats",
 		"gp_log_dynamic_partition_pruning",
 		"gp_log_format",


### PR DESCRIPTION
On master the code for the guc is buggy since PG9.5 merge, and we could
actually use guc wal_keep_segments to complete the similar functionality. This
guc is one of the "DEVELOPER_OPTIONS" so there is no need to document it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
