### PR TITLE
Pick number of distributed log buffers based on shared_buffers

### DIFF
--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -42,9 +42,6 @@ typedef struct DistributedLogEntry
 
 } DistributedLogEntry;
 
-/* Number of SLRU buffers to use for the distributed log */
-#define NUM_DISTRIBUTEDLOG_BUFFERS	8
-
 extern void DistributedLog_SetCommittedTree(TransactionId xid, int nxids, TransactionId *xids,
 								DistributedTransactionTimeStamp	distribTimeStamp,
 								DistributedTransactionId distribXid,
@@ -62,6 +59,7 @@ extern TransactionId DistributedLog_AdvanceOldestXmin(TransactionId oldestInProg
 								 DistributedTransactionId oldestDistribXid);
 extern TransactionId DistributedLog_GetOldestXmin(TransactionId oldestLocalXmin);
 
+extern Size DistributedLog_ShmemBuffers(void);
 extern Size DistributedLog_ShmemSize(void);
 extern void DistributedLog_ShmemInit(void);
 extern void DistributedLog_BootStrap(void);


### PR DESCRIPTION
Distributed log buffers were hard-coded to 8. Mostly in HTAP
work-load, it is possible to have many distributed log page requests
in flight at one time which could lead to disk access for distributed
log page if the required page is not found in memory. Testing revealed
that we can get the best performance by having 128 distributed log
buffers, more than that it doesn't improve performance.

Hence, seeking inspiration from CLOG buffers, number of distributed
log buffers are also selected based on shared_buffers.

Discussion:
https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/l_iNnfwTF7s/m/Fk-6UVlbAwAJ

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
