### PR TITLE
Fix the interconnect_address when hot_standby is on

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1041,7 +1041,19 @@ ensureInterconnectAddress(void)
 		 * from `cdbcomponent*`. We couldn't get it in a way as the QEs.
 		 */
 		CdbComponentDatabaseInfo *qdInfo;
-		qdInfo = cdbcomponent_getComponentInfo(MASTER_CONTENT_ID);
+		CdbComponentDatabases *cdbs;
+		cdbs = cdbcomponent_getCdbComponents();
+		qdInfo = NULL;
+		for (int i = 0; i < cdbs->total_entry_dbs; i++)
+		{
+			if (cdbs->entry_db_info[i].config->dbid == GpIdentity.dbid)
+			{
+				qdInfo = &cdbs->entry_db_info[i];
+				break;
+			}
+		}
+		Assert(qdInfo != NULL);
+
 		interconnect_address = MemoryContextStrdup(TopMemoryContext, qdInfo->config->hostip);
 	}
 	else if (qdHostname && qdHostname[0] != '\0')


### PR DESCRIPTION
When hot_standby is on, the interconnect_address is
wrong if the addresses for the coordinator/master
are different. The dbinfo for the standby is not
the first entry from `entry_db_info`

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
