### PR TITLE
[6X Backport]Correct cost estimate for bmcostestimate()

### DIFF
--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -730,3 +730,140 @@ SELECT * from bm_test_reindex where c2 = 65536;
   1 | 65536
 (1 row)
 
+SET enable_seqscan = ON;
+SET enable_indexscan = ON;
+--
+-- correct cost estimate to avoid bm index scan for wrong result
+--
+CREATE TABLE test_bmselec(id int, type int, msg text) distributed by (id);
+INSERT INTO test_bmselec (id, type, msg) SELECT g, g % 10000, md5(g::text) FROM generate_series(1,100000) as g;
+CREATE INDEX ON test_bmselec USING bitmap(type);
+ANALYZE test_bmselec;
+-- it used to choose bitmap index over seq scan, which not right.
+explain (analyze, verbose) select * from test_bmselec where type < 500;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..562.63 rows=5097 width=41) (actual time=0.325..5.944 rows=5000 loops=1)
+   Output: id, type, msg
+   ->  Seq Scan on public.test_bmselec  (cost=0.00..494.67 rows=1699 width=41) (actual time=0.029..5.094 rows=1693 loops=1)
+         Output: id, type, msg
+         Filter: (test_bmselec.type < 500)
+         Rows Removed by Filter: 31769
+ Planning Time: 0.620 ms
+   (slice0)    Executor memory: 36K bytes.
+   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=on, enable_indexscan=on, enable_seqscan=on
+ Execution Time: 6.606 ms
+(13 rows)
+
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+-- we can see the bitmap index scan is much more slower
+explain (analyze, verbose) select * from test_bmselec where type < 500;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5931.19 rows=5097 width=41) (actual time=25.173..84.703 rows=5000 loops=1)
+   Output: id, type, msg
+   ->  Index Scan using test_bmselec_type_idx on public.test_bmselec  (cost=0.00..5863.22 rows=1699 width=41) (actual time=24.676..49.892 rows=1693 loops=1)
+         Output: id, type, msg
+         Index Cond: (test_bmselec.type < 500)
+ Planning Time: 0.358 ms
+   (slice0)    Executor memory: 39K bytes.
+   (slice1)    Executor memory: 15732K bytes avg x 3 workers, 15785K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_indexscan=on, enable_seqscan=off
+ Execution Time: 87.205 ms
+(12 rows)
+
+DROP TABLE test_bmselec;
+SET enable_seqscan = ON;
+SET enable_bitmapscan = ON;
+-- for sparse bitmap index
+create table test_bmsparse(id int, type int, msg text) distributed by (id);
+INSERT INTO test_bmsparse (id, type, msg) SELECT g, g % 10000, md5(g::text) FROM generate_series(1,10000) as g;
+INSERT INTO test_bmsparse (id, type, msg) SELECT g, g % 200, md5(g::text) FROM generate_series(1,80000) as g;
+INSERT INTO test_bmsparse (id, type, msg) SELECT g, g % 10000, md5(g::text) FROM generate_series(1,10000) as g;
+CREATE INDEX ON test_bmsparse USING bitmap(type);
+ANALYZE test_bmsparse;
+-- select lots of rows but on small part of distinct values, should use seq scan
+explain (analyze, verbose) select * from test_bmsparse where type < 200;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1559.93 rows=79895 width=41) (actual time=0.846..27.219 rows=80400 loops=1)
+   Output: id, type, msg
+   ->  Seq Scan on public.test_bmsparse  (cost=0.00..494.67 rows=26632 width=41) (actual time=0.029..7.373 rows=26975 loops=1)
+         Output: id, type, msg
+         Filter: (test_bmsparse.type < 200)
+         Rows Removed by Filter: 6596
+ Planning Time: 0.549 ms
+   (slice0)    Executor memory: 36K bytes.
+   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=on, enable_indexscan=on, enable_seqscan=on
+ Execution Time: 31.714 ms
+(13 rows)
+
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+explain (analyze, verbose) select * from test_bmsparse where type < 200;
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..35546.79 rows=79895 width=41) (actual time=21.727..232.170 rows=80400 loops=1)
+   Output: id, type, msg
+   ->  Index Scan using test_bmsparse_type_idx on public.test_bmsparse  (cost=0.00..34481.53 rows=26632 width=41) (actual time=11.498..206.903 rows=26975 loops=1)
+         Output: id, type, msg
+         Index Cond: (test_bmsparse.type < 200)
+ Planning Time: 0.271 ms
+   (slice0)    Executor memory: 39K bytes.
+   (slice1)    Executor memory: 6499K bytes avg x 3 workers, 6499K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_indexscan=on, enable_seqscan=off
+ Execution Time: 237.311 ms
+(12 rows)
+
+SET enable_seqscan = ON;
+SET enable_bitmapscan = ON;
+-- select small part of table but on lots of distinct values, should use seq scan
+explain (analyze, verbose) select * from test_bmsparse where type > 500;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..748.40 rows=19030 width=41) (actual time=0.327..9.309 rows=18998 loops=1)
+   Output: id, type, msg
+   ->  Seq Scan on public.test_bmsparse  (cost=0.00..494.67 rows=6343 width=41) (actual time=0.042..5.347 rows=6448 loops=1)
+         Output: id, type, msg
+         Filter: (test_bmsparse.type > 500)
+         Rows Removed by Filter: 26979
+ Planning Time: 0.330 ms
+   (slice0)    Executor memory: 36K bytes.
+   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=on, enable_indexscan=on, enable_seqscan=on
+ Execution Time: 10.469 ms
+(13 rows)
+
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+explain (analyze, verbose) select * from test_bmsparse where type > 500;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8707.89 rows=19030 width=41) (actual time=446.186..930.016 rows=18998 loops=1)
+   Output: id, type, msg
+   ->  Index Scan using test_bmsparse_type_idx on public.test_bmsparse  (cost=0.00..8454.16 rows=6343 width=41) (actual time=445.685..927.002 rows=6448 loops=1)
+         Output: id, type, msg
+         Index Cond: (test_bmsparse.type > 500)
+ Planning Time: 0.240 ms
+   (slice0)    Executor memory: 39K bytes.
+   (slice1)    Executor memory: 100254K bytes avg x 3 workers, 102077K bytes max (seg1).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_indexscan=on, enable_seqscan=off
+ Execution Time: 950.231 ms
+(12 rows)
+
+DROP TABLE test_bmsparse;

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -732,3 +732,143 @@ SELECT * from bm_test_reindex where c2 = 65536;
   1 | 65536
 (1 row)
 
+SET enable_seqscan = ON;
+SET enable_indexscan = ON;
+--
+-- correct cost estimate to avoid bm index scan for wrong result
+--
+CREATE TABLE test_bmselec(id int, type int, msg text) distributed by (id);
+INSERT INTO test_bmselec (id, type, msg) SELECT g, g % 10000, md5(g::text) FROM generate_series(1,100000) as g;
+CREATE INDEX ON test_bmselec USING bitmap(type);
+ANALYZE test_bmselec;
+-- it used to choose bitmap index over seq scan, which not right.
+explain (analyze, verbose) select * from test_bmselec where type < 500;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..434.28 rows=4943 width=41) (actual time=0.435..7.910 rows=5000 loops=1)
+   Output: id, type, msg
+   ->  Seq Scan on public.test_bmselec  (cost=0.00..433.52 rows=1648 width=41) (actual time=0.030..5.213 rows=1693 loops=1)
+         Output: id, type, msg
+         Filter: (test_bmselec.type < 500)
+         Rows Removed by Filter: 31769
+ Planning Time: 49.134 ms
+   (slice0)    Executor memory: 36K bytes.
+   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=on, enable_indexscan=on, enable_seqscan=on
+ Execution Time: 8.972 ms
+(13 rows)
+
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+-- we can see the bitmap index scan is much more slower
+explain (analyze, verbose) select * from test_bmselec where type < 500;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..434.28 rows=4943 width=41) (actual time=0.439..8.396 rows=5000 loops=1)
+   Output: id, type, msg
+   ->  Seq Scan on public.test_bmselec  (cost=0.00..433.52 rows=1648 width=41) (actual time=0.032..6.750 rows=1693 loops=1)
+         Output: id, type, msg
+         Filter: (test_bmselec.type < 500)
+         Rows Removed by Filter: 31769
+ Planning Time: 4.239 ms
+   (slice0)    Executor memory: 36K bytes.
+   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=off, enable_indexscan=on, enable_seqscan=off
+ Execution Time: 9.222 ms
+(13 rows)
+
+DROP TABLE test_bmselec;
+SET enable_seqscan = ON;
+SET enable_bitmapscan = ON;
+-- for sparse bitmap index
+create table test_bmsparse(id int, type int, msg text) distributed by (id);
+INSERT INTO test_bmsparse (id, type, msg) SELECT g, g % 10000, md5(g::text) FROM generate_series(1,10000) as g;
+INSERT INTO test_bmsparse (id, type, msg) SELECT g, g % 200, md5(g::text) FROM generate_series(1,80000) as g;
+INSERT INTO test_bmsparse (id, type, msg) SELECT g, g % 10000, md5(g::text) FROM generate_series(1,10000) as g;
+CREATE INDEX ON test_bmsparse USING bitmap(type);
+ANALYZE test_bmsparse;
+-- select lots of rows but on small part of distinct values, should use seq scan
+explain (analyze, verbose) select * from test_bmsparse where type < 200;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..447.65 rows=79956 width=41) (actual time=0.888..24.753 rows=80400 loops=1)
+   Output: id, type, msg
+   ->  Seq Scan on public.test_bmsparse  (cost=0.00..435.43 rows=26652 width=41) (actual time=0.037..7.395 rows=26975 loops=1)
+         Output: id, type, msg
+         Filter: (test_bmsparse.type < 200)
+         Rows Removed by Filter: 6596
+ Planning Time: 161.423 ms
+   (slice0)    Executor memory: 36K bytes.
+   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=on, enable_indexscan=on, enable_seqscan=on
+ Execution Time: 29.185 ms
+(13 rows)
+
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+explain (analyze, verbose) select * from test_bmsparse where type < 200;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..447.65 rows=79956 width=41) (actual time=0.866..24.050 rows=80400 loops=1)
+   Output: id, type, msg
+   ->  Seq Scan on public.test_bmsparse  (cost=0.00..435.43 rows=26652 width=41) (actual time=0.029..7.666 rows=26975 loops=1)
+         Output: id, type, msg
+         Filter: (test_bmsparse.type < 200)
+         Rows Removed by Filter: 6596
+ Planning Time: 5.059 ms
+   (slice0)    Executor memory: 36K bytes.
+   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=off, enable_indexscan=on, enable_seqscan=off
+ Execution Time: 28.480 ms
+(13 rows)
+
+SET enable_seqscan = ON;
+SET enable_bitmapscan = ON;
+-- select small part of table but on lots of distinct values, should use seq scan
+explain (analyze, verbose) select * from test_bmsparse where type > 500;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..436.80 rows=19101 width=41) (actual time=0.391..12.640 rows=18998 loops=1)
+   Output: id, type, msg
+   ->  Seq Scan on public.test_bmsparse  (cost=0.00..433.88 rows=6367 width=41) (actual time=0.049..5.123 rows=6448 loops=1)
+         Output: id, type, msg
+         Filter: (test_bmsparse.type > 500)
+         Rows Removed by Filter: 26979
+ Planning Time: 5.442 ms
+   (slice0)    Executor memory: 36K bytes.
+   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=on, enable_indexscan=on, enable_seqscan=on
+ Execution Time: 14.206 ms
+(13 rows)
+
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+explain (analyze, verbose) select * from test_bmsparse where type > 500;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..436.80 rows=19101 width=41) (actual time=0.352..9.098 rows=18998 loops=1)
+   Output: id, type, msg
+   ->  Seq Scan on public.test_bmsparse  (cost=0.00..433.88 rows=6367 width=41) (actual time=0.049..5.299 rows=6448 loops=1)
+         Output: id, type, msg
+         Filter: (test_bmsparse.type > 500)
+         Rows Removed by Filter: 26979
+ Planning Time: 5.703 ms
+   (slice0)    Executor memory: 36K bytes.
+   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=off, enable_indexscan=on, enable_seqscan=off
+ Execution Time: 10.390 ms
+(13 rows)
+
+DROP TABLE test_bmsparse;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -12786,20 +12786,18 @@ select * from foo join tbtree on foo.a=tbtree.a where tbtree.a < 5000;
 -- 4 bitmap with select pred
 explain (costs off)
 select * from foo join tbitmap on foo.a=tbitmap.a where tbitmap.a < 5000;
-                    QUERY PLAN                    
---------------------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: (tbitmap.a = foo.a)
-         ->  Bitmap Heap Scan on tbitmap
-               Recheck Cond: (a < 5000)
-               ->  Bitmap Index Scan on tbitmapxa
-                     Index Cond: (a < 5000)
+         ->  Seq Scan on tbitmap
+               Filter: (a < 5000)
          ->  Hash
                ->  Seq Scan on foo
                      Filter: (a < 5000)
  Optimizer: Postgres query optimizer
-(11 rows)
+(9 rows)
 
 select * from foo join tbitmap on foo.a=tbitmap.a where tbitmap.a < 5000;
   a   |  b   |  c   |  a   |  b   |  c   
@@ -12966,22 +12964,20 @@ select * from foo join (select a, count(*) + 5 as cnt from tbtree where tbtree.a
 -- 10 bitmap with proj select grby select
 explain (costs off)
 select * from foo join (select a, count(*) + 5 as cnt from tbitmap where tbitmap.a < 5000 group by a having count(*) < 2) proj_sel_grby_sel on foo.a=proj_sel_grby_sel.a;
-                       QUERY PLAN                       
---------------------------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: (tbitmap.a = foo.a)
          ->  HashAggregate
                Group Key: tbitmap.a
                Filter: (count(*) < 2)
-               ->  Bitmap Heap Scan on tbitmap
-                     Recheck Cond: (a < 5000)
-                     ->  Bitmap Index Scan on tbitmapxa
-                           Index Cond: (a < 5000)
+               ->  Seq Scan on tbitmap
+                     Filter: (a < 5000)
          ->  Hash
                ->  Seq Scan on foo
  Optimizer: Postgres query optimizer
-(13 rows)
+(11 rows)
 
 select * from foo join (select a, count(*) + 5 as cnt from tbitmap where tbitmap.a < 5000 group by a having count(*) < 2) proj_sel_grby_sel on foo.a=proj_sel_grby_sel.a;
   a   |  b   |  c   |  a   | cnt 

--- a/src/test/regress/sql/bitmap_index.sql
+++ b/src/test/regress/sql/bitmap_index.sql
@@ -311,3 +311,52 @@ SELECT * from bm_test_reindex where c2 = 32767;
 SELECT * from bm_test_reindex where c2 = 32768;
 SELECT * from bm_test_reindex where c2 = 32769;
 SELECT * from bm_test_reindex where c2 = 65536;
+
+SET enable_seqscan = ON;
+SET enable_indexscan = ON;
+
+--
+-- correct cost estimate to avoid bm index scan for wrong result
+--
+CREATE TABLE test_bmselec(id int, type int, msg text) distributed by (id);
+INSERT INTO test_bmselec (id, type, msg) SELECT g, g % 10000, md5(g::text) FROM generate_series(1,100000) as g;
+CREATE INDEX ON test_bmselec USING bitmap(type);
+ANALYZE test_bmselec;
+
+-- it used to choose bitmap index over seq scan, which not right.
+explain (analyze, verbose) select * from test_bmselec where type < 500;
+
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+-- we can see the bitmap index scan is much more slower
+explain (analyze, verbose) select * from test_bmselec where type < 500;
+DROP TABLE test_bmselec;
+
+SET enable_seqscan = ON;
+SET enable_bitmapscan = ON;
+
+-- for sparse bitmap index
+create table test_bmsparse(id int, type int, msg text) distributed by (id);
+INSERT INTO test_bmsparse (id, type, msg) SELECT g, g % 10000, md5(g::text) FROM generate_series(1,10000) as g;
+INSERT INTO test_bmsparse (id, type, msg) SELECT g, g % 200, md5(g::text) FROM generate_series(1,80000) as g;
+INSERT INTO test_bmsparse (id, type, msg) SELECT g, g % 10000, md5(g::text) FROM generate_series(1,10000) as g;
+CREATE INDEX ON test_bmsparse USING bitmap(type);
+ANALYZE test_bmsparse;
+
+-- select lots of rows but on small part of distinct values, should use seq scan
+explain (analyze, verbose) select * from test_bmsparse where type < 200;
+
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+explain (analyze, verbose) select * from test_bmsparse where type < 200;
+
+SET enable_seqscan = ON;
+SET enable_bitmapscan = ON;
+-- select small part of table but on lots of distinct values, should use seq scan
+explain (analyze, verbose) select * from test_bmsparse where type > 500;
+
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+explain (analyze, verbose) select * from test_bmsparse where type > 500;
+
+DROP TABLE test_bmsparse;


### PR DESCRIPTION
We create a LOV for each distinct key in bitmap index. And the LOV point
to the bitmap vector pages. Since each bitmap vector has the same length,
although we do compress for the bits, we can assume each distinct
key has the approximately same number of bitmap vector pages(although there
must be some counterexamples). So the indexPages should be:
selectedDistinctValues / numDistinctValues * index->pages.

But the issue is we can't estimate both of the distinct values from stats
through estimate_num_groups since it produces larger estimates. Especially
for selectedDistinctValues.

Image below cases:
1. indexSelectivity also correspond to how may distinct values get selected.
Then the result of genericcostestimate's indexPages will be accurate.
2. indexSelectivity is high but only match a small number of distinct values.
This means the bitmap vector is sparse. So the total index pages number should
be small.
3. indexSelectivity is low but match lots of distinct values. This also means
the bitmap vector is sparse, and the total index page number should be small.

The estimate in genericcostestimate should work fine for the above cases although
it's not accurate.

(cherry picked from commit f1d541102e88b61a9b95608a5f2d46b2ddfcc7e2)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
