### PR TITLE
[6X Backport]Fix execution of functions with EXECUTE ON options in utility mode.

### DIFF
--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -95,6 +95,7 @@ query_planner(PlannerInfo *root, List *tlist,
 		root->canon_pathkeys = NIL;
 		(*qp_callback) (root, qp_extra);
 
+		if (Gp_role == GP_ROLE_DISPATCH)
 		{
 			char		exec_location;
 
@@ -106,6 +107,8 @@ query_planner(PlannerInfo *root, List *tlist,
 				CdbPathLocus_MakeStrewn(&result_path->locus,
 										getgpsegmentCount());
 		}
+		else
+			CdbPathLocus_MakeEntry(&result_path->locus);
 
 		return final_rel;
 	}

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -34,6 +34,7 @@
 #include "cdb/cdbhash.h"        /* cdb_default_distribution_opfamily_for_type() */
 #include "cdb/cdbpath.h"        /* cdb_create_motion_path() etc */
 #include "cdb/cdbutil.h"		/* getgpsegmentCount() */
+#include "cdb/cdbvars.h"
 #include "executor/nodeHash.h"
 
 typedef enum
@@ -2608,8 +2609,6 @@ create_functionscan_path(PlannerInfo *root, RelOptInfo *rel,
 {
 	Path	   *pathnode = makeNode(Path);
 	ListCell   *lc;
-	char		exec_location;
-	bool		contain_mutables = false;
 
 	pathnode->pathtype = T_FunctionScan;
 	pathnode->parent = rel;
@@ -2618,117 +2617,124 @@ create_functionscan_path(PlannerInfo *root, RelOptInfo *rel,
 	pathnode->pathkeys = pathkeys;
 
 	/*
-	 * If the function desires to run on segments, mark randomly-distributed.
-	 * If expression contains mutable functions, evaluate it on entry db.
-	 * Otherwise let it be evaluated in the same slice as its parent operator.
-	 */
-	Assert(rte->rtekind == RTE_FUNCTION);
-
-	/*
 	 * Decide where to execute the FunctionScan.
 	 */
-	contain_mutables = false;
-	exec_location = PROEXECLOCATION_ANY;
-	foreach (lc, rte->functions)
+	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		RangeTblFunction *rtfunc = (RangeTblFunction *) lfirst(lc);
+		char		exec_location = PROEXECLOCATION_ANY;
+		bool		contain_mutables = false;
 
-		if (rtfunc->funcexpr && IsA(rtfunc->funcexpr, FuncExpr))
+		/*
+		 * If the function desires to run on segments, mark randomly-distributed.
+		 * If expression contains mutable functions, evaluate it on entry db.
+		 * Otherwise let it be evaluated in the same slice as its parent operator.
+		 */
+		Assert(rte->rtekind == RTE_FUNCTION);
+
+		foreach (lc, rte->functions)
 		{
-			FuncExpr   *funcexpr = (FuncExpr *) rtfunc->funcexpr;
-			char		this_exec_location;
+			RangeTblFunction *rtfunc = (RangeTblFunction *) lfirst(lc);
 
-			this_exec_location = func_exec_location(funcexpr->funcid);
-
-			switch (this_exec_location)
+			if (rtfunc->funcexpr && IsA(rtfunc->funcexpr, FuncExpr))
 			{
-				case PROEXECLOCATION_ANY:
-					/*
-					 * This can be executed anywhere. Remember if it was
-					 * mutable (or contained any mutable arguments), that
-					 * will affect the decision after this loop on where
-					 * to actually execute it.
-					 */
-					if (!contain_mutables)
-						contain_mutables = contain_mutable_functions((Node *) funcexpr);
-					break;
-				case PROEXECLOCATION_MASTER:
-					/*
-					 * This function forces the execution to master.
-					 */
-					if (exec_location == PROEXECLOCATION_ALL_SEGMENTS)
-					{
-						ereport(ERROR,
-								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 (errmsg("cannot mix EXECUTE ON MASTER and ALL SEGMENTS functions in same function scan"))));
-					}
-					exec_location = PROEXECLOCATION_MASTER;
-					break;
-				case PROEXECLOCATION_INITPLAN:
-					/*
-					 * This function forces the execution to master.
-					 */
-					if (exec_location == PROEXECLOCATION_ALL_SEGMENTS)
-					{
-						ereport(ERROR,
-								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 (errmsg("cannot mix EXECUTE ON INITPLAN and ALL SEGMENTS functions in same function scan"))));
-					}
-					exec_location = PROEXECLOCATION_INITPLAN;
-					break;
-				case PROEXECLOCATION_ALL_SEGMENTS:
-					/*
-					 * This function forces the execution to segments.
-					 */
-					if (exec_location == PROEXECLOCATION_MASTER)
-					{
-						ereport(ERROR,
-								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 (errmsg("cannot mix EXECUTE ON MASTER and ALL SEGMENTS functions in same function scan"))));
-					}
-					exec_location = PROEXECLOCATION_ALL_SEGMENTS;
-					break;
-				default:
-					elog(ERROR, "unrecognized proexeclocation '%c'", exec_location);
+				FuncExpr   *funcexpr = (FuncExpr *) rtfunc->funcexpr;
+				char		this_exec_location;
+
+				this_exec_location = func_exec_location(funcexpr->funcid);
+
+				switch (this_exec_location)
+				{
+					case PROEXECLOCATION_ANY:
+						/*
+						 * This can be executed anywhere. Remember if it was
+						 * mutable (or contained any mutable arguments), that
+						 * will affect the decision after this loop on where
+						 * to actually execute it.
+						 */
+						if (!contain_mutables)
+							contain_mutables = contain_mutable_functions((Node *) funcexpr);
+						break;
+					case PROEXECLOCATION_MASTER:
+						/*
+						 * This function forces the execution to master.
+						 */
+						if (exec_location == PROEXECLOCATION_ALL_SEGMENTS)
+						{
+							ereport(ERROR,
+									(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+									 (errmsg("cannot mix EXECUTE ON MASTER and ALL SEGMENTS functions in same function scan"))));
+						}
+						exec_location = PROEXECLOCATION_MASTER;
+						break;
+					case PROEXECLOCATION_INITPLAN:
+						/*
+						 * This function forces the execution to master.
+						 */
+						if (exec_location == PROEXECLOCATION_ALL_SEGMENTS)
+						{
+							ereport(ERROR,
+									(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+									 (errmsg("cannot mix EXECUTE ON INITPLAN and ALL SEGMENTS functions in same function scan"))));
+						}
+						exec_location = PROEXECLOCATION_INITPLAN;
+						break;
+					case PROEXECLOCATION_ALL_SEGMENTS:
+						/*
+						 * This function forces the execution to segments.
+						 */
+						if (exec_location == PROEXECLOCATION_MASTER)
+						{
+							ereport(ERROR,
+									(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+									 (errmsg("cannot mix EXECUTE ON MASTER and ALL SEGMENTS functions in same function scan"))));
+						}
+						exec_location = PROEXECLOCATION_ALL_SEGMENTS;
+						break;
+					default:
+						elog(ERROR, "unrecognized proexeclocation '%c'", exec_location);
+				}
+			}
+			else
+			{
+				/*
+				 * The expression might've been simplified into a Const. Which can
+				 * be executed anywhere.
+				 */
 			}
 		}
-		else
+
+		switch (exec_location)
 		{
-			/*
-			 * The expression might've been simplified into a Const. Which can
-			 * be executed anywhere.
-			 */
+			case PROEXECLOCATION_ANY:
+				/*
+				 * If all the functions are ON ANY, we presumably could execute
+				 * the function scan anywhere. However, historically, before the
+				 * EXECUTE ON syntax was introduced, we always executed
+				 * non-IMMUTABLE functions on the master. Keep that behavior
+				 * for backwards compatibility.
+				 */
+				if (contain_mutables)
+					CdbPathLocus_MakeEntry(&pathnode->locus);
+				else
+					CdbPathLocus_MakeGeneral(&pathnode->locus,
+											 getgpsegmentCount());
+				break;
+			case PROEXECLOCATION_MASTER:
+				CdbPathLocus_MakeEntry(&pathnode->locus);
+				break;
+			case PROEXECLOCATION_INITPLAN:
+				CdbPathLocus_MakeEntry(&pathnode->locus);
+				break;
+			case PROEXECLOCATION_ALL_SEGMENTS:
+				CdbPathLocus_MakeStrewn(&pathnode->locus,
+										getgpsegmentCount());
+				break;
+			default:
+				elog(ERROR, "unrecognized proexeclocation '%c'", exec_location);
 		}
 	}
-	switch (exec_location)
-	{
-		case PROEXECLOCATION_ANY:
-			/*
-			 * If all the functions are ON ANY, we presumably could execute
-			 * the function scan anywhere. However, historically, before the
-			 * EXECUTE ON syntax was introduced, we always executed
-			 * non-IMMUTABLE functions on the master. Keep that behavior
-			 * for backwards compatibility.
-			 */
-			if (contain_mutables)
-				CdbPathLocus_MakeEntry(&pathnode->locus);
-			else
-				CdbPathLocus_MakeGeneral(&pathnode->locus,
-										 getgpsegmentCount());
-			break;
-		case PROEXECLOCATION_MASTER:
-			CdbPathLocus_MakeEntry(&pathnode->locus);
-			break;
-		case PROEXECLOCATION_INITPLAN:
-			CdbPathLocus_MakeEntry(&pathnode->locus);
-			break;
-		case PROEXECLOCATION_ALL_SEGMENTS:
-			CdbPathLocus_MakeStrewn(&pathnode->locus,
-									getgpsegmentCount());
-			break;
-		default:
-			elog(ERROR, "unrecognized proexeclocation '%c'", exec_location);
-	}
+	else
+		CdbPathLocus_MakeEntry(&pathnode->locus);
 
 	pathnode->motionHazard = false;
 

--- a/src/test/isolation2/expected/execute_on_utilitymode.out
+++ b/src/test/isolation2/expected/execute_on_utilitymode.out
@@ -1,0 +1,102 @@
+--
+-- Test using functions with EXECUTE ON options in utility mode.
+--
+
+-- First, create test functions with different EXECUTE ON options
+
+create function srf_on_master () returns setof text as $$ begin	/* in func */ return next 'foo ' || current_setting('gp_contentid');	/* in func */ return next 'bar ' || current_setting('gp_contentid');	/* in func */ end;	/* in func */ $$ language plpgsql EXECUTE ON MASTER;
+CREATE
+
+create function srf_on_all_segments () returns setof text as $$ begin	/* in func */ return next 'foo ' || current_setting('gp_contentid');	/* in func */ return next 'bar ' || current_setting('gp_contentid');	/* in func */ end;	/* in func */ $$ language plpgsql EXECUTE ON ALL SEGMENTS;
+CREATE
+
+create function srf_on_any () returns setof text as $$ begin	/* in func */ return next 'foo ' || current_setting('gp_contentid');	/* in func */ return next 'bar ' || current_setting('gp_contentid');	/* in func */ end;	/* in func */ $$ language plpgsql EXECUTE ON ANY IMMUTABLE;
+CREATE
+
+create function srf_on_initplan () returns setof text as $$ begin	/* in func */ return next 'foo ' || current_setting('gp_contentid');	/* in func */ return next 'bar ' || current_setting('gp_contentid');	/* in func */ end;	/* in func */ $$ language plpgsql EXECUTE ON INITPLAN;
+CREATE
+
+-- Now try executing them in utility mode, in the master node and on a
+-- segment. The expected behavior is that the function runs on the node
+-- we're connected to, ignoring the EXECUTE ON directives.
+--
+-- Join with a table, to give the planner something more exciting to do
+-- than just create the FunctionScan plan.
+create table fewrows (t text) distributed by (t);
+CREATE
+insert into fewrows select g from generate_series(1, 10) g;
+INSERT 10
+
+-1U: select * from srf_on_master()       as srf (x) left join fewrows on x = t;
+ x      | t 
+--------+---
+ foo -1 |   
+ bar -1 |   
+(2 rows)
+-1U: select * from srf_on_all_segments() as srf (x) left join fewrows on x = t;
+ x      | t 
+--------+---
+ foo -1 |   
+ bar -1 |   
+(2 rows)
+-1U: select * from srf_on_any()          as srf (x) left join fewrows on x = t;
+ x      | t 
+--------+---
+ foo -1 |   
+ bar -1 |   
+(2 rows)
+-1U: select * from srf_on_initplan()     as srf (x) left join fewrows on x = t;
+ x      | t 
+--------+---
+ foo -1 |   
+ bar -1 |   
+(2 rows)
+
+1U: select * from srf_on_master(),       fewrows;
+ srf_on_master | t 
+---------------+---
+ foo 1         | 2 
+ foo 1         | 3 
+ foo 1         | 4 
+ foo 1         | 7 
+ bar 1         | 2 
+ bar 1         | 3 
+ bar 1         | 4 
+ bar 1         | 7 
+(8 rows)
+1U: select * from srf_on_all_segments(), fewrows;
+ srf_on_all_segments | t 
+---------------------+---
+ foo 1               | 2 
+ foo 1               | 3 
+ foo 1               | 4 
+ foo 1               | 7 
+ bar 1               | 2 
+ bar 1               | 3 
+ bar 1               | 4 
+ bar 1               | 7 
+(8 rows)
+1U: select * from srf_on_any(),          fewrows;
+ srf_on_any | t 
+------------+---
+ foo 1      | 2 
+ foo 1      | 3 
+ foo 1      | 4 
+ foo 1      | 7 
+ bar 1      | 2 
+ bar 1      | 3 
+ bar 1      | 4 
+ bar 1      | 7 
+(8 rows)
+1U: select * from srf_on_initplan(),     fewrows;
+ srf_on_initplan | t 
+-----------------+---
+ foo 1           | 2 
+ foo 1           | 3 
+ foo 1           | 4 
+ foo 1           | 7 
+ bar 1           | 2 
+ bar 1           | 3 
+ bar 1           | 4 
+ bar 1           | 7 
+(8 rows)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -9,8 +9,7 @@ test: ao_partition_lock
 test: dml_on_root_locks_all_parts
 
 test: select_dropped_table
-# test update hash col under utility mode
-test: update_hash_col_utilitymode
+test: update_hash_col_utilitymode execute_on_utilitymode
 
 # Tests for crash recovery
 test: uao_crash_compaction_column

--- a/src/test/isolation2/sql/execute_on_utilitymode.sql
+++ b/src/test/isolation2/sql/execute_on_utilitymode.sql
@@ -1,0 +1,52 @@
+--
+-- Test using functions with EXECUTE ON options in utility mode.
+--
+
+-- First, create test functions with different EXECUTE ON options
+
+create function srf_on_master () returns setof text as $$
+begin	/* in func */
+  return next 'foo ' || current_setting('gp_contentid');	/* in func */
+  return next 'bar ' || current_setting('gp_contentid');	/* in func */
+end;	/* in func */
+$$ language plpgsql EXECUTE ON MASTER;
+
+create function srf_on_all_segments () returns setof text as $$
+begin	/* in func */
+  return next 'foo ' || current_setting('gp_contentid');	/* in func */
+  return next 'bar ' || current_setting('gp_contentid');	/* in func */
+end;	/* in func */
+$$ language plpgsql EXECUTE ON ALL SEGMENTS;
+
+create function srf_on_any () returns setof text as $$
+begin	/* in func */
+  return next 'foo ' || current_setting('gp_contentid');	/* in func */
+  return next 'bar ' || current_setting('gp_contentid');	/* in func */
+end;	/* in func */
+$$ language plpgsql EXECUTE ON ANY IMMUTABLE;
+
+create function srf_on_initplan () returns setof text as $$
+begin	/* in func */
+  return next 'foo ' || current_setting('gp_contentid');	/* in func */
+  return next 'bar ' || current_setting('gp_contentid');	/* in func */
+end;	/* in func */
+$$ language plpgsql EXECUTE ON INITPLAN;
+
+-- Now try executing them in utility mode, in the master node and on a
+-- segment. The expected behavior is that the function runs on the node
+-- we're connected to, ignoring the EXECUTE ON directives.
+--
+-- Join with a table, to give the planner something more exciting to do
+-- than just create the FunctionScan plan.
+create table fewrows (t text) distributed by (t);
+insert into fewrows select g from generate_series(1, 10) g;
+
+-1U: select * from srf_on_master()       as srf (x) left join fewrows on x = t;
+-1U: select * from srf_on_all_segments() as srf (x) left join fewrows on x = t;
+-1U: select * from srf_on_any()          as srf (x) left join fewrows on x = t;
+-1U: select * from srf_on_initplan()     as srf (x) left join fewrows on x = t;
+
+1U: select * from srf_on_master(),       fewrows;
+1U: select * from srf_on_all_segments(), fewrows;
+1U: select * from srf_on_any(),          fewrows;
+1U: select * from srf_on_initplan(),     fewrows;

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1207,7 +1207,7 @@ select p from
           (box(point(0.8,0.8), point(1.0,1.0)))) as v(bb)
 cross join lateral
   (select p from gist_tbl_github9733 where p <@ bb order by p <-> bb[0] limit 2) ss;
-ERROR:  could not devise a query plan for the given query (pathnode.c:420)
+ERROR:  could not devise a query plan for the given query (pathnode.c:421)
 reset enable_seqscan;
 explain (costs off)
 select p from

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1223,7 +1223,7 @@ select p from
           (box(point(0.8,0.8), point(1.0,1.0)))) as v(bb)
 cross join lateral
   (select p from gist_tbl_github9733 where p <@ bb order by p <-> bb[0] limit 2) ss;
-ERROR:  could not devise a query plan for the given query (pathnode.c:420)
+ERROR:  could not devise a query plan for the given query (pathnode.c:421)
 reset enable_seqscan;
 explain (costs off)
 select p from


### PR DESCRIPTION
It's not entirely clear what the behavior should be in utility mode.
With this commit, the EXECUTE ON options are effectively ignored in
utility mode, so the function is executed locally on the node you're
connected to. To achieve that, force Entry locus for the FunctionScan
path in the planner, when in utility mode. This is how other kinds
of scans are planned in utility mode, too.

Without this fix, the join queries added in the test case, with
EXECUTE ON SEGMENTS function, generated a plan with a Motion, even in
utility mode, which failed an assertion in the executor. EXECUTE ON
INITPLAN had similar issues, causing an error in the executor, when it
tried to open a non-existent tuplestore file.

(cherry picked from commit 83178d191e47b8f4f34f5c5e2e46d9d915ff44d7)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
