### PR TITLE
gpstart: Update catalog directly when there are down hosts

### DIFF
--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -338,7 +338,8 @@ class GpStart:
         pool = base.WorkerPool(numWorkers=num_workers)
         try:
             for host in hostlist:
-                cmd = Command(name='check %s is up' % host, cmdStr="ssh %s 'echo %s'" % (host, host))
+                cmd = Command(name='check %s is up' % host,
+                        cmdStr="ssh -o BatchMode=yes -o ConnectTimeout=5 %s 'echo %s'" % (host, host))
                 pool.addCommand(cmd)
             pool.join()
         finally:
@@ -362,15 +363,32 @@ class GpStart:
         return None
 
     def mark_segments_down_for_unreachable_hosts(self, unreachable_hosts):
-        # We only mark the segment down in gparray for use by later checks, as
-        # setting the actual segment down in gp_segment_configuration leads to
-        # an inconsistent state and may prevent the database from starting.
+        conn = dbconn.connect(self.dburl, utility=True, allowSystemTableMods='dml')
         for segment in self.gparray.segments:
-            for seg in [segment.primaryDB] + segment.mirrorDBs:
-                host = seg.getSegmentHostName()
-                if host in unreachable_hosts:
-                    logger.warning("Marking segment %d down because %s is unreachable" % (seg.dbid, host))
-                    seg.setSegmentStatus(STATUS_DOWN)
+            primary_host, mirror_host = segment.primaryDB.getSegmentHostName(), segment.mirrorDBs[0].getSegmentHostName()
+            if not (primary_host in unreachable_hosts or mirror_host in unreachable_hosts):
+                continue # both hosts are reachable, nothing to do
+            if primary_host in unreachable_hosts and mirror_host in unreachable_hosts:
+                continue # double-fault scenario, don't update the catalog as the cluster won't start anyway
+
+            seg, peer = None, None
+            swap_roles = False
+            if primary_host in unreachable_hosts:
+                seg = segment.primaryDB
+                peer = segment.mirrorDBs[0]
+                swap_roles = True
+            elif mirror_host in unreachable_hosts:
+                seg = segment.mirrorDBs[0]
+                peer = segment.primaryDB
+
+            logger.warning("Marking segment %d down because %s is unreachable" % (seg.getSegmentDbId(), seg.getSegmentHostName()))
+            dbconn.executeUpdateOrInsert(conn, "UPDATE gp_segment_configuration SET %sstatus = 'd' WHERE dbid = %d" % ("role = 'm', " if swap_roles else "", seg.getSegmentDbId()), 1)
+            dbconn.executeUpdateOrInsert(conn, "UPDATE gp_segment_configuration SET %smode = 'c' WHERE dbid = %d" % ("role = 'p', " if swap_roles else "", peer.getSegmentDbId()), 1)
+            conn.commit()
+        conn.close()
+
+        # Re-init the gparray instance so it matches the updated catalog
+        self.gparray = GpArray.initFromCatalog(self.dburl, utility=True)
 
     ######
     def _recovery_startup(self):

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -369,21 +369,24 @@ class GpStart:
             if not (primary_host in unreachable_hosts or mirror_host in unreachable_hosts):
                 continue # both hosts are reachable, nothing to do
             if primary_host in unreachable_hosts and mirror_host in unreachable_hosts:
-                continue # double-fault scenario, don't update the catalog as the cluster won't start anyway
+                continue # In a double-fault scenario, don't update the catalog since the cluster won't start anyway
 
-            seg, peer = None, None
-            swap_roles = False
+            down_seg, peer = None, None
             if primary_host in unreachable_hosts:
-                seg = segment.primaryDB
+                down_seg = segment.primaryDB
                 peer = segment.mirrorDBs[0]
-                swap_roles = True
-            elif mirror_host in unreachable_hosts:
-                seg = segment.mirrorDBs[0]
+            else:
+                down_seg = segment.mirrorDBs[0]
                 peer = segment.primaryDB
 
-            logger.warning("Marking segment %d down because %s is unreachable" % (seg.getSegmentDbId(), seg.getSegmentHostName()))
-            dbconn.executeUpdateOrInsert(conn, "UPDATE gp_segment_configuration SET %sstatus = 'd' WHERE dbid = %d" % ("role = 'm', " if swap_roles else "", seg.getSegmentDbId()), 1)
-            dbconn.executeUpdateOrInsert(conn, "UPDATE gp_segment_configuration SET %smode = 'c' WHERE dbid = %d" % ("role = 'p', " if swap_roles else "", peer.getSegmentDbId()), 1)
+            logger.warning("Marking segment %d down because %s is unreachable" % (down_seg.getSegmentDbId(), down_seg.getSegmentHostName()))
+            dbconn.executeUpdateOrInsert(conn, "UPDATE gp_segment_configuration SET status = 'd' WHERE dbid = %d" % down_seg.getSegmentDbId(), 1)
+            # If the segments are not synchronized, this is a mirror acting as a primary and its peer segment has failed over, so it's not safe
+            # to artificially "fail it over" again.
+            if down_seg.isSegmentModeSynchronized() and peer.isSegmentModeSynchronized():
+                logger.debug("Setting segment %d to mirror and segment %d to primary" % (down_seg.getSegmentDbId(), peer.getSegmentDbId()))
+                dbconn.executeUpdateOrInsert(conn, "UPDATE gp_segment_configuration SET role = 'm' WHERE dbid = %d" % down_seg.getSegmentDbId(), 1)
+                dbconn.executeUpdateOrInsert(conn, "UPDATE gp_segment_configuration SET role = 'p', mode = 'c' WHERE dbid = %d" % peer.getSegmentDbId(), 1)
             conn.commit()
         conn.close()
 

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -125,7 +125,13 @@ Feature: Validate command line arguments
      Then gpstart should print "Host invalid_host is unreachable" to stdout
       And gpstart should print unreachable host messages for the down segments
       And the status of the primary on content 0 should be "d"
+      And the role of the primary on content 0 should be "m"
+      And the mode of the mirror on content 0 should be "c"
+      And the role of the mirror on content 0 should be "p"
       And the status of the primary on content 1 should be "d"
+      And the role of the primary on content 1 should be "m"
+      And the mode of the mirror on content 1 should be "c"
+      And the role of the mirror on content 1 should be "p"
       And the cluster is returned to a good state
 
     # Once the mirror is marked down, gpstart will not start it.  In this case, connections
@@ -142,4 +148,12 @@ Feature: Validate command line arguments
 
          Then gpstart should print "Host invalid_host is unreachable" to stdout
           And gpstart should print unreachable host messages for the down segments
+          And the status of the primary on content 0 should be "d"
+          And the role of the primary on content 0 should be "m"
+          And the mode of the mirror on content 0 should be "c"
+          And the role of the mirror on content 0 should be "p"
+          And the mode of the primary on content 1 should be "c"
+          And the role of the primary on content 1 should be "p"
+          And the status of the mirror on content 1 should be "d"
+          And the role of the mirror on content 1 should be "m"
           And the cluster is returned to a good state

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -119,14 +119,14 @@ def impl(context):
     for dbid in sorted(context.down_segment_dbids):
         context.execute_steps(u'Then gpstart should print "Marking segment %s down because invalid_host is unreachable" to stdout' % dbid)
 
-def must_have_expected_status(content, preferred_role, expected_status):
+def must_have_expected_field(content, preferred_role, field, expected):
     with dbconn.connect(dbconn.DbURL(dbname="template1")) as conn:
-        status = dbconn.execSQLForSingleton(conn, "SELECT status FROM gp_segment_configuration WHERE content = %s AND preferred_role = '%s'" % (content, preferred_role))
-    if status != expected_status:
-        raise Exception("Expected status for role %s to be %s, but it is %s" % (preferred_role, expected_status, status))
+        result = dbconn.execSQLForSingleton(conn, "SELECT %s FROM gp_segment_configuration WHERE content = %s AND preferred_role = '%s'" % (field, content, preferred_role))
+    if result != expected:
+        raise Exception("Expected %s for role %s to be %s, but it is %s" % (field, preferred_role, expected, result))
 
-@then('the status of the {seg_type} on content {content} should be "{expected_status}"')
-def impl(context, seg_type, content, expected_status):
+@then('the {field} of the {seg_type} on content {content} should be "{expected}"')
+def impl(context, field, seg_type, content, expected):
     if seg_type == "primary":
         preferred_role = 'p'
     elif seg_type == "mirror":
@@ -136,7 +136,7 @@ def impl(context, seg_type, content, expected_status):
 
     wait_for_unblocked_transactions(context)
 
-    must_have_expected_status(content, preferred_role, expected_status)
+    must_have_expected_field(content, preferred_role, field, expected)
 
 @then('the cluster is returned to a good state')
 def impl(context):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -5472,9 +5472,13 @@ def impl(context, gppkg_name):
 @when('the user runs command "{command}" on all hosts without validation')
 @then('the user runs command "{command}" on all hosts without validation')
 def impl(context, command):
-    hostlist = get_all_hostnames_as_list(context, 'template1')
+    #hostlist = get_all_hostnames_as_list(context, 'template1')
+    with dbconn.connect(dbconn.DbURL(dbname="template1"), utility=True, allowSystemTableMods='dml') as conn:
+        curs = dbconn.execSQL(conn, "SELECT DISTINCT(hostname) FROM gp_segment_configuration")
+        hostnames = [h[0].strip() for h in curs.fetchall()]
 
-    for hostname in set(hostlist):
+    #for hostname in set(hostlist):
+    for hostname in hostnames:
         cmd = Command(name='running command:%s' % command,
                       cmdStr=command,
                       ctxt=REMOTE,


### PR DESCRIPTION
In certain cases, attempting to start the cluster when a mirror's host
is unreachable but the mirror is still marked up in configuration will
cause gpstart to hang and then fail to start the cluster.  This issue
was not fixed by the previous commit addressing down host behavior in
gpstart because in this case the problem is not with running checks
before startup but with the startup process itself.

This commit fixes the problem by updating the gp_segment_configuration
rows for each affected mirror and its primary during startup with the
values that they would have had if the cluster had started and then FTS
had recognized the failed mirror and modified the table accordingly.

This is not a backport of a fix on master or 6X_STABLE, as the issue
only appears in 5X_STABLE.