### PR TITLE
[6X_STABLE] Improve ORCA partition pruning for OR'd equal comparisons on part key

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
@@ -728,7 +728,9 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="15"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="15"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
@@ -417,7 +417,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
@@ -305,7 +305,9 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -1734,7 +1734,9 @@
                                                   </dxl:Properties>
                                                   <dxl:ProjList/>
                                                   <dxl:PartEqFilters>
-                                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2002"/>
+                                                    <dxl:PartEqFilterElems>
+                                                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2002"/>
+                                                    </dxl:PartEqFilterElems>
                                                   </dxl:PartEqFilters>
                                                   <dxl:PartFilters>
                                                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGetDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGetDroppedCols.mdp
@@ -2441,8 +2441,12 @@ EXPLAIN SELECT * FROM solo WHERE year_id=2017 AND month_id=6;
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2017"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2017"/>
+              </dxl:PartEqFilterElems>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
@@ -320,7 +320,9 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
@@ -387,7 +387,9 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
@@ -371,7 +371,9 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
@@ -287,7 +287,9 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
@@ -10536,7 +10536,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="27" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="27" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -10596,7 +10598,9 @@
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:PartEqFilters>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2001"/>
+                      <dxl:PartEqFilterElems>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2001"/>
+                      </dxl:PartEqFilterElems>
                     </dxl:PartEqFilters>
                     <dxl:PartFilters>
                       <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
@@ -14943,7 +14943,9 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:PartEqFilters>
-                        <dxl:Ident ColId="55" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                        <dxl:PartEqFilterElems>
+                          <dxl:Ident ColId="55" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                        </dxl:PartEqFilterElems>
                       </dxl:PartEqFilters>
                       <dxl:PartFilters>
                         <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-2.mdp
@@ -4306,7 +4306,9 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:PartEqFilters>
-                    <dxl:Ident ColId="27" ColName="date" TypeMdid="0.1114.1.0"/>
+                    <dxl:PartEqFilterElems>
+                      <dxl:Ident ColId="27" ColName="date" TypeMdid="0.1114.1.0"/>
+                    </dxl:PartEqFilterElems>
                   </dxl:PartEqFilters>
                   <dxl:PartFilters>
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
@@ -955,7 +955,9 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="12" ColName="c3" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="12" ColName="c3" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-ForPartialIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-ForPartialIndex.mdp
@@ -509,7 +509,9 @@ explain select t1.a from t1, foo_prt t2, t3 where (t1.b = t2.a) and t2.a = t3.b;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:Ident ColId="14" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:Ident ColId="14" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
@@ -637,7 +637,9 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:PartEqFilters>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                  <dxl:PartEqFilterElems>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                  </dxl:PartEqFilterElems>
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicates.mdp
@@ -472,7 +472,9 @@ explain select 1+row_number() over(partition by foo.c) from foo, bar where foo.a
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:PartEqFilters>
-                      <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
+                      <dxl:PartEqFilterElems>
+                        <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
+                      </dxl:PartEqFilterElems>
                     </dxl:PartEqFilters>
                     <dxl:PartFilters>
                       <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -504,7 +506,9 @@ explain select 1+row_number() over(partition by foo.c) from foo, bar where foo.a
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:PartEqFilters>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                          <dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                          </dxl:PartEqFilterElems>
                         </dxl:PartEqFilters>
                         <dxl:PartFilters>
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-vcpart-txt.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-vcpart-txt.mdp
@@ -827,9 +827,11 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
-                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
-              </dxl:Cast>
+              <dxl:PartEqFilterElems>
+                <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
+                </dxl:Cast>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
@@ -501,7 +501,9 @@
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:PartEqFilters>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                  <dxl:PartEqFilterElems>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                  </dxl:PartEqFilterElems>
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned-SortDisabled.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned-SortDisabled.mdp
@@ -446,7 +446,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -455,7 +457,7 @@
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:ResidualFilter>
             <dxl:PropagationExpression>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
             </dxl:PropagationExpression>
             <dxl:PrintableFilter>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned.mdp
@@ -485,7 +485,9 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -494,7 +496,7 @@
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:ResidualFilter>
               <dxl:PropagationExpression>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
               </dxl:PropagationExpression>
               <dxl:PrintableFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
@@ -281,7 +281,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned.mdp
@@ -308,7 +308,9 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
@@ -331,7 +331,9 @@ explain insert into pt2 select * from r;
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution.mdp
@@ -331,7 +331,9 @@ explain insert into pt2 select * from r;
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -4147,7 +4147,9 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:PartEqFilters>
-                        <dxl:Ident ColId="26" ColName="ymd" TypeMdid="0.1082.1.0"/>
+                        <dxl:PartEqFilterElems>
+                          <dxl:Ident ColId="26" ColName="ymd" TypeMdid="0.1082.1.0"/>
+                        </dxl:PartEqFilterElems>
                       </dxl:PartEqFilters>
                       <dxl:PartFilters>
                         <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
@@ -481,7 +481,9 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndexWithSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndexWithSelect.mdp
@@ -463,7 +463,9 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-1.mdp
@@ -3281,7 +3281,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3403,7 +3405,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3525,7 +3529,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3647,7 +3653,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3769,7 +3777,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3891,7 +3901,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4013,7 +4025,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4135,7 +4149,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4257,7 +4273,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4379,7 +4397,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4501,7 +4521,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4623,7 +4645,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4745,7 +4769,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-2.mdp
@@ -3281,7 +3281,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3403,7 +3405,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3525,7 +3529,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3647,7 +3653,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3769,7 +3777,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3891,7 +3901,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4013,7 +4025,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4135,7 +4149,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4257,7 +4273,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4379,7 +4397,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4501,7 +4521,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4623,7 +4645,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4745,7 +4769,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-4.mdp
@@ -3014,7 +3014,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3235,7 +3237,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3456,7 +3460,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3677,7 +3683,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3898,7 +3906,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4119,7 +4129,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4340,7 +4352,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4561,7 +4575,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4782,7 +4798,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -5003,7 +5021,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -5224,7 +5244,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -5445,7 +5467,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -5666,7 +5690,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-5.mdp
@@ -1056,7 +1056,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1196,7 +1198,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1336,7 +1340,9 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:PartEqFilterElems>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              </dxl:PartEqFilterElems>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-6.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-6.mdp
@@ -1024,7 +1024,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1267,7 +1269,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1510,7 +1514,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-7.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-7.mdp
@@ -1024,7 +1024,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1267,7 +1269,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1510,7 +1514,9 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            </dxl:PartEqFilterElems>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
@@ -1747,7 +1747,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide2.mdp
@@ -1697,7 +1697,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayCoerce.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ArrayCoerce.mdp
@@ -275,33 +275,17 @@ select * from pt where gender in ( 'F', 'FM');
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                  <dxl:ConstValue TypeMdid="0.1043.1.0" Value="AAAABUY=" LintValue="160743980"/>
+                </dxl:Cast>
+                <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                  <dxl:ConstValue TypeMdid="0.1043.1.0" Value="AAAABkZN" LintValue="689808164"/>
+                </dxl:Cast>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
-              <dxl:Or>
-                <dxl:Or>
-                  <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
-                    <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                      <dxl:ConstValue TypeMdid="0.1043.1.0" Value="AAAABUY=" LintValue="160743980"/>
-                    </dxl:Cast>
-                    <dxl:ArrayCoerceExpr ElementFunc="0.0.0.0" TypeMdid="0.1009.1.0" IsExplicit="true" CoercionForm="3" Location="-1">
-                      <dxl:PartListValues Level="0" ResultType="0.1015.1.0" ElementType="0.1043.1.0"/>
-                    </dxl:ArrayCoerceExpr>
-                  </dxl:ArrayComp>
-                  <dxl:DefaultPart Level="0"/>
-                </dxl:Or>
-                <dxl:Or>
-                  <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
-                    <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                      <dxl:ConstValue TypeMdid="0.1043.1.0" Value="AAAABkZN" LintValue="689808164"/>
-                    </dxl:Cast>
-                    <dxl:ArrayCoerceExpr ElementFunc="0.0.0.0" TypeMdid="0.1009.1.0" IsExplicit="true" CoercionForm="3" Location="-1">
-                      <dxl:PartListValues Level="0" ResultType="0.1015.1.0" ElementType="0.1043.1.0"/>
-                    </dxl:ArrayCoerceExpr>
-                  </dxl:ArrayComp>
-                  <dxl:DefaultPart Level="0"/>
-                </dxl:Or>
-              </dxl:Or>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartFilters>
             <dxl:ResidualFilter>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
@@ -963,7 +963,9 @@ FROM abuela JOIN bar ON a = c AND b BETWEEN d - 1 AND d + 4
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Correlated-NLOuter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Correlated-NLOuter.mdp
@@ -369,7 +369,9 @@ select (select h.i from t2) from h where h.j = 1;
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
@@ -635,7 +635,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="13" ColName="tid" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="13" ColName="tid" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Limit.mdp
@@ -622,7 +622,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="13" ColName="tid" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="13" ColName="tid" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-WindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-WindowFunction.mdp
@@ -773,7 +773,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ4.mdp
@@ -338,7 +338,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ5.mdp
@@ -378,7 +378,9 @@ select * from s,t where s.b=t.a and t.b=35;
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -427,7 +429,9 @@ select * from s,t where s.b=t.a and t.b=35;
                   </dxl:Properties>
                   <dxl:ProjList/>
                   <dxl:PartEqFilters>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
+                    <dxl:PartEqFilterElems>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
+                    </dxl:PartEqFilterElems>
                   </dxl:PartEqFilters>
                   <dxl:PartFilters>
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
@@ -1287,7 +1287,9 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:PartEqFilters>
-                  <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAAPAA==" DoubleValue="15.000000"/>
+                  <dxl:PartEqFilterElems>
+                    <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAAPAA==" DoubleValue="15.000000"/>
+                  </dxl:PartEqFilterElems>
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
@@ -1445,7 +1445,9 @@ select * from (select * from p1 except select * from p2) as p, tt where p.b=tt.b
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1475,7 +1477,9 @@ select * from (select * from p1 except select * from p2) as p, tt where p.b=tt.b
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
@@ -1326,7 +1326,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1425,7 +1427,9 @@
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:PartEqFilters>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                          <dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                          </dxl:PartEqFilterElems>
                         </dxl:PartEqFilters>
                         <dxl:PartFilters>
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg.mdp
@@ -386,7 +386,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
@@ -1463,7 +1463,9 @@ select * from (select * from p1 intersect select * from p2) as p, tt where p.b=t
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1493,7 +1495,9 @@ select * from (select * from p1 intersect select * from p2) as p, tt where p.b=t
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
@@ -1412,7 +1412,9 @@ select * from (select * from p1 union all select * from p2) as p, tt where p.b=t
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1442,7 +1444,9 @@ select * from (select * from p1 union all select * from p2) as p, tt where p.b=t
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
@@ -1013,7 +1013,9 @@ select * from (select * from tt union all select * from p2) as p, tt where p.b=t
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Int-Predicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Int-Predicates.mdp
@@ -356,7 +356,9 @@ select * from foo where b is not null;
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -500,25 +502,13 @@ select * from foo where b is not null;
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:Or>
-                    <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                      <dxl:PartListValues Level="0" ResultType="0.1007.1.0" ElementType="0.23.1.0"/>
-                    </dxl:ArrayComp>
-                    <dxl:DefaultPart Level="0"/>
-                  </dxl:Or>
-                  <dxl:Or>
-                    <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      <dxl:PartListValues Level="0" ResultType="0.1007.1.0" ElementType="0.23.1.0"/>
-                    </dxl:ArrayComp>
-                    <dxl:DefaultPart Level="0"/>
-                  </dxl:Or>
-                </dxl:Or>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Varchar-Predicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Varchar-Predicates.mdp
@@ -399,7 +399,9 @@ select * from pt where gender is null;
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABUY=" LintValue="160743980"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABUY=" LintValue="160743980"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -553,33 +555,17 @@ select * from pt where gender is null;
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                    <dxl:ConstValue TypeMdid="0.1043.1.0" Value="AAAABUY=" LintValue="160743980"/>
+                  </dxl:Cast>
+                  <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                    <dxl:ConstValue TypeMdid="0.1043.1.0" Value="AAAABkZN" LintValue="689808164"/>
+                  </dxl:Cast>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:Or>
-                    <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
-                      <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                        <dxl:ConstValue TypeMdid="0.1043.1.0" Value="AAAABUY=" LintValue="160743980"/>
-                      </dxl:Cast>
-                      <dxl:ArrayCoerceExpr ElementFunc="0.0.0.0" TypeMdid="0.1009.1.0" IsExplicit="true" CoercionForm="3" Location="-1">
-                        <dxl:PartListValues Level="0" ResultType="0.1015.1.0" ElementType="0.1043.1.0"/>
-                      </dxl:ArrayCoerceExpr>
-                    </dxl:ArrayComp>
-                    <dxl:DefaultPart Level="0"/>
-                  </dxl:Or>
-                  <dxl:Or>
-                    <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
-                      <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                        <dxl:ConstValue TypeMdid="0.1043.1.0" Value="AAAABkZN" LintValue="689808164"/>
-                      </dxl:Cast>
-                      <dxl:ArrayCoerceExpr ElementFunc="0.0.0.0" TypeMdid="0.1009.1.0" IsExplicit="true" CoercionForm="3" Location="-1">
-                        <dxl:PartListValues Level="0" ResultType="0.1015.1.0" ElementType="0.1043.1.0"/>
-                      </dxl:ArrayCoerceExpr>
-                    </dxl:ArrayComp>
-                    <dxl:DefaultPart Level="0"/>
-                  </dxl:Or>
-                </dxl:Or>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
@@ -1880,7 +1880,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -4357,7 +4357,9 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:Ident ColId="64" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:Ident ColId="64" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                </dxl:PartEqFilterElems>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4562,7 +4564,9 @@
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:PartEqFilters>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1999"/>
+                      <dxl:PartEqFilterElems>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1999"/>
+                      </dxl:PartEqFilterElems>
                     </dxl:PartEqFilters>
                     <dxl:PartFilters>
                       <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Equality.mdp
@@ -294,7 +294,9 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACjIwMDgwMA==" LintValue="249955124"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACjIwMDgwMA==" LintValue="249955124"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncSinglePredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncSinglePredPushDown.mdp
@@ -428,7 +428,9 @@
                   <dxl:ProjList/>
                   <dxl:PartEqFilters>
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB3VzYQ==" LintValue="2607030223"/>
+                    <dxl:PartEqFilterElems>
+                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB3VzYQ==" LintValue="2607030223"/>
+                    </dxl:PartEqFilterElems>
                   </dxl:PartEqFilters>
                   <dxl:PartFilters>
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
@@ -504,7 +504,9 @@ explain select i, count(j) from pt2  where k=5 group by i;
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:PartEqFilters>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                          <dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                          </dxl:PartEqFilterElems>
                         </dxl:PartEqFilters>
                         <dxl:PartFilters>
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
@@ -741,7 +741,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDistKeyMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDistKeyMismatchedDistribution.mdp
@@ -358,7 +358,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:PartEqFilters>
-            <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
+            <dxl:PartEqFilterElems>
+              <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
+            </dxl:PartEqFilterElems>
           </dxl:PartEqFilters>
           <dxl:PartFilters>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
@@ -295,7 +295,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:PartEqFilters>
-            <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
+            <dxl:PartEqFilterElems>
+              <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:PartEqFilterElems>
           </dxl:PartEqFilters>
           <dxl:PartFilters>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateNoDistKeyMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateNoDistKeyMismatchedDistribution.mdp
@@ -359,7 +359,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:PartEqFilters>
-            <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
+            <dxl:PartEqFilterElems>
+              <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
+            </dxl:PartEqFilterElems>
           </dxl:PartEqFilters>
           <dxl:PartFilters>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdatePartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdatePartTable.mdp
@@ -295,7 +295,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:PartEqFilters>
-            <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
+            <dxl:PartEqFilterElems>
+              <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:PartEqFilterElems>
           </dxl:PartEqFilters>
           <dxl:PartFilters>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_boundary_value_to_date.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_boundary_value_to_date.mdp
@@ -362,7 +362,9 @@ explain select * from TestPartitionFilterCasting where p1 = 'a';
             <dxl:ProjList/>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+              </dxl:PartEqFilterElems>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_partition_column_to_text.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_partition_column_to_text.mdp
@@ -384,7 +384,9 @@ explain select * from TestPartitionFilterCasting where p2 = '2015-01-01';
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
+              </dxl:PartEqFilterElems>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-no_casting.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-no_casting.mdp
@@ -363,7 +363,9 @@ explain select * from TestPartitionFilterCasting where p3 = 1.0;
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAQABAA==" DoubleValue="1.000000"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAQABAA==" DoubleValue="1.000000"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-all-levels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-all-levels.mdp
@@ -368,9 +368,15 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
-              <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAABAA==" DoubleValue="1.000000"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
+              </dxl:PartEqFilterElems>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+              </dxl:PartEqFilterElems>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAABAA==" DoubleValue="1.000000"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-leaf-levels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-leaf-levels.mdp
@@ -464,8 +464,12 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
+              </dxl:PartEqFilterElems>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+              </dxl:PartEqFilterElems>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-root-levels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-root-levels.mdp
@@ -429,8 +429,12 @@ explain select * from TestPartitionFilterCasting where p2 = '2015-01-01' and p3 
             <dxl:ProjList/>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
-              <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAABAA==" DoubleValue="1.000000"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+              </dxl:PartEqFilterElems>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAABAA==" DoubleValue="1.000000"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-Default.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-Default.mdp
@@ -294,7 +294,9 @@ select * from PT where j = 5;
             <dxl:ProjList/>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-NoDefault.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-NoDefault.mdp
@@ -292,7 +292,9 @@ select * from PT where j = 5;
             <dxl:ProjList/>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+              <dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-AllLevels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-AllLevels.mdp
@@ -434,8 +434,12 @@ select * from pt, t where pt.j = t.t1 and pt.k = t.t2;
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="7" ColName="t2" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="7" ColName="t2" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-Level1.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-Level1.mdp
@@ -448,7 +448,9 @@ select * from pt, t where pt.k = t.t1;
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-Level2.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-Level2.mdp
@@ -449,7 +449,9 @@ select * from pt, t where pt.j = t.t1;
             </dxl:ProjList>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Nary-Join.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Nary-Join.mdp
@@ -1560,7 +1560,9 @@ select * from pt, foo, bar where pt.k=foo.a and pt.j = bar.a;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:PartEqFilterElems>
+                  <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:PartEqFilterElems>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
@@ -1633,7 +1635,9 @@ select * from pt, foo, bar where pt.k=foo.a and pt.j = bar.a;
             </dxl:ProjList>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:PartEqFilterElems>
+                <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:PartEqFilterElems>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPredicateUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPredicateUtils.h
@@ -113,9 +113,10 @@ public:
 	// is the given expression a scalar comparison
 	static BOOL FComparison(CExpression *pexpr);
 
-	// is the given expression a conjunction of equality comparisons
-	static BOOL FConjunctionOfEqComparisons(CMemoryPool *mp,
-											CExpression *pexpr);
+	// is the given expression a disjunction of equality comparisons
+	static BOOL FDisjunctionOfIdentEqComparisons(CMemoryPool *mp,
+												 CExpression *pexpr,
+												 CColRef *colref);
 
 	// is the given expression a comparison of the given type
 	static BOOL FComparison(CExpression *pexpr, IMDType::ECmpType cmp_type);

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -450,12 +450,21 @@ private:
 		BOOL *pfDML, CExpression *pexprScalarCond,
 		CDXLPhysicalProperties *dxl_properties);
 
-	// translate partition filter list
-	CDXLNode *PdxlnPartFilterList(CExpression *pexpr, BOOL fEqFilters);
+	// construct a part eq filter list for fast pass
+	CDXLNode *PdxlPartEqFilterList(CExpression *pexpr);
+
+	// construct a part filter list with all children being scalar const true
+	CDXLNode *PdxlnPartFilterListDummy(CExpression *pexpr);
+
+	// construct a part eq filter elem list for the given partition level
+	CDXLNode *PdxlnPartEqFilterElemList(
+		CExpression *pexpr, bool fEqFilter, ULONG level,
+		CPhysicalPartitionSelector *popSelector);
 
 	// check whether the given partition selector only has equality filters
-	// or no filters on all partitioning levels. return false if it has
-	// non-equality filters.
+	// or no filters on all partitioning levels. If fCheckGeneralFilters is
+	// true, returns true if content of general filter is disjunction of ident
+	// equality filters
 	BOOL FEqPartFiltersAllLevels(CExpression *pexpr, BOOL fCheckGeneralFilters);
 
 	// translate a filter-based partition selector

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarOpList.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarOpList.h
@@ -34,6 +34,7 @@ public:
 	enum EdxlOpListType
 	{
 		EdxloplistEqFilterList,
+		EdxloplistEqFilterElemList,
 		EdxloplistFilterList,
 		EdxloplistGeneral,
 		EdxloplistSentinel

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -211,6 +211,7 @@ enum Edxltoken
 	EdxltokenScalarOpList,
 
 	EdxltokenPartLevelEqFilterList,
+	EdxltokenPartLevelEqFilterElemList,
 	EdxltokenPartLevelFilterList,
 	EdxltokenPartLevel,
 	EdxltokenScalarPartOid,

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLScalarOpList.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLScalarOpList.cpp
@@ -65,6 +65,10 @@ CDXLScalarOpList::GetOpNameStr() const
 			dxl_token = EdxltokenPartLevelEqFilterList;
 			break;
 
+		case EdxloplistEqFilterElemList:
+			dxl_token = EdxltokenPartLevelEqFilterElemList;
+			break;
+
 		case EdxloplistFilterList:
 			dxl_token = EdxltokenPartLevelFilterList;
 			break;

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerFactory.cpp
@@ -186,6 +186,7 @@ CParseHandlerFactory::Init(CMemoryPool *mp)
 		 &CreateScSubPlanParamListParseHandler},
 		{EdxltokenScalarSubPlanParam, &CreateScSubPlanParamParseHandler},
 		{EdxltokenScalarOpList, &CreateScOpListParseHandler},
+		{EdxltokenPartLevelEqFilterElemList, &CreateScOpListParseHandler},
 		{EdxltokenScalarPartOid, &CreateScPartOidParseHandler},
 		{EdxltokenScalarPartDefault, &CreateScPartDefaultParseHandler},
 		{EdxltokenScalarPartBound, &CreateScPartBoundParseHandler},

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarOpList.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarOpList.cpp
@@ -70,6 +70,24 @@ CParseHandlerScalarOpList::StartElement(const XMLCh *const element_uri,
 		m_dxl_node = GPOS_NEW(m_mp) CDXLNode(
 			m_mp, GPOS_NEW(m_mp) CDXLScalarOpList(m_mp, m_dxl_op_list_type));
 	}
+	else if (CDXLScalarOpList::EdxloplistEqFilterList == dxl_op_list_type)
+	{
+		// we must have already initialized the list node
+		GPOS_ASSERT(NULL != m_dxl_node);
+
+		// parse scalar child
+		CParseHandlerBase *child_parse_handler =
+			CParseHandlerFactory::GetParseHandler(
+				m_mp, CDXLTokens::XmlstrToken(EdxltokenScalarOpList),
+				m_parse_handler_mgr, this);
+		m_parse_handler_mgr->ActivateParseHandler(child_parse_handler);
+
+		// store parse handler
+		this->Append(child_parse_handler);
+
+		child_parse_handler->startElement(element_uri, element_local_name,
+										  element_qname, attrs);
+	}
 	else
 	{
 		// we must have already initialized the list node
@@ -114,6 +132,13 @@ CParseHandlerScalarOpList::GetDXLOpListType(
 				 element_local_name))
 	{
 		return CDXLScalarOpList::EdxloplistEqFilterList;
+	}
+
+	if (0 == XMLString::compareString(
+				 CDXLTokens::XmlstrToken(EdxltokenPartLevelEqFilterElemList),
+				 element_local_name))
+	{
+		return CDXLScalarOpList::EdxloplistEqFilterElemList;
 	}
 
 	if (0 == XMLString::compareString(

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -252,6 +252,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenScalarSubPlanTypeAll, GPOS_WSZ_LIT("AllSubPlan")},
 
 		{EdxltokenPartLevelEqFilterList, GPOS_WSZ_LIT("PartEqFilters")},
+		{EdxltokenPartLevelEqFilterElemList, GPOS_WSZ_LIT("PartEqFilterElems")},
 		{EdxltokenPartLevelFilterList, GPOS_WSZ_LIT("PartFilters")},
 		{EdxltokenPartLevel, GPOS_WSZ_LIT("Level")},
 		{EdxltokenScalarPartOid, GPOS_WSZ_LIT("PartOid")},

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2717,6 +2717,14 @@ _equalDistributedBy(const DistributedBy *a, const DistributedBy *b)
 }
 
 static bool
+_equalPartitionRule(const PartitionRule *a, const PartitionRule *b)
+{
+	COMPARE_SCALAR_FIELD(parchildrelid);
+
+	return true;
+}
+
+static bool
 _equalXmlSerialize(const XmlSerialize *a, const XmlSerialize *b)
 {
 	COMPARE_SCALAR_FIELD(xmloption);
@@ -3505,6 +3513,9 @@ equal(const void *a, const void *b)
 			break;
 		case T_DistributedBy:
 			retval = _equalDistributedBy(a, b);
+			break;
+		case T_PartitionRule:
+			retval = _equalPartitionRule(a, b);
 			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d",

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -442,12 +442,13 @@ private:
 		CDXLTranslateContext *output_context,
 		CDXLTranslationContextArray *ctxt_translation_prev_siblings);
 
-	// translate DXL filter list into GPDB filter list
+	// translate DXL filter or filter elem list into GPDB filter list
 	List *TranslateDXLFilterList(
 		const CDXLNode *filter_list_dxlnode,
 		const CDXLTranslateContextBaseTable *base_table_context,
 		CDXLTranslationContextArray *child_contexts,
-		CDXLTranslateContext *output_context);
+		CDXLTranslateContext *output_context, bool is_eq_filters,
+		bool is_eq_filter_elems);
 
 	// create range table entry from a CDXLPhysicalTVF node
 	RangeTblEntry *TranslateDXLTvfToRangeTblEntry(

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1506,7 +1506,7 @@ typedef struct PartitionSelector
 	int32		selectorId;				/* id of this partition selector */
 
 	/* Fields for dynamic selection */
-	List		*levelEqExpressions;	/* equality expressions used for individual levels */
+	List		*levelEqExpressions;	/* list of list of equality expressions used for individual levels */
 	List		*levelExpressions;  	/* predicates used for individual levels */
 	Node		*residualPredicate; 	/* residual predicate (to be applied at the end) */
 	Node		*propagationExpression; /* propagation expression */

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -3179,7 +3179,7 @@ ALTER PARTITION FOR (RANK(1))
 EXCHANGE PARTITION FOR ('usa') WITH TABLE sales_exchange_part ;
 NOTICE:  exchanged partition "usa" of partition for rank 1 of relation "sales" with relation "sales_exchange_part"
 ANALYZE sales;
--- TODO: #141973839. Expected 10 parts, currently selecting 15 parts. First level: 4 parts + 1 default. Second level 2 parts. Total 10 parts.
+-- Expect 10 parts. First level: 4 parts + 1 default. Second level 2 parts.
 select get_selected_parts('explain analyze select * from sales where region = ''usa'' or region = ''asia'';');
  get_selected_parts 
 --------------------

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -2788,11 +2788,11 @@ ALTER PARTITION FOR (RANK(1))
 EXCHANGE PARTITION FOR ('usa') WITH TABLE sales_exchange_part ;
 NOTICE:  exchanged partition "usa" of partition for rank 1 of relation "sales" with relation "sales_exchange_part"
 ANALYZE sales;
--- TODO: #141973839. Expected 10 parts, currently selecting 15 parts. First level: 4 parts + 1 default. Second level 2 parts. Total 10 parts.
+-- Expect 10 parts. First level: 4 parts + 1 default. Second level 2 parts.
 select get_selected_parts('explain analyze select * from sales where region = ''usa'' or region = ''asia'';');
  get_selected_parts 
 --------------------
- [15, 20]
+ [10, 20]
 (1 row)
 
 select * from sales where region = 'usa' or region = 'asia';

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -827,7 +827,7 @@ ALTER PARTITION FOR (RANK(1))
 EXCHANGE PARTITION FOR ('usa') WITH TABLE sales_exchange_part ;
 ANALYZE sales;
 
--- TODO: #141973839. Expected 10 parts, currently selecting 15 parts. First level: 4 parts + 1 default. Second level 2 parts. Total 10 parts.
+-- Expect 10 parts. First level: 4 parts + 1 default. Second level 2 parts.
 select get_selected_parts('explain analyze select * from sales where region = ''usa'' or region = ''asia'';');
 select * from sales where region = 'usa' or region = 'asia';
 


### PR DESCRIPTION
Previously, a predicate that contains only disjunction(s) of equal
comparisons, with one side being the partition key, such as:

```
"partkey = 1 OR partkey = 2"
"partkey IN ('a', 'b')"
```

is the partition selector's general filter. A general filter is always
evaluated with every partition rule of the current partition level. For
a range partitioned table with many partitions, iterating through every
partition rule for just a few OR'd equal comparisons is inefficient
comparing to performing binary searches with the few given values. We
also always conservatively select the default partition for all general
filters, for both range partitions or list partitions.

This patch improves partition selection for this type of predicates
by re-categorising them as equal filters. To do this, the following
changes are made:

#### CTranslatorExprToDXL
Examine the general filter of the CPhysicalPartitionSelector, if it
contains only disjunction(s) of equality comparisons, add them into the
list of equality filter elements of the equal filter CDXLNode instead of
the general filter node. This introduces DXL plan changes as below for
predicate "where b in (0,1)"

Before:
```
    <dxl:PartEqFilters>
      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
    </dxl:PartEqFilters>
    <dxl:PartFilters>
      <dxl:Or>
        <dxl:Or>
          <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
            <dxl:PartListValues Level="0" ResultType="0.1007.1.0" ElementType="0.23.1.0"/>
          </dxl:ArrayComp>
          <dxl:DefaultPart Level="0"/>
        </dxl:Or>
        <dxl:Or>
          <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
            <dxl:PartListValues Level="0" ResultType="0.1007.1.0" ElementType="0.23.1.0"/>
          </dxl:ArrayComp>
          <dxl:DefaultPart Level="0"/>
        </dxl:Or>
      </dxl:Or>
      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
    </dxl:PartFilters>
```

After:
```
    <dxl:PartEqFilters>
      <dxl:PartEqFilterElems>
        <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
      </dxl:PartEqFilterElems>
    </dxl:PartEqFilters>
    <dxl:PartFilters>
      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
    </dxl:PartFilters>
```
As shown above, we encapsulate a list of scalar values for each
partition level in the newly introduced `PartEqFilterElems` DXLNode.
Most of the MDP changes in this patch are simply update the existing
non-empty[^1] `PartEqFilters` by surrounding the single scalar value
with `PartEqFilterElems`. For the interesting changes that have more
than one scalar values inside `PartEqFilterElems`, please see the
following MDP tests:

PartTbl-ArrayCoerce.mdp
PartTbl-List-DPE-Int-Predicates.mdp
PartTbl-List-DPE-Varchar-Predicates.mdp

[^1] An empty `PartEqFilters` or `PartFilters` contains one child node:
<dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

#### CTranslatorDXLToPlStmt & Executor
`PartitionSelector->levelEqExpressions` used to be a list of scalar
values, where the list length is the number of partition levels. It is
now a list of list of scalar values, where the inner list length is the
number of OR'd equal comparisons, and the outer list length is as before
the number of partition levels. During execution, each value from the
inner list is evaluated, and the chosen partition rules for all the
values are concatenated.

