### PR TITLE
docs - add ref info for gp_interconnect_transmit_timeout guc

### DIFF
--- a/gpdb-doc/dita/admin_guide/managing/configure.xml
+++ b/gpdb-doc/dita/admin_guide/managing/configure.xml
@@ -1099,6 +1099,9 @@
                   <codeph>gp_interconnect_setup_timeout</codeph>
                 </p>
                 <p>
+                  <codeph>gp_interconnect_transmit_timeout</codeph>
+                </p>
+                <p>
                   <codeph>gp_interconnect_type</codeph>
                 </p>
                 <p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -3795,8 +3795,8 @@
   <topic id="gp_interconnect_setup_timeout">
     <title>gp_interconnect_setup_timeout</title>
     <body>
-      <p>Specifies the amount of time to wait for the Greenplum Database interconnect to complete
-        setup before it times out.</p>
+      <p>Specifies the amount of time, in seconds, that Greenplum Database waits
+        for the interconnect to complete setup before it times out.</p>
       <table id="gp_interconnect_setup_timeout_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -3811,8 +3811,8 @@
           </thead>
           <tbody>
             <row>
-              <entry colname="col1">Any valid time expression (number and unit)</entry>
-              <entry colname="col2">2 hours</entry>
+              <entry colname="col1">0 - 7200 seconds</entry>
+              <entry colname="col2">7200 seconds (2 hours)</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>
@@ -3844,6 +3844,35 @@
             <row>
               <entry colname="col1">1 - 4096</entry>
               <entry colname="col2">2 </entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gp_interconnect_transmit_timeout">
+    <title>gp_interconnect_transmit_timeout</title>
+    <body>
+      <p>Specifies the amount of time, in seconds, that Greenplum Database waits
+        for network transmission of interconnect traffic to complete before it
+        times out.</p>
+      <table id="gp_interconnect_transmit_timeout_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">1 - 7200 seconds</entry>
+              <entry colname="col2">3600 seconds (1 hour)</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1350,15 +1350,19 @@
                 <xref href="guc-list.xml#gp_interconnect_queue_depth" type="section"
                   >gp_interconnect_queue_depth</xref>
               </p>
-            </stentry>
-            <stentry>
               <p>
                 <xref href="guc-list.xml#gp_interconnect_setup_timeout" type="section"
                   >gp_interconnect_setup_timeout</xref>
               </p>
+            </stentry>
+            <stentry>
               <p>
                 <xref href="guc-list.xml#gp_interconnect_snd_queue_depth" type="section"
                   >gp_interconnect_snd_queue_depth</xref>
+              </p>
+              <p>
+                <xref href="guc-list.xml#gp_interconnect_transmit_timeout" type="section"
+                  >gp_interconnect_transmit_timeout</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_interconnect_type" type="section"

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -121,6 +121,7 @@
             <topicref href="guc-list.xml#gp_interconnect_queue_depth"/>
             <topicref href="guc-list.xml#gp_interconnect_setup_timeout"/>
             <topicref href="guc-list.xml#gp_interconnect_snd_queue_depth"/>
+            <topicref href="guc-list.xml#gp_interconnect_transmit_timeout"/>
             <topicref href="guc-list.xml#gp_interconnect_type"/>
             <topicref href="guc-list.xml#gp_log_format"/>
             <topicref href="guc-list.xml#gp_log_fts"/>


### PR DESCRIPTION
add content for guc gp_interconnect_transmit_timeout to the reference guide.

while investigating, i noticed that our docs for gp_interconnect_setup_timeout appeared to be incorrect.  this PR includes a doc changes for that guc as well.
