### PR TITLE
Allow Orca to handle empty target list

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -2613,7 +2613,6 @@ CTranslatorQueryToDXL::CreateDXLSetOpFromColumns(
 	CDXLNodeArray *children_dxlnodes, BOOL is_cast_across_input,
 	BOOL keep_res_junked) const
 {
-	GPOS_ASSERT(NULL != output_target_list);
 	GPOS_ASSERT(NULL != output_colids);
 	GPOS_ASSERT(NULL != input_colids);
 	GPOS_ASSERT(NULL != children_dxlnodes);
@@ -2731,7 +2730,6 @@ CTranslatorQueryToDXL::SetOpNeedsCast(List *target_list,
 									  IMdIdArray *input_col_mdids) const
 {
 	GPOS_ASSERT(NULL != input_col_mdids);
-	GPOS_ASSERT(NULL != target_list);
 	GPOS_ASSERT(
 		input_col_mdids->Size() <=
 		gpdb::ListLength(target_list));	 // there may be resjunked columns
@@ -2772,39 +2770,6 @@ CTranslatorQueryToDXL::TranslateSetOpChild(Node *child_node,
 {
 	GPOS_ASSERT(NULL != colids);
 	GPOS_ASSERT(NULL != input_col_mdids);
-
-	// GPDB_12_MERGE_FIXME: We have to fallback here because otherwise we trip
-	// the following assert in ORCA:
-	//
-	// INFO:  GPORCA failed to produce a plan, falling back to planner
-	// DETAIL:  CKeyCollection.cpp:84: Failed assertion: __null != colref_array && 0 < colref_array->Size()
-	// Stack trace:
-	// 1    0x000055c239243b8a gpos::CException::Raise + 278
-	// 2    0x000055c2393ab075 gpopt::CKeyCollection::CKeyCollection + 221
-	// 3    0x000055c239449ab6 gpopt::CLogicalSetOp::DeriveKeyCollection + 98
-	// 4    0x000055c2393a5a67 gpopt::CDrvdPropRelational::DeriveKeyCollection + 135
-	// 5    0x000055c2393a4937 gpopt::CDrvdPropRelational::Derive + 197
-	// 6    0x000055c239405d9f gpopt::CExpression::PdpDerive + 703
-	// 7    0x000055c2394d1e14 gpopt::CMemo::PgroupInsert + 512
-	// 8    0x000055c2393dd734 gpopt::CEngine::PgroupInsert + 632
-	// 9    0x000055c2393dcd73 gpopt::CEngine::InitLogicalExpression + 225
-	// 10   0x000055c2393dd106 gpopt::CEngine::Init + 884
-	// 11   0x000055c23949da9f gpopt::COptimizer::PexprOptimize + 103
-	// 12   0x000055c23949d3d8 gpopt::COptimizer::PdxlnOptimize + 1414
-	// 13   0x000055c23960e55e COptTasks::OptimizeTask + 1530
-	// 14   0x000055c2392572b6 gpos::CTask::Execute + 196
-	// 15   0x000055c239259dbf gpos::CWorker::Execute + 191
-	// 16   0x000055c2392556b5 gpos::CAutoTaskProxy::Execute + 221
-	// 17   0x000055c23925c0c0 gpos_exec + 876
-	//
-	// Currently there are a lot of asserts on NULL != target_list in the
-	// translator, but most of them are unnecessary. We should instead fix ORCA
-	// to handle empty target list.
-	if (NIL == target_list)
-	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
-				   GPOS_WSZ_LIT("Empty target list"));
-	}
 
 	if (IsA(child_node, RangeTblRef))
 	{

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1250,7 +1250,6 @@ CTranslatorUtils::GenerateColIds(
 		is_outer_ref,  // array of flags indicating if input columns are outer references
 	CIdGenerator *colid_generator)
 {
-	GPOS_ASSERT(NULL != target_list);
 	GPOS_ASSERT(NULL != input_mdid_arr);
 	GPOS_ASSERT(NULL != input_colids);
 	GPOS_ASSERT(NULL != is_outer_ref);
@@ -1310,7 +1309,6 @@ CTranslatorUtils::FixUnknownTypeConstant(Query *old_query,
 										 List *output_target_list)
 {
 	GPOS_ASSERT(NULL != old_query);
-	GPOS_ASSERT(NULL != output_target_list);
 
 	Query *new_query = NULL;
 
@@ -1451,8 +1449,6 @@ ULongPtrArray *
 CTranslatorUtils::GetPosInTargetList(CMemoryPool *mp, List *target_list,
 									 BOOL keep_res_junked)
 {
-	GPOS_ASSERT(NULL != target_list);
-
 	ListCell *target_entry_cell = NULL;
 	ULongPtrArray *positions = GPOS_NEW(mp) ULongPtrArray(mp);
 	ULONG ul = 0;

--- a/src/backend/gporca/libgpopt/src/base/CKeyCollection.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CKeyCollection.cpp
@@ -63,7 +63,7 @@ CKeyCollection::CKeyCollection(CMemoryPool *mp, CColRefArray *colref_array)
 	: m_pdrgpcrs(NULL)
 {
 	GPOS_ASSERT(NULL != mp);
-	GPOS_ASSERT(NULL != colref_array && 0 < colref_array->Size());
+	GPOS_ASSERT(NULL != colref_array);
 
 	m_pdrgpcrs = GPOS_NEW(mp) CColRefSetArray(mp);
 

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -592,13 +592,16 @@ set enable_hashagg = true;
 set enable_sort = false;
 explain (costs off)
 select from generate_series(1,5) union select from generate_series(1,3);
-                           QUERY PLAN                           
-----------------------------------------------------------------
- HashAggregate
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Aggregate
    ->  Append
-         ->  Function Scan on generate_series
-         ->  Function Scan on generate_series generate_series_1
-(4 rows)
+         ->  Aggregate
+               ->  Function Scan on generate_series
+         ->  Aggregate
+               ->  Function Scan on generate_series generate_series_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 explain (costs off)
 select from generate_series(1,5) intersect select from generate_series(1,3);
@@ -641,13 +644,16 @@ set enable_hashagg = false;
 set enable_sort = true;
 explain (costs off)
 select from generate_series(1,5) union select from generate_series(1,3);
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Unique
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Aggregate
    ->  Append
-         ->  Function Scan on generate_series
-         ->  Function Scan on generate_series generate_series_1
-(4 rows)
+         ->  Aggregate
+               ->  Function Scan on generate_series
+         ->  Aggregate
+               ->  Function Scan on generate_series generate_series_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 explain (costs off)
 select from generate_series(1,5) intersect select from generate_series(1,3);


### PR DESCRIPTION
There existed several assertions that disallowed an empty target list
since pre-GPDB 4. This is likely due the lack of support in executor
pre-v10 (ref Postgres commit e1b8e0e4a61).

Postgres v10 fixed this issue (ref Postgres commit c4c2885cbb1). After
removing the assertions then Orca can also handle an empty target list
without falling back to Planner:

```
postgres=# EXPLAIN SELECT UNION SELECT;
                      QUERY PLAN
------------------------------------------------------
 Aggregate  (cost=0.00..0.00 rows=1 width=1)
   ->  Append  (cost=0.00..0.00 rows=2 width=1)
         ->  Result  (cost=0.00..0.00 rows=1 width=1)
         ->  Result  (cost=0.00..0.00 rows=1 width=1)
 Optimizer: Pivotal Optimizer (GPORCA)
(5 rows)
```