### PR TITLE
Destruct MyTmGxactLocal->waitGxids with list_free() instead of pfree().

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1308,7 +1308,7 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 		int lastRepeat = -1;
 		if (MyTmGxactLocal->waitGxids)
 		{
-			pfree(MyTmGxactLocal->waitGxids);
+			list_free(MyTmGxactLocal->waitGxids);
 			MyTmGxactLocal->waitGxids = NULL;
 		}
 
@@ -1417,7 +1417,7 @@ resetGxact(void)
 	MyTmGxactLocal->isOnePhaseCommit = false;
 	if (MyTmGxactLocal->waitGxids != NULL)
 	{
-		pfree(MyTmGxactLocal->waitGxids);
+		list_free(MyTmGxactLocal->waitGxids);
 		MyTmGxactLocal->waitGxids = NULL;
 	}
 	setCurrentDtxState(DTX_STATE_NONE);


### PR DESCRIPTION
Related issue is here: https://github.com/greenplum-db/gpdb/issues/11309

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
