### PR TITLE
[6X backport] Add a validation on the mount hierarchy of 'cpu' and 'cpuset' subsystem

### DIFF
--- a/gpMgmt/bin/gpcheckresgroupimpl
+++ b/gpMgmt/bin/gpcheckresgroupimpl
@@ -75,6 +75,8 @@ class cgroup(object):
             self.validate_permission("cpuset", "gpdb/cpuset.cpus", "rw")
             self.validate_permission("cpuset", "gpdb/cpuset.mems", "rw")
 
+            self.validate_comp_hierarchy();
+
     def die(self, msg):
         exit(self.impl + self.error_prefix + msg)
 
@@ -122,6 +124,27 @@ class cgroup(object):
                 return False
 
         return True
+
+    def validate_comp_hierarchy(self):
+        """
+        Validate the mount hierarchy of cpu and cpuset subsystem.
+
+        Raise an error if cpu and cpuset are mounted on the same hierarchy.
+        """
+
+        path = "/proc/1/cgroup"
+        if not os.path.exists(path):
+            self.die("can't check component mount hierarchy: \
+                     file '/proc/1/cgroup' doesn't exist")
+
+        for line in open(path):
+            line = line.strip()
+            compid, compnames, comppath = line.split(":")
+            if not compnames or '=' in compnames:
+                continue
+            complist = compnames.split(',')
+            if "cpu" in complist and "cpuset" in complist:
+                self.die("can't mount 'cpu' and 'cpuset' on the same hierarchy")
 
     def detect_cgroup_mount_point(self):
         proc_mounts_path = "/proc/self/mounts"

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -125,6 +125,7 @@ static void writeStr(Oid group, BaseType base, ResGroupCompType comp, const char
 static bool permListCheck(const PermList *permlist, Oid group, bool report);
 static bool checkPermission(Oid group, bool report);
 static bool checkCpuSetPermission(Oid group, bool report);
+static void checkCompHierarchy();
 static void getMemoryInfo(unsigned long *ram, unsigned long *swap);
 static void getCgMemoryInfo(uint64 *cgram, uint64 *cgmemsw);
 static int getOvercommitRatio(void);
@@ -1090,6 +1091,81 @@ checkCpuSetPermission(Oid group, bool report)
 	return true;
 }
 
+/*
+ * Check the mount hierarchy of cpu and cpuset subsystem.
+ *
+ * Raise an error if cpu and cpuset are mounted on the same hierarchy.
+ */
+static void
+checkCompHierarchy()
+{
+	ResGroupCompType comp;
+	FILE       *f;
+	char        buf[MAXPATHLEN * 2];
+	
+	f = fopen("/proc/1/cgroup", "r");
+	if (!f)
+	{
+		CGROUP_CONFIG_ERROR("can't check component mount hierarchy \
+					file '/proc/1/cgroup' doesn't exist");
+		return;
+	}
+
+	/*
+	 * format: id:comps:path, e.g.:
+	 *
+	 * 10:cpuset:/
+	 * 4:cpu,cpuacct:/
+	 * 1:name=systemd:/init.scope
+	 * 0::/init.scope
+	 */
+	while (fscanf(f, "%*d:%s", buf) != EOF)
+	{
+		char       *ptr;
+		char       *tmp;
+		char        sep = '\0';
+		/* mark if the line has alread contained cpu or cpuset comp */
+		int        markComp = RESGROUP_COMP_TYPE_UNKNOWN;
+
+		/* buf is stored with "comps:path" */
+		if (buf[0] == ':')
+			continue; /* ignore empty comp */
+
+		/* split comps */
+		for (ptr = buf; sep != ':'; ptr = tmp)
+		{
+			tmp = strpbrk(ptr, ":,=");
+			
+			sep = *tmp;
+			*tmp++ = 0;
+
+			/* for name=comp case there is nothing to do with the name */
+			if (sep == '=')
+				continue;
+			
+			comp = compByName(ptr);
+
+			if (comp == RESGROUP_COMP_TYPE_UNKNOWN)
+				continue; /* not used by us */
+			
+			if (comp == RESGROUP_COMP_TYPE_CPU || comp == RESGROUP_COMP_TYPE_CPUSET)
+			{
+				if (markComp == RESGROUP_COMP_TYPE_UNKNOWN)
+					markComp = comp;
+				else
+				{
+					Assert(markComp != comp);
+					fclose(f);
+					CGROUP_CONFIG_ERROR("can't mount 'cpu' and 'cpuset' on the same hierarchy");
+					return;
+				}
+			}
+		}
+	}
+
+	fclose(f);
+}
+
 /* get total ram and total swap (in Byte) from sysinfo */
 static void
 getMemoryInfo(unsigned long *ram, unsigned long *swap)
@@ -1336,6 +1412,16 @@ ResGroupOps_Bless(void)
 	 * Check again, this time we will fail on unmet requirements.
 	 */
 	checkPermission(RESGROUP_ROOT_ID, true);
+
+	/*
+ 	 * Check if cpu and cpuset subsystems are mounted on the same hierarchy.
+ 	 * We do not allow they mount on the same hierarchy, because writting pid
+ 	 * to DEFAULT_CPUSET_GROUP_ID in ResGroupOps_AssignGroup will cause the
+ 	 * removal of the pid in group BASETYPE_GPDB, which will make cpu usage
+ 	 * out of control.
+	 */
+	if (!CGROUP_CPUSET_IS_OPTIONAL)
+		checkCompHierarchy();
 
 	/*
 	 * Dump the cgroup comp dirs to logs.


### PR DESCRIPTION
For version 6X or higher, 'cpuset' is a necessary subsystem for resource group.
However, if 'cpu' and 'cpuset' are mounted on the same hierarchy, the cpu usage
will be out of control. So we need a validation on this before we using resource
group.

Co-authored-by: wuchengwen <wcw190496@alibaba-inc.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
