### PR TITLE
Do not optimize locking behavior for cursor.

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2027,6 +2027,19 @@ _SPI_prepare_plan(const char *src, SPIPlanPtr plan)
 		List	   *stmt_list;
 		CachedPlanSource *plansource;
 
+		if (IsA(parsetree->stmt, SelectStmt))
+		{
+			/*
+			 * Greenplum specific behavior
+			 * Cursor's query is executed by a reader gang and in Greenplum
+			 * reader gang cannot lock tuples. If a cursor's query is SELECT
+			 * statement with locking clause, Greenplum will ignore the locking
+			 * clause, always locks the relation using Exclusive Lock and
+			 * does not generate LockRows plannode.
+			 */
+			((SelectStmt *)parsetree->stmt)->disableLockingOptimization = GlobalDisableLockingOptimization;
+		}
+
 		/*
 		 * Create the CachedPlanSource before we do parse analysis, since it
 		 * needs to see the unmodified raw parse tree.

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -78,6 +78,8 @@ typedef struct QueryNodeSearchContext
 /* Hook for plugins to get control at end of parse analysis */
 post_parse_analyze_hook_type post_parse_analyze_hook = NULL;
 
+bool GlobalDisableLockingOptimization = false;
+
 static Query *transformOptionalSelectInto(ParseState *pstate, Node *parseTree);
 static Query *transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt);
 static Query *transformInsertStmt(ParseState *pstate, InsertStmt *stmt);

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -21,6 +21,7 @@ typedef void (*post_parse_analyze_hook_type) (ParseState *pstate,
 											  Query *query);
 extern PGDLLIMPORT post_parse_analyze_hook_type post_parse_analyze_hook;
 
+extern bool GlobalDisableLockingOptimization;
 
 extern Query *parse_analyze(RawStmt *parseTree, const char *sourceText,
 							Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);

--- a/src/test/isolation2/expected/gdd/cursor_for_update.out
+++ b/src/test/isolation2/expected/gdd/cursor_for_update.out
@@ -1,0 +1,32 @@
+-- If a cursor's query is SELECT with locking clause, Greenplum
+-- should not generate lockrows plannode to avoid lock tuples
+-- in segments because cursor is excuted by a reader gang.
+create table cursor_initplan(a int, b int);
+CREATE
+insert into cursor_initplan select i, i from generate_series(1, 10)i;
+INSERT 10
+
+create or replace function func_test_cursor1() returns void as $body$ declare cur cursor for select * from cursor_initplan for update;-- var1 record;-- var2 record;-- begin open cur;-- fetch cur into var1;-- update cursor_initplan set b = var1.b + 1 where current of cur; end;-- $body$ language 'plpgsql';
+CREATE
+
+create or replace function func_test_cursor2() returns void as $body$ declare cur refcursor;-- var1 record;-- var2 record;-- begin open cur for select * from cursor_initplan for update;-- fetch cur into var1;-- update cursor_initplan set b = var1.b + 1 where current of cur; end;-- $body$ language 'plpgsql';
+CREATE
+
+create or replace function func_test_cursor3() returns void as $body$ declare cur refcursor;-- var1 record;-- var2 record;-- begin open cur for execute 'select * from cursor_initplan for update';-- fetch cur into var1;-- update cursor_initplan set b = var1.b + 1 where current of cur; end;-- $body$ language 'plpgsql';
+CREATE
+
+select func_test_cursor1();
+ func_test_cursor1 
+-------------------
+                   
+(1 row)
+select func_test_cursor2();
+ func_test_cursor2 
+-------------------
+                   
+(1 row)
+select func_test_cursor3();
+ func_test_cursor3 
+-------------------
+                   
+(1 row)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -26,6 +26,7 @@ test: packcore
 
 # Tests on global deadlock detector
 test: gdd/prepare
+test: gdd/cursor_for_update
 test: gdd/concurrent_update
 test: gdd/dist-deadlock-01 gdd/dist-deadlock-04 gdd/dist-deadlock-05 gdd/dist-deadlock-06 gdd/dist-deadlock-07 gdd/dist-deadlock-102 gdd/dist-deadlock-103 gdd/dist-deadlock-104 gdd/dist-deadlock-106 gdd/non-lock-105
 test: gdd/dist-deadlock-upsert

--- a/src/test/isolation2/sql/gdd/cursor_for_update.sql
+++ b/src/test/isolation2/sql/gdd/cursor_for_update.sql
@@ -1,0 +1,42 @@
+-- If a cursor's query is SELECT with locking clause, Greenplum
+-- should not generate lockrows plannode to avoid lock tuples
+-- in segments because cursor is excuted by a reader gang.
+create table cursor_initplan(a int, b int);
+insert into cursor_initplan select i, i from generate_series(1, 10)i;
+
+create or replace function func_test_cursor1() returns void as
+$body$
+declare cur cursor for select * from cursor_initplan for update;--
+var1 record;--
+var2 record;--
+begin
+open cur;--
+fetch cur into var1;--
+update cursor_initplan set b = var1.b + 1 where current of cur; end;--
+$body$ language 'plpgsql';
+
+create or replace function func_test_cursor2() returns void as
+$body$
+declare cur refcursor;--
+var1 record;--
+var2 record;--
+begin
+open cur for select * from cursor_initplan for update;--
+fetch cur into var1;--
+update cursor_initplan set b = var1.b + 1 where current of cur; end;--
+$body$ language 'plpgsql';
+
+create or replace function func_test_cursor3() returns void as
+$body$
+declare cur refcursor;--
+var1 record;--
+var2 record;--
+begin
+open cur for execute 'select * from cursor_initplan for update';--
+fetch cur into var1;--
+update cursor_initplan set b = var1.b + 1 where current of cur; end;--
+$body$ language 'plpgsql';
+
+select func_test_cursor1();
+select func_test_cursor2();
+select func_test_cursor3();


### PR DESCRIPTION
Cursor is executed by a reader gang in Greenplum so it cannot
lock tuples. For a cursor whose query is SELECT with locking
clause, we should not generate LockRows plannode.

Previously we think cursor cannot be top level SELECT statement
but this is not ture in plpgsql. This commit fixes for plpgsql's
cursor usage for SELECT with locking clause.
