### PR TITLE
[5X only] Make gp_toolkit bloat computation more lenient

### DIFF
--- a/src/test/regress/expected/gp_toolkit.out
+++ b/src/test/regress/expected/gp_toolkit.out
@@ -668,10 +668,9 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 set allow_system_table_mods=dml ;
 update pg_statistic set stawidth=2034567890 where starelid = (select oid from pg_class where relname='test');
 select * from gp_toolkit.gp_bloat_diag;
- bdirelid | bdinspname | bdirelname | bdirelpages | bdiexppages |              bdidiag               
-----------+------------+------------+-------------+-------------+------------------------------------
-     2618 | pg_catalog | pg_rewrite |          19 |           5 | moderate amount of bloat suspected
-(1 row)
+ bdirelid | bdinspname | bdirelname | bdirelpages | bdiexppages | bdidiag 
+----------+------------+------------+-------------+-------------+---------
+(0 rows)
 
 \c regression
 drop database gptoolkit

--- a/src/test/regress/expected/gp_toolkit.out
+++ b/src/test/regress/expected/gp_toolkit.out
@@ -660,17 +660,22 @@ drop role toolkit_user1;
 drop role toolkit_admin;
 create database gptoolkit;
 \c gptoolkit
-drop table if exists test;
-NOTICE:  table "test" does not exist, skipping
-create table test as select * from pg_attribute;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'attrelid' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-set allow_system_table_mods=dml ;
-update pg_statistic set stawidth=2034567890 where starelid = (select oid from pg_class where relname='test');
-select * from gp_toolkit.gp_bloat_diag;
- bdirelid | bdinspname | bdirelname | bdirelpages | bdiexppages | bdidiag 
-----------+------------+------------+-------------+-------------+---------
-(0 rows)
+-- cover "moderate bloat" case
+create table test (a int, b int) distributed by (a);
+insert into test select i, i from generate_series(1,5000)i;
+-- update all rows five times, so that relpages is 5 times greater
+-- than expected pages.
+update test set b = -a;
+update test set b = -a;
+update test set b = -a;
+update test set b = -a;
+update test set b = -a;
+analyze test;
+select bdinspname, bdirelname, bdirelpages, bdiexppages, bdidiag from gp_toolkit.gp_bloat_diag;
+ bdinspname | bdirelname | bdirelpages | bdiexppages |              bdidiag               
+------------+------------+-------------+-------------+------------------------------------
+ public     | test       |          31 |           6 | moderate amount of bloat suspected
+(1 row)
 
 \c regression
 drop database gptoolkit


### PR DESCRIPTION
The `gp_toolkit.gp_bloat_diag` view uses average width of a row as computed from a sample of a relation's blocks (by analyze) and multiplies it with `reltuples` to compute expected size of the relation.  The width itself is approximate and using it as a multiplying factor further increases the error.  Consequently, we have seen confusion in production deployments where the `gp_bloat_diag` reported "moderate bloat" for a relation right after it was vacuumed using "vacuum full".

To fix this confusion, a factor is added to the approximate width computed from `pg_statistic`.  The added amount is proportional to the number of variable length attributes in the relation.  The thresholds used to report moderate and severe bloat are changed too, so that the bloat computation now errors on the side of "not vacuuming".

This is a 5X only change because it address a problem seen so far only on 5X production deployments.  In Greenplum 6 and beyond, we may evaluate a more accurate alternative - `pgstattuple` contrib module.