### PR TITLE
fix gpload config file ' and " issue in 6x

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1876,7 +1876,7 @@ class gpload:
                     self.log(self.DEBUG,
                              'getting source column data type from target')
                     for name, typ, mapto, hasseq in self.into_columns:
-                        if sqlIdentifierCompare(name,quote_ident(key) ):
+                        if sqlIdentifierCompare(name,key):
                             d[key] = typ
                             break
 
@@ -1888,7 +1888,7 @@ class gpload:
 
                 # Mark this column as having no mapping, which is important
                 # for do_insert()
-                self.from_columns.append([quote_ident(key),d[key].lower(),None, False])
+                self.from_columns.append([key,d[key].lower(),None, False])
         else:
             self.from_columns = self.into_columns
             self.from_cols_from_user = False
@@ -2437,7 +2437,8 @@ class gpload:
         sql += "(%s)" % ','.join(map(lambda a:'%s %s' % (a[0], a[1]), from_cols))
 
         sql += "location(%s) "%locationStr
-        sql += "format%s "% quote(formatType)
+        sql += "format %s "% quote(formatType)
+
         if len(self.formatOpts) > 0:
             sql += "(%s) "% self.formatOpts
         if encodingStr:

--- a/gpMgmt/bin/gpload_test/gpload2/query44.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query44.ans
@@ -1,0 +1,51 @@
+2021-01-07 07:27:52|INFO|gpload session started 2021-01-07 07:27:52
+2021-01-07 07:27:52|INFO|setting schema 'public' for table 'testspecialchar'
+2021-01-07 07:27:52|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-07 07:27:52|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d9f87890_50b9_11eb_97d4_0242ac120005
+2021-01-07 07:27:52|ERROR|could not run SQL "create external table ext_gpload_reusable_d9f87890_50b9_11eb_97d4_0242ac120005("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+                                                                 ^
+
+2021-01-07 07:27:52|INFO|rows Inserted          = 0
+2021-01-07 07:27:52|INFO|rows Updated           = 0
+2021-01-07 07:27:52|INFO|data formatting errors = 0
+2021-01-07 07:27:52|INFO|gpload failed
+2021-01-07 07:27:52|INFO|gpload session started 2021-01-07 07:27:52
+2021-01-07 07:27:52|INFO|setting schema 'public' for table 'testspecialchar'
+2021-01-07 07:27:52|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-07 07:27:52|INFO|did not find an external table to reuse. creating ext_gpload_reusable_da410e34_50b9_11eb_b64d_0242ac120005
+2021-01-07 07:27:52|ERROR|could not run SQL "create external table ext_gpload_reusable_da410e34_50b9_11eb_b64d_0242ac120005("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+                                                                 ^
+
+2021-01-07 07:27:52|INFO|rows Inserted          = 0
+2021-01-07 07:27:52|INFO|rows Updated           = 0
+2021-01-07 07:27:52|INFO|data formatting errors = 0
+2021-01-07 07:27:52|INFO|gpload failed
+2021-01-07 07:27:53|INFO|gpload session started 2021-01-07 07:27:53
+2021-01-07 07:27:53|INFO|setting schema 'public' for table 'testspecialchar'
+2021-01-07 07:27:53|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file2.txt" -t 30
+2021-01-07 07:27:53|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
+2021-01-07 07:27:53|INFO|did not find an external table to reuse. creating ext_gpload_reusable_da82af6a_50b9_11eb_a7cb_0242ac120005
+2021-01-07 07:27:53|ERROR|could not run SQL "create external table ext_gpload_reusable_da82af6a_50b9_11eb_a7cb_0242ac120005("Field1" bigint,"Field#2" text)location('gpfdist://*:pathto/data_file2.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
+                                                                 ^
+
+2021-01-07 07:27:53|INFO|rows Inserted          = 0
+2021-01-07 07:27:53|INFO|rows Updated           = 0
+2021-01-07 07:27:53|INFO|data formatting errors = 0
+2021-01-07 07:27:53|INFO|gpload failed
+2021-01-07 07:27:53|INFO|gpload session started 2021-01-07 07:27:53
+2021-01-07 07:27:53|INFO|setting schema 'public' for table 'testspecialchar'
+2021-01-07 07:27:53|ERROR|no mapping for input column "'Field1'" to output table
+2021-01-07 07:27:53|INFO|rows Inserted          = 0
+2021-01-07 07:27:53|INFO|rows Updated           = 0
+2021-01-07 07:27:53|INFO|data formatting errors = 0
+2021-01-07 07:27:53|INFO|gpload failed
+2021-01-07 07:27:53|INFO|gpload session started 2021-01-07 07:27:53
+2021-01-07 07:27:53|INFO|setting schema 'public' for table 'testspecialchar'
+2021-01-07 07:27:54|ERROR|no mapping for input column "Field1" to output table
+2021-01-07 07:27:54|INFO|rows Inserted          = 0
+2021-01-07 07:27:54|INFO|rows Updated           = 0
+2021-01-07 07:27:54|INFO|data formatting errors = 0
+2021-01-07 07:27:54|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query45.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query45.ans
@@ -1,0 +1,42 @@
+2021-01-07 03:26:41|INFO|gpload session started 2021-01-07 03:26:41
+2021-01-07 03:26:41|INFO|setting schema 'public' for table 'testspecialchar'
+2021-01-07 03:26:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-01-07 03:26:41|INFO|did not find an external table to reuse. creating ext_gpload_reusable_28d204da_5098_11eb_b7ae_0242ac120005
+2021-01-07 03:26:41|INFO|running time: 0.15 seconds
+2021-01-07 03:26:41|INFO|rows Inserted          = 8
+2021-01-07 03:26:41|INFO|rows Updated           = 0
+2021-01-07 03:26:41|INFO|data formatting errors = 0
+2021-01-07 03:26:41|INFO|gpload succeeded
+2021-01-07 03:26:41|INFO|gpload session started 2021-01-07 03:26:41
+2021-01-07 03:26:41|INFO|setting schema 'public' for table 'testspecialchar'
+2021-01-07 03:26:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-01-07 03:26:41|INFO|reusing external table ext_gpload_reusable_28d204da_5098_11eb_b7ae_0242ac120005
+2021-01-07 03:26:42|INFO|running time: 0.11 seconds
+2021-01-07 03:26:42|INFO|rows Inserted          = 8
+2021-01-07 03:26:42|INFO|rows Updated           = 0
+2021-01-07 03:26:42|INFO|data formatting errors = 0
+2021-01-07 03:26:42|INFO|gpload succeeded
+2021-01-07 03:26:42|INFO|gpload session started 2021-01-07 03:26:42
+2021-01-07 03:26:42|INFO|setting schema 'public' for table 'testspecialchar'
+2021-01-07 03:26:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file2.txt" -t 30
+2021-01-07 03:26:42|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
+2021-01-07 03:26:42|INFO|did not find an external table to reuse. creating ext_gpload_reusable_294a54da_5098_11eb_933f_0242ac120005
+2021-01-07 03:26:42|INFO|running time: 0.27 seconds
+2021-01-07 03:26:42|INFO|rows Inserted          = 2
+2021-01-07 03:26:42|INFO|rows Updated           = 12
+2021-01-07 03:26:42|INFO|data formatting errors = 0
+2021-01-07 03:26:42|INFO|gpload succeeded
+2021-01-07 03:26:42|INFO|gpload session started 2021-01-07 03:26:42
+2021-01-07 03:26:42|INFO|setting schema 'public' for table 'testspecialchar'
+2021-01-07 03:26:42|ERROR|no mapping for input column "'Field1'" to output table
+2021-01-07 03:26:42|INFO|rows Inserted          = 0
+2021-01-07 03:26:42|INFO|rows Updated           = 0
+2021-01-07 03:26:42|INFO|data formatting errors = 0
+2021-01-07 03:26:42|INFO|gpload failed
+2021-01-07 03:26:43|INFO|gpload session started 2021-01-07 03:26:43
+2021-01-07 03:26:43|INFO|setting schema 'public' for table 'testspecialchar'
+2021-01-07 03:26:43|ERROR|no mapping for input column "Field1" to output table
+2021-01-07 03:26:43|INFO|rows Inserted          = 0
+2021-01-07 03:26:43|INFO|rows Updated           = 0
+2021-01-07 03:26:43|INFO|data formatting errors = 0
+2021-01-07 03:26:43|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/setup.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.ans
@@ -6,6 +6,7 @@ You are now connected to database "reuse_gptest" as user "gpadmin".
 CREATE SCHEMA test;
 CREATE SCHEMA
 DROP EXTERNAL TABLE IF EXISTS temp_gpload_staging_table;
+NOTICE:  table "temp_gpload_staging_table" does not exist, skipping
 DROP EXTERNAL TABLE
 DROP TABLE IF EXISTS texttable;
 NOTICE:  table "texttable" does not exist, skipping
@@ -15,6 +16,9 @@ NOTICE:  table "csvtable" does not exist, skipping
 DROP TABLE
 DROP TABLE IF EXISTS texttable1;
 NOTICE:  table "texttable1" does not exist, skipping
+DROP TABLE
+DROP TABLE IF EXISTS test.csvtable;
+NOTICE:  table "csvtable" does not exist, skipping
 DROP TABLE
 DROP TABLE IF EXISTS testSpecialChar;
 NOTICE:  table "testspecialchar" does not exist, skipping

--- a/gpMgmt/bin/gpload_test/gpload2/setup.sql
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.sql
@@ -10,6 +10,7 @@ DROP EXTERNAL TABLE IF EXISTS temp_gpload_staging_table;
 DROP TABLE IF EXISTS texttable;
 DROP TABLE IF EXISTS csvtable;
 DROP TABLE IF EXISTS texttable1;
+DROP TABLE IF EXISTS test.csvtable;
 DROP TABLE IF EXISTS testSpecialChar;
 reset client_min_messages;
 CREATE TABLE texttable (


### PR DESCRIPTION
Fix gpload ' and " in config file input column. Make `'"col"',  "\"col\"", '"col"', "col" `and col in YAML input columns work fine
We just transmit what in the quotations or double quotations into gpdb.

add test case 44

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
