### PR TITLE
Add test for autovacuum of template0 on segments

### DIFF
--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -15,6 +15,7 @@
 /appendonly.out
 /auth_constraint.out
 /autovacuum-template0.out
+/autovacuum-template0-segment.out
 /bb_memory_quota.out
 /bb_mpph.out
 /collect_tabstat.out

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -256,6 +256,7 @@ test: oid_wraparound
 test: fts_recovery_in_progress
 test: mirror_replay
 test: autovacuum-template0
+test: autovacuum-template0-segment
 test: pgstat_qd_tabstat
 
 # gpexpand introduce the partial tables, check them if they can run correctly

--- a/src/test/regress/input/autovacuum-template0-segment.source
+++ b/src/test/regress/input/autovacuum-template0-segment.source
@@ -1,0 +1,47 @@
+-- start_ignore
+create extension if not exists gp_inject_fault;
+
+create or replace function test_consume_xids(int4) returns void
+as '@abs_srcdir@/regress.so', 'test_consume_xids'
+language C;
+
+\! gpconfig -c debug_burn_xids -v on --skipvalidation
+\! gpstop -au
+-- end_ignore
+
+-- Autovacuum should take care of anti-XID wraparounds of 'template0'. Because
+-- of that, the age of template0 should not go much above
+-- autovacuum_freeze_max_age (we assume the default of 200 million here).
+select age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
+
+-- track that we've updated the row in pg_database for template0
+SELECT gp_inject_fault_infinite('vacuum_update_dat_frozen_xid', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+-- Suspend the autovacuum worker from vacuuming before
+-- ShmemVariableCache->latestCompletedXid is expected to be updated
+SELECT gp_inject_fault_infinite('auto_vac_worker_before_do_autovacuum', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+select test_consume_xids(10 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+
+-- Wait until autovacuum is triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+-- wait until autovacuum worker updates pg_database
+SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+-- template0 should be young
+select age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
+
+-- But autovacuum should not touch other databases. Hence, our database
+-- should be well above the 200 million mark.
+select age(datfrozenxid) > 200 * 1000000 from gp_dist_random('pg_database') where datname=current_database() and gp_segment_id = 0;
+
+-- start_ignore
+\! gpconfig -c debug_burn_xids -v off --skipvalidation
+\! gpstop -au
+-- end_ignore
+

--- a/src/test/regress/output/autovacuum-template0-segment.source
+++ b/src/test/regress/output/autovacuum-template0-segment.source
@@ -1,0 +1,113 @@
+-- start_ignore
+create extension if not exists gp_inject_fault;
+create or replace function test_consume_xids(int4) returns void
+as '@abs_srcdir@/regress.so', 'test_consume_xids'
+language C;
+\! gpconfig -c debug_burn_xids -v on --skipvalidation
+20201009:19:05:11:034329 gpconfig:gpdb6:zhanyi-[INFO]:-completed successfully with parameters '-c debug_burn_xids -v on --skipvalidation'
+\! gpstop -au
+20201009:19:05:12:034666 gpstop:gpdb6:zhanyi-[INFO]:-Starting gpstop with args: -au
+20201009:19:05:12:034666 gpstop:gpdb6:zhanyi-[INFO]:-Gathering information and validating the environment...
+20201009:19:05:12:034666 gpstop:gpdb6:zhanyi-[INFO]:-Obtaining Greenplum Master catalog information
+20201009:19:05:12:034666 gpstop:gpdb6:zhanyi-[INFO]:-Obtaining Segment details from master...
+20201009:19:05:12:034666 gpstop:gpdb6:zhanyi-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.11.1+dev.22.gcf4e9dbf19 build dev'
+20201009:19:05:12:034666 gpstop:gpdb6:zhanyi-[INFO]:-Signalling all postmaster processes to reload
+-- end_ignore
+-- Autovacuum should take care of anti-XID wraparounds of 'template0'. Because
+-- of that, the age of template0 should not go much above
+-- autovacuum_freeze_max_age (we assume the default of 200 million here).
+select age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
+ ?column? 
+----------
+ t
+ t
+ t
+(3 rows)
+
+-- track that we've updated the row in pg_database for template0
+SELECT gp_inject_fault_infinite('vacuum_update_dat_frozen_xid', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+-- Suspend the autovacuum worker from vacuuming before
+-- ShmemVariableCache->latestCompletedXid is expected to be updated
+SELECT gp_inject_fault_infinite('auto_vac_worker_before_do_autovacuum', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+ test_consume_xids 
+-------------------
+ 
+(1 row)
+
+select test_consume_xids(100 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+ test_consume_xids 
+-------------------
+ 
+(1 row)
+
+select test_consume_xids(10 * 1000000) from gp_dist_random('gp_id') where gp_segment_id = 0;
+ test_consume_xids 
+-------------------
+ 
+(1 row)
+
+-- Wait until autovacuum is triggered
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- wait until autovacuum worker updates pg_database
+SELECT gp_wait_until_triggered_fault('vacuum_update_dat_frozen_xid', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('vacuum_update_dat_frozen_xid', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- template0 should be young
+select age(datfrozenxid) < 200 * 1000000 from gp_dist_random('pg_database') where datname='template0';
+ ?column? 
+----------
+ t
+ t
+ t
+(3 rows)
+
+-- But autovacuum should not touch other databases. Hence, our database
+-- should be well above the 200 million mark.
+select age(datfrozenxid) > 200 * 1000000 from gp_dist_random('pg_database') where datname=current_database() and gp_segment_id = 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- start_ignore
+\! gpconfig -c debug_burn_xids -v off --skipvalidation
+20201009:19:06:18:034710 gpconfig:gpdb6:zhanyi-[INFO]:-completed successfully with parameters '-c debug_burn_xids -v off --skipvalidation'
+\! gpstop -au
+20201009:19:06:19:035047 gpstop:gpdb6:zhanyi-[INFO]:-Starting gpstop with args: -au
+20201009:19:06:19:035047 gpstop:gpdb6:zhanyi-[INFO]:-Gathering information and validating the environment...
+20201009:19:06:19:035047 gpstop:gpdb6:zhanyi-[INFO]:-Obtaining Greenplum Master catalog information
+20201009:19:06:19:035047 gpstop:gpdb6:zhanyi-[INFO]:-Obtaining Segment details from master...
+20201009:19:06:19:035047 gpstop:gpdb6:zhanyi-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.11.1+dev.22.gcf4e9dbf19 build dev'
+20201009:19:06:19:035047 gpstop:gpdb6:zhanyi-[INFO]:-Signalling all postmaster processes to reload
+-- end_ignore

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -15,6 +15,7 @@
 /appendonly.sql
 /auth_constraint.sql
 /autovacuum-template0.sql
+/autovacuum-template0-segment.sql
 /bb_memory_quota.sql
 /bb_mpph.sql
 /collect_tabstat.sql


### PR DESCRIPTION
This is forward port of test from GPDB6 which was committed as part of
commit e0f598b1d81df45f53c9fca2ebda1adab5188df2.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
