### PR TITLE
WIP: Implement type input functions for extended statistics types

### DIFF
--- a/src/test/regress/sql/stats_ext.sql
+++ b/src/test/regress/sql/stats_ext.sql
@@ -517,3 +517,43 @@ RESET SESSION AUTHORIZATION;
 DROP VIEW priv_test_view;
 DROP TABLE priv_test_tbl;
 DROP USER regress_stats_user1;
+
+-- Test pg_ndistinct_in
+drop table if exists mytable;
+create table mytable(i int, ii pg_ndistinct);
+insert into mytable values (1, '{"1, 2": 1}');
+insert into mytable values (2, '{"1, 2": 2, "1, 3": 3, "2, 3": 2, "1, 2, 3": 3}');
+insert into mytable values (3, '{"123, 234": 11}');
+select * from mytable;
+
+-- leading space
+insert into mytable values (1, ' {"1, 2": 1}');
+-- trailing space
+insert into mytable values (1, '{"1, 2": 1} ');
+-- unmatched quote
+insert into mytable values (1, '{"1", 2": 1} ');
+-- space in attribute list
+insert into mytable values (1, '{"1 3, 2": 1} ');
+-- colon in attribute list
+insert into mytable values (1, '{"1: 2": 1}');
+insert into mytable values (1, '{"1, 2:" 1}');
+insert into mytable values (1, '{":1 2": 1}');
+-- zero/single item attribute list
+insert into mytable values (1, '{"1": 1}');
+insert into mytable values (1, '{: 1}');
+insert into mytable values (1, '{"": 1}');
+insert into mytable values (1, '{" ": 1}');
+insert into mytable values (1, '{}');
+insert into mytable values (1, '{:}');
+-- illegal character
+insert into mytable values (1, '{"1,| 2": 1}');
+
+-- multiple consecutive characters
+insert into mytable values (1, '{"1,, 2": 1}');
+insert into mytable values (1, '{"1": 1}');
+
+-- Need to add check on catalog table insert that atribute numbers are legal
+-- (e.g. there shouldn't be attribute number 100 for a table with only 2
+-- columns also it should match)
+
+select * from mytable;


### PR DESCRIPTION
In order for gpsd/minirepro to restore dumped extended statistics (stxdndistinct, stxddependencies, stxdmcv) we need provide an input function to parse pg_ndistinct strings (today we get the ERROR "cannot accept a value of type pg_ndistinct" when we try to do an insert).

Alternative to the approach we tried:
1) do something similar to syncrep_gram.y.
2) Instead of returning pretty output from _out function, we could return byte arrays like for `pg_mcv_list()` and have a separate SRF, like `pg_mcv_list_items()` to pretty format the contents.  That way the input function trivially becomes a bytea_in followed by a deserialize.

**We have opened this PR to get early feedback on our approach before we apply the same approach to other extended statistics fields.**

TODO: catalog bump
TODO: more tests?
TODO: submit patch to upstream
TODO: Take same approach to implement input functions for pg_dependencies

Upstream discussion which provides context as to why _in and _recv functions were not implemented for ndistinct:
https://www.postgresql.org/message-id/20170201225248.aajzts2on4ka4ky5%40alvherre.pgsql

***Future Work Notes:***
We should probably just call `bytea_in` followed by a `statext_mcv_deserialize` in the body of `pg_mcv_list_in` as the text format for `pg_mcv_list` is a `bytea`.
To implement the recv functions, we can do a `bytearecv()` followed by a deserialize function as a sanity check.

Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>