### PR TITLE
[6X Backport] Destruct MyTmGxactLocal->waitGxids with list_free() instead of pfree().

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1384,7 +1384,7 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 		int lastRepeat = -1;
 		if (MyTmGxactLocal->waitGxids)
 		{
-			pfree(MyTmGxactLocal->waitGxids);
+			list_free(MyTmGxactLocal->waitGxids);
 			MyTmGxactLocal->waitGxids = NULL;
 		}
 
@@ -1496,7 +1496,7 @@ resetGxact()
 	MyTmGxactLocal->isOnePhaseCommit = false;
 	if (MyTmGxactLocal->waitGxids != NULL)
 	{
-		pfree(MyTmGxactLocal->waitGxids);
+		list_free(MyTmGxactLocal->waitGxids);
 		MyTmGxactLocal->waitGxids = NULL;
 	}
 	setCurrentDtxState(DTX_STATE_NONE);


### PR DESCRIPTION
MyTmGxactLocal->waitGxids is a List of gxids, but it's currently destructed with pfree().
This commit changes it to list_free().

(cherry picked from commit 69da6add7d2966f2a107d47da9e963dc9140a44e)